### PR TITLE
feat: reuse PR-creator Devin session when addressing Cubic AI reviews

### DIFF
--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -46,7 +46,7 @@ jobs:
             
             core.setOutput('has-prompt', 'true');
 
-      - name: Check for existing Devin session from PR comments
+      - name: Check for existing Devin session
         if: steps.extract-prompt.outputs.has-prompt == 'true'
         id: check-session
         uses: actions/github-script@v7
@@ -54,56 +54,73 @@ jobs:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
         with:
           script: |
+            async function checkSessionStatus(sessionId) {
+              const response = await fetch(`https://api.devin.ai/v1/sessions/${sessionId}`, {
+                headers: {
+                  'Authorization': `Bearer ${process.env.DEVIN_API_KEY}`,
+                  'Content-Type': 'application/json'
+                }
+              });
+              
+              if (!response.ok) {
+                console.log(`Failed to fetch session ${sessionId}: ${response.status}`);
+                return null;
+              }
+              
+              return await response.json();
+            }
+            
+            // First, check PR description for the original Devin session that created the PR
+            const prBody = context.payload.pull_request.body || '';
+            const prSessionMatch = prBody.match(/app\.devin\.ai\/sessions\/([a-f0-9-]+)/);
+            
+            if (prSessionMatch) {
+              const sessionId = prSessionMatch[1];
+              console.log(`Found session ID from PR description: ${sessionId}`);
+              
+              const session = await checkSessionStatus(sessionId);
+              if (session) {
+                console.log(`PR creator session ${sessionId} status: ${session.status_enum}`);
+                core.exportVariable('EXISTING_SESSION_ID', sessionId);
+                core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
+                core.setOutput('has-active-session', 'true');
+                return;
+              }
+            }
+            
+            // Fallback: check PR comments for sessions from previous Cubic AI reviews
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number
             });
             
-            let sessionId = null;
             for (const comment of comments.data.reverse()) {
               if (comment.body.includes('Devin AI is addressing Cubic AI')) {
                 const match = comment.body.match(/app\.devin\.ai\/sessions\/([a-f0-9-]+)/);
                 if (match) {
-                  sessionId = match[1];
-                  break;
+                  const sessionId = match[1];
+                  console.log(`Found session ID from comment: ${sessionId}`);
+                  
+                  const session = await checkSessionStatus(sessionId);
+                  if (session) {
+                    const activeStatuses = ['working', 'blocked', 'resumed'];
+                    if (activeStatuses.includes(session.status_enum)) {
+                      console.log(`Comment session ${sessionId} is active (status: ${session.status_enum})`);
+                      core.exportVariable('EXISTING_SESSION_ID', sessionId);
+                      core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
+                      core.setOutput('has-active-session', 'true');
+                      return;
+                    } else {
+                      console.log(`Comment session ${sessionId} is not active (status: ${session.status_enum})`);
+                    }
+                  }
                 }
               }
             }
             
-            if (!sessionId) {
-              console.log('No existing Devin session found in PR comments');
-              core.setOutput('has-active-session', 'false');
-              return;
-            }
-            
-            console.log(`Found session ID from comment: ${sessionId}`);
-            
-            const response = await fetch(`https://api.devin.ai/v1/sessions/${sessionId}`, {
-              headers: {
-                'Authorization': `Bearer ${process.env.DEVIN_API_KEY}`,
-                'Content-Type': 'application/json'
-              }
-            });
-            
-            if (!response.ok) {
-              console.log(`Failed to fetch session details: ${response.status}`);
-              core.setOutput('has-active-session', 'false');
-              return;
-            }
-            
-            const session = await response.json();
-            const activeStatuses = ['working', 'blocked', 'resumed'];
-            
-            if (activeStatuses.includes(session.status_enum)) {
-              console.log(`Session ${sessionId} is active (status: ${session.status_enum})`);
-              core.exportVariable('EXISTING_SESSION_ID', sessionId);
-              core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
-              core.setOutput('has-active-session', 'true');
-            } else {
-              console.log(`Session ${sessionId} is not active (status: ${session.status_enum})`);
-              core.setOutput('has-active-session', 'false');
-            }
+            console.log('No active Devin session found');
+            core.setOutput('has-active-session', 'false');
 
       - name: Send message to existing Devin session
         if: steps.extract-prompt.outputs.has-prompt == 'true' && steps.check-session.outputs.has-active-session == 'true'

