### PR TITLE
fix(auth): add trustHost for reverse proxy deployments

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -500,6 +500,9 @@ export const getOptions = ({
   /** Ad tracking data for Stripe customer metadata */
   getTrackingData: () => TrackingData;
 }): AuthOptions => ({
+  // Trust the host header from reverse proxies (Kubernetes ingress, nginx, etc.)
+  // This fixes redirect issues when deployed behind a proxy
+  trustHost: true,
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   adapter: calcomAdapter,


### PR DESCRIPTION
## Summary
- Adds `trustHost: true` to NextAuth options to properly handle the X-Forwarded-Host header from reverse proxies
- This fixes the issue where authentication redirects to `localhost:3000` instead of the configured domain when deployed behind Kubernetes ingress controllers, nginx, or other reverse proxies

## Test plan
- [ ] Deploy behind a reverse proxy (Kubernetes ingress, nginx, etc.)
- [ ] Set NEXTAUTH_URL and NEXT_PUBLIC_WEBAPP_URL to the public domain
- [ ] Verify authentication redirects to the correct domain instead of localhost:3000

Fixes #21921

🤖 Generated with [Claude Code](https://claude.com/claude-code)