### PR TITLE
feat: add retry mechanism for UNKNOWN mergeable status PRs

### DIFF
--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -82,31 +82,32 @@ jobs:
             }
             
             const conflictingPRs = [];
+            const unknownPRs = [];
             
-            for (const pr of allPRs) {
+            function processPR(pr, mergeableStatus) {
               const isTargetPR = manualPrNumber && pr.number === manualPrNumber;
               
               if (!isTargetPR && pr.isDraft) {
                 console.log(`PR #${pr.number} is a draft, skipping`);
-                continue;
+                return { skip: true };
               }
               
               if (!isTargetPR) {
                 const hasDevinLabel = pr.labels.nodes.some(label => label.name === 'devin-conflict-resolution');
                 if (hasDevinLabel) {
                   console.log(`PR #${pr.number} already has devin-conflict-resolution label, skipping`);
-                  continue;
+                  return { skip: true };
                 }
               }
               
-              if (pr.mergeable === 'CONFLICTING' || (isTargetPR && pr.mergeable !== 'MERGEABLE')) {
+              if (mergeableStatus === 'CONFLICTING' || (isTargetPR && mergeableStatus !== 'MERGEABLE')) {
                 const isFork = pr.headRepository?.owner?.login !== owner;
                 const headRepoOwner = pr.headRepository?.owner?.login || owner;
                 const headRepoName = pr.headRepository?.name || repo;
                 
                 if (!isTargetPR && isFork && !pr.maintainerCanModify) {
                   console.log(`PR #${pr.number} is from a fork without maintainer push access, skipping`);
-                  continue;
+                  return { skip: true };
                 }
                 
                 if (isTargetPR) {
@@ -115,23 +116,82 @@ jobs:
                   console.log(`PR #${pr.number} has conflicts${isFork ? ' (from fork)' : ''}`);
                 }
                 
-                conflictingPRs.push({
-                  number: pr.number,
-                  title: pr.title,
-                  head_ref: pr.headRefName,
-                  base_ref: pr.baseRefName,
-                  html_url: pr.url,
-                  is_fork: isFork,
-                  head_repo_owner: headRepoOwner,
-                  head_repo_name: headRepoName,
-                  is_manual: isTargetPR
-                });
-                
-                if (isTargetPR) break;
-              } else if (pr.mergeable === 'UNKNOWN') {
-                console.log(`PR #${pr.number} mergeable status is still being computed`);
+                return {
+                  conflict: true,
+                  data: {
+                    number: pr.number,
+                    title: pr.title,
+                    head_ref: pr.headRefName,
+                    base_ref: pr.baseRefName,
+                    html_url: pr.url,
+                    is_fork: isFork,
+                    head_repo_owner: headRepoOwner,
+                    head_repo_name: headRepoName,
+                    is_manual: isTargetPR
+                  },
+                  isTargetPR
+                };
+              } else if (mergeableStatus === 'UNKNOWN') {
+                return { unknown: true };
               } else {
-                console.log(`PR #${pr.number} has no conflicts (mergeable: ${pr.mergeable})`);
+                console.log(`PR #${pr.number} has no conflicts (mergeable: ${mergeableStatus})`);
+                return { skip: true };
+              }
+            }
+            
+            for (const pr of allPRs) {
+              const result = processPR(pr, pr.mergeable);
+              
+              if (result.conflict) {
+                conflictingPRs.push(result.data);
+                if (result.isTargetPR) break;
+              } else if (result.unknown) {
+                console.log(`PR #${pr.number} mergeable status is still being computed`);
+                const isTargetPR = manualPrNumber && pr.number === manualPrNumber;
+                if (!pr.isDraft || isTargetPR) {
+                  const hasDevinLabel = pr.labels.nodes.some(label => label.name === 'devin-conflict-resolution');
+                  if (!hasDevinLabel || isTargetPR) {
+                    unknownPRs.push(pr);
+                  }
+                }
+              }
+            }
+            
+            if (unknownPRs.length > 0) {
+              console.log(`\n${unknownPRs.length} PRs have UNKNOWN mergeable status, waiting 20 seconds before retrying...`);
+              await new Promise(resolve => setTimeout(resolve, 20000));
+              
+              console.log(`Retrying ${unknownPRs.length} PRs via REST API...`);
+              
+              for (const pr of unknownPRs) {
+                try {
+                  const { data } = await github.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: pr.number
+                  });
+                  
+                  let mergeableStatus;
+                  if (data.mergeable === true) {
+                    mergeableStatus = 'MERGEABLE';
+                  } else if (data.mergeable === false) {
+                    mergeableStatus = 'CONFLICTING';
+                  } else {
+                    mergeableStatus = 'UNKNOWN';
+                  }
+                  
+                  console.log(`PR #${pr.number} retry result: mergeable=${mergeableStatus}`);
+                  
+                  const result = processPR(pr, mergeableStatus);
+                  if (result.conflict) {
+                    conflictingPRs.push(result.data);
+                    if (result.isTargetPR) break;
+                  } else if (result.unknown) {
+                    console.log(`PR #${pr.number} still has UNKNOWN status after retry`);
+                  }
+                } catch (error) {
+                  console.error(`Error retrying PR #${pr.number}: ${error.message}`);
+                }
               }
             }
             

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -132,7 +132,7 @@ jobs:
                   isTargetPR
                 };
               } else if (mergeableStatus === 'UNKNOWN') {
-                return { unknown: true };
+                return { unknown: true, isTargetPR };
               } else {
                 console.log(`PR #${pr.number} has no conflicts (mergeable: ${mergeableStatus})`);
                 return { skip: true };
@@ -147,13 +147,7 @@ jobs:
                 if (result.isTargetPR) break;
               } else if (result.unknown) {
                 console.log(`PR #${pr.number} mergeable status is still being computed`);
-                const isTargetPR = manualPrNumber && pr.number === manualPrNumber;
-                if (!pr.isDraft || isTargetPR) {
-                  const hasDevinLabel = pr.labels.nodes.some(label => label.name === 'devin-conflict-resolution');
-                  if (!hasDevinLabel || isTargetPR) {
-                    unknownPRs.push(pr);
-                  }
-                }
+                unknownPRs.push(pr);
               }
             }
             


