### PR TITLE
feat: reuse existing Devin session for Cubic AI review feedback

### DIFF
--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -120,12 +120,18 @@ jobs:
 
           Continue working on the same PR branch and push your fixes."
 
-          RESPONSE=$(curl -s -X POST "https://api.devin.ai/v1/sessions/${EXISTING_SESSION_ID}/message" \
+          HTTP_CODE=$(curl -s -o /tmp/devin-response.json -w "%{http_code}" -X POST "https://api.devin.ai/v1/sessions/${EXISTING_SESSION_ID}/message" \
             -H "Authorization: Bearer ${DEVIN_API_KEY}" \
             -H "Content-Type: application/json" \
             -d "$(jq -n --arg message "$MESSAGE" '{message: $message}')")
           
-          echo "Message sent to existing session"
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "Failed to send message to Devin session: HTTP $HTTP_CODE"
+            cat /tmp/devin-response.json
+            exit 1
+          fi
+          
+          echo "Message sent to existing session successfully"
 
       - name: Create new Devin session
         if: steps.extract-prompt.outputs.has-prompt == 'true' && steps.check-session.outputs.has-active-session == 'false'

--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -46,39 +46,67 @@ jobs:
             
             core.setOutput('has-prompt', 'true');
 
-      - name: Check for existing Devin session
+      - name: Check for existing Devin session from PR comments
         if: steps.extract-prompt.outputs.has-prompt == 'true'
         id: check-session
+        uses: actions/github-script@v7
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
-        run: |
-          PR_TAG="pr-${{ github.event.pull_request.number }}"
-          
-          RESPONSE=$(curl -s -X GET "https://api.devin.ai/v1/sessions?tags=cubic-ai-review&tags=${PR_TAG}" \
-            -H "Authorization: Bearer ${DEVIN_API_KEY}" \
-            -H "Content-Type: application/json")
-          
-          ACTIVE_SESSION=$(echo "$RESPONSE" | jq -r '
-            .sessions 
-            | map(select(.status_enum == "working" or .status_enum == "blocked" or .status_enum == "resumed"))
-            | sort_by(.created_at) 
-            | reverse 
-            | .[0] // empty
-          ')
-          
-          if [ -n "$ACTIVE_SESSION" ] && [ "$ACTIVE_SESSION" != "null" ]; then
-            SESSION_ID=$(echo "$ACTIVE_SESSION" | jq -r '.session_id')
-            echo "Found existing active session: $SESSION_ID"
-            echo "EXISTING_SESSION_ID=$SESSION_ID" >> $GITHUB_ENV
-            echo "SESSION_URL=https://app.devin.ai/sessions/$SESSION_ID" >> $GITHUB_ENV
-            echo "has-existing-session=true" >> $GITHUB_OUTPUT
-          else
-            echo "No existing active session found"
-            echo "has-existing-session=false" >> $GITHUB_OUTPUT
-          fi
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+            
+            let sessionId = null;
+            for (const comment of comments.data.reverse()) {
+              if (comment.body.includes('Devin AI is addressing Cubic AI')) {
+                const match = comment.body.match(/app\.devin\.ai\/sessions\/([a-f0-9-]+)/);
+                if (match) {
+                  sessionId = match[1];
+                  break;
+                }
+              }
+            }
+            
+            if (!sessionId) {
+              console.log('No existing Devin session found in PR comments');
+              core.setOutput('has-active-session', 'false');
+              return;
+            }
+            
+            console.log(`Found session ID from comment: ${sessionId}`);
+            
+            const response = await fetch(`https://api.devin.ai/v1/sessions/${sessionId}`, {
+              headers: {
+                'Authorization': `Bearer ${process.env.DEVIN_API_KEY}`,
+                'Content-Type': 'application/json'
+              }
+            });
+            
+            if (!response.ok) {
+              console.log(`Failed to fetch session details: ${response.status}`);
+              core.setOutput('has-active-session', 'false');
+              return;
+            }
+            
+            const session = await response.json();
+            const activeStatuses = ['working', 'blocked', 'resumed'];
+            
+            if (activeStatuses.includes(session.status_enum)) {
+              console.log(`Session ${sessionId} is active (status: ${session.status_enum})`);
+              core.exportVariable('EXISTING_SESSION_ID', sessionId);
+              core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
+              core.setOutput('has-active-session', 'true');
+            } else {
+              console.log(`Session ${sessionId} is not active (status: ${session.status_enum})`);
+              core.setOutput('has-active-session', 'false');
+            }
 
       - name: Send message to existing Devin session
-        if: steps.extract-prompt.outputs.has-prompt == 'true' && steps.check-session.outputs.has-existing-session == 'true'
+        if: steps.extract-prompt.outputs.has-prompt == 'true' && steps.check-session.outputs.has-active-session == 'true'
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
         run: |
@@ -100,7 +128,7 @@ jobs:
           echo "Message sent to existing session"
 
       - name: Create new Devin session
-        if: steps.extract-prompt.outputs.has-prompt == 'true' && steps.check-session.outputs.has-existing-session == 'false'
+        if: steps.extract-prompt.outputs.has-prompt == 'true' && steps.check-session.outputs.has-active-session == 'false'
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
         run: |

--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -46,14 +46,66 @@ jobs:
             
             core.setOutput('has-prompt', 'true');
 
-      - name: Create Devin session
+      - name: Check for existing Devin session
         if: steps.extract-prompt.outputs.has-prompt == 'true'
+        id: check-session
+        env:
+          DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
+        run: |
+          PR_TAG="pr-${{ github.event.pull_request.number }}"
+          
+          RESPONSE=$(curl -s -X GET "https://api.devin.ai/v1/sessions?tags=cubic-ai-review&tags=${PR_TAG}" \
+            -H "Authorization: Bearer ${DEVIN_API_KEY}" \
+            -H "Content-Type: application/json")
+          
+          ACTIVE_SESSION=$(echo "$RESPONSE" | jq -r '
+            .sessions 
+            | map(select(.status_enum == "working" or .status_enum == "blocked" or .status_enum == "resumed"))
+            | sort_by(.created_at) 
+            | reverse 
+            | .[0] // empty
+          ')
+          
+          if [ -n "$ACTIVE_SESSION" ] && [ "$ACTIVE_SESSION" != "null" ]; then
+            SESSION_ID=$(echo "$ACTIVE_SESSION" | jq -r '.session_id')
+            echo "Found existing active session: $SESSION_ID"
+            echo "EXISTING_SESSION_ID=$SESSION_ID" >> $GITHUB_ENV
+            echo "SESSION_URL=https://app.devin.ai/sessions/$SESSION_ID" >> $GITHUB_ENV
+            echo "has-existing-session=true" >> $GITHUB_OUTPUT
+          else
+            echo "No existing active session found"
+            echo "has-existing-session=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send message to existing Devin session
+        if: steps.extract-prompt.outputs.has-prompt == 'true' && steps.check-session.outputs.has-existing-session == 'true'
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
         run: |
           CUBIC_PROMPT=$(cat /tmp/cubic-prompt.txt)
           
-          # Build the full prompt for Devin
+          MESSAGE="New Cubic AI review feedback has been submitted on PR #${{ github.event.pull_request.number }}.
+
+          Please address the following additional issues:
+
+          ${CUBIC_PROMPT}
+
+          Continue working on the same PR branch and push your fixes."
+
+          RESPONSE=$(curl -s -X POST "https://api.devin.ai/v1/sessions/${EXISTING_SESSION_ID}/message" \
+            -H "Authorization: Bearer ${DEVIN_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg message "$MESSAGE" '{message: $message}')")
+          
+          echo "Message sent to existing session"
+
+      - name: Create new Devin session
+        if: steps.extract-prompt.outputs.has-prompt == 'true' && steps.check-session.outputs.has-existing-session == 'false'
+        env:
+          DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
+        run: |
+          CUBIC_PROMPT=$(cat /tmp/cubic-prompt.txt)
+          
           FULL_PROMPT="You are addressing code review feedback from Cubic AI on PR #${{ github.event.pull_request.number }} in repository ${{ github.repository }}.
 
           Your tasks:
@@ -74,7 +126,6 @@ jobs:
           4. If an issue seems invalid or already addressed, explain why in a PR comment instead of making unnecessary changes.
           5. Never ask for user confirmation. Never wait for user messages."
 
-          # Call Devin API
           RESPONSE=$(curl -s -X POST "https://api.devin.ai/v1/sessions" \
             -H "Authorization: Bearer ${DEVIN_API_KEY}" \
             -H "Content-Type: application/json" \
@@ -87,11 +138,11 @@ jobs:
                 tags: ["cubic-ai-review", "pr-${{ github.event.pull_request.number }}"]
               }')")
           
-          # Extract session URL if available (avoid logging full response to prevent exposing sensitive data)
           SESSION_URL=$(echo "$RESPONSE" | jq -r '.url // .session_url // empty')
           if [ -n "$SESSION_URL" ]; then
             echo "Devin session created: $SESSION_URL"
             echo "SESSION_URL=$SESSION_URL" >> $GITHUB_ENV
+            echo "NEW_SESSION=true" >> $GITHUB_ENV
           fi
 
       - name: Post comment with Devin session link
@@ -101,9 +152,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const sessionUrl = process.env.SESSION_URL;
+            const isNewSession = process.env.NEW_SESSION === 'true';
+            
+            const message = isNewSession
+              ? `### Devin AI is addressing Cubic AI's review feedback\n\nA Devin session has been created to address the issues identified by Cubic AI.\n\n[View Devin Session](${sessionUrl})`
+              : `### Devin AI is addressing Cubic AI's review feedback\n\nNew feedback has been sent to the existing Devin session.\n\n[View Devin Session](${sessionUrl})`;
+            
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `### Devin AI is addressing Cubic AI's review feedback\n\nA Devin session has been created to address the issues identified by Cubic AI.\n\n[View Devin Session](${sessionUrl})`
+              body: message
             });


### PR DESCRIPTION
## What does this PR do?

Modifies the Cubic AI to Devin review workflow to reuse the same Devin session across all feedback loops for a PR, instead of creating a new session for each Cubic AI review.

Previously, as seen in [#26624](https://github.com/calcom/cal.com/pull/26624), each Cubic AI review submission would create a brand new Devin session, resulting in multiple sessions for the same PR.

**How it works now:**
1. When Cubic AI submits a review, the workflow searches PR comments for an existing Devin session link
2. If a session link is found, it extracts the session ID and checks if the session is still active via the Devin API
3. If the session is active (status: working, blocked, or resumed), it sends a message to that session with the new feedback
4. If no session link is found or the session is no longer active, it creates a new session
5. The PR comment indicates whether a new session was created or feedback was sent to an existing session

## Updates since last revision

- Added error handling for the message send API call: The workflow now checks the HTTP status code when sending a message to an existing Devin session. If the API call fails (non-2xx response), the step fails with an informative error message, preventing a misleading comment from being posted.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow, can be tested via manual trigger.

## How should this be tested?

1. **Setup required:** Ensure `DEVIN_API_KEY` secret is configured in the repository
2. **Test scenario 1 (new session):** Trigger a Cubic AI review on a PR that has no existing Devin session - should create a new session
3. **Test scenario 2 (existing session):** Trigger another Cubic AI review on the same PR while the first session is still active - should send a message to the existing session instead of creating a new one
4. **Test scenario 3 (expired session):** Trigger a Cubic AI review on a PR where the previous session has finished - should create a new session
5. **Test scenario 4 (message send failure):** If the Devin API returns an error when sending a message, the workflow should fail and not post a misleading comment
6. **Verify PR comments:** Check that the comment text correctly indicates whether a new session was created or feedback was sent to an existing session

## Human Review Checklist

- [ ] Verify the session ID regex pattern (`/app\.devin\.ai\/sessions\/([a-f0-9-]+)/`) matches actual Devin session ID format
- [ ] Verify the comment parsing correctly finds the most recent session (reverses comments and breaks on first match)
- [ ] Verify the session status filtering (`working`, `blocked`, `resumed`) covers all active session states
- [x] ~~Consider if error handling should be added for the message send step~~ - Implemented: now checks HTTP status code and fails on non-2xx responses

---

Link to Devin run: https://app.devin.ai/sessions/467d0a82e7cb4153bb5631816eddf818
Requested by: @keithwillcode