### PR TITLE
feat: add automated stale PR completion workflow with Devin API

### DIFF
--- a/.github/workflows/stale-pr-devin-completion.yml
+++ b/.github/workflows/stale-pr-devin-completion.yml
@@ -1,4 +1,4 @@
-name: Stale PR Devin Completion
+name: Stale Community PR Devin Completion
 
 on:
   pull_request:
@@ -10,36 +10,67 @@ permissions:
 
 jobs:
   complete-stale-pr:
-    name: Trigger Devin to Complete Stale PR
+    name: Trigger Devin to Complete Stale Community PR
     # Only run if the 'stale' label was added
     if: github.event.label.name == 'stale'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
+      - name: Check if PR is from community member
+        id: check-community
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            
+            // Skip bot accounts
+            if (prAuthor.endsWith('[bot]')) {
+              console.log(`Skipping: ${prAuthor} is a bot`);
+              core.setOutput('is-community', 'false');
+              return;
+            }
+            
+            // Check if author is a member of the calcom organization
+            try {
+              await github.rest.orgs.checkMembershipForUser({
+                org: 'calcom',
+                username: prAuthor
+              });
+              // If we get here, user is a member - skip
+              console.log(`Skipping: ${prAuthor} is a calcom org member`);
+              core.setOutput('is-community', 'false');
+            } catch (error) {
+              if (error.status === 404) {
+                // User is not a member - this is a community PR
+                console.log(`Processing: ${prAuthor} is a community contributor`);
+                core.setOutput('is-community', 'true');
+              } else {
+                // Some other error - log and skip to be safe
+                console.log(`Error checking membership for ${prAuthor}: ${error.message}`);
+                core.setOutput('is-community', 'false');
+              }
+            }
+
       - name: Get PR details
+        if: steps.check-community.outputs.is-community == 'true'
         id: pr-details
         uses: actions/github-script@v7
         with:
           script: |
             const pr = context.payload.pull_request;
-            
-            // Get PR description and comments for context
             const prBody = pr.body || 'No description provided';
             const prTitle = pr.title;
             const prNumber = pr.number;
             const prBranch = pr.head.ref;
             const prAuthor = pr.user.login;
             
-            // Get the list of changed files
             const { data: files } = await github.rest.pulls.listFiles({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: prNumber,
               per_page: 100
             });
-            
             const changedFiles = files.map(f => f.filename).join('\n');
             
-            // Get PR comments for additional context
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -47,7 +78,6 @@ jobs:
               per_page: 50
             });
             
-            // Get review comments
             const { data: reviewComments } = await github.rest.pulls.listReviewComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -55,7 +85,6 @@ jobs:
               per_page: 50
             });
             
-            // Compile feedback from comments
             let feedback = '';
             if (comments.length > 0) {
               feedback += 'PR Comments:\n';
@@ -74,7 +103,6 @@ jobs:
               });
             }
             
-            // Save context to files
             const fs = require('fs');
             fs.writeFileSync('/tmp/pr-body.txt', prBody);
             fs.writeFileSync('/tmp/pr-feedback.txt', feedback || 'No feedback comments found');
@@ -87,6 +115,7 @@ jobs:
             core.setOutput('has-feedback', feedback ? 'true' : 'false');
 
       - name: Create Devin session
+        if: steps.check-community.outputs.is-community == 'true'
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
         run: |
@@ -94,7 +123,6 @@ jobs:
           PR_FEEDBACK=$(cat /tmp/pr-feedback.txt)
           CHANGED_FILES=$(cat /tmp/changed-files.txt)
           
-          # Build the full prompt for Devin
           FULL_PROMPT="You are completing a stale community PR #${{ steps.pr-details.outputs.pr-number }} in repository ${{ github.repository }}.
 
           This PR was started by @${{ steps.pr-details.outputs.pr-author }} but has become stale. Your job is to complete it.
@@ -133,7 +161,6 @@ jobs:
           5. Never ask for user confirmation. Never wait for user messages.
           6. Credit the original author in your commit messages where appropriate."
 
-          # Call Devin API
           RESPONSE=$(curl -s -X POST "https://api.devin.ai/v1/sessions" \
             -H "Authorization: Bearer ${DEVIN_API_KEY}" \
             -H "Content-Type: application/json" \
@@ -146,7 +173,6 @@ jobs:
                 tags: ["stale-pr-completion", "pr-${{ steps.pr-details.outputs.pr-number }}"]
               }')")
           
-          # Extract session URL if available
           SESSION_URL=$(echo "$RESPONSE" | jq -r '.url // .session_url // empty')
           if [ -n "$SESSION_URL" ]; then
             echo "Devin session created: $SESSION_URL"
