### PR TITLE
feat: implement git checkout caching to speed up CI workflows

### DIFF
--- a/.github/actions/cache-checkout/action.yml
+++ b/.github/actions/cache-checkout/action.yml
@@ -18,7 +18,7 @@ runs:
           !.git
           !node_modules
           !**/node_modules
-        key: git-checkout-${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.sha }}
+        key: git-checkout-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
         fail-on-cache-miss: true
 
     - name: Save git checkout to cache
@@ -30,4 +30,4 @@ runs:
           !.git
           !node_modules
           !**/node_modules
-        key: git-checkout-${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.sha }}
+        key: git-checkout-${{ github.head_ref || github.ref_name }}-${{ github.sha }}

--- a/.github/actions/cache-checkout/action.yml
+++ b/.github/actions/cache-checkout/action.yml
@@ -21,6 +21,13 @@ runs:
         key: git-checkout-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
         fail-on-cache-miss: true
 
+    - name: Delete previous git-checkout caches for this branch
+      if: ${{ inputs.mode == 'save' }}
+      uses: useblacksmith/cache-delete@v1
+      with:
+        key: git-checkout-${{ github.head_ref || github.ref_name }}
+        prefix: "true"
+
     - name: Save git checkout to cache
       if: ${{ inputs.mode == 'save' }}
       uses: actions/cache/save@v4

--- a/.github/actions/cache-checkout/action.yml
+++ b/.github/actions/cache-checkout/action.yml
@@ -25,7 +25,7 @@ runs:
       if: ${{ inputs.mode == 'save' }}
       uses: useblacksmith/cache-delete@v1
       with:
-        key: git-checkout-${{ github.head_ref || github.ref_name }}
+        key: git-checkout-${{ github.head_ref || github.ref_name }}-
         prefix: "true"
 
     - name: Save git checkout to cache

--- a/.github/actions/cache-checkout/action.yml
+++ b/.github/actions/cache-checkout/action.yml
@@ -18,7 +18,7 @@ runs:
           !.git
           !node_modules
           !**/node_modules
-        key: git-checkout-${{ github.event.pull_request.head.sha }}
+        key: git-checkout-${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.sha }}
         fail-on-cache-miss: true
 
     - name: Save git checkout to cache
@@ -30,4 +30,4 @@ runs:
           !.git
           !node_modules
           !**/node_modules
-        key: git-checkout-${{ github.event.pull_request.head.sha }}
+        key: git-checkout-${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.sha }}

--- a/.github/actions/cache-checkout/action.yml
+++ b/.github/actions/cache-checkout/action.yml
@@ -1,0 +1,36 @@
+name: Cache Git Checkout
+description: "Save or restore git checkout from cache to speed up CI workflows"
+inputs:
+  mode:
+    description: "Mode of operation: 'save' to cache the checkout, 'restore' to restore from cache"
+    required: true
+  commit-sha:
+    description: "The commit SHA to use as cache key"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore git checkout from cache
+      if: ${{ inputs.mode == 'restore' }}
+      uses: actions/cache/restore@v4
+      id: cache-restore
+      with:
+        path: |
+          .
+          !.git
+          !node_modules
+          !**/node_modules
+        key: git-checkout-${{ inputs.commit-sha }}
+        fail-on-cache-miss: true
+
+    - name: Save git checkout to cache
+      if: ${{ inputs.mode == 'save' }}
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          .
+          !.git
+          !node_modules
+          !**/node_modules
+        key: git-checkout-${{ inputs.commit-sha }}

--- a/.github/actions/cache-checkout/action.yml
+++ b/.github/actions/cache-checkout/action.yml
@@ -4,9 +4,6 @@ inputs:
   mode:
     description: "Mode of operation: 'save' to cache the checkout, 'restore' to restore from cache"
     required: true
-  commit-sha:
-    description: "The commit SHA to use as cache key"
-    required: true
 
 runs:
   using: "composite"
@@ -21,7 +18,7 @@ runs:
           !.git
           !node_modules
           !**/node_modules
