### PR TITLE
fix: use base64 encoding for encryption key to ensure full AES-256 security

### DIFF
--- a/packages/lib/crypto.ts
+++ b/packages/lib/crypto.ts
@@ -12,8 +12,8 @@ const IV_LENGTH = 16; // AES blocksize
  *
  * @returns Encrypted value using key
  */
-export const symmetricEncrypt = function (text: string, key: string) {
-  const _key = Buffer.from(key, "latin1");
+export const symmetricEncrypt = (text: string, key: string): string => {
+  const _key = Buffer.from(key, "base64");
   const iv = crypto.randomBytes(IV_LENGTH);
   const cipher = crypto.createCipheriv(ALGORITHM, _key, iv);
   let ciphered = cipher.update(text, INPUT_ENCODING, OUTPUT_ENCODING);
@@ -28,8 +28,8 @@ export const symmetricEncrypt = function (text: string, key: string) {
  * @param text Value to decrypt
  * @param key Key used to decrypt value must be 32 bytes for AES256 encryption algorithm
  */
-export const symmetricDecrypt = function (text: string, key: string) {
-  const _key = Buffer.from(key, "latin1");
+export const symmetricDecrypt = (text: string, key: string): string => {
+  const _key = Buffer.from(key, "base64");
 
   const components = text.split(":");
   const iv_from_ciphertext = Buffer.from(components.shift() || "", OUTPUT_ENCODING);

--- a/packages/lib/crypto.ts
+++ b/packages/lib/crypto.ts
@@ -5,6 +5,20 @@ const INPUT_ENCODING = "utf8";
 const OUTPUT_ENCODING = "hex";
 const IV_LENGTH = 16; // AES blocksize
 
+function decryptWithKeyEncoding(
+  ciphertext: string,
+  ivHex: string,
+  key: string,
+  encoding: BufferEncoding
+): string {
+  const keyBuffer = Buffer.from(key, encoding);
+  const iv = Buffer.from(ivHex, OUTPUT_ENCODING);
+  const decipher = crypto.createDecipheriv(ALGORITHM, keyBuffer, iv);
+  let deciphered = decipher.update(ciphertext, OUTPUT_ENCODING, INPUT_ENCODING);
+  deciphered += decipher.final(INPUT_ENCODING);
+  return deciphered;
+}
+
 /**
  *
  * @param text Value to be encrypted
@@ -12,30 +26,31 @@ const IV_LENGTH = 16; // AES blocksize
  *
  * @returns Encrypted value using key
  */
-export const symmetricEncrypt = (text: string, key: string): string => {
-  const _key = Buffer.from(key, "base64");
+export function symmetricEncrypt(text: string, key: string): string {
+  const keyBuffer = Buffer.from(key, "base64");
   const iv = crypto.randomBytes(IV_LENGTH);
-  const cipher = crypto.createCipheriv(ALGORITHM, _key, iv);
+  const cipher = crypto.createCipheriv(ALGORITHM, keyBuffer, iv);
   let ciphered = cipher.update(text, INPUT_ENCODING, OUTPUT_ENCODING);
   ciphered += cipher.final(OUTPUT_ENCODING);
-  const ciphertext = `${iv.toString(OUTPUT_ENCODING)}:${ciphered}`;
 
-  return ciphertext;
-};
+  return `${iv.toString(OUTPUT_ENCODING)}:${ciphered}`;
+}
 
 /**
  *
  * @param text Value to decrypt
  * @param key Key used to decrypt value must be 32 bytes for AES256 encryption algorithm
+ *
+ * Tries base64 key encoding first, falls back to latin1 for legacy encrypted data
  */
-export const symmetricDecrypt = (text: string, key: string): string => {
-  const _key = Buffer.from(key, "base64");
-
+export function symmetricDecrypt(text: string, key: string): string {
   const components = text.split(":");
-  const iv_from_ciphertext = Buffer.from(components.shift() || "", OUTPUT_ENCODING);
-  const decipher = crypto.createDecipheriv(ALGORITHM, _key, iv_from_ciphertext);
-  let deciphered = decipher.update(components.join(":"), OUTPUT_ENCODING, INPUT_ENCODING);
-  deciphered += decipher.final(INPUT_ENCODING);
+  const ivHex = components.shift() || "";
+  const ciphertext = components.join(":");
 
-  return deciphered;
-};
+  try {
+    return decryptWithKeyEncoding(ciphertext, ivHex, key, "base64");
+  } catch {
+    return decryptWithKeyEncoding(ciphertext, ivHex, key, "latin1");
+  }
+}


### PR DESCRIPTION
## Summary
- Changes encryption key encoding from `latin1` to `base64` in `symmetricEncrypt` and `symmetricDecrypt` functions
- The previous latin1 encoding only used 6 bits of entropy per character when parsing base64-encoded keys, effectively reducing AES-256 to AES-192 security
- Using base64 encoding properly decodes the key to utilize all 256 bits

## Test plan
- [ ] Verify existing encrypted data can still be decrypted (requires migration for production deployments)
- [ ] Test encryption/decryption with `openssl rand -base64 32` generated keys
- [ ] Confirm the key length is exactly 32 bytes after base64 decoding

## Breaking Change
This is a **breaking change** for existing deployments. Existing encrypted data will not be decryptable with the new encoding. A migration strategy is recommended (e.g., `OLD_ENCRYPTION_KEY` environment variable for gradual migration).

Fixes #10805

🤖 Generated with [Claude Code](https://claude.com/claude-code)