@@ -158,7 +184,7 @@ jobs:
           fi
 
       - name: Post comment with Devin session link
-        if: env.SESSION_URL != ''
+        if: steps.check-community.outputs.is-community == 'true' && env.SESSION_URL != ''
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-pr-devin-completion.yml
+++ b/.github/workflows/stale-pr-devin-completion.yml
@@ -20,35 +20,41 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prAuthor = context.payload.pull_request.user.login;
-            
-            // Skip bot accounts
-            if (prAuthor.endsWith('[bot]')) {
-              console.log(`Skipping: ${prAuthor} is a bot`);
+            const trustedAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            async function hasWriteAccess(username) {
+              try {
+                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
+                  username,
+                });
+                return ['admin', 'maintain', 'write'].includes(permission.permission);
+              } catch (e) {
+                console.log(`Permission check failed for ${username}: ${e.message}`);
+                return false;
+              }
+            }
+
+            console.log(`PR #${pr.number} by ${pr.user.login} (${pr.author_association})`);
+
+            if (trustedAssociations.includes(pr.author_association)) {
+              console.log(`Skipping: Author has trusted association: ${pr.author_association}`);
               core.setOutput('is-community', 'false');
               return;
             }
-            
-            // Check if author is a member of the calcom organization
-            try {
-              await github.rest.orgs.checkMembershipForUser({
-                org: 'calcom',
-                username: prAuthor
-              });
-              // If we get here, user is a member - skip
-              console.log(`Skipping: ${prAuthor} is a calcom org member`);
+
+            if (await hasWriteAccess(pr.user.login)) {
+              console.log(`Skipping: Author has write access`);
               core.setOutput('is-community', 'false');
-            } catch (error) {
-              if (error.status === 404) {
-                // User is not a member - this is a community PR
-                console.log(`Processing: ${prAuthor} is a community contributor`);
-                core.setOutput('is-community', 'true');
-              } else {
-                // Some other error - log and skip to be safe
-                console.log(`Error checking membership for ${prAuthor}: ${error.message}`);
-                core.setOutput('is-community', 'false');
-              }
+              return;
             }
+
+            console.log(`Processing: ${pr.user.login} is a community contributor`);
+            core.setOutput('is-community', 'true');
 
       - name: Get PR details
         if: steps.check-community.outputs.is-community == 'true'

--- a/.github/workflows/stale-pr-devin-completion.yml
+++ b/.github/workflows/stale-pr-devin-completion.yml
@@ -11,144 +11,31 @@ permissions:
 jobs:
   complete-stale-pr:
     name: Trigger Devin to Complete Stale Community PR
-    # Only run if the 'stale' label was added
-    if: github.event.label.name == 'stale'
+    # Only run if the 'stale' label was added and PR has 'community' label
+    if: github.event.label.name == 'stale' && contains(github.event.pull_request.labels.*.name, 'community')
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - name: Check if PR is from community member
-        id: check-community
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const trustedAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
-            const pr = context.payload.pull_request;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-
-            async function hasWriteAccess(username) {
-              try {
-                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner,
-                  repo,
-                  username,
-                });
-                return ['admin', 'maintain', 'write'].includes(permission.permission);
-              } catch (e) {
-                console.log(`Permission check failed for ${username}: ${e.message}`);
-                return false;
-              }
-            }
-
-            console.log(`PR #${pr.number} by ${pr.user.login} (${pr.author_association})`);
-
-            if (trustedAssociations.includes(pr.author_association)) {
-              console.log(`Skipping: Author has trusted association: ${pr.author_association}`);
-              core.setOutput('is-community', 'false');
-              return;
-            }
-
-            if (await hasWriteAccess(pr.user.login)) {
-              console.log(`Skipping: Author has write access`);
-              core.setOutput('is-community', 'false');
-              return;
-            }
-
-            console.log(`Processing: ${pr.user.login} is a community contributor`);
-            core.setOutput('is-community', 'true');
-
-      - name: Get PR details
-        if: steps.check-community.outputs.is-community == 'true'
-        id: pr-details
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            const prBody = pr.body || 'No description provided';
-            const prTitle = pr.title;
-            const prNumber = pr.number;
-            const prBranch = pr.head.ref;
-            const prAuthor = pr.user.login;
-            
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              per_page: 100
-            });
-            const changedFiles = files.map(f => f.filename).join('\n');
-            
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 50
-            });
-            
-            const { data: reviewComments } = await github.rest.pulls.listReviewComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              per_page: 50
-            });
-            
-            let feedback = '';
-            if (comments.length > 0) {
-              feedback += 'PR Comments:\n';
-              comments.forEach(c => {
-                if (c.user.login !== 'github-actions[bot]' && c.user.login !== 'devin-ai-integration[bot]') {
-                  feedback += `- @${c.user.login}: ${c.body.substring(0, 500)}\n`;
-                }
-              });
-            }
-            if (reviewComments.length > 0) {
-              feedback += '\nCode Review Comments:\n';
-              reviewComments.forEach(c => {
-                if (c.user.login !== 'github-actions[bot]' && c.user.login !== 'devin-ai-integration[bot]') {
-                  feedback += `- @${c.user.login} on ${c.path}: ${c.body.substring(0, 500)}\n`;
-                }
-              });
-            }
-            
-            const fs = require('fs');
-            fs.writeFileSync('/tmp/pr-body.txt', prBody);
-            fs.writeFileSync('/tmp/pr-feedback.txt', feedback || 'No feedback comments found');
-            fs.writeFileSync('/tmp/changed-files.txt', changedFiles);
-            
-            core.setOutput('pr-title', prTitle);
-            core.setOutput('pr-number', prNumber);
-            core.setOutput('pr-branch', prBranch);
-            core.setOutput('pr-author', prAuthor);
-            core.setOutput('has-feedback', feedback ? 'true' : 'false');
-
       - name: Create Devin session