-        key: git-checkout-${{ inputs.commit-sha }}
+        key: git-checkout-${{ github.event.pull_request.head.sha }}
         fail-on-cache-miss: true
 
     - name: Save git checkout to cache
@@ -33,4 +30,4 @@ runs:
           !.git
           !node_modules
           !**/node_modules
-        key: git-checkout-${{ inputs.commit-sha }}
+        key: git-checkout-${{ github.event.pull_request.head.sha }}

--- a/.github/actions/dangerous-git-checkout/action.yml
+++ b/.github/actions/dangerous-git-checkout/action.yml
@@ -8,3 +8,8 @@ runs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 2
+        sparse-checkout-cone-mode: false
+        sparse-checkout: |
+          /*
+          !/example-apps/
+          !**/*.mp4

--- a/.github/workflows/api-v1-production-build.yml
+++ b/.github/workflows/api-v1-production-build.yml
@@ -69,13 +69,16 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
       - name: Cache API v1 production build

--- a/.github/workflows/api-v1-production-build.yml
+++ b/.github/workflows/api-v1-production-build.yml
@@ -2,6 +2,11 @@ name: Production Builds
 
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -65,7 +70,12 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
       - name: Cache API v1 production build

--- a/.github/workflows/api-v1-production-build.yml
+++ b/.github/workflows/api-v1-production-build.yml
@@ -2,11 +2,6 @@ name: Production Builds
 
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -69,16 +64,12 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
       - name: Cache API v1 production build

--- a/.github/workflows/api-v2-production-build.yml
+++ b/.github/workflows/api-v2-production-build.yml
@@ -39,13 +39,16 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - name: Generate Prisma schemas
         working-directory: apps/api/v2

--- a/.github/workflows/api-v2-production-build.yml
+++ b/.github/workflows/api-v2-production-build.yml
@@ -2,11 +2,6 @@ name: Production Build
 
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 
 env:
   DATABASE_URL: ${{ secrets.CI_DATABASE_URL }}
@@ -39,16 +34,12 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - name: Generate Prisma schemas
         working-directory: apps/api/v2

--- a/.github/workflows/api-v2-production-build.yml
+++ b/.github/workflows/api-v2-production-build.yml
@@ -2,6 +2,11 @@ name: Production Build
 
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 
 env:
   DATABASE_URL: ${{ secrets.CI_DATABASE_URL }}
@@ -35,7 +40,12 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - name: Generate Prisma schemas
         working-directory: apps/api/v2

--- a/.github/workflows/api-v2-unit-tests.yml
+++ b/.github/workflows/api-v2-unit-tests.yml
@@ -1,6 +1,11 @@
 name: API v2 Unit
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 env:
   LINGO_DOT_DEV_API_KEY: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY }}
 permissions:
@@ -12,7 +17,12 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - name: Run API v2 unit tests

--- a/.github/workflows/api-v2-unit-tests.yml
+++ b/.github/workflows/api-v2-unit-tests.yml
@@ -1,11 +1,6 @@
 name: API v2 Unit
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 env:
   LINGO_DOT_DEV_API_KEY: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY }}
 permissions:
@@ -16,16 +11,12 @@ jobs:
     timeout-minutes: 20
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - name: Run API v2 unit tests

--- a/.github/workflows/api-v2-unit-tests.yml
+++ b/.github/workflows/api-v2-unit-tests.yml
@@ -16,13 +16,16 @@ jobs:
     timeout-minutes: 20
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - name: Run API v2 unit tests

--- a/.github/workflows/atoms-production-build.yml
+++ b/.github/workflows/atoms-production-build.yml
@@ -2,11 +2,6 @@ name: Atoms production Build
 
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 
 jobs:
   build:
@@ -16,16 +11,12 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - name: Cache atoms production build
         uses: actions/cache@v4

--- a/.github/workflows/atoms-production-build.yml
+++ b/.github/workflows/atoms-production-build.yml
@@ -2,6 +2,11 @@ name: Atoms production Build
 
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 
 jobs:
   build:
@@ -12,7 +17,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - name: Cache atoms production build
         uses: actions/cache@v4

