### PR TITLE
fix: refactor cache-checkout to use actions/cache@v4 with fallback

### DIFF
--- a/.github/actions/cache-checkout/action.yml
+++ b/.github/actions/cache-checkout/action.yml
@@ -1,17 +1,11 @@
 name: Cache Git Checkout
-description: "Save or restore git checkout from cache to speed up CI workflows"
-inputs:
-  mode:
-    description: "Mode of operation: 'save' to cache the checkout, 'restore' to restore from cache"
-    required: true
-
+description: "Cache or restore git checkout to speed up CI workflows"
 runs:
   using: "composite"
   steps:
-    - name: Restore git checkout from cache
-      if: ${{ inputs.mode == 'restore' }}
-      uses: actions/cache/restore@v4
-      id: cache-restore
+    - name: Cache git checkout
+      uses: actions/cache@v4
+      id: cache-checkout
       with:
         path: |
           .
@@ -19,15 +13,14 @@ runs:
           !node_modules
           !**/node_modules
         key: git-checkout-${{ github.head_ref || github.ref_name }}-${{ github.event.pull_request.head.sha || github.sha }}
-        fail-on-cache-miss: true
-
-    - name: Save git checkout to cache
-      if: ${{ inputs.mode == 'save' }}
-      uses: actions/cache/save@v4
+    - name: Checkout PR code (on cache miss)
+      if: steps.cache-checkout.outputs.cache-hit != 'true'
+      uses: actions/checkout@v4
       with:
-        path: |
-          .
-          !.git
-          !node_modules
-          !**/node_modules
-        key: git-checkout-${{ github.head_ref || github.ref_name }}-${{ github.event.pull_request.head.sha || github.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 2
+        sparse-checkout-cone-mode: false
+        sparse-checkout: |
+          /*
+          !/example-apps/
+          !**/*.mp4

--- a/.github/workflows/api-v1-production-build.yml
+++ b/.github/workflows/api-v1-production-build.yml
@@ -68,8 +68,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
       - name: Cache API v1 production build

--- a/.github/workflows/api-v2-production-build.yml
+++ b/.github/workflows/api-v2-production-build.yml
@@ -38,8 +38,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - name: Generate Prisma schemas
         working-directory: apps/api/v2

--- a/.github/workflows/api-v2-unit-tests.yml
+++ b/.github/workflows/api-v2-unit-tests.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - name: Run API v2 unit tests

--- a/.github/workflows/atoms-production-build.yml
+++ b/.github/workflows/atoms-production-build.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - name: Cache atoms production build
         uses: actions/cache@v4

--- a/.github/workflows/check-api-v2-breaking-changes.yml
+++ b/.github/workflows/check-api-v2-breaking-changes.yml
@@ -37,8 +37,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
 
       - name: Generate Swagger

--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - name: Show info
         run: node -e "console.log(require('v8').getHeapStatistics())"

--- a/.github/workflows/companion-build.yml
+++ b/.github/workflows/companion-build.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - name: Cache Docs build
         uses: actions/cache@v4
         id: cache-docs-build

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -77,8 +77,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
       - name: Build platform packages with Turbo

--- a/.github/workflows/e2e-app-store.yml
+++ b/.github/workflows/e2e-app-store.yml
@@ -84,8 +84,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e-embed-react.yml
+++ b/.github/workflows/e2e-embed-react.yml
@@ -76,8 +76,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -84,8 +84,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,8 +85,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - run: yarn prisma generate

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,8 +82,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - uses: ./.github/actions/cache-db

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - name: Run Lint
         run: yarn lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -174,11 +174,7 @@ jobs:
       db-cache-hit: ${{ steps.cache-db-check.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
-      - name: Cache git checkout
-        uses: ./.github/actions/cache-checkout
-        with:
-          mode: save
+      - uses: ./.github/actions/cache-checkout
       - name: Generate DB cache key
         id: cache-db-key
         uses: ./.github/actions/cache-db-key

--- a/.github/workflows/production-build-without-database.yml
+++ b/.github/workflows/production-build-without-database.yml
@@ -46,8 +46,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - name: Generate cache key

--- a/.github/workflows/setup-db.yml
+++ b/.github/workflows/setup-db.yml
@@ -50,8 +50,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
         if: inputs.DB_CACHE_HIT != 'true'
       - run: yarn prisma generate

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/cache-checkout
-        with:
-          mode: restore
       - uses: ./.github/actions/yarn-install
       - run: yarn prisma generate
       - run: yarn test -- --no-isolate


### PR DESCRIPTION
## What does this PR do?

Fixes cache propagation delay issues with Blacksmith's distributed cache that were causing CI failures.

**Root cause:** The Prepare job saves the cache, but subsequent jobs starting ~14 seconds later couldn't find it because the cache hadn't propagated yet in Blacksmith's distributed system. The previous implementation used separate `actions/cache/save@v4` and `actions/cache/restore@v4` with `fail-on-cache-miss: true`, which caused immediate failures.

**Solution:** Refactored `cache-checkout` to use `actions/cache@v4` (combined save/restore) with a fallback to do the checkout if cache miss occurs. This matches the pattern used by `cache-build` and `cache-db` which don't have this issue.

Changes:
- Refactored `cache-checkout` action to use `actions/cache@v4` instead of separate save/restore
- Added fallback checkout step when cache miss occurs (using same sparse-checkout config as `dangerous-git-checkout`)
- Removed `mode` input (no longer needed)
- Updated all 19 workflow files to use the simplified `cache-checkout` action
- Removed separate `dangerous-git-checkout` step from `pr.yml` Prepare job (now handled by cache-checkout)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow changes only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI workflow changes can only be tested by running the actual CI pipeline.

## How should this be tested?

1. Create/update a PR to trigger the CI workflow
2. Observe the Prepare job - it should save the cache on first run (cache miss triggers checkout)
3. Observe subsequent jobs (type-check, lint, etc.) - they should either:
   - Hit the cache and skip checkout, OR
   - Miss the cache and perform checkout via the fallback step (instead of failing)
4. Verify all CI jobs complete successfully

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the fallback checkout uses correct ref (`github.event.pull_request.head.sha`) in all workflow contexts
- [ ] Confirm cache key format is unchanged for backward compatibility
- [ ] Run CI on this PR to validate the fix works

<!-- Link to Devin run: https://app.devin.ai/sessions/2405788a416e4f6783e001b35e05bfbd -->
<!-- Requested by: @keithwillcode -->