-        if: steps.check-community.outputs.is-community == 'true'
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
         run: |
-          PR_BODY=$(cat /tmp/pr-body.txt)
-          PR_FEEDBACK=$(cat /tmp/pr-feedback.txt)
-          CHANGED_FILES=$(cat /tmp/changed-files.txt)
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
           
-          FULL_PROMPT="You are completing a stale community PR #${{ steps.pr-details.outputs.pr-number }} in repository ${{ github.repository }}.
+          FULL_PROMPT="You are completing a stale community PR #${PR_NUMBER} in repository ${{ github.repository }}.
 
-          This PR was started by @${{ steps.pr-details.outputs.pr-author }} but has become stale. Your job is to complete it.
+          This PR was started by @${PR_AUTHOR} but has become stale. Your job is to complete it.
 
-          PR Title: ${{ steps.pr-details.outputs.pr-title }}
-
-          PR Description:
-          ${PR_BODY}
-
-          Changed Files:
-          ${CHANGED_FILES}
-
-          Feedback and Review Comments:
-          ${PR_FEEDBACK}
+          PR Title: ${PR_TITLE}
+          PR Branch: ${PR_BRANCH}
 
           Your tasks:
           1. Clone the repository ${{ github.repository }} locally.
-          2. Check out the PR branch: ${{ steps.pr-details.outputs.pr-branch }}
+          2. Check out the PR branch: ${PR_BRANCH}
           3. Review the current state of the PR and understand what it's trying to accomplish.
-          4. Review any feedback or review comments that have been left on the PR.
+          4. Read the PR description and any comments/review feedback on the PR.
           5. Complete any unfinished work on the PR:
              - Fix any issues mentioned in review comments
              - Ensure the code follows the repository's coding standards
@@ -172,11 +59,11 @@ jobs:
             -H "Content-Type: application/json" \
             -d "$(jq -n \
               --arg prompt "$FULL_PROMPT" \
-              --arg title "Complete Stale PR #${{ steps.pr-details.outputs.pr-number }}: ${{ steps.pr-details.outputs.pr-title }}" \
+              --arg title "Complete Stale PR #${PR_NUMBER}: ${PR_TITLE}" \
               '{
                 prompt: $prompt,
                 title: $title,
-                tags: ["stale-pr-completion", "pr-${{ steps.pr-details.outputs.pr-number }}"]
+                tags: ["stale-pr-completion", "pr-'${PR_NUMBER}'"]
               }')")
           
           SESSION_URL=$(echo "$RESPONSE" | jq -r '.url // .session_url // empty')
@@ -185,18 +72,17 @@ jobs:
             echo "SESSION_URL=$SESSION_URL" >> $GITHUB_ENV
           else
             echo "Failed to create Devin session"
-            echo "Response: $RESPONSE"
             exit 1
           fi
 
       - name: Post comment with Devin session link
