### PR TITLE
fix(tests): return sleep result from randomSleep function

### DIFF
--- a/packages/testing/performance/utils/config.js
+++ b/packages/testing/performance/utils/config.js
@@ -55,5 +55,5 @@ export function randomSleep(min = SLEEP_DURATION.SHORT, max = SLEEP_DURATION.MED
     throw new Error("min cannot be greater than max");
   }
   const sleepTime = Math.random() * (max - min) + min;
-  sleep(sleepTime);
+  return sleep(sleepTime);
 }


### PR DESCRIPTION
## Summary
- Returns the sleep function result from randomSleep for proper chaining
- Ensures consistent behavior in performance test utilities

## Test plan
- [x] Verify randomSleep still works correctly in k6 tests

Fixes #24030

🤖 Generated with [Claude Code](https://claude.com/claude-code)