### PR TITLE
fix(ci): improve conflict resolver prompt to prevent bad merge commits

### DIFF
--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -226,11 +226,11 @@ jobs:
             IMPORTANT: This PR is from a fork. The contributor has enabled "Allow edits from maintainers".
             - Clone the FORK repository: ${pr.head_repo_owner}/${pr.head_repo_name}
             - The branch to work on is: ${pr.head_ref}
-            - Add the upstream remote: git remote add upstream https://github.com/${owner}/${repo}.git
-            - Fetch upstream and merge: git fetch upstream && git merge upstream/${pr.base_ref}` : `
+            - Add the upstream remote for ${owner}/${repo}
+            - Fetch and merge the upstream ${pr.base_ref} branch using standard git merge` : `
             - Clone the repository: ${owner}/${repo}
             - Check out the PR branch: ${pr.head_ref}
-            - Merge the base branch: git merge origin/${pr.base_ref}`;
+            - Merge the base branch (${pr.base_ref}) using standard git merge`;
               
               const prompt = `You are resolving merge conflicts on PR #${pr.number} in repository ${owner}/${repo}.
 
@@ -251,8 +251,15 @@ jobs:
                - If unsure about a conflict, prefer keeping both changes where possible
             2. Test that the code still works after resolving conflicts (run lint/type checks).
             3. Commit the merge resolution with a clear commit message.
-            4. Push the resolved changes to the PR branch.
-            5. After successfully pushing the resolved changes, remove the \`devin-conflict-resolution\` label from the PR using the GitHub API.
+            4. CRITICAL VALIDATION BEFORE PUSHING: You MUST validate your merge commit before pushing:
+               - Run: git diff --stat HEAD^1...HEAD (shows changes relative to PR branch parent)
+               - Run: git diff --stat HEAD^2...HEAD (shows changes relative to base branch parent)
+               - The changes relative to the base branch parent (HEAD^2) should be SIMILAR to the original PR changes, NOT include all the new commits from ${pr.base_ref}
+               - If your merge commit shows hundreds of files changed or includes changes that were already in ${pr.base_ref}, STOP IMMEDIATELY
+               - A proper merge commit only contains conflict resolutions, not reproduced changes from the target branch
+               - If validation fails: DO NOT PUSH. Log the error, explain what went wrong, and abort the task.
+            5. Push the resolved changes to the PR branch only after validation passes.
+            6. After successfully pushing the resolved changes, remove the \`devin-conflict-resolution\` label from the PR using the GitHub API.
 
             Rules and Guidelines:
             1. Be careful when resolving conflicts - understand the context of both changes.
@@ -260,7 +267,8 @@ jobs:
             3. Run lint and type checks before pushing to ensure the code is valid.
             4. If a conflict seems too complex or risky to resolve automatically, explain the situation in a PR comment instead.
             5. Never ask for user confirmation. Never wait for user messages.
-            6. CRITICAL: If this is a fork PR and you encounter ANY error when pushing (permission denied, authentication failure, etc.), you MUST fail the task immediately. Do NOT attempt to push to a new branch in the main ${owner}/${repo} repository as a workaround. Simply report the error and stop.`;
+            6. CRITICAL: If this is a fork PR and you encounter ANY error when pushing (permission denied, authentication failure, etc.), you MUST fail the task immediately. Do NOT attempt to push to a new branch in the main ${owner}/${repo} repository as a workaround. Simply report the error and stop.
+            7. CRITICAL: Never reproduce or recreate changes from the target branch. Your merge commit should ONLY contain conflict resolutions. If you find yourself manually copying file contents from ${pr.base_ref} or creating changes that mirror what's already in ${pr.base_ref}, you are doing it wrong. Use git's merge functionality properly - it handles bringing in changes automatically.`;
 
               try {
                 const response = await fetch('https://api.devin.ai/v1/sessions', {


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the Devin conflict resolver was creating merge commits that reproduced all changes from the target branch instead of properly merging them. This was observed in [PR #26117](https://github.com/calcom/cal.com/pull/26117/commits/dd523e82030b06679c24d6111cfb1108e7c16759) where the merge commit showed thousands of file changes that were already in main.

Changes:
- Removed explicit git commands from the prompt to avoid Devin misinterpreting them
- Added a validation step requiring Devin to check `git diff --stat HEAD^1...HEAD` and `HEAD^2...HEAD` before pushing
- Added explicit rule to never reproduce/recreate changes from the target branch

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow change only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This is a prompt change for the Devin conflict resolver workflow. To test:
1. Wait for a PR to have merge conflicts
2. Let the workflow trigger a Devin session
3. Verify Devin performs the validation step before pushing
4. Verify the resulting merge commit only contains conflict resolutions, not reproduced changes from main

## Human Review Checklist

- [ ] Verify the validation logic using `HEAD^1` (PR branch parent) and `HEAD^2` (base branch parent) is correct for detecting bad merges
- [ ] Consider if the instructions might cause false positives on legitimate large conflict resolutions

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/26e3a13396064e4b871cbf0dd00ffcb0
Requested by: @keithwillcode