--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -77,11 +77,15 @@ jobs:
             if (prSessionMatch) {
               const sessionId = prSessionMatch[1];
               console.log(`PR was created by Devin session: ${sessionId}`);
-              console.log('Using PR creator session for all Cubic reviews');
-              core.exportVariable('EXISTING_SESSION_ID', sessionId);
-              core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
-              core.setOutput('has-active-session', 'true');
-              return;
+              
+              const session = await checkSessionStatus(sessionId);
+              if (session) {
+                console.log(`PR creator session status: ${session.status_enum}`);
+                core.exportVariable('EXISTING_SESSION_ID', sessionId);
+                core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
+                core.setOutput('has-active-session', 'true');
+                return;
+              }
             }
             
             // PR was not created through Devin - check comments for previous Cubic review sessions
@@ -91,32 +95,42 @@ jobs:
               issue_number: context.payload.pull_request.number
             });
             
+            let sessionId = null;
             for (const comment of comments.data.reverse()) {
               if (comment.body.includes('Devin AI is addressing Cubic AI')) {
                 const match = comment.body.match(/app\.devin\.ai\/sessions\/([a-f0-9-]+)/);
                 if (match) {
-                  const sessionId = match[1];
-                  console.log(`Found session ID from previous Cubic review: ${sessionId}`);
-                  
-                  const session = await checkSessionStatus(sessionId);
-                  if (session) {
-                    const activeStatuses = ['working', 'blocked', 'resumed'];
-                    if (activeStatuses.includes(session.status_enum)) {
-                      console.log(`Session ${sessionId} is active (status: ${session.status_enum}), reusing it`);
-                      core.exportVariable('EXISTING_SESSION_ID', sessionId);
-                      core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
-                      core.setOutput('has-active-session', 'true');
-                      return;
-                    } else {
-                      console.log(`Session ${sessionId} is not active (status: ${session.status_enum})`);
-                    }
-                  }
+                  sessionId = match[1];
+                  break;
                 }
               }
             }
             
-            console.log('No existing session to reuse, will create new session');
-            core.setOutput('has-active-session', 'false');
+            if (!sessionId) {
+              console.log('No existing Devin session found in PR comments');
+              core.setOutput('has-active-session', 'false');
+              return;
+            }
+            
+            console.log(`Found session ID from comment: ${sessionId}`);
+            
+            const session = await checkSessionStatus(sessionId);
+            if (!session) {
+              core.setOutput('has-active-session', 'false');
+              return;
+            }
+            
+            const activeStatuses = ['working', 'blocked', 'resumed'];
+            
+            if (activeStatuses.includes(session.status_enum)) {
+              console.log(`Session ${sessionId} is active (status: ${session.status_enum})`);
+              core.exportVariable('EXISTING_SESSION_ID', sessionId);
+              core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
+              core.setOutput('has-active-session', 'true');
+            } else {
+              console.log(`Session ${sessionId} is not active (status: ${session.status_enum})`);
+              core.setOutput('has-active-session', 'false');
+            }
 
       - name: Send message to existing Devin session
         if: steps.extract-prompt.outputs.has-prompt == 'true' && steps.check-session.outputs.has-active-session == 'true'

--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -88,7 +88,7 @@ jobs:
               }
             }
             
-            // PR was not created through Devin - check comments for previous Cubic review sessions
+            // PR was not created through Devin - check for existing Devin session from PR comments
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -70,25 +70,21 @@ jobs:
               return await response.json();
             }
             
