### PR TITLE
docs: fix CALENDSO_ENCRYPTION_KEY generation command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,7 +94,7 @@ CRON_ENABLE_APP_SYNC=false
 
 # Application Key for symmetric encryption and decryption
 # must be 32 bytes for AES256 encryption algorithm
-# You can use: `openssl rand -base64 32` to generate one
+# You can use: `openssl rand -base64 24` to generate a 32-character key
 CALENDSO_ENCRYPTION_KEY=
 
 # Intercom Config

--- a/agents/knowledge-base.md
+++ b/agents/knowledge-base.md
@@ -13,7 +13,8 @@ Development
 - Install dependencies: `yarn`
 - Set up environment:
   - Copy `.env.example` to `.env`
-  - Generate keys with `openssl rand -base64 32` for both `NEXTAUTH_SECRET` and `CALENDSO_ENCRYPTION_KEY`
+  - Generate NEXTAUTH_SECRET with `openssl rand -base64 32`
+  - Generate CALENDSO_ENCRYPTION_KEY with `openssl rand -base64 24` (must be 32 characters for AES256)
   - Configure Postgres database URL in `.env`
   - Set DATABASE_DIRECT_URL to the same value as DATABASE_URL
 


### PR DESCRIPTION
## Summary
- Fixed the `openssl` command for generating `CALENDSO_ENCRYPTION_KEY` in `.env.example`
- Updated `agents/knowledge-base.md` with correct command

## Problem
The AES256 encryption algorithm used for 2FA requires **exactly 32 bytes**. The documentation suggested:
```bash
openssl rand -base64 32
```
This generates a ~44 character base64 string (32 random bytes encoded), which is too long and causes:
- `RangeError: Invalid key length`
- 2FA setup failing with "Something went wrong"

## Solution
Changed to:
```bash
openssl rand -base64 24
```
This generates exactly 32 characters (24 bytes → 32 base64 characters), which is the correct length for AES256.

**Note:** The `.gitpod.yml` already uses the correct command, confirming this is the intended behavior.

## Test plan
- [ ] Generate key with `openssl rand -base64 24` - should be 32 characters
- [ ] Set up fresh self-hosted installation with the new key
- [ ] Enable 2FA successfully

Fixes #22365

🤖 Generated with [Claude Code](https://claude.com/claude-code)