### PR TITLE
fix: disable workflow Save button when no changes made

### DIFF
--- a/apps/web/modules/ee/workflows/views/WorkflowPage.tsx
+++ b/apps/web/modules/ee/workflows/views/WorkflowPage.tsx
@@ -509,7 +509,7 @@ function WorkflowPage({
               </Tooltip>
               <Button
                 loading={updateMutation.isPending}
-                disabled={permissions.readOnly || updateMutation.isPending}
+                disabled={permissions.readOnly || updateMutation.isPending || !form.formState.isDirty}
                 data-testid="save-workflow"
                 type="submit"
                 size="sm"


### PR DESCRIPTION
## Summary
- Disables the workflow editor Save button when no changes have been made
- Previously the button was always enabled, allowing unnecessary saves

## Root Cause
The Save button's disabled state only checked for `permissions.readOnly` and `updateMutation.isPending`, but not whether the form had any changes (`form.formState.isDirty`).

## Fix
Added `!form.formState.isDirty` to the disabled condition, so the Save button is now disabled when:
- User doesn't have write permissions (`permissions.readOnly`)
- Save request is in progress (`updateMutation.isPending`)
- **No changes have been made to the form** (`!form.formState.isDirty`)

## Test plan
- [ ] Open an existing workflow for editing
- [ ] Without making any changes, verify Save button is disabled
- [ ] Make a change to the workflow (name, trigger, step, etc.)
- [ ] Verify Save button becomes enabled
- [ ] Save the changes
- [ ] Verify Save button becomes disabled again

Fixes #25971

🤖 Generated with [Claude Code](https://claude.com/claude-code)