### PR TITLE
fix: use cross-platform rm for Windows compatibility

### DIFF
--- a/packages/platform/enums/package.json
+++ b/packages/platform/enums/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "test": "jest ./tests",
-    "build": "rm -rf ./dist && tsc --build --force tsconfig.json",
+    "build": "node -e \"require('fs').rmSync('./dist',{recursive:true,force:true})\" && tsc --build --force tsconfig.json",
     "build:watch": "tsc --build --force ./tsconfig.json --watch",
     "post-install": "yarn build"
   },


### PR DESCRIPTION
## Summary
- Replaces `rm -rf ./dist` with Node.js built-in `fs.rmSync('./dist', {recursive: true, force: true})` in the platform-enums build script
- This fixes `yarn` installation failing on Windows where `rm` is not recognized

## Test plan
- [ ] Run `yarn` on Windows to verify installation completes
- [ ] Run `yarn build` in packages/platform/enums to verify build works
- [ ] Verify build still works on macOS/Linux

Fixes #25812

🤖 Generated with [Claude Code](https://claude.com/claude-code)