-        if: steps.check-community.outputs.is-community == 'true' && env.SESSION_URL != ''
+        if: env.SESSION_URL != ''
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const sessionUrl = process.env.SESSION_URL;
-            const prAuthor = '${{ steps.pr-details.outputs.pr-author }}';
+            const prAuthor = '${{ github.event.pull_request.user.login }}';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/stale-pr-devin-completion.yml
+++ b/.github/workflows/stale-pr-devin-completion.yml
@@ -1,0 +1,173 @@
+name: Stale PR Devin Completion
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  complete-stale-pr:
+    name: Trigger Devin to Complete Stale PR
+    # Only run if the 'stale' label was added
+    if: github.event.label.name == 'stale'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Get PR details
+        id: pr-details
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            
+            // Get PR description and comments for context
+            const prBody = pr.body || 'No description provided';
+            const prTitle = pr.title;
+            const prNumber = pr.number;
+            const prBranch = pr.head.ref;
+            const prAuthor = pr.user.login;
+            
+            // Get the list of changed files
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100
+            });
+            
+            const changedFiles = files.map(f => f.filename).join('\n');
+            
+            // Get PR comments for additional context
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 50
+            });
+            
+            // Get review comments
+            const { data: reviewComments } = await github.rest.pulls.listReviewComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 50
+            });
+            
+            // Compile feedback from comments
+            let feedback = '';
+            if (comments.length > 0) {
+              feedback += 'PR Comments:\n';
+              comments.forEach(c => {
+                if (c.user.login !== 'github-actions[bot]' && c.user.login !== 'devin-ai-integration[bot]') {
+                  feedback += `- @${c.user.login}: ${c.body.substring(0, 500)}\n`;
+                }
+              });
+            }
+            if (reviewComments.length > 0) {
+              feedback += '\nCode Review Comments:\n';
+              reviewComments.forEach(c => {
+                if (c.user.login !== 'github-actions[bot]' && c.user.login !== 'devin-ai-integration[bot]') {
+                  feedback += `- @${c.user.login} on ${c.path}: ${c.body.substring(0, 500)}\n`;
+                }
+              });
+            }
+            
+            // Save context to files
+            const fs = require('fs');
+            fs.writeFileSync('/tmp/pr-body.txt', prBody);
+            fs.writeFileSync('/tmp/pr-feedback.txt', feedback || 'No feedback comments found');
+            fs.writeFileSync('/tmp/changed-files.txt', changedFiles);
+            
+            core.setOutput('pr-title', prTitle);
+            core.setOutput('pr-number', prNumber);
+            core.setOutput('pr-branch', prBranch);
+            core.setOutput('pr-author', prAuthor);
+            core.setOutput('has-feedback', feedback ? 'true' : 'false');
+
+      - name: Create Devin session
+        env:
+          DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
+        run: |
+          PR_BODY=$(cat /tmp/pr-body.txt)
+          PR_FEEDBACK=$(cat /tmp/pr-feedback.txt)
+          CHANGED_FILES=$(cat /tmp/changed-files.txt)
+          
+          # Build the full prompt for Devin
+          FULL_PROMPT="You are completing a stale community PR #${{ steps.pr-details.outputs.pr-number }} in repository ${{ github.repository }}.
+
+          This PR was started by @${{ steps.pr-details.outputs.pr-author }} but has become stale. Your job is to complete it.
+
+          PR Title: ${{ steps.pr-details.outputs.pr-title }}
+
+          PR Description:
+          ${PR_BODY}
+
+          Changed Files:
+          ${CHANGED_FILES}
+
+          Feedback and Review Comments:
+          ${PR_FEEDBACK}
+
+          Your tasks:
+          1. Clone the repository ${{ github.repository }} locally.
+          2. Check out the PR branch: ${{ steps.pr-details.outputs.pr-branch }}
+          3. Review the current state of the PR and understand what it's trying to accomplish.
+          4. Review any feedback or review comments that have been left on the PR.
+          5. Complete any unfinished work on the PR:
+             - Fix any issues mentioned in review comments
+             - Ensure the code follows the repository's coding standards
+             - Add any missing tests if applicable
+             - Fix any linting or type errors
+          6. Run the appropriate checks (lint, type-check, tests) to ensure the PR is ready for review.
+          7. Commit your changes with clear commit messages.
+          8. Push your changes to the PR branch.
+          9. Post a summary comment on the PR explaining what you completed.
+
+          Rules and Guidelines:
+          1. Respect the original author's intent and approach - don't rewrite the PR from scratch.
+          2. Make minimal, focused changes that complete the PR's original goal.
+          3. Follow the existing code style and conventions in the repository.
+          4. If the PR's original approach seems fundamentally flawed, explain why in a comment instead of making major changes.
+          5. Never ask for user confirmation. Never wait for user messages.
+          6. Credit the original author in your commit messages where appropriate."
+
+          # Call Devin API
+          RESPONSE=$(curl -s -X POST "https://api.devin.ai/v1/sessions" \
+            -H "Authorization: Bearer ${DEVIN_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg prompt "$FULL_PROMPT" \
+              --arg title "Complete Stale PR #${{ steps.pr-details.outputs.pr-number }}: ${{ steps.pr-details.outputs.pr-title }}" \
+              '{
+                prompt: $prompt,
+                title: $title,
+                tags: ["stale-pr-completion", "pr-${{ steps.pr-details.outputs.pr-number }}"]
+              }')")
+          
+          # Extract session URL if available
+          SESSION_URL=$(echo "$RESPONSE" | jq -r '.url // .session_url // empty')
+          if [ -n "$SESSION_URL" ]; then
+            echo "Devin session created: $SESSION_URL"
+            echo "SESSION_URL=$SESSION_URL" >> $GITHUB_ENV
+          else
+            echo "Failed to create Devin session"
+            echo "Response: $RESPONSE"
+            exit 1
+          fi
+
+      - name: Post comment with Devin session link
+        if: env.SESSION_URL != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const sessionUrl = process.env.SESSION_URL;
+            const prAuthor = '${{ steps.pr-details.outputs.pr-author }}';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `### Devin AI is completing this stale PR\n\nThis PR by @${prAuthor} has been marked as stale. A Devin session has been created to complete the remaining work.\n\n[View Devin Session](${sessionUrl})\n\n---\n*Devin will review the PR, address any feedback, and push updates to complete this PR.*`
+            });

