### PR TITLE
chore: delete cached build after bundle analysis completes

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -68,3 +68,9 @@ jobs:
         with:
           name: bundle
           path: apps/web/.next/analyze/__bundle_analysis.json
+
+      - name: Delete cached build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh cache list --key prod-build-main- --json id --jq '.[].id' | xargs -I {} gh cache delete {} || true

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -70,7 +70,7 @@ jobs:
           path: apps/web/.next/analyze/__bundle_analysis.json
 
       - name: Delete cached build
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh cache list --key prod-build-main- --json id --jq '.[].id' | xargs -I {} gh cache delete {} || true
+        uses: useblacksmith/cache-delete@v1
+        with:
+          key: prod-build-main-
+          prefix: "true"


### PR DESCRIPTION
## What does this PR do?

Adds a cleanup step to the `nextjs-bundle-analysis.yml` workflow that deletes the cached production build after the bundle analysis is complete. This prevents `prod-build-main-*` cache entries from accumulating in Blacksmith.

Uses `useblacksmith/cache-delete@v1` action with prefix matching, consistent with the pattern in `delete-blacksmith-cache.yml`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI workflow change that will be validated when the workflow runs.

## How should this be tested?

1. Merge this PR
2. Wait for the next push to `main` that triggers the bundle analysis workflow
3. Verify that after the workflow completes, there are no `prod-build-main-*` cache entries remaining in the GitHub Actions cache

## Human Review Checklist

- [ ] Verify the cache key pattern `prod-build-main-` correctly matches the keys generated by `cache-build-key` action
- [ ] Confirm `useblacksmith/cache-delete@v1` action is appropriate for this use case (matches pattern in `delete-blacksmith-cache.yml`)

<!-- Link to Devin run: https://app.devin.ai/sessions/e3ead48ad4b24d8092b075a5261046ef -->
<!-- Requested by: @keithwillcode -->