### PR TITLE
fix(license): use 'valid' field instead of 'status' for license check

### DIFF
--- a/packages/features/ee/common/server/LicenseKeyService.test.ts
+++ b/packages/features/ee/common/server/LicenseKeyService.test.ts
@@ -1,8 +1,8 @@
 import "@calcom/testing/lib/__mocks__/prisma";
 
+import process from "node:process";
 import * as cache from "memory-cache";
-import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDeploymentKey, getDeploymentSignatureToken } from "../../deployment/lib/getDeploymentKey";
 import { NoopLicenseKeyService } from "./LicenseKeyService";
 import { createSignature, generateNonce } from "./private-api-utils";
@@ -152,7 +152,7 @@ describe("LicenseKeyService", () => {
     it("should fetch license validity from API if not cached", async () => {
       const url = `${baseUrl}/v1/license/${licenseKey}`;
       vi.mocked(cache.get).mockReturnValue(null);
-      const mockResponse = { status: true };
+      const mockResponse = { valid: true };
       const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
         json: vi.fn().mockResolvedValue(mockResponse),
       } as any);

--- a/packages/features/ee/common/server/LicenseKeyService.ts
+++ b/packages/features/ee/common/server/LicenseKeyService.ts
@@ -1,5 +1,4 @@
-import * as cache from "memory-cache";
-
+import process from "node:process";
 import {
   getDeploymentKey,
   getDeploymentSignatureToken,
@@ -7,8 +6,8 @@ import {
 import type { IDeploymentRepository } from "@calcom/features/ee/deployment/repositories/IDeploymentRepository";
 import { CALCOM_PRIVATE_API_ROUTE } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
-
-import { generateNonce, createSignature } from "./private-api-utils";
+import * as cache from "memory-cache";
+import { createSignature, generateNonce } from "./private-api-utils";
 
 export enum UsageEvent {
   BOOKING = "booking",
@@ -114,8 +113,8 @@ class LicenseKeyService implements ILicenseKeyService {
     try {
       const response = await this.fetcher({ url, licenseKey: this.licenseKey, options: { mode: "cors" } });
       const data = await response.json();
-      cache.put(url, data.status, this.CACHING_TIME);
-      return data.status;
+      cache.put(url, data.valid, this.CACHING_TIME);
+      return data.valid;
     } catch (error) {
       console.error("Check license failed:", error);
       return false;


### PR DESCRIPTION
## Summary
- Fix license validation API response field check from `.status` to `.valid`
- The license API returns `{ valid: boolean }` but code was checking `.status`
- This caused self-hosted installations with valid license keys to get 401 errors

## Changes
- `apps/api/v2/src/modules/deployments/deployments.service.ts`: Update type and field access
- `packages/features/ee/common/server/LicenseKeyService.ts`: Update field access  
- `packages/features/ee/common/server/LicenseKeyService.test.ts`: Update mock response

## Test plan
- [x] Verified license API returns `{ valid: true }` format
- [x] Updated test to match new response shape
- [ ] Test on self-hosted installation with valid license key

Fixes #26502

🤖 Generated with [Claude Code](https://claude.com/claude-code)