### PR TITLE
fix: improve Devin conflict resolver for fork PRs and label cleanup

### DIFF
--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -254,12 +254,15 @@ jobs:
             3. Commit the merge resolution with a clear commit message.
             4. Push the resolved changes to the PR branch.
 
+            5. After successfully pushing the resolved changes, remove the \`devin-conflict-resolution\` label from the PR using the GitHub API.
+
             Rules and Guidelines:
             1. Be careful when resolving conflicts - understand the context of both changes.
             2. Follow the existing code style and conventions in the repository.
             3. Run lint and type checks before pushing to ensure the code is valid.
             4. If a conflict seems too complex or risky to resolve automatically, explain the situation in a PR comment instead.
-            5. Never ask for user confirmation. Never wait for user messages.`;
+            5. Never ask for user confirmation. Never wait for user messages.
+            6. CRITICAL: If this is a fork PR and you encounter ANY error when pushing (permission denied, authentication failure, etc.), you MUST fail the task immediately. Do NOT attempt to push to a new branch in the main ${owner}/${repo} repository as a workaround. Simply report the error and stop.`;
 
               try {
                 const response = await fetch('https://api.devin.ai/v1/sessions', {

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -253,7 +253,6 @@ jobs:
             2. Test that the code still works after resolving conflicts (run lint/type checks).
             3. Commit the merge resolution with a clear commit message.
             4. Push the resolved changes to the PR branch.
-
             5. After successfully pushing the resolved changes, remove the \`devin-conflict-resolution\` label from the PR using the GitHub API.
 
             Rules and Guidelines:


### PR DESCRIPTION
## What does this PR do?

Updates the Devin PR Conflict Resolver workflow with two improvements:

1. **Label cleanup**: Instructs Devin to remove the `devin-conflict-resolution` label from the PR after successfully resolving conflicts and pushing changes
2. **Fork error handling**: Adds a CRITICAL rule that if Devin encounters any push error on a fork PR (permission denied, auth failure, etc.), it must fail immediately rather than attempting to push to a new branch in the main cal.com repository

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow changes only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - prompt changes cannot be automatically tested.

## How should this be tested?

These are prompt-based changes to the Devin workflow. To verify:

1. **Label removal**: Trigger the workflow on a PR with conflicts, let Devin resolve them, and verify the `devin-conflict-resolution` label is removed after successful push
2. **Fork error handling**: This is a safeguard - verify the instruction is clear by reviewing the prompt wording

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> [!NOTE]
> This PR was created by [Devin](https://app.devin.ai/sessions/66204193a4224e3ebdf01472f8e2b31b) as requested by @keithwillcode