### PR TITLE
chore: ignore fork PRs in devin-conflict-resolver workflow

### DIFF
--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -86,9 +86,15 @@ jobs:
             
             function processPR(pr, mergeableStatus) {
               const isTargetPR = manualPrNumber && pr.number === manualPrNumber;
+              const isFork = pr.headRepository?.owner?.login !== owner;
               
               if (!isTargetPR && pr.isDraft) {
                 console.log(`PR #${pr.number} is a draft, skipping`);
+                return { skip: true };
+              }
+              
+              if (!isTargetPR && isFork) {
+                console.log(`PR #${pr.number} is from a fork, skipping`);
                 return { skip: true };
               }
               
@@ -101,19 +107,13 @@ jobs:
               }
               
               if (mergeableStatus === 'CONFLICTING' || (isTargetPR && mergeableStatus !== 'MERGEABLE')) {
-                const isFork = pr.headRepository?.owner?.login !== owner;
                 const headRepoOwner = pr.headRepository?.owner?.login || owner;
                 const headRepoName = pr.headRepository?.name || repo;
-                
-                if (!isTargetPR && isFork && !pr.maintainerCanModify) {
-                  console.log(`PR #${pr.number} is from a fork without maintainer push access, skipping`);
-                  return { skip: true };
-                }
                 
                 if (isTargetPR) {
                   console.log(`PR #${pr.number} manually targeted for conflict resolution${isFork ? ' (from fork)' : ''}`);
                 } else {
-                  console.log(`PR #${pr.number} has conflicts${isFork ? ' (from fork)' : ''}`);
+                  console.log(`PR #${pr.number} has conflicts`);
                 }
                 
                 return {


### PR DESCRIPTION
## What does this PR do?

Modifies the Devin PR Conflict Resolver workflow to skip all fork PRs by default. Previously, the workflow would attempt to resolve conflicts on fork PRs if the contributor had enabled "Allow edits from maintainers". Now, fork PRs are ignored entirely unless manually targeted via `workflow_dispatch`.

The manual targeting feature (`pr_number` input) still works for fork PRs if needed.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - workflow behavior will be tested when it runs.

## How should this be tested?

This change will be tested when the workflow runs on push to main. Fork PRs with conflicts should now be skipped with the log message "PR #X is from a fork, skipping".

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/5f35bbeac01442d1b898ae3ab00c5709
Requested by: @keithwillcode