### PR TITLE
fix: switch conflict resolver from push to schedule trigger to save runner costs

### DIFF
--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -1,9 +1,11 @@
 name: Devin PR Conflict Resolver
 
 on:
-  push:
-    branches:
-      - main
+  # Run every 5 minutes instead of on push to main.
+  # This saves runner costs by avoiding the 20-second sleep that was needed
+  # to wait for GitHub to compute mergeable status after merges to main.
+  schedule:
+    - cron: '*/5 * * * *'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -152,10 +154,7 @@ jobs:
             }
             
             if (unknownPRs.length > 0) {
-              console.log(`\n${unknownPRs.length} PRs have UNKNOWN mergeable status, waiting 20 seconds before retrying...`);
-              await new Promise(resolve => setTimeout(resolve, 20000));
-              
-              console.log(`Retrying ${unknownPRs.length} PRs via REST API...`);
+              console.log(`\n${unknownPRs.length} PRs have UNKNOWN mergeable status, retrying via REST API...`);
               
               for (const pr of unknownPRs) {
                 try {
@@ -181,7 +180,7 @@ jobs:
                     conflictingPRs.push(result.data);
                     if (result.isTargetPR) break;
                   } else if (result.unknown) {
-                    console.log(`PR #${pr.number} still has UNKNOWN status after retry`);
+                    console.log(`PR #${pr.number} still has UNKNOWN status, will be checked on next run`);
                   }
                 } catch (error) {
                   console.error(`Error retrying PR #${pr.number}: ${error.message}`);


### PR DESCRIPTION
## What does this PR do?

Switches the Devin PR Conflict Resolver workflow from a `push` trigger to a `schedule` trigger (every 5 minutes) to save Blacksmith runner costs.

**Problem:** When the workflow triggered on push to main, it had to wait 20 seconds for GitHub to compute the mergeable status of all open PRs. This sleep time was consuming runner costs unnecessarily.

**Solution:** By switching to a scheduled trigger, the workflow runs periodically when GitHub has already computed the mergeable status, eliminating the need for the 20-second sleep.

**Trade-off:** Conflicts are now detected within 5 minutes of a push to main instead of immediately. Manual triggering via `workflow_dispatch` is still available for urgent cases.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - workflow changes can only be tested in production.

## How should this be tested?

1. Merge a PR to main
2. Wait up to 5 minutes for the scheduled workflow to run
3. Verify that PRs with conflicts are detected and Devin sessions are created
4. Confirm the workflow no longer has the 20-second sleep in the logs

## Human Review Checklist

- [ ] Verify the 5-minute schedule interval is acceptable for conflict detection timing
- [ ] Confirm PRs with UNKNOWN status being deferred to the next run is acceptable behavior

---

Link to Devin run: https://app.devin.ai/sessions/45bd1efe46a0416ea9acedb0081da987
Requested by: @keithwillcode