-            // First, check PR description for the original Devin session that created the PR
+            // If PR was created through Devin, always use that session
             const prBody = context.payload.pull_request.body || '';
             const prSessionMatch = prBody.match(/app\.devin\.ai\/sessions\/([a-f0-9-]+)/);
             
             if (prSessionMatch) {
               const sessionId = prSessionMatch[1];
-              console.log(`Found session ID from PR description: ${sessionId}`);
-              
-              const session = await checkSessionStatus(sessionId);
-              if (session) {
-                console.log(`PR creator session ${sessionId} status: ${session.status_enum}`);
-                core.exportVariable('EXISTING_SESSION_ID', sessionId);
-                core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
-                core.setOutput('has-active-session', 'true');
-                return;
-              }
+              console.log(`PR was created by Devin session: ${sessionId}`);
+              console.log('Using PR creator session for all Cubic reviews');
+              core.exportVariable('EXISTING_SESSION_ID', sessionId);
+              core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
+              core.setOutput('has-active-session', 'true');
+              return;
             }
             
-            // Fallback: check PR comments for sessions from previous Cubic AI reviews
+            // PR was not created through Devin - check comments for previous Cubic review sessions
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -100,26 +96,26 @@ jobs:
                 const match = comment.body.match(/app\.devin\.ai\/sessions\/([a-f0-9-]+)/);
                 if (match) {
                   const sessionId = match[1];
-                  console.log(`Found session ID from comment: ${sessionId}`);
+                  console.log(`Found session ID from previous Cubic review: ${sessionId}`);
                   
                   const session = await checkSessionStatus(sessionId);
                   if (session) {
                     const activeStatuses = ['working', 'blocked', 'resumed'];
                     if (activeStatuses.includes(session.status_enum)) {
-                      console.log(`Comment session ${sessionId} is active (status: ${session.status_enum})`);
+                      console.log(`Session ${sessionId} is active (status: ${session.status_enum}), reusing it`);
                       core.exportVariable('EXISTING_SESSION_ID', sessionId);
                       core.exportVariable('SESSION_URL', `https://app.devin.ai/sessions/${sessionId}`);
                       core.setOutput('has-active-session', 'true');
                       return;
                     } else {
-                      console.log(`Comment session ${sessionId} is not active (status: ${session.status_enum})`);
+                      console.log(`Session ${sessionId} is not active (status: ${session.status_enum})`);
                     }
                   }
                 }
               }
             }
             
-            console.log('No active Devin session found');
+            console.log('No existing session to reuse, will create new session');
             core.setOutput('has-active-session', 'false');
 
       - name: Send message to existing Devin session


### PR DESCRIPTION
## What does this PR do?

Updates the Cubic AI to Devin review workflow to prioritize reusing the original Devin session that created a PR when addressing Cubic AI review feedback.

**Session reuse logic:**
1. If PR was created through Devin (has session URL in PR description) → Always use that session for all Cubic reviews
2. If PR was NOT created through Devin → Reuse session from previous "Devin AI is addressing Cubic AI" comments if active, otherwise create new session

This ensures continuity when Devin addresses multiple rounds of Cubic AI feedback on the same PR.

Link to Devin run: https://app.devin.ai/sessions/a14c168d0f11439db44860592bd04eb1
Requested by: @anikdhabal

## Updates since last revision

- Added `checkSessionStatus` helper function that's now used for both PR description sessions and comment sessions
- PR-creator sessions are verified via API before use (but don't require active status)
- Comment sessions still require active status (`working`, `blocked`, `resumed`) to be reused

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow change only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This is a CI workflow change that can only be tested by triggering the actual workflow:

1. Create a PR through Devin (PR description will contain Devin session URL)
2. Wait for Cubic AI to submit a review with feedback
3. Verify the workflow sends a message to the original PR-creator session instead of creating a new one
4. For PRs NOT created through Devin: verify it reuses sessions from previous Cubic review comments

## Human Review Checklist

- [ ] Verify the regex `app\.devin\.ai\/sessions\/([a-f0-9-]+)` correctly matches Devin session URLs in PR descriptions
- [ ] Confirm `checkSessionStatus` helper is correctly used for both PR description and comment session checks
- [ ] Verify PR-creator sessions are used regardless of status (only need to exist), while comment sessions require active status

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings