### PR TITLE
fix(scripts): normalize paths for Windows compatibility in copy-app-store-static

### DIFF
--- a/apps/web/scripts/copy-app-store-static.js
+++ b/apps/web/scripts/copy-app-store-static.js
@@ -11,8 +11,10 @@ const copyAppStoreStatic = () => {
   const SVG_HASHES = {};
 
   staticFiles.forEach((file) => {
+    // Normalize path to use forward slashes (glob returns backslashes on Windows)
+    const normalizedFile = file.replace(/\\/g, "/");
     // Extract app name from path
-    const appNameMatch = file.match(/app-store\/(.*?)\/static/);
+    const appNameMatch = normalizedFile.match(/app-store\/(.*?)\/static/);
     if (!appNameMatch) return;
 
     const appDirName = appNameMatch[1];


### PR DESCRIPTION
## Summary
- Fixes app store static assets not being copied on Windows
- Root cause: glob returns paths with backslashes on Windows, but the regex pattern expected forward slashes
- Added path normalization to convert backslashes to forward slashes before regex matching

## Test plan
- [ ] Clone cal.com on Windows
- [ ] Run `yarn copy-app-store-static` from `apps/web`
- [ ] Verify files are copied to `apps/web/public/app-store/`
- [ ] Run `yarn dev` and verify app logos appear in the UI

Fixes #25777

🤖 Generated with [Claude Code](https://claude.com/claude-code)