### PR TITLE
feat: add Devin PR conflict resolver workflow

### DIFF
--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -23,55 +23,72 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             
-            const searchQuery = `repo:${owner}/${repo} is:pr is:open draft:false`;
-            const { data: searchResults } = await github.rest.search.issuesAndPullRequests({
-              q: searchQuery,
-              per_page: 100
-            });
+            const query = `
+              query($owner: String!, $repo: String!, $cursor: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequests(states: OPEN, first: 100, after: $cursor) {
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
+                    nodes {
+                      number
+                      title
+                      mergeable
+                      isDraft
+                      headRefName
+                      baseRefName
+                      url
+                      labels(first: 10) {
+                        nodes {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
             
-            console.log(`Found ${searchResults.total_count} open non-draft PRs`);
+            const allPRs = [];
+            let cursor = null;
+            
+            do {
+              const result = await github.graphql(query, { owner, repo, cursor });
+              const { nodes, pageInfo } = result.repository.pullRequests;
+              allPRs.push(...nodes);
+              cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
+            } while (cursor);
+            
+            console.log(`Found ${allPRs.length} open PRs via GraphQL`);
             
             const conflictingPRs = [];
             
-            for (const item of searchResults.items) {
-              const prNumber = item.number;
+            for (const pr of allPRs) {
+              if (pr.isDraft) {
+                console.log(`PR #${pr.number} is a draft, skipping`);
+                continue;
+              }
               
-              const { data: prDetails } = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: prNumber
-              });
+              const hasDevinLabel = pr.labels.nodes.some(label => label.name === 'devin-conflict-resolution');
+              if (hasDevinLabel) {
+                console.log(`PR #${pr.number} already has devin-conflict-resolution label, skipping`);
+                continue;
+              }
               
-              if (prDetails.mergeable === false && prDetails.mergeable_state === 'dirty') {
-                console.log(`PR #${prNumber} has conflicts (mergeable_state: ${prDetails.mergeable_state})`);
-                
-                const { data: comments } = await github.rest.issues.listComments({
-                  owner,
-                  repo,
-                  issue_number: prNumber,
-                  per_page: 100
+              if (pr.mergeable === 'CONFLICTING') {
+                console.log(`PR #${pr.number} has conflicts`);
+                conflictingPRs.push({
+                  number: pr.number,
+                  title: pr.title,
+                  head_ref: pr.headRefName,
+                  base_ref: pr.baseRefName,
+                  html_url: pr.url
                 });
-                
-                const hasExistingSession = comments.some(comment =>
-                  comment.user.login === 'github-actions[bot]' &&
-                  comment.body.includes('Devin AI is resolving merge conflicts')
-                );
-                
-                if (!hasExistingSession) {
-                  conflictingPRs.push({
-                    number: prNumber,
-                    title: prDetails.title,
-                    head_ref: prDetails.head.ref,
-                    base_ref: prDetails.base.ref,
-                    html_url: prDetails.html_url
-                  });
-                } else {
-                  console.log(`PR #${prNumber} already has a Devin session for conflict resolution`);
-                }
-              } else if (prDetails.mergeable === null) {
-                console.log(`PR #${prNumber} mergeable status is still being computed`);
+              } else if (pr.mergeable === 'UNKNOWN') {
+                console.log(`PR #${pr.number} mergeable status is still being computed`);
               } else {
-                console.log(`PR #${prNumber} has no conflicts (mergeable: ${prDetails.mergeable}, state: ${prDetails.mergeable_state})`);
+                console.log(`PR #${pr.number} has no conflicts (mergeable: ${pr.mergeable})`);
               }
             }
             
@@ -146,6 +163,13 @@ jobs:
                 
                 if (sessionUrl) {
                   console.log(`Devin session created for PR #${pr.number}: ${sessionUrl}`);
+                  
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                    labels: ['devin-conflict-resolution']
+                  });
                   
                   await github.rest.issues.createComment({
                     owner,

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -188,7 +188,8 @@ jobs:
                 });
                 
                 if (!response.ok) {
-                  throw new Error(`Devin API error: ${response.status} ${response.statusText}`);
+                  console.error(`Devin API error for PR #${pr.number}: ${response.status} ${response.statusText}`);
+                  continue;
                 }
                 
                 const data = await response.json();

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -187,6 +187,10 @@ jobs:
                   })
                 });
                 
