### PR TITLE
fix: add fallback for ref parameter in cache-checkout action

### DIFF
--- a/.github/actions/cache-checkout/action.yml
+++ b/.github/actions/cache-checkout/action.yml
@@ -17,7 +17,7 @@ runs:
       if: steps.cache-checkout.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
         fetch-depth: 2
         sparse-checkout-cone-mode: false
         sparse-checkout: |


### PR DESCRIPTION
## What does this PR do?

Addresses feedback from [cubic's review on PR #26702](https://github.com/calcom/cal.com/pull/26702#discussion_r2678917911).

The `cache-checkout` action's fallback checkout step was missing a fallback for the `ref` parameter, which would break the action in non-PR contexts (e.g., `workflow_dispatch`). The cache key already correctly uses `${{ github.event.pull_request.head.sha || github.sha }}` but the checkout `ref` lacked the same fallback.

This PR adds the `|| github.sha` fallback to match the cache key pattern.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow changes only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI workflow changes can only be tested by running the actual CI pipeline.

## How should this be tested?

1. Trigger a workflow that uses `cache-checkout` via `workflow_dispatch` (non-PR context)
2. Verify the checkout step succeeds using `github.sha` as the fallback ref

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the fallback `|| github.sha` is appropriate for all workflow contexts where this action is used
- [ ] Confirm the pattern matches the cache key on line 15

<!-- Link to Devin run: https://app.devin.ai/sessions/bedeaf62912e4892aceebc2e3b26c2f1 -->
<!-- Requested by: @keithwillcode -->