### PR TITLE
fix: respect disableStandardEmails setting for cancellation emails

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -690,13 +690,17 @@ async function handler(input: CancelBookingInput) {
     const eventTypeMetadata = bookingToDelete?.eventType?.metadata as EventTypeMetadata;
     const disableStandardEmails = eventTypeMetadata?.disableStandardEmails;
 
-    if (!disableStandardEmails) {
+    const isHostDisabled = disableStandardEmails?.all?.host === true;
+    const isAttendeeDisabled = disableStandardEmails?.all?.attendee === true;
+    const shouldSkipEmail = isHostDisabled && isAttendeeDisabled;
+
+    if (!shouldSkipEmail) {
       // TODO: if emails fail try to requeue them
       if (!platformClientId || (platformClientId && arePlatformEmailsEnabled)) {
         await sendCancelledEmailsAndSMS(
           evt,
           { eventName: bookingToDelete?.eventType?.eventName },
-          eventTypeMetadata // Use the variable we just defined
+          eventTypeMetadata
         );
       }
     }

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -687,13 +687,19 @@ async function handler(input: CancelBookingInput) {
   }
 
   try {
-    // TODO: if emails fail try to requeue them
-    if (!platformClientId || (platformClientId && arePlatformEmailsEnabled))
-      await sendCancelledEmailsAndSMS(
-        evt,
-        { eventName: bookingToDelete?.eventType?.eventName },
-        bookingToDelete?.eventType?.metadata as EventTypeMetadata
-      );
+    const eventTypeMetadata = bookingToDelete?.eventType?.metadata as EventTypeMetadata;
+    const disableStandardEmails = eventTypeMetadata?.disableStandardEmails;
+
+    if (!disableStandardEmails) {
+      // TODO: if emails fail try to requeue them
+      if (!platformClientId || (platformClientId && arePlatformEmailsEnabled)) {
+        await sendCancelledEmailsAndSMS(
+          evt,
+          { eventName: bookingToDelete?.eventType?.eventName },
+          eventTypeMetadata // Use the variable we just defined
+        );
+      }
+    }
   } catch (error) {
     log.error("Error deleting event", error);
   }


### PR DESCRIPTION
Fixes #26417

## Description
Currently, the `BookingCancelledEmail` is sent even when the "Disable default emails" setting is enabled in the Event Type.

This PR adds a check for `eventType.metadata.disableStandardEmails` in `handleCancelBooking.ts`. If this setting is true, the default cancellation email will be skipped.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
1. Create an Event Type and enable "Disable default emails" in the Advanced settings.
2. Book a meeting for this event type.
3. Cancel the meeting.
4. Verify that the Booker and Organizer do NOT receive the default cancellation email.