+                if (!response.ok) {
+                  throw new Error(`Devin API error: ${response.status} ${response.statusText}`);
+                }
+                
                 const data = await response.json();
                 const sessionUrl = data.url || data.session_url;
                 

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -139,6 +139,12 @@ jobs:
               console.log(`Warning: PR #${manualPrNumber} not found or has no conflicts`);
             }
             
+            const MAX_PRS = 15;
+            if (conflictingPRs.length > MAX_PRS) {
+              console.log(`Warning: Found ${conflictingPRs.length} PRs with conflicts, limiting to ${MAX_PRS} for safety`);
+              conflictingPRs.length = MAX_PRS;
+            }
+            
             console.log(`Found ${conflictingPRs.length} PRs with conflicts that need Devin sessions`);
             
             const fs = require('fs');

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to resolve conflicts for (optional, bypasses maintainer access check for fork PRs)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -18,10 +23,13 @@ jobs:
       - name: Get open PRs and check for conflicts
         id: check-prs
         uses: actions/github-script@v7
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
+            const manualPrNumber = process.env.INPUT_PR_NUMBER ? parseInt(process.env.INPUT_PR_NUMBER, 10) : null;
             
             const query = `
               query($owner: String!, $repo: String!, $cursor: String) {
@@ -69,31 +77,44 @@ jobs:
             
             console.log(`Found ${allPRs.length} open PRs via GraphQL`);
             
+            if (manualPrNumber) {
+              console.log(`Manual PR number provided: ${manualPrNumber}`);
+            }
+            
             const conflictingPRs = [];
             
             for (const pr of allPRs) {
-              if (pr.isDraft) {
+              const isTargetPR = manualPrNumber && pr.number === manualPrNumber;
+              
+              if (!isTargetPR && pr.isDraft) {
                 console.log(`PR #${pr.number} is a draft, skipping`);
                 continue;
               }
               