--- a/.github/workflows/stale-pr-devin-completion.yml
+++ b/.github/workflows/stale-pr-devin-completion.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Create Devin session
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO_NAME: ${{ github.repository }}
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
-          
-          FULL_PROMPT="You are completing a stale community PR #${PR_NUMBER} in repository ${{ github.repository }}.
+          FULL_PROMPT="You are completing a stale community PR #${PR_NUMBER} in repository ${REPO_NAME}.
 
           This PR was started by @${PR_AUTHOR} but has become stale. Your job is to complete it.
 
@@ -32,7 +32,7 @@ jobs:
           PR Branch: ${PR_BRANCH}
 
           Your tasks:
-          1. Clone the repository ${{ github.repository }} locally.
+          1. Clone the repository ${REPO_NAME} locally.
           2. Check out the PR branch: ${PR_BRANCH}
           3. Review the current state of the PR and understand what it's trying to accomplish.
           4. Read the PR description and any comments/review feedback on the PR.
@@ -78,11 +78,13 @@ jobs:
       - name: Post comment with Devin session link
         if: env.SESSION_URL != ''
         uses: actions/github-script@v7
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const sessionUrl = process.env.SESSION_URL;
-            const prAuthor = '${{ github.event.pull_request.user.login }}';
+            const prAuthor = process.env.PR_AUTHOR;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## What does this PR do?

Adds a GitHub Actions workflow that automatically triggers Devin AI to complete stale **community** PRs when they receive the `stale` label.

**How it works:**
1. Triggers on `pull_request` labeled events
2. Job-level `if` condition checks both: the `stale` label was just added AND the PR has the `community` label
3. Creates a Devin session via the Devin API with a prompt instructing Devin to complete the PR
4. Posts a comment on the PR with a link to the Devin session

Devin is instructed to gather PR details (description, comments, review feedback) himself during the session, keeping the workflow simple.

This follows the same pattern as the Cubic AI integration in #26618.

## Updates since last revision

- Simplified community check: now just checks for `community` label on the PR instead of `author_association`/write access checks
- Removed comment/file gathering logic - Devin gathers this info himself during the session
- Reduced workflow from ~200 lines to ~90 lines
- **Security fix:** Moved user-controlled values (`PR_TITLE`, `PR_AUTHOR`, `PR_BRANCH`) to the `env:` block instead of inline `${{ }}` interpolation to prevent potential shell injection attacks (addresses Cubic AI review feedback)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow, tested by triggering with stale label.

## How should this be tested?

1. **Setup required:** Ensure `DEVIN_API_KEY` secret is configured in the repository (Settings → Secrets and variables → Actions)
2. Find or create a test PR that has the `community` label
3. Add the `stale` label to the PR
4. Verify the workflow triggers and creates a Devin session
5. Verify a comment is posted on the PR with the Devin session link
6. **Negative test:** Add `stale` label to a PR without the `community` label and verify the workflow skips

## Human Review Checklist

- [ ] Verify the `community` label is consistently applied to community PRs in this repository
- [ ] Verify the `stale` label name matches the exact label used in the repository's stale PR process
- [ ] Confirm `DEVIN_API_KEY` secret is configured in the repository

---

Link to Devin run: https://app.devin.ai/sessions/300a83ce09fd4d8fbe558c396f2678d8
Requested by: @anikdhabal