### PR DESCRIPTION
## What does this PR do?

Adds a retry mechanism to the Devin PR Conflict Resolver workflow to handle PRs where GitHub hasn't finished computing the mergeable status.

**Problem**: When a PR merges into main, GitHub needs to recompute the mergeable status for all open PRs. The workflow runs so fast after a merge that many PRs show `UNKNOWN` status (100+ PRs in recent runs), meaning actual conflicts could be missed.

**Solution**: 
- Collect PRs with `UNKNOWN` mergeable status during the initial pass
- Wait 20 seconds for GitHub to compute the status
- Re-query those specific PRs via REST API (which can trigger GitHub to compute the status)
- Process any newly discovered conflicts

The code was refactored to extract a `processPR` helper function to avoid duplicating the conflict detection logic between the initial pass and retry pass.

### Updates since last revision

Addressed Cubic AI review feedback by having `processPR` return `isTargetPR` consistently for both conflict and unknown cases, removing redundant filtering logic in the main loop that was re-checking draft status and devin label (already checked in `processPR`).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow, can only be tested by running the workflow.

## How should this be tested?

1. Trigger the workflow manually via `workflow_dispatch` or wait for a PR to merge to main
2. Check the workflow logs for:
   - "X PRs have UNKNOWN mergeable status, waiting 20 seconds before retrying..."
   - "Retrying X PRs via REST API..."
   - "PR #X retry result: mergeable=MERGEABLE/CONFLICTING/UNKNOWN"
3. Verify that PRs with conflicts are correctly identified after the retry

## Human Review Checklist

- [ ] Verify `processPR` returns consistent data structure (`isTargetPR` included in both conflict and unknown cases)
- [ ] Verify the retry loop correctly handles the returned values

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> Requested by: @keithwillcode
> [Link to Devin run](https://app.devin.ai/sessions/25e7fae6db55436cabc9f028a293f0fd)