### PR TITLE
fix: improve ListLinkItem responsive layout for narrow viewports

### DIFF
--- a/packages/ui/components/list/List.tsx
+++ b/packages/ui/components/list/List.tsx
@@ -93,7 +93,7 @@ export function ListLinkItem(props: ListLinkItemProps) {
     <li
       data-testid="list-link-item"
       className={classNames(
-        "group flex w-full items-center justify-between p-5 pb-4",
+        "group flex w-full flex-col gap-3 p-5 pb-4 sm:flex-row sm:items-center sm:justify-between",
         className,
         disabled ? "hover:bg-cal-muted" : ""
       )}>
@@ -101,13 +101,13 @@ export function ListLinkItem(props: ListLinkItemProps) {
         passHref
         href={href}
         className={classNames(
-          "text-default grow truncate text-sm",
+          "text-default min-w-0 grow text-sm",
           disabled ? "pointer-events-none cursor-not-allowed opacity-30" : ""
         )}>
-        <div className="flex items-center">
-          <h1 className="text-sm font-semibold leading-none">{heading}</h1>
+        <div className="flex flex-wrap items-center gap-1">
+          <h1 className="truncate text-sm font-semibold leading-none">{heading}</h1>
           {readOnly && (
-            <Badge data-testid="badge" variant="gray" className="ml-2">
+            <Badge data-testid="badge" variant="gray">
               {t("readonly")}
             </Badge>
           )}
@@ -118,7 +118,7 @@ export function ListLinkItem(props: ListLinkItemProps) {
         </h2>
         <div className="mt-2">{children}</div>
       </Link>
-      {actions}
+      <div className="flex shrink-0 items-center">{actions}</div>
     </li>
   );
 }


### PR DESCRIPTION
## Summary
- Use flex-col layout on mobile, flex-row on larger screens (sm breakpoint)
- Add min-w-0 to Link element for proper text truncation in flex containers
- Wrap heading and readonly badge with flex-wrap to allow proper wrapping
- Wrap actions in shrink-0 container to prevent them from compressing content

This fixes text being cut off and actions overlapping content at narrow viewports like 325px.

Fixes #26579

## Test plan
- [ ] View routing forms list at 325px viewport width
- [ ] Verify form name is visible and truncates properly
- [ ] Verify actions don't overlap content
- [ ] Verify layout stacks properly on mobile (below 640px)
- [ ] Verify layout is horizontal on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)