### PR TITLE
fix: make BookingReferenceRepository integration tests use unique identifiers

### DIFF
--- a/packages/features/bookingReference/repositories/BookingReferenceRepository.integration-test.ts
+++ b/packages/features/bookingReference/repositories/BookingReferenceRepository.integration-test.ts
@@ -5,6 +5,8 @@ import type { Booking, Credential, User } from "@calcom/prisma/client";
 
 import { BookingReferenceRepository } from "./BookingReferenceRepository";
 
+const testRunId = `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+
 describe("BookingReferenceRepository Integration Tests", () => {
   let testUser: User;
   let testCredential: Credential;
@@ -14,8 +16,8 @@ describe("BookingReferenceRepository Integration Tests", () => {
   beforeAll(async () => {
     testUser = await prisma.user.create({
       data: {
-        email: "bookingreference-test@example.com",
-        username: "bookingreference-test",
+        email: `bookingreference-test-${testRunId}@example.com`,
+        username: `bookingreference-test-${testRunId}`,
       },
     });
 
@@ -29,7 +31,7 @@ describe("BookingReferenceRepository Integration Tests", () => {
 
     testBooking = await prisma.booking.create({
       data: {
-        uid: "test-booking-uid-123",
+        uid: `test-booking-uid-${testRunId}`,
         title: "Test Booking",
         startTime: new Date(),
         endTime: new Date(),
@@ -52,19 +54,25 @@ describe("BookingReferenceRepository Integration Tests", () => {
   });
 
   afterAll(async () => {
-    await prisma.booking.delete({
+    await prisma.bookingReference.deleteMany({
+      where: {
+        bookingId: testBooking.id,
+      },
+    });
+
+    await prisma.booking.deleteMany({
       where: {
         id: testBooking.id,
       },
     });
 
-    await prisma.credential.delete({
+    await prisma.credential.deleteMany({
       where: {
         id: testCredential.id,
       },
     });
 
-    await prisma.user.delete({
+    await prisma.user.deleteMany({
       where: {
         id: testUser.id,
       },


### PR DESCRIPTION
## What does this PR do?

Fixes flaky integration tests in `BookingReferenceRepository.integration-test.ts` that were failing intermittently in CI.

**Root cause:** The tests used fixed identifiers (email: `bookingreference-test@example.com`, username: `bookingreference-test`, uid: `test-booking-uid-123`) that could conflict across parallel test runs or with leftover data from previous runs.

**CI failure link:** https://github.com/calcom/cal.com/actions/runs/20882312663/job/60000883109?pr=26698

**Changes:**
- Add unique `testRunId` using timestamp + random suffix to ensure test isolation
- Use `testRunId` in email, username, and booking uid
- Change `afterAll` cleanup from `delete` to `deleteMany` to prevent failures when records are already deleted
- Add explicit cleanup of booking references before booking deletion

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - test-only changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This fix will be validated by CI when the integration tests run. The tests should now pass consistently without the previous flaky failures:
- `should not return soft-deleted references in regular queries`
- `should allow querying soft-deleted references explicitly`

The fix ensures each test run creates unique test data that won't conflict with parallel runs or leftover data.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> [!NOTE]
> This PR was created by [Devin](https://app.devin.ai/sessions/3ff15b2305d4479d8ac5a67b6b7759e1) at the request of @anikdhabal.