### PR TITLE
feat: add availability snapshot to booking audit CREATED action

### DIFF
--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -2405,6 +2405,11 @@ async function handler(
       operationId: null,
     });
   } else {
+    const organizerUserAvailability = availableUsers.find((user) => user.id === booking?.userId);
+    const availabilitySnapshot = organizerUserAvailability?.availabilityData
+      ? formatAvailabilitySnapshot(organizerUserAvailability.availabilityData)
+      : null;
+
     await bookingEventHandler.onBookingCreated({
       payload: bookingCreatedPayload,
       actor: auditActor,
@@ -2412,6 +2417,7 @@ async function handler(
         startTime: bookingCreatedPayload.booking.startTime.getTime(),
         endTime: bookingCreatedPayload.booking.endTime.getTime(),
         status: bookingCreatedPayload.booking.status,
+        availabilitySnapshot,
       },
       source: actionSource,
       operationId: null,


### PR DESCRIPTION
## What does this PR do?

Adds availability snapshot data to the booking audit CREATED action. This captures the organizer's availability at the time of booking creation, persisting it in the audit trail rather than only logging it to criticalLogger.

**Changes:**
- Extended `CreatedAuditActionService` with V2 schema that includes optional `availabilitySnapshot` field
- Implemented V1 → V2 migration logic for backward compatibility with existing audit records
- Updated `RegularBookingService` to pass the formatted availability snapshot to `onBookingCreated`

The availability snapshot contains:
- `dateRanges`: Available time slots with ISO string timestamps
- `oooExcludedDateRanges`: Out-of-office excluded date ranges

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal audit system change
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a new booking and verify the audit record includes the availability snapshot
2. Verify existing V1 audit records can still be parsed (migration adds null availabilitySnapshot)
3. Check that the availability data matches what was previously logged to criticalLogger

## Human Review Checklist

- [ ] Verify V1 → V2 migration logic correctly handles existing audit records
- [ ] Confirm the availability snapshot format matches the expected structure from `formatAvailabilitySnapshot`
- [ ] Review type assertions in `parseStored` and `getDisplayJson` methods

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/054f843cbde14334a02de775b3cfe859
Requested by: @joeauyeung