### PR TITLE
fix(api): make label optional for phone booking field

### DIFF
--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
@@ -342,8 +342,11 @@ export class PhoneFieldInput_2024_06_14 {
   slug!: string;
 
   @IsString()
-  @DocsProperty()
-  label!: string;
+  @IsOptional()
+  @DocsPropertyOptional({
+    description: "Label for the phone field. If not provided, the default translated label will be used.",
+  })
+  label?: string;
 
   @IsBoolean()
   @DocsProperty()
@@ -351,7 +354,7 @@ export class PhoneFieldInput_2024_06_14 {
 
   @IsString()
   @IsOptional()
-  @DocsProperty()
+  @DocsPropertyOptional()
   placeholder?: string;
 
   @IsBoolean()
@@ -367,7 +370,7 @@ export class PhoneFieldInput_2024_06_14 {
 
   @IsBoolean()
   @IsOptional()
-  @DocsProperty({
+  @DocsPropertyOptional({
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })


### PR DESCRIPTION
## What does this PR do?

Makes the `label` field optional for phone booking fields in the v2 API. When label is not provided, the default translated label will be used.

- Fixes #25589

## Problem

When creating an event type via the v2 API with a phone booking field, users were required to provide a `label`:
```
Validation failed for phone booking field: label must be a string
```

However, setting a custom label causes loss of translation capabilities. The UI allows leaving the phone field label blank and uses the translatable default label.

## Solution

Changed `PhoneFieldInput_2024_06_14.label` from required to optional:
- Added `@IsOptional()` decorator
- Changed `@DocsProperty` to `@DocsPropertyOptional` with description
- Changed type from `label!: string` to `label?: string`
- Fixed transformer to properly handle undefined label with fallback to empty string

## Updates since last revision

- Fixed type error in `booking-fields.ts` transformer where `label` could be `undefined`
- Added automated tests to verify the fallback logic:
  - Test for phone field with label provided
  - Test for phone field without label (verifies empty string fallback)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - API behavior change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create event type via API with phone field without label - should succeed
2. Create event type via API with phone field with custom label - should succeed
3. Run the automated tests: `yarn jest --testPathPattern="api-to-internal.spec.ts"`

## Human Review Checklist

- [ ] Verify the fallback to empty string `""` is correct (translation happens at render time, not in transformer)
- [ ] Check if other field types with optional labels need similar transformer fixes

---


🤖 Generated with [Claude Code](https://claude.com/claude-code)