### PR TITLE
fix: pass returnTo in OAuth state for onboarding calendar connection

### DIFF
--- a/apps/web/modules/onboarding/personal/_components/InstallableAppCard.tsx
+++ b/apps/web/modules/onboarding/personal/_components/InstallableAppCard.tsx
@@ -1,5 +1,5 @@
-import { InstallAppButtonWithoutPlanCheck } from "@calcom/app-store/InstallAppButtonWithoutPlanCheck";
 import type { UseAddAppMutationOptions } from "@calcom/app-store/_utils/useAddAppMutation";
+import { InstallAppButtonWithoutPlanCheck } from "@calcom/app-store/InstallAppButtonWithoutPlanCheck";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { App } from "@calcom/types/App";
 import { Button } from "@calcom/ui/components/button";
@@ -52,8 +52,6 @@ export const InstallableAppCard = ({
             loading={isInstalling || buttonProps?.loading}
             className="mt-auto w-full items-center justify-center rounded-[10px]"
             onClick={(event) => {
-              // Save cookie to return to this page after OAuth
-              document.cookie = `return-to=${window.location.href};path=/;max-age=3600;SameSite=Lax`;
               onInstallClick(app.slug);
               buttonProps?.onClick?.(event);
             }}>

--- a/apps/web/modules/onboarding/personal/_components/useAppInstallation.ts
+++ b/apps/web/modules/onboarding/personal/_components/useAppInstallation.ts
@@ -1,18 +1,21 @@
-import { useState } from "react";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { showToast } from "@calcom/ui/components/toast";
+import { useState } from "react";
 
 type InstallSuccessCallback = (appSlug: string) => void;
 
-export const useAppInstallation = () => {
+export const useAppInstallation = (returnTo?: string) => {
   const { t } = useLocale();
   const utils = trpc.useUtils();
   const [installingAppSlug, setInstallingAppSlug] = useState<string | null>(null);
 
+  // Use provided returnTo or fallback to current page URL
+  const returnToUrl = returnTo ?? (typeof window !== "undefined" ? window.location.href : undefined);
+
   const createInstallHandlers = (appSlug: string, onSuccess?: InstallSuccessCallback) => {
     return {
+      returnTo: returnToUrl,
       onSuccess: () => {
         setInstallingAppSlug(null);
         utils.viewer.apps.integrations.invalidate();


### PR DESCRIPTION
## Summary
- Fixed issue where connecting a calendar during onboarding redirected users to the "choose account" page instead of continuing onboarding
- Modified `useAppInstallation` hook to include `returnTo` URL in OAuth state
- This ensures the OAuth callback redirects back to the onboarding page after successful calendar connection

Fixes #26572

## Test plan
- [ ] Start onboarding flow and select "Personal" plan
- [ ] Navigate to calendar connection step
- [ ] Click "Connect" on Google Calendar
- [ ] Complete Google OAuth authorization
- [ ] Verify redirect back to onboarding calendar page (not apps/installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)