### PR TITLE
fix(docker): create multi-arch manifest for ARM support

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -172,3 +172,71 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
+
+  create-manifest:
+    name: "Create Multi-Arch Manifest"
+    needs: [prepare, release-amd64, release-arm]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    if: ${{ (github.event_name == 'push' || inputs.PUSH_IMAGE) && !github.event.release.prerelease }}
+    env:
+      RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifests
+        run: |
+          REGISTRIES=(
+            "docker.io/calcom/cal.com"
+            "docker.io/calendso/calendso"
+            "ghcr.io/calcom/cal.com"
+          )
+
+          for registry in "${REGISTRIES[@]}"; do
+            amd64_image="$registry:$RELEASE_TAG"
+            arm64_image="$registry:$RELEASE_TAG-arm"
+
+            echo "Creating manifest for $registry:$RELEASE_TAG"
+            docker manifest create "$registry:$RELEASE_TAG" \
+              "$amd64_image" \
+              "$arm64_image"
+            docker manifest push "$registry:$RELEASE_TAG"
+
+            echo "Creating manifest for $registry:latest"
+            docker manifest create --amend "$registry:latest" \
+              "$amd64_image" \
+              "$arm64_image"
+            docker manifest push "$registry:latest"
+          done
+
+      - name: Notify Slack on Success
+        if: success()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": ":large_green_circle: Workflow *${{ github.workflow }}* (Multi-Arch Manifest) succeeded.\nSee: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": ":red_circle: Workflow *${{ github.workflow }}* (Multi-Arch Manifest) failed.\nSee: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- Adds a new `create-manifest` job that runs after both AMD64 and ARM builds complete
- Creates Docker manifest lists that include both architectures under the same tag
- Enables `docker pull calcom/cal.com:latest` to work seamlessly on ARM devices

## Problem
Previously, the `latest` tag only pointed to the AMD64 image, causing ARM users to get the error:
```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

ARM users had to explicitly use the `-arm` suffix tags (e.g., `v6.0.7-arm`).

## Solution
After both architecture-specific images are pushed, a new job creates multi-arch manifests that combine both images under:
- The version tag (e.g., `v6.0.7`)
- The `latest` tag

This allows Docker to automatically select the correct architecture when pulling.

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test on next release by pulling `calcom/cal.com:latest` on an ARM device

Fixes #26421

🤖 Generated with [Claude Code](https://claude.com/claude-code)