### PR TITLE
fix(ui): remove double hover background on destructive dropdown items

### DIFF
--- a/packages/ui/components/dropdown/Dropdown.tsx
+++ b/packages/ui/components/dropdown/Dropdown.tsx
@@ -59,11 +59,14 @@ export const DropdownMenuLabel = (props: DropdownMenuLabelProps) => (
   />
 );
 
-type DropdownMenuItemProps = ComponentProps<(typeof DropdownMenuPrimitive)["CheckboxItem"]>;
+type DropdownMenuItemProps = ComponentProps<(typeof DropdownMenuPrimitive)["Item"]>;
 export const DropdownMenuItem = forwardRef<HTMLDivElement, DropdownMenuItemProps>(
-  ({ className = "", ...props }, forwardedRef) => (
+  ({ className, ...props }, forwardedRef) => (
     <DropdownMenuPrimitive.Item
-      className={`hover:bg-subtle hover:text-emphasis text-default text-sm ring-inset first-of-type:rounded-t-[inherit] last-of-type:rounded-b-[inherit] hover:ring-0 focus:outline-none focus:bg-subtle focus:text-emphasis ${className}`}
+      className={classNames(
+        "text-default text-sm ring-inset first-of-type:rounded-t-[inherit] last-of-type:rounded-b-[inherit] focus:outline-none focus:ring-0",
+        className
+      )}
       {...props}
       ref={forwardedRef}
     />


### PR DESCRIPTION
## Summary
- Removes `hover:bg-subtle` from `DropdownMenuItem` since the child `DropdownItem` already handles hover styling
- Fixes the visual conflict where both the parent's subtle background and the child's error background appeared on hover for destructive actions

## Problem
When hovering over a destructive dropdown action (like "Delete"), both hover backgrounds were visible:
1. The parent `DropdownMenuItem`'s `hover:bg-subtle` (gray)
2. The child `DropdownItem`'s `hover:bg-error` (red)

This created a layered hover state that looked inconsistent.

## Solution
Removed hover styling from `DropdownMenuItem` since the inner `DropdownItem` component already provides appropriate hover styling for both destructive (`hover:bg-error`) and non-destructive (`hover:bg-subtle`) variants.

## Test plan
- [ ] Hover over destructive dropdown actions (Delete buttons) - should show only error background
- [ ] Hover over non-destructive dropdown actions - should show only subtle background
- [ ] Test keyboard navigation still works correctly

Fixes #26256

🤖 Generated with [Claude Code](https://claude.com/claude-code)