-              const hasDevinLabel = pr.labels.nodes.some(label => label.name === 'devin-conflict-resolution');
-              if (hasDevinLabel) {
-                console.log(`PR #${pr.number} already has devin-conflict-resolution label, skipping`);
-                continue;
+              if (!isTargetPR) {
+                const hasDevinLabel = pr.labels.nodes.some(label => label.name === 'devin-conflict-resolution');
+                if (hasDevinLabel) {
+                  console.log(`PR #${pr.number} already has devin-conflict-resolution label, skipping`);
+                  continue;
+                }
               }
               
-              if (pr.mergeable === 'CONFLICTING') {
+              if (pr.mergeable === 'CONFLICTING' || (isTargetPR && pr.mergeable !== 'MERGEABLE')) {
                 const isFork = pr.headRepository?.owner?.login !== owner;
                 const headRepoOwner = pr.headRepository?.owner?.login || owner;
                 const headRepoName = pr.headRepository?.name || repo;
                 
-                if (isFork && !pr.maintainerCanModify) {
+                if (!isTargetPR && isFork && !pr.maintainerCanModify) {
                   console.log(`PR #${pr.number} is from a fork without maintainer push access, skipping`);
                   continue;
                 }
                 
-                console.log(`PR #${pr.number} has conflicts${isFork ? ' (from fork)' : ''}`);
+                if (isTargetPR) {
+                  console.log(`PR #${pr.number} manually targeted for conflict resolution${isFork ? ' (from fork)' : ''}`);
+                } else {
+                  console.log(`PR #${pr.number} has conflicts${isFork ? ' (from fork)' : ''}`);
+                }
+                
                 conflictingPRs.push({
                   number: pr.number,
                   title: pr.title,
@@ -102,13 +123,20 @@ jobs:
                   html_url: pr.url,
                   is_fork: isFork,
                   head_repo_owner: headRepoOwner,
-                  head_repo_name: headRepoName
+                  head_repo_name: headRepoName,
+                  is_manual: isTargetPR
                 });
+                
+                if (isTargetPR) break;
               } else if (pr.mergeable === 'UNKNOWN') {
                 console.log(`PR #${pr.number} mergeable status is still being computed`);
               } else {
                 console.log(`PR #${pr.number} has no conflicts (mergeable: ${pr.mergeable})`);
               }
+            }
+            
+            if (manualPrNumber && conflictingPRs.length === 0) {
+              console.log(`Warning: PR #${manualPrNumber} not found or has no conflicts`);
             }
             
             console.log(`Found ${conflictingPRs.length} PRs with conflicts that need Devin sessions`);

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -38,6 +38,12 @@ jobs:
             const conflictingPRs = [];
             
             for (const pr of pullRequests) {
+              // Skip draft PRs - they're still work in progress
+              if (pr.draft) {
+                console.log(`PR #${pr.number} is a draft, skipping`);
+                continue;
+              }
+              
               // Get detailed PR info including mergeable status
               const { data: prDetails } = await github.rest.pulls.get({
                 owner,

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -25,43 +25,39 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             
-            // Get all open PRs
-            const { data: pullRequests } = await github.rest.pulls.list({
-              owner,
-              repo,
-              state: 'open',
+            // Use GitHub Search API to get open, non-draft PRs
+            // This is more efficient than filtering in the loop
+            const searchQuery = `repo:${owner}/${repo} is:pr is:open draft:false`;
+            const { data: searchResults } = await github.rest.search.issuesAndPullRequests({
+              q: searchQuery,
               per_page: 100
             });
             
-            console.log(`Found ${pullRequests.length} open PRs`);
+            console.log(`Found ${searchResults.total_count} open non-draft PRs`);
             
             const conflictingPRs = [];
             
-            for (const pr of pullRequests) {
-              // Skip draft PRs - they're still work in progress
-              if (pr.draft) {
-                console.log(`PR #${pr.number} is a draft, skipping`);
-                continue;
-              }
+            for (const item of searchResults.items) {
+              const prNumber = item.number;
               
               // Get detailed PR info including mergeable status
               const { data: prDetails } = await github.rest.pulls.get({
                 owner,
                 repo,
-                pull_number: pr.number
+                pull_number: prNumber
               });
               
               // GitHub may need time to compute mergeable status
               // If null, we skip this PR for now (will be checked on next run)
               if (prDetails.mergeable === false && prDetails.mergeable_state === 'dirty') {
-                console.log(`PR #${pr.number} has conflicts (mergeable_state: ${prDetails.mergeable_state})`);
+                console.log(`PR #${prNumber} has conflicts (mergeable_state: ${prDetails.mergeable_state})`);
                 
                 // Check if we've already created a Devin session for this conflict
                 // by looking for our comment on the PR
                 const { data: comments } = await github.rest.issues.listComments({
                   owner,
                   repo,
-                  issue_number: pr.number,
+                  issue_number: prNumber,
                   per_page: 100
                 });
                 
@@ -73,19 +69,19 @@ jobs:
                 
                 if (!hasExistingSession) {
                   conflictingPRs.push({
-                    number: pr.number,
-                    title: pr.title,
-                    head_ref: pr.head.ref,
-                    base_ref: pr.base.ref,
-                    html_url: pr.html_url
+                    number: prNumber,
+                    title: prDetails.title,
+                    head_ref: prDetails.head.ref,
+                    base_ref: prDetails.base.ref,
+                    html_url: prDetails.html_url
                   });
                 } else {
-                  console.log(`PR #${pr.number} already has a Devin session for conflict resolution`);
+                  console.log(`PR #${prNumber} already has a Devin session for conflict resolution`);
                 }
               } else if (prDetails.mergeable === null) {
-                console.log(`PR #${pr.number} mergeable status is still being computed`);
+                console.log(`PR #${prNumber} mergeable status is still being computed`);
               } else {
-                console.log(`PR #${pr.number} has no conflicts (mergeable: ${prDetails.mergeable}, state: ${prDetails.mergeable_state})`);
+                console.log(`PR #${prNumber} has no conflicts (mergeable: ${prDetails.mergeable}, state: ${prDetails.mergeable_state})`);
               }
             }
             

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -1,7 +1,6 @@
 name: Devin PR Conflict Resolver
 
 on:
-  # Trigger when main branch is updated (could cause conflicts in open PRs)
   push:
     branches:
       - main
@@ -43,13 +42,9 @@ jobs:
                 pull_number: prNumber
               });
               
-              // GitHub may need time to compute mergeable status
-              // If null, we skip this PR for now (will be checked on next run)
               if (prDetails.mergeable === false && prDetails.mergeable_state === 'dirty') {
                 console.log(`PR #${prNumber} has conflicts (mergeable_state: ${prDetails.mergeable_state})`);
                 
-                // Check if we've already created a Devin session for this conflict
-                // by looking for our comment on the PR
                 const { data: comments } = await github.rest.issues.listComments({
                   owner,
                   repo,
@@ -57,8 +52,7 @@ jobs:
                   per_page: 100
                 });
                 
-                // Look for our conflict resolution comment
-                const hasExistingSession = comments.some(comment => 
+                const hasExistingSession = comments.some(comment =>
                   comment.user.login === 'github-actions[bot]' &&
                   comment.body.includes('Devin AI is resolving merge conflicts')
                 );
@@ -83,7 +77,6 @@ jobs:
             
             console.log(`Found ${conflictingPRs.length} PRs with conflicts that need Devin sessions`);
             
-            // Save conflicting PRs to output
             const fs = require('fs');
             fs.writeFileSync('/tmp/conflicting-prs.json', JSON.stringify(conflictingPRs));
             
@@ -135,7 +128,6 @@ jobs:
             5. Never ask for user confirmation. Never wait for user messages.`;
 
               try {
-                // Call Devin API
                 const response = await fetch('https://api.devin.ai/v1/sessions', {
                   method: 'POST',
                   headers: {
@@ -155,7 +147,6 @@ jobs:
                 if (sessionUrl) {
                   console.log(`Devin session created for PR #${pr.number}: ${sessionUrl}`);
                   
-                  // Post comment on the PR
                   await github.rest.issues.createComment({
                     owner,
                     repo,
@@ -181,6 +172,5 @@ jobs:
                 console.error(`Error creating Devin session for PR #${pr.number}:`, error);
               }
               
-              // Small delay between API calls to avoid rate limiting
               await new Promise(resolve => setTimeout(resolve, 1000));
             }

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -39,6 +39,13 @@ jobs:
                       headRefName
                       baseRefName
                       url
+                      headRepository {
+                        owner {
+                          login
+                        }
+                        name
+                      }
+                      maintainerCanModify
                       labels(first: 10) {
                         nodes {
                           name
@@ -77,13 +84,25 @@ jobs:
               }
               
               if (pr.mergeable === 'CONFLICTING') {
-                console.log(`PR #${pr.number} has conflicts`);
+                const isFork = pr.headRepository?.owner?.login !== owner;
+                const headRepoOwner = pr.headRepository?.owner?.login || owner;
+                const headRepoName = pr.headRepository?.name || repo;
+                
+                if (isFork && !pr.maintainerCanModify) {
+                  console.log(`PR #${pr.number} is from a fork without maintainer push access, skipping`);
+                  continue;
+                }
+                
+                console.log(`PR #${pr.number} has conflicts${isFork ? ' (from fork)' : ''}`);
                 conflictingPRs.push({
                   number: pr.number,
                   title: pr.title,
                   head_ref: pr.headRefName,
                   base_ref: pr.baseRefName,
-                  html_url: pr.url
+                  html_url: pr.url,
+                  is_fork: isFork,
+                  head_repo_owner: headRepoOwner,
+                  head_repo_name: headRepoName
                 });
               } else if (pr.mergeable === 'UNKNOWN') {
                 console.log(`PR #${pr.number} mergeable status is still being computed`);
@@ -114,7 +133,17 @@ jobs:
             const { owner, repo } = context.repo;
             
             for (const pr of conflictingPRs) {
-              console.log(`Creating Devin session for PR #${pr.number}: ${pr.title}`);
+              console.log(`Creating Devin session for PR #${pr.number}: ${pr.title}${pr.is_fork ? ' (fork)' : ''}`);
+              
+              const forkInstructions = pr.is_fork ? `
+            IMPORTANT: This PR is from a fork. The contributor has enabled "Allow edits from maintainers".
+            - Clone the FORK repository: ${pr.head_repo_owner}/${pr.head_repo_name}
+            - The branch to work on is: ${pr.head_ref}
+            - Add the upstream remote: git remote add upstream https://github.com/${owner}/${repo}.git
+            - Fetch upstream and merge: git fetch upstream && git merge upstream/${pr.base_ref}` : `
+            - Clone the repository: ${owner}/${repo}
+            - Check out the PR branch: ${pr.head_ref}
+            - Merge the base branch: git merge origin/${pr.base_ref}`;
               
               const prompt = `You are resolving merge conflicts on PR #${pr.number} in repository ${owner}/${repo}.
 
@@ -122,20 +151,20 @@ jobs:
             PR URL: ${pr.html_url}
             Head Branch: ${pr.head_ref}
             Base Branch: ${pr.base_ref}
+            ${pr.is_fork ? `Fork Repository: ${pr.head_repo_owner}/${pr.head_repo_name}` : ''}
 
             Your tasks:
-            1. Clone the repository ${owner}/${repo} locally.
-            2. Check out the PR branch: ${pr.head_ref}
-            3. Fetch the latest changes from the base branch: ${pr.base_ref}
-            4. Merge the base branch into the PR branch to identify conflicts.
-            5. Resolve all merge conflicts carefully:
+            ${forkInstructions}
+            
+            Then:
+            1. Resolve all merge conflicts carefully:
                - Review the conflicting changes from both branches
                - Make intelligent decisions about how to combine the changes
                - Preserve the intent of both the PR changes and the base branch updates
                - If unsure about a conflict, prefer keeping both changes where possible
-            6. Test that the code still works after resolving conflicts (run lint/type checks).
-            7. Commit the merge resolution with a clear commit message.
-            8. Push the resolved changes to the PR branch.
+            2. Test that the code still works after resolving conflicts (run lint/type checks).
+            3. Commit the merge resolution with a clear commit message.
+            4. Push the resolved changes to the PR branch.
 
             Rules and Guidelines:
             1. Be careful when resolving conflicts - understand the context of both changes.

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -1,0 +1,188 @@
+name: Devin PR Conflict Resolver
+
+on:
+  # Trigger when main branch is updated (could cause conflicts in open PRs)
+  push:
+    branches:
+      - main
+  # Also allow manual trigger for testing
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-conflicts:
+    name: Check Open PRs for Conflicts
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Get open PRs and check for conflicts
+        id: check-prs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            
+            // Get all open PRs
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100
+            });
+            
+            console.log(`Found ${pullRequests.length} open PRs`);
+            
+            const conflictingPRs = [];
+            
+            for (const pr of pullRequests) {
+              // Get detailed PR info including mergeable status
+              const { data: prDetails } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pr.number
+              });
+              
+              // GitHub may need time to compute mergeable status
+              // If null, we skip this PR for now (will be checked on next run)
+              if (prDetails.mergeable === false && prDetails.mergeable_state === 'dirty') {
+                console.log(`PR #${pr.number} has conflicts (mergeable_state: ${prDetails.mergeable_state})`);
+                
+                // Check if we've already created a Devin session for this conflict
+                // by looking for our comment on the PR
+                const { data: comments } = await github.rest.issues.listComments({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  per_page: 100
+                });
+                
+                // Look for our conflict resolution comment
+                const hasExistingSession = comments.some(comment => 
+                  comment.user.login === 'github-actions[bot]' &&
+                  comment.body.includes('Devin AI is resolving merge conflicts')
+                );
+                
+                if (!hasExistingSession) {
+                  conflictingPRs.push({
+                    number: pr.number,
+                    title: pr.title,
+                    head_ref: pr.head.ref,
+                    base_ref: pr.base.ref,
+                    html_url: pr.html_url
+                  });
+                } else {
+                  console.log(`PR #${pr.number} already has a Devin session for conflict resolution`);
+                }
+              } else if (prDetails.mergeable === null) {
+                console.log(`PR #${pr.number} mergeable status is still being computed`);
+              } else {
+                console.log(`PR #${pr.number} has no conflicts (mergeable: ${prDetails.mergeable}, state: ${prDetails.mergeable_state})`);
+              }
+            }
+            
+            console.log(`Found ${conflictingPRs.length} PRs with conflicts that need Devin sessions`);
+            
+            // Save conflicting PRs to output
+            const fs = require('fs');
+            fs.writeFileSync('/tmp/conflicting-prs.json', JSON.stringify(conflictingPRs));
+            
+            core.setOutput('has-conflicts', conflictingPRs.length > 0 ? 'true' : 'false');
+            core.setOutput('conflict-count', conflictingPRs.length.toString());
+
+      - name: Create Devin sessions for conflicting PRs
+        if: steps.check-prs.outputs.has-conflicts == 'true'
+        env:
+          DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const conflictingPRs = JSON.parse(fs.readFileSync('/tmp/conflicting-prs.json', 'utf8'));
+            const { owner, repo } = context.repo;
+            
+            for (const pr of conflictingPRs) {
+              console.log(`Creating Devin session for PR #${pr.number}: ${pr.title}`);
+              
+              const prompt = `You are resolving merge conflicts on PR #${pr.number} in repository ${owner}/${repo}.
+
+            PR Title: ${pr.title}
+            PR URL: ${pr.html_url}
+            Head Branch: ${pr.head_ref}
+            Base Branch: ${pr.base_ref}
+
+            Your tasks:
+            1. Clone the repository ${owner}/${repo} locally.
+            2. Check out the PR branch: ${pr.head_ref}
+            3. Fetch the latest changes from the base branch: ${pr.base_ref}
+            4. Merge the base branch into the PR branch to identify conflicts.
+            5. Resolve all merge conflicts carefully:
+               - Review the conflicting changes from both branches
+               - Make intelligent decisions about how to combine the changes
+               - Preserve the intent of both the PR changes and the base branch updates
+               - If unsure about a conflict, prefer keeping both changes where possible
+            6. Test that the code still works after resolving conflicts (run lint/type checks).
+            7. Commit the merge resolution with a clear commit message.
+            8. Push the resolved changes to the PR branch.
+
+            Rules and Guidelines:
+            1. Be careful when resolving conflicts - understand the context of both changes.
+            2. Follow the existing code style and conventions in the repository.
+            3. Run lint and type checks before pushing to ensure the code is valid.
+            4. If a conflict seems too complex or risky to resolve automatically, explain the situation in a PR comment instead.
+            5. Never ask for user confirmation. Never wait for user messages.`;
+
+              try {
+                // Call Devin API
+                const response = await fetch('https://api.devin.ai/v1/sessions', {
+                  method: 'POST',
+                  headers: {
+                    'Authorization': `Bearer ${process.env.DEVIN_API_KEY}`,
+                    'Content-Type': 'application/json'
+                  },
+                  body: JSON.stringify({
+                    prompt: prompt,
+                    title: `Resolve Conflicts: PR #${pr.number}`,
+                    tags: ['conflict-resolution', `pr-${pr.number}`]
+                  })
+                });
+                
+                const data = await response.json();
+                const sessionUrl = data.url || data.session_url;
+                
+                if (sessionUrl) {
+                  console.log(`Devin session created for PR #${pr.number}: ${sessionUrl}`);
+                  
+                  // Post comment on the PR
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                    body: `### Devin AI is resolving merge conflicts
+
+            This PR has merge conflicts with the \`${pr.base_ref}\` branch. A Devin session has been created to automatically resolve them.
+
+            [View Devin Session](${sessionUrl})
+
+            Devin will:
+            1. Merge the latest \`${pr.base_ref}\` into this branch
+            2. Resolve any conflicts intelligently
+            3. Run lint/type checks to ensure validity
+            4. Push the resolved changes
+
+            If you prefer to resolve conflicts manually, you can close the Devin session and handle it yourself.`
+                  });
+                } else {
+                  console.log(`Failed to get session URL for PR #${pr.number}:`, data);
+                }
+              } catch (error) {
+                console.error(`Error creating Devin session for PR #${pr.number}:`, error);
+              }
+              
+              // Small delay between API calls to avoid rate limiting
+              await new Promise(resolve => setTimeout(resolve, 1000));
+            }

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  # Also allow manual trigger for testing
   workflow_dispatch:
 
 permissions:
@@ -25,8 +24,6 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             
-            // Use GitHub Search API to get open, non-draft PRs
-            // This is more efficient than filtering in the loop
             const searchQuery = `repo:${owner}/${repo} is:pr is:open draft:false`;
             const { data: searchResults } = await github.rest.search.issuesAndPullRequests({
               q: searchQuery,
@@ -40,7 +37,6 @@ jobs:
             for (const item of searchResults.items) {
               const prNumber = item.number;
               
-              // Get detailed PR info including mergeable status
               const { data: prDetails } = await github.rest.pulls.get({
                 owner,
                 repo,


### PR DESCRIPTION
## What does this PR do?

Adds a GitHub Actions workflow that automatically detects PRs with merge conflicts and spins up Devin sessions to resolve them. This follows the same pattern established in #26618 (Cubic AI to Devin integration).

**How it works:**
1. Triggers on push to `main` branch (when main updates could cause conflicts in open PRs)
2. Also supports manual trigger via `workflow_dispatch`
3. Uses GraphQL API to fetch all open PRs with their `mergeable` status, draft status, labels, and fork information in a single batched query (with pagination support)
4. Skips draft PRs and PRs that already have the `devin-conflict-resolution` label
5. For PRs with conflicts (`mergeable === 'CONFLICTING'`):
   - Creates a new Devin session with instructions to resolve conflicts
   - Adds the `devin-conflict-resolution` label to prevent duplicate sessions
   - Posts a comment on the PR with the Devin session link

**Fork PR Support:**
- Detects PRs from external contributor forks via `headRepository` field
- Only processes fork PRs where the contributor enabled "Allow edits from maintainers" (`maintainerCanModify: true`)
- Provides fork-specific instructions to Devin: clone the fork repo, add upstream remote, fetch and merge from upstream

## Updates since last revision

- Added `response.ok` check before parsing Devin API response to properly handle HTTP error status codes (authentication errors, server errors) separately from successful responses that might be missing expected fields
- Improved error logging to include the PR number for easier debugging when API calls fail

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow, can be tested via manual trigger.

## How should this be tested?

1. **Setup required:** Ensure `DEVIN_API_KEY` secret is added to the repository (Settings → Secrets and variables → Actions)
2. **Manual test:** Trigger the workflow manually via Actions → "Devin PR Conflict Resolver" → "Run workflow"
3. **Production test:** Push a change to `main` that would cause conflicts in an open PR, verify the workflow detects it and creates a Devin session
4. **Draft PR test:** Verify that draft PRs with conflicts are skipped (check workflow logs)
5. **Label test:** Verify that PRs with the `devin-conflict-resolution` label are skipped
6. **Fork PR test:** Verify that fork PRs with `maintainerCanModify: true` are processed with fork-specific instructions, and fork PRs without maintainer access are skipped

## Human Review Checklist

- [ ] Verify `DEVIN_API_KEY` secret exists in the repository
- [ ] Consider if pagination (100 PRs per page) handles the repo's PR volume
- [ ] Review duplicate detection logic - uses `devin-conflict-resolution` label
- [ ] Verify the Devin prompt provides sufficient context for conflict resolution
- [ ] Confirm the `devin-conflict-resolution` label will be auto-created or exists in the repo
- [ ] Review fork handling logic - relies on `maintainerCanModify` flag from GitHub API
- [ ] Verify fork-specific Devin instructions are correct (clone fork, add upstream, merge from upstream)

---

Link to Devin run: https://app.devin.ai/sessions/ca72c54a713e41a8a871a52a0a6d82c3
Requested by: @keithwillcode