### PR TITLE
fix(billing): allow team disbanding when Stripe is not configured

### DIFF
--- a/packages/features/ee/billing/service/teams/TeamBillingServiceFactory.ts
+++ b/packages/features/ee/billing/service/teams/TeamBillingServiceFactory.ts
@@ -1,3 +1,5 @@
+import { IS_STRIPE_ENABLED } from "@calcom/lib/constants";
+
 import type { IBillingRepository } from "../../repository/billing/IBillingRepository";
 import type { ITeamBillingDataRepository } from "../../repository/teamBillingData/ITeamBillingDataRepository";
 import type { IBillingProviderService } from "../billingProvider/IBillingProviderService";
@@ -19,7 +21,9 @@ export class TeamBillingServiceFactory {
 
   /** Initialize a single team billing */
   init(team: TeamBillingInput): ITeamBillingService {
-    if (!this.deps.isTeamBillingEnabled) {
+    // Use stub service if team billing is disabled OR if Stripe is not configured.
+    // This prevents errors when disbanding teams on self-hosted instances without Stripe.
+    if (!this.deps.isTeamBillingEnabled || !IS_STRIPE_ENABLED) {
       return new StubTeamBillingService(team);
     }
 


### PR DESCRIPTION
## Summary
- Fixes team disbanding failing on self-hosted instances when `STRIPE_PRIVATE_KEY` is not set
- Root cause: The `TeamBillingServiceFactory` was using the real billing service (which requires Stripe) even when Stripe was not configured
- Added an additional runtime check for `IS_STRIPE_ENABLED` to use the stub service when Stripe is unavailable

## Test plan
- [ ] Deploy on a self-hosted instance without `STRIPE_PRIVATE_KEY` configured
- [ ] Enable `HOSTED_CAL_FEATURES` (e.g., for commercial license)
- [ ] Create a team
- [ ] Attempt to disband the team
- [ ] Verify the team is successfully disbanded without errors

Fixes #25986

🤖 Generated with [Claude Code](https://claude.com/claude-code)