--- a/.github/workflows/atoms-production-build.yml
+++ b/.github/workflows/atoms-production-build.yml
@@ -16,13 +16,16 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - name: Cache atoms production build
         uses: actions/cache@v4

--- a/.github/workflows/check-api-v2-breaking-changes.yml
+++ b/.github/workflows/check-api-v2-breaking-changes.yml
@@ -38,13 +38,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
 
       - name: Generate Swagger

--- a/.github/workflows/check-api-v2-breaking-changes.yml
+++ b/.github/workflows/check-api-v2-breaking-changes.yml
@@ -2,6 +2,11 @@ name: Check API v2 breaking changes
 
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -34,7 +39,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
 
       - name: Generate Swagger

--- a/.github/workflows/check-api-v2-breaking-changes.yml
+++ b/.github/workflows/check-api-v2-breaking-changes.yml
@@ -2,11 +2,6 @@ name: Check API v2 breaking changes
 
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -38,16 +33,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
 
       - name: Generate Swagger

--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -1,11 +1,6 @@
 name: Check types
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 env:
   NODE_OPTIONS: --max-old-space-size=4096
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -16,16 +11,12 @@ jobs:
   check-types:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - name: Show info
         run: node -e "console.log(require('v8').getHeapStatistics())"

--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -16,13 +16,16 @@ jobs:
   check-types:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - name: Show info
         run: node -e "console.log(require('v8').getHeapStatistics())"

--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -1,6 +1,11 @@
 name: Check types
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 env:
   NODE_OPTIONS: --max-old-space-size=4096
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -12,7 +17,12 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - name: Show info
         run: node -e "console.log(require('v8').getHeapStatistics())"

--- a/.github/workflows/companion-build.yml
+++ b/.github/workflows/companion-build.yml
@@ -21,13 +21,16 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/companion-build.yml
+++ b/.github/workflows/companion-build.yml
@@ -2,11 +2,6 @@ name: Companion Builds
 
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -21,16 +16,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/companion-build.yml
+++ b/.github/workflows/companion-build.yml
@@ -2,6 +2,11 @@ name: Companion Builds
 
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -17,7 +22,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/delete-blacksmith-cache.yml
+++ b/.github/workflows/delete-blacksmith-cache.yml
@@ -31,3 +31,13 @@ jobs:
         with:
           key: ${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.ref }}
           prefix: "true"
+
+  delete-git-checkout-cache-on-pr-close:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Delete git-checkout cache
+        uses: useblacksmith/cache-delete@v1
+        with:
+          key: git-checkout-${{ github.event.pull_request.head.ref }}
+          prefix: "true"

--- a/.github/workflows/delete-blacksmith-cache.yml
+++ b/.github/workflows/delete-blacksmith-cache.yml
@@ -39,5 +39,5 @@ jobs:
       - name: Delete git-checkout cache
         uses: useblacksmith/cache-delete@v1
         with:
-          key: git-checkout-${{ github.event.pull_request.head.ref }}
+          key: git-checkout-${{ github.event.pull_request.head.ref }}-
           prefix: "true"

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -3,11 +3,6 @@ name: Build
 
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 
 jobs:
   build:
@@ -16,16 +11,12 @@ jobs:
       contents: read
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - name: Cache Docs build
         uses: actions/cache@v4
         id: cache-docs-build

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -16,13 +16,16 @@ jobs:
       contents: read
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - name: Cache Docs build
         uses: actions/cache@v4
         id: cache-docs-build

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -3,6 +3,11 @@ name: Build
 
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 
 jobs:
   build:
@@ -12,7 +17,12 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - name: Cache Docs build
         uses: actions/cache@v4
         id: cache-docs-build

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -1,6 +1,11 @@
 name: Check breaking changes and run E2E
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 env:
   ALLOWED_HOSTNAMES: ${{ vars.CI_ALLOWED_HOSTNAMES }}
   API_KEY_PREFIX: ${{ secrets.CI_API_KEY_PREFIX }}
@@ -74,7 +79,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
       - name: Build platform packages with Turbo

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -1,11 +1,6 @@
 name: Check breaking changes and run E2E
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 env:
   ALLOWED_HOSTNAMES: ${{ vars.CI_ALLOWED_HOSTNAMES }}
   API_KEY_PREFIX: ${{ secrets.CI_API_KEY_PREFIX }}
