### PR TITLE
fix: remove license requirement from team members page

### DIFF
--- a/apps/web/modules/ee/teams/views/team-members-view.tsx
+++ b/apps/web/modules/ee/teams/views/team-members-view.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import type { MemberPermissions } from "@calcom/features/pbac/lib/team-member-permissions";
@@ -43,34 +42,32 @@ export const TeamMembersView = ({ team, facetedTeamValues, permissions }: TeamMe
   const canLoggedInUserSeeMembers = permissions?.canListMembers ?? false;
 
   return (
-    <LicenseRequired>
-      <div>
-        {canLoggedInUserSeeMembers && (
-          <div className="mb-6">
-            <MemberList
-              team={team}
-              isOrgAdminOrOwner={false}
-              setShowMemberInvitationModal={setShowMemberInvitationModal}
-              facetedTeamValues={facetedTeamValues}
-              permissions={permissions}
-            />
-          </div>
-        )}
-        {!canLoggedInUserSeeMembers && (
-          <div className="border-subtle rounded-xl border p-6" data-testid="members-privacy-warning">
-            <h2 className="text-default">{t("only_admin_can_see_members_of_team")}</h2>
-          </div>
-        )}
-        {showMemberInvitationModal && team && team.id && (
-          <MemberInvitationModalWithoutMembers
-            hideInvitationModal={() => setShowMemberInvitationModal(false)}
-            showMemberInvitationModal={showMemberInvitationModal}
-            teamId={team.id}
-            token={team.inviteToken?.token}
-            onSettingsOpen={() => setShowInviteLinkSettingsModal(true)}
+    <div>
+      {canLoggedInUserSeeMembers && (
+        <div className="mb-6">
+          <MemberList
+            team={team}
+            isOrgAdminOrOwner={false}
+            setShowMemberInvitationModal={setShowMemberInvitationModal}
+            facetedTeamValues={facetedTeamValues}
+            permissions={permissions}
           />
-        )}
-      </div>
-    </LicenseRequired>
+        </div>
+      )}
+      {!canLoggedInUserSeeMembers && (
+        <div className="border-subtle rounded-xl border p-6" data-testid="members-privacy-warning">
+          <h2 className="text-default">{t("only_admin_can_see_members_of_team")}</h2>
+        </div>
+      )}
+      {showMemberInvitationModal && team && team.id && (
+        <MemberInvitationModalWithoutMembers
+          hideInvitationModal={() => setShowMemberInvitationModal(false)}
+          showMemberInvitationModal={showMemberInvitationModal}
+          teamId={team.id}
+          token={team.inviteToken?.token}
+          onSettingsOpen={() => setShowInviteLinkSettingsModal(true)}
+        />
+      )}
+    </div>
   );
 };

--- a/packages/ui/components/list/List.tsx
+++ b/packages/ui/components/list/List.tsx
@@ -93,7 +93,7 @@ export function ListLinkItem(props: ListLinkItemProps) {
     <li
       data-testid="list-link-item"
       className={classNames(
-        "group flex w-full items-center justify-between p-5 pb-4",
+        "group flex w-full flex-col gap-3 p-5 pb-4 sm:flex-row sm:items-center sm:justify-between",
         className,
         disabled ? "hover:bg-cal-muted" : ""
       )}>
@@ -101,13 +101,13 @@ export function ListLinkItem(props: ListLinkItemProps) {
         passHref
         href={href}
         className={classNames(
-          "text-default grow truncate text-sm",
+          "text-default min-w-0 grow text-sm",
           disabled ? "pointer-events-none cursor-not-allowed opacity-30" : ""
         )}>
-        <div className="flex items-center">
-          <h1 className="text-sm font-semibold leading-none">{heading}</h1>
+        <div className="flex flex-wrap items-center gap-1">
+          <h1 className="truncate text-sm font-semibold leading-none">{heading}</h1>
           {readOnly && (
-            <Badge data-testid="badge" variant="gray" className="ml-2">
+            <Badge data-testid="badge" variant="gray">
               {t("readonly")}
             </Badge>
           )}
@@ -118,7 +118,7 @@ export function ListLinkItem(props: ListLinkItemProps) {
         </h2>
         <div className="mt-2">{children}</div>
       </Link>
-      {actions}
+      <div className="flex shrink-0 items-center">{actions}</div>
     </li>
   );
 }


### PR DESCRIPTION
## Summary
- Removes the `LicenseRequired` wrapper from the team members view component
- Allows self-hosted users to view/add/remove team members without needing an enterprise license
- Basic team member management is core functionality that should not be gated

## Test plan
- [ ] Self-hosted instance without a license can view team members
- [ ] Self-hosted instance without a license can add team members
- [ ] Self-hosted instance without a license can remove team members

Fixes #23227

🤖 Generated with [Claude Code](https://claude.com/claude-code)