@@ -78,16 +73,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
       - name: Build platform packages with Turbo

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -78,13 +78,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
       - name: Build platform packages with Turbo

--- a/.github/workflows/e2e-app-store.yml
+++ b/.github/workflows/e2e-app-store.yml
@@ -1,11 +1,6 @@
 name: E2E App Store Tests
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 permissions:
   actions: write
   contents: read
@@ -85,16 +80,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e-app-store.yml
+++ b/.github/workflows/e2e-app-store.yml
@@ -1,6 +1,11 @@
 name: E2E App Store Tests
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 permissions:
   actions: write
   contents: read
@@ -81,7 +86,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e-app-store.yml
+++ b/.github/workflows/e2e-app-store.yml
@@ -85,13 +85,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e-embed-react.yml
+++ b/.github/workflows/e2e-embed-react.yml
@@ -77,13 +77,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e-embed-react.yml
+++ b/.github/workflows/e2e-embed-react.yml
@@ -1,11 +1,6 @@
 name: E2E Embed React tests and booking flow (for non-embed as well)
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 permissions:
   actions: write
   contents: read
@@ -77,16 +72,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e-embed-react.yml
+++ b/.github/workflows/e2e-embed-react.yml
@@ -1,6 +1,11 @@
 name: E2E Embed React tests and booking flow (for non-embed as well)
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 permissions:
   actions: write
   contents: read
@@ -73,7 +78,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -85,13 +85,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -1,6 +1,11 @@
 name: E2E Embed Core tests and booking flow (for non-embed as well)
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 permissions:
   actions: write
   contents: read
@@ -81,7 +86,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -1,11 +1,6 @@
 name: E2E Embed Core tests and booking flow (for non-embed as well)
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 permissions:
   actions: write
   contents: read
@@ -85,16 +80,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,11 @@
 name: E2E
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 permissions:
   actions: write
   contents: read
@@ -82,7 +87,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,13 +86,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,11 +1,6 @@
 name: E2E
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 permissions:
   actions: write
   contents: read
@@ -86,16 +81,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,11 @@
 name: Integration
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 permissions:
   contents: read
 env:
@@ -79,7 +84,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - uses: ./.github/actions/cache-db

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,11 +1,6 @@
 name: Integration
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 permissions:
   contents: read
 env:
@@ -83,16 +78,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - uses: ./.github/actions/cache-db

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,13 +83,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - uses: ./.github/actions/cache-db

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,13 +14,16 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - name: Run Lint
         run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,6 @@
 name: Lint
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 permissions:
   actions: write
   contents: read
@@ -14,16 +9,12 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - name: Run Lint
         run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Lint
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 permissions:
   actions: write
   contents: read
@@ -10,7 +15,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - name: Run Lint
         run: yarn lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -175,6 +175,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
+      - name: Get Latest Commit SHA
+        id: get_sha
+        run: |
+          echo "commit-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Cache git checkout
+        uses: ./.github/actions/cache-checkout
+        with:
+          mode: save
+          commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
       - name: Generate DB cache key
         id: cache-db-key
         uses: ./.github/actions/cache-db-key
@@ -212,10 +221,6 @@ jobs:
               - "packages/trpc/**"
               - "packages/prisma/schema.prisma"
               - "docs/api-reference/v2/**"
-      - name: Get Latest Commit SHA
-        id: get_sha
-        run: |
-          echo "commit-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Check if PR exists with ready-for-e2e label for this SHA
         id: check-if-pr-has-label
         uses: actions/github-script@v7
@@ -290,6 +295,8 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/check-types.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   lint:
@@ -297,6 +304,8 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/lint.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   unit-test:
@@ -304,6 +313,8 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/unit-tests.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   api-v2-unit-test:
@@ -311,6 +322,8 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v2-unit-tests.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   setup-db:
@@ -320,6 +333,7 @@ jobs:
     uses: ./.github/workflows/setup-db.yml
     with:
       DB_CACHE_HIT: ${{ needs.prepare.outputs.db-cache-hit }}
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-api-v1:
@@ -327,6 +341,8 @@ jobs:
     needs: [prepare, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v1-production-build.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-api-v2:
@@ -334,6 +350,8 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v2-production-build.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-atoms:
@@ -341,6 +359,8 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/atoms-production-build.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-docs:
@@ -348,6 +368,8 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/docs-build.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-companion:
@@ -355,6 +377,8 @@ jobs:
     needs: [prepare]
     if: needs.prepare.outputs.has_companion == 'true'
     uses: ./.github/workflows/companion-build.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build:
@@ -362,6 +386,8 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/production-build-without-database.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   integration-test:
@@ -369,6 +395,8 @@ jobs:
     needs: [prepare, build, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   e2e:
@@ -376,6 +404,8 @@ jobs:
     needs: [prepare, build, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   check-api-v2-breaking-changes:
@@ -383,6 +413,8 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-api-v2-changes == 'true' }}
     uses: ./.github/workflows/check-api-v2-breaking-changes.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   e2e-api-v2:
@@ -390,6 +422,8 @@ jobs:
     needs: [prepare, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-api-v2.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   e2e-app-store:
@@ -397,6 +431,8 @@ jobs:
     needs: [prepare, build, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-app-store.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   e2e-embed:
@@ -404,6 +440,8 @@ jobs:
     needs: [prepare, build, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   e2e-embed-react:
@@ -411,6 +449,8 @@ jobs:
     needs: [prepare, build, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed-react.yml
+    with:
+      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   analyze:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -169,21 +169,15 @@ jobs:
       has-files-requiring-all-checks: ${{ steps.filter.outputs.has-files-requiring-all-checks }}
       has_companion: ${{ steps.filter.outputs.has_companion }}
       has-api-v2-changes: ${{ steps.filter.outputs.has-api-v2-changes }}
-      commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
       run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' }}
       db-cache-hit: ${{ steps.cache-db-check.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
-      - name: Get Latest Commit SHA
-        id: get_sha
-        run: |
-          echo "commit-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Cache git checkout
         uses: ./.github/actions/cache-checkout
         with:
           mode: save
-          commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
       - name: Generate DB cache key
         id: cache-db-key
         uses: ./.github/actions/cache-db-key
@@ -295,8 +289,6 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/check-types.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   lint:
@@ -304,8 +296,6 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/lint.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   unit-test:
@@ -313,8 +303,6 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/unit-tests.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   api-v2-unit-test:
@@ -322,8 +310,6 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v2-unit-tests.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   setup-db:
@@ -333,7 +319,6 @@ jobs:
     uses: ./.github/workflows/setup-db.yml
     with:
       DB_CACHE_HIT: ${{ needs.prepare.outputs.db-cache-hit }}
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-api-v1:
@@ -341,8 +326,6 @@ jobs:
     needs: [prepare, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v1-production-build.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-api-v2:
@@ -350,8 +333,6 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v2-production-build.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-atoms:
@@ -359,8 +340,6 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/atoms-production-build.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-docs:
@@ -368,8 +347,6 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/docs-build.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-companion:
@@ -377,8 +354,6 @@ jobs:
     needs: [prepare]
     if: needs.prepare.outputs.has_companion == 'true'
     uses: ./.github/workflows/companion-build.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build:
@@ -386,8 +361,6 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/production-build-without-database.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   integration-test:
@@ -395,8 +368,6 @@ jobs:
     needs: [prepare, build, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   e2e:
@@ -404,8 +375,6 @@ jobs:
     needs: [prepare, build, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   check-api-v2-breaking-changes:
@@ -413,8 +382,6 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-api-v2-changes == 'true' }}
     uses: ./.github/workflows/check-api-v2-breaking-changes.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   e2e-api-v2:
@@ -422,8 +389,6 @@ jobs:
     needs: [prepare, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-api-v2.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   e2e-app-store:
@@ -431,8 +396,6 @@ jobs:
     needs: [prepare, build, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-app-store.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   e2e-embed:
@@ -440,8 +403,6 @@ jobs:
     needs: [prepare, build, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   e2e-embed-react:
@@ -449,8 +410,6 @@ jobs:
     needs: [prepare, build, setup-db]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed-react.yml
-    with:
-      commit-sha: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   analyze:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -169,6 +169,7 @@ jobs:
       has-files-requiring-all-checks: ${{ steps.filter.outputs.has-files-requiring-all-checks }}
       has_companion: ${{ steps.filter.outputs.has_companion }}
       has-api-v2-changes: ${{ steps.filter.outputs.has-api-v2-changes }}
+      commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
       run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' }}
       db-cache-hit: ${{ steps.cache-db-check.outputs.cache-hit }}
     steps:
@@ -215,6 +216,10 @@ jobs:
               - "packages/trpc/**"
               - "packages/prisma/schema.prisma"
               - "docs/api-reference/v2/**"
+      - name: Get Latest Commit SHA
+        id: get_sha
+        run: |
+          echo "commit-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Check if PR exists with ready-for-e2e label for this SHA
         id: check-if-pr-has-label
         uses: actions/github-script@v7

--- a/.github/workflows/production-build-without-database.yml
+++ b/.github/workflows/production-build-without-database.yml
@@ -1,11 +1,6 @@
 name: Production Builds
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -47,16 +42,12 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - name: Generate cache key

--- a/.github/workflows/production-build-without-database.yml
+++ b/.github/workflows/production-build-without-database.yml
@@ -47,13 +47,16 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - name: Generate cache key

--- a/.github/workflows/production-build-without-database.yml
+++ b/.github/workflows/production-build-without-database.yml
@@ -1,6 +1,11 @@
 name: Production Builds
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -43,7 +48,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - name: Generate cache key

--- a/.github/workflows/setup-db.yml
+++ b/.github/workflows/setup-db.yml
@@ -50,13 +50,16 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
         if: inputs.DB_CACHE_HIT != 'true'
       - run: yarn prisma generate

--- a/.github/workflows/setup-db.yml
+++ b/.github/workflows/setup-db.yml
@@ -8,6 +8,10 @@ on:
         type: string
         default: "false"
         description: "Whether the DB cache was hit (skip yarn-install and cache-db if true)"
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -47,7 +51,12 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
         if: inputs.DB_CACHE_HIT != 'true'
       - run: yarn prisma generate

--- a/.github/workflows/setup-db.yml
+++ b/.github/workflows/setup-db.yml
@@ -8,10 +8,6 @@ on:
         type: string
         default: "false"
         description: "Whether the DB cache was hit (skip yarn-install and cache-db if true)"
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -50,16 +46,12 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
         if: inputs.DB_CACHE_HIT != 'true'
       - run: yarn prisma generate

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,11 @@
 name: Unit
 on:
   workflow_call:
+    inputs:
+      commit-sha:
+        description: "Commit SHA for cache key"
+        required: true
+        type: string
 env:
   LINGO_DOT_DEV_API_KEY: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY }}
 permissions:
@@ -12,7 +17,12 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
+          commit-sha: ${{ inputs.commit-sha }}
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - run: yarn test -- --no-isolate

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,13 +16,16 @@ jobs:
     timeout-minutes: 20
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - name: Restore git checkout from cache
+        uses: actions/cache/restore@v4
         with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
-          commit-sha: ${{ inputs.commit-sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !**/node_modules
+          key: git-checkout-${{ inputs.commit-sha }}
+          fail-on-cache-miss: true
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - run: yarn test -- --no-isolate

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,11 +1,6 @@
 name: Unit
 on:
   workflow_call:
-    inputs:
-      commit-sha:
-        description: "Commit SHA for cache key"
-        required: true
-        type: string
 env:
   LINGO_DOT_DEV_API_KEY: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY }}
 permissions:
@@ -16,16 +11,12 @@ jobs:
     timeout-minutes: 20
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - name: Restore git checkout from cache
-        uses: actions/cache/restore@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            .
-            !.git
-            !node_modules
-            !**/node_modules
-          key: git-checkout-${{ inputs.commit-sha }}
-          fail-on-cache-miss: true
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+        with:
+          mode: restore
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - run: yarn test -- --no-isolate


### PR DESCRIPTION
## What does this PR do?

Implements git checkout caching to reduce CI workflow times by eliminating redundant git checkouts across parallel jobs.

Previously, every job in the PR workflow performed its own full git checkout (via `actions/checkout@v4` + `dangerous-git-checkout`), resulting in 20+ separate checkouts per workflow run. This was particularly slow for the cal.com repo (~1.3GB).

This PR:
- Creates a new `cache-checkout` action that saves/restores the git working directory
- The `prepare` job saves the checkout to cache after `dangerous-git-checkout`
- All downstream workflows use sparse-checkout of `.github` (to access the action) then restore from cache
- Uses cache key format `git-checkout-{branch}-{sha}` to ensure cache is only reused within a single PR
- **Deletes previous caches for the branch before saving** to keep cache storage low (only one cache per branch)
- Automatically cleans up git-checkout caches when PRs are closed (via `delete-blacksmith-cache.yml`)
- **Uses sparse-checkout in `dangerous-git-checkout` to exclude `/example-apps/` and `*.mp4` files** (~38MB saved from salesroom demo video)

**Expected impact**: Reduces checkout time from ~10+ minutes per job to a fast cache restore, with only one full checkout per workflow run.

Link to Devin run: https://app.devin.ai/sessions/00c0c2b934dc40609aaf765ab206daaa
Requested by: @keithwillcode

## Updates since last revision

- Fixed cache key to use `github.head_ref || github.ref_name` and `github.sha` instead of `github.event.pull_request.head.ref/sha` (the latter is not available in workflow_call contexts)
- Final cache key format: `git-checkout-${{ github.head_ref || github.ref_name }}-${{ github.sha }}`
- Added prefix delete step **before saving cache** to clear previous checkout caches for the same branch (uses `useblacksmith/cache-delete@v1` with `prefix: "true"`)
- Added cache cleanup job in `delete-blacksmith-cache.yml` to delete all git-checkout caches with the PR branch prefix when PR is closed
- Added sparse-checkout to `dangerous-git-checkout` action to exclude `example-apps/` directory and all `.mp4` files
- **Fixed: Restored `get_sha` step and `commit-sha` output** that was accidentally removed when adding the cache-checkout step (this was breaking the ready-for-e2e label check)
- **Fixed: Added trailing `-` to cache key prefix** to prevent accidental deletion of other branches' caches (e.g., branch `feature` no longer deletes caches for `feature-2`)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI infrastructure change only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This PR modifies CI infrastructure and can only be tested by running the actual workflows:

1. Create/update a PR to trigger the workflow
2. Verify the `prepare` job successfully deletes old caches and saves the checkout to cache
3. Verify downstream jobs (lint, type-check, unit-tests, etc.) successfully restore from cache
4. Push another commit and verify the old cache is deleted before the new one is saved
5. Compare total workflow time before and after this change
6. Close a PR and verify the git-checkout caches are cleaned up

## Human Review Checklist


- [x] Verify `fail-on-cache-miss: true` is acceptable behavior (downstream jobs will fail if prepare job fails before caching)
- [x] Confirm cache paths correctly exclude `.git` and `node_modules`
- [x] Verify `github.head_ref || github.ref_name` and `github.sha` are available in all workflow_call contexts
- [x] Consider edge cases: what happens if cache is evicted mid-workflow?
- [x] Confirm sparse-checkout of `.github` is fast enough to be worthwhile vs. the previous approach
- [x] Verify cache key handles branch names with special characters correctly
- [x] ~~Confirm prefix-based cache deletion (`git-checkout-{branch}`) won't accidentally delete unrelated caches~~ - Fixed by adding trailing `-` to prefix
- [x] Verify no workflows need files from `example-apps/` or the salesroom mp4 file
- [x] Confirm sparse-checkout patterns (`/*`, `!/example-apps/`, `!**/*.mp4`) work correctly in non-cone mode
- [x] Verify `get_sha` step and `commit-sha` output are properly restored in pr.yml

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings