### PR TITLE
fix: add Exchange Server 2016 on-premise support

### DIFF
--- a/apps/web/components/apps/exchange2016calendar/Setup.tsx
+++ b/apps/web/components/apps/exchange2016calendar/Setup.tsx
@@ -7,7 +7,9 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Alert } from "@calcom/ui/components/alert";
 import { Button } from "@calcom/ui/components/button";
 import { Form } from "@calcom/ui/components/form";
-import { TextField } from "@calcom/ui/components/form";
+import { SelectField, TextField } from "@calcom/ui/components/form";
+
+import { ExchangeAuthentication } from "@calcom/app-store/exchange2016calendar/enums";
 
 export default function Exchange2016CalendarSetup() {
   const { t } = useLocale();
@@ -17,8 +19,14 @@ export default function Exchange2016CalendarSetup() {
       username: "",
       password: "",
       url: process.env.EXCHANGE_DEFAULT_EWS_URL || "",
+      authenticationMethod: ExchangeAuthentication.NTLM,
     },
   });
+
+  const authenticationOptions = [
+    { value: ExchangeAuthentication.STANDARD, label: "Standard (Basic Auth)" },
+    { value: ExchangeAuthentication.NTLM, label: "NTLM (Windows Auth)" },
+  ];
 
   const [errorMessage, setErrorMessage] = useState("");
 
@@ -76,6 +84,11 @@ export default function Exchange2016CalendarSetup() {
                   label="Password"
                   placeholder="•••••••••••••"
                   autoComplete="password"
+                />
+                <SelectField
+                  label="Authentication Method"
+                  options={authenticationOptions}
+                  {...form.register("authenticationMethod", { valueAsNumber: true })}
                 />
               </fieldset>
 

--- a/packages/app-store/exchange2016calendar/api/add.ts
+++ b/packages/app-store/exchange2016calendar/api/add.ts
@@ -8,6 +8,7 @@ import { defaultResponder } from "@calcom/lib/server/defaultResponder";
 import prisma from "@calcom/prisma";
 
 import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+import { ExchangeAuthentication, ExchangeVersion } from "../enums";
 import { BuildCalendarService } from "../lib";
 
 const bodySchema = z
@@ -15,6 +16,8 @@ const bodySchema = z
     username: z.string(),
     password: z.string(),
     url: z.string().url(),
+    authenticationMethod: z.number().default(ExchangeAuthentication.NTLM),
+    exchangeVersion: z.number().default(ExchangeVersion.Exchange2016),
   })
   .strict();
 

--- a/packages/app-store/exchange2016calendar/enums.ts
+++ b/packages/app-store/exchange2016calendar/enums.ts
@@ -1,0 +1,4 @@
+export enum ExchangeAuthentication {
+  STANDARD = 0,
+  NTLM = 1,
+}

--- a/packages/app-store/exchange2016calendar/enums.ts
+++ b/packages/app-store/exchange2016calendar/enums.ts
@@ -2,3 +2,13 @@ export enum ExchangeAuthentication {
   STANDARD = 0,
   NTLM = 1,
 }
+export enum ExchangeVersion {
+  Exchange2007_SP1 = 0,
+  Exchange2010 = 1,
+  Exchange2010_SP1 = 2,
+  Exchange2010_SP2 = 3,
+  Exchange2013 = 4,
+  Exchange2013_SP1 = 5,
+  Exchange2015 = 6,
+  Exchange2016 = 7,
+}

--- a/packages/app-store/exchange2016calendar/lib/CalendarService.ts
+++ b/packages/app-store/exchange2016calendar/lib/CalendarService.ts
@@ -21,8 +21,8 @@ import {
 } from "ews-javascript-api";
 
 import { symmetricDecrypt } from "@calcom/lib/crypto";
-// Probably don't need
-// import { CALENDAR_INTEGRATIONS_TYPES } from "@calcom/lib/integrations/calendar/constants/generals";
+
+
 import logger from "@calcom/lib/logger";
 import type {
   Calendar,
@@ -34,15 +34,18 @@ import type {
 } from "@calcom/types/Calendar";
 import type { CredentialPayload } from "@calcom/types/Credential";
 
+import { ExchangeAuthentication } from "../enums";
+
 class ExchangeCalendarService implements Calendar {
   private url = "";
   private integrationName = "";
   private log: typeof logger;
   private readonly exchangeVersion: ExchangeVersion;
   private credentials: Record<string, string>;
+  private authenticationMethod: ExchangeAuthentication;
 
   constructor(credential: CredentialPayload) {
-    // this.integrationName = CALENDAR_INTEGRATIONS_TYPES.exchange;
+    
     this.integrationName = "exchange2016_calendar";
 
     this.log = logger.getSubLogger({ prefix: [`[[lib] ${this.integrationName}`] });
@@ -53,8 +56,12 @@ class ExchangeCalendarService implements Calendar {
     const username = decryptedCredential.username;
     const url = decryptedCredential.url;
     const password = decryptedCredential.password;
+    // Default to NTLM for on-premise Exchange 2016 compatibility
+    const authenticationMethod =
+      decryptedCredential.authenticationMethod ?? ExchangeAuthentication.NTLM;
 
     this.url = url;
+    this.authenticationMethod = authenticationMethod;
 
     this.credentials = {
       username,

--- a/packages/app-store/exchange2016calendar/lib/CalendarService.ts
+++ b/packages/app-store/exchange2016calendar/lib/CalendarService.ts
@@ -1,18 +1,24 @@
+import type { FindFoldersResults, FindItemsResults } from "ews-javascript-api";
 import {
   Appointment,
   Attendee,
+  BasePropertySet,
   CalendarView,
   ConflictResolutionMode,
   DateTime,
   DeleteMode,
   ExchangeService,
-  ExchangeVersion,
+  Folder,
   FolderId,
+  FolderSchema,
+  FolderTraversal,
   FolderView,
   ItemId,
   LegacyFreeBusyStatus,
+  LogicalOperator,
   MessageBody,
   PropertySet,
+  SearchFilter,
   SendInvitationsMode,
   SendInvitationsOrCancellationsMode,
   Uri,
@@ -21,8 +27,6 @@ import {
 } from "ews-javascript-api";
 
 import { symmetricDecrypt } from "@calcom/lib/crypto";
-
-
 import logger from "@calcom/lib/logger";
 import type {
   Calendar,
@@ -31,217 +35,177 @@ import type {
   GetAvailabilityParams,
   IntegrationCalendar,
   NewCalendarEventType,
+  Person,
 } from "@calcom/types/Calendar";
 import type { CredentialPayload } from "@calcom/types/Credential";
 
 import { ExchangeAuthentication } from "../enums";
 
 class ExchangeCalendarService implements Calendar {
-  private url = "";
   private integrationName = "";
   private log: typeof logger;
-  private readonly exchangeVersion: ExchangeVersion;
-  private credentials: Record<string, string>;
-  private authenticationMethod: ExchangeAuthentication;
+  private payload;
 
   constructor(credential: CredentialPayload) {
-    
     this.integrationName = "exchange2016_calendar";
-
     this.log = logger.getSubLogger({ prefix: [`[[lib] ${this.integrationName}`] });
-
-    const decryptedCredential = JSON.parse(
+    this.payload = JSON.parse(
       symmetricDecrypt(credential.key?.toString() || "", process.env.CALENDSO_ENCRYPTION_KEY || "")
     );
-    const username = decryptedCredential.username;
-    const url = decryptedCredential.url;
-    const password = decryptedCredential.password;
-    // Default to NTLM for on-premise Exchange 2016 compatibility
-    const authenticationMethod =
-      decryptedCredential.authenticationMethod ?? ExchangeAuthentication.NTLM;
-
-    this.url = url;
-    this.authenticationMethod = authenticationMethod;
-
-    this.credentials = {
-      username,
-      password,
-    };
-    this.exchangeVersion = ExchangeVersion.Exchange2016;
   }
 
   async createEvent(event: CalendarEvent): Promise<NewCalendarEventType> {
-    try {
-      const appointment = new Appointment(this.getExchangeService()); // service instance of ExchangeService
-      appointment.Subject = event.title;
-      appointment.Start = DateTime.Parse(event.startTime); // moment string
-      appointment.End = DateTime.Parse(event.endTime); // moment string
-      appointment.Location = event.location || "Location not defined!";
-      appointment.Body = new MessageBody(event.description || ""); // you can not use any special character or escape the content
-
-      for (let i = 0; i < event.attendees.length; i++) {
-        appointment.RequiredAttendees.Add(new Attendee(event.attendees[i].email));
-      }
-
-      if (event.team?.members) {
-        event.team.members.forEach((member) => {
-          appointment.RequiredAttendees.Add(new Attendee(member.email));
-        });
-      }
-
-      await appointment.Save(SendInvitationsMode.SendToAllAndSaveCopy);
-
-      return {
-        uid: appointment.Id.UniqueId,
-        id: appointment.Id.UniqueId,
-        password: "",
-        type: "",
-        url: "",
-        additionalInfo: {},
-      };
-    } catch (reason) {
-      this.log.error(reason);
-      throw reason;
+    const appointment: Appointment = new Appointment(await this.getExchangeService());
+    appointment.Subject = event.title;
+    appointment.Start = DateTime.Parse(event.startTime);
+    appointment.End = DateTime.Parse(event.endTime);
+    appointment.Location = event.location || "";
+    appointment.Body = new MessageBody(event.description || "");
+    event.attendees.forEach((attendee: Person) => {
+      appointment.RequiredAttendees.Add(new Attendee(attendee.email));
+    });
+    if (event.team?.members) {
+      event.team.members.forEach((member: Person) => {
+        appointment.RequiredAttendees.Add(new Attendee(member.email));
+      });
     }
+    return appointment
+      .Save(SendInvitationsMode.SendToAllAndSaveCopy)
+      .then(() => {
+        return {
+          uid: appointment.Id.UniqueId,
+          id: appointment.Id.UniqueId,
+          password: "",
+          type: "",
+          url: "",
+          additionalInfo: {},
+        };
+      })
+      .catch((reason) => {
+        this.log.error(reason);
+        throw reason;
+      });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async updateEvent(uid: string, event: CalendarEvent): Promise<any> {
-    try {
-      const appointment = await Appointment.Bind(
-        this.getExchangeService(),
-        new ItemId(uid),
-        new PropertySet()
-      );
-      appointment.Subject = event.title;
-      appointment.Start = DateTime.Parse(event.startTime); // moment string
-      appointment.End = DateTime.Parse(event.endTime); // moment string
-      appointment.Location = event.location || "Location not defined!";
-      appointment.Body = new MessageBody(event.description || ""); // you can not use any special character or escape the content
-      for (let i = 0; i < event.attendees.length; i++) {
-        appointment.RequiredAttendees.Add(new Attendee(event.attendees[i].email));
-      }
-      if (event.team?.members) {
-        event.team.members.forEach((member) => {
-          appointment.RequiredAttendees.Add(new Attendee(member.email));
-        });
-      }
-      appointment.Update(
-        ConflictResolutionMode.AlwaysOverwrite,
-        SendInvitationsOrCancellationsMode.SendToAllAndSaveCopy
-      );
-    } catch (reason) {
-      this.log.error(reason);
-      throw reason;
+  async updateEvent(
+    uid: string,
+    event: CalendarEvent
+  ): Promise<NewCalendarEventType | NewCalendarEventType[]> {
+    const appointment: Appointment = await Appointment.Bind(await this.getExchangeService(), new ItemId(uid));
+    appointment.Subject = event.title;
+    appointment.Start = DateTime.Parse(event.startTime);
+    appointment.End = DateTime.Parse(event.endTime);
+    appointment.Location = event.location || "";
+    appointment.Body = new MessageBody(event.description || "");
+    event.attendees.forEach((attendee: Person) => {
+      appointment.RequiredAttendees.Add(new Attendee(attendee.email));
+    });
+    if (event.team?.members) {
+      event.team.members.forEach((member) => {
+        appointment.RequiredAttendees.Add(new Attendee(member.email));
+      });
     }
+    return appointment
+      .Update(
+        ConflictResolutionMode.AlwaysOverwrite,
+        SendInvitationsOrCancellationsMode.SendToChangedAndSaveCopy
+      )
+      .then(() => {
+        return {
+          uid: appointment.Id.UniqueId,
+          id: appointment.Id.UniqueId,
+          password: "",
+          type: "",
+          url: "",
+          additionalInfo: {},
+        };
+      })
+      .catch((reason) => {
+        this.log.error(reason);
+        throw reason;
+      });
   }
 
   async deleteEvent(uid: string): Promise<void> {
-    try {
-      const appointment = await Appointment.Bind(
-        this.getExchangeService(),
-        new ItemId(uid),
-        new PropertySet()
-      );
-      // Delete the appointment. Note that the item ID will change when the item is moved to the Deleted Items folder.
-      appointment.Delete(DeleteMode.MoveToDeletedItems);
-    } catch (reason) {
+    const appointment: Appointment = await Appointment.Bind(await this.getExchangeService(), new ItemId(uid));
+    return appointment.Delete(DeleteMode.MoveToDeletedItems).catch((reason) => {
       this.log.error(reason);
       throw reason;
-    }
+    });
   }
 
   async getAvailability(params: GetAvailabilityParams): Promise<EventBusyDate[]> {
     const { dateFrom, dateTo, selectedCalendars } = params;
-    try {
-      const externalCalendars = await this.listCalendars();
-      const calendarsToGetAppointmentsFrom = [];
-      for (let i = 0; i < selectedCalendars.length; i++) {
-        //Only select valid calendars! (We get all all active calendars on the instance! even from different users!)
-        for (let k = 0; k < externalCalendars.length; k++) {
-          if (selectedCalendars[i].externalId == externalCalendars[k].externalId) {
-            calendarsToGetAppointmentsFrom.push(selectedCalendars[i]);
-          }
-        }
-      }
-
-      const finaleRet = [];
-      for (let i = 0; i < calendarsToGetAppointmentsFrom.length; i++) {
-        const calendarFolderId = new FolderId(calendarsToGetAppointmentsFrom[i].externalId);
-        const localReturn = await this.getExchangeService()
+    const calendars: IntegrationCalendar[] = await this.listCalendars();
+    const promises: Promise<EventBusyDate[]>[] = calendars
+      .filter((lcal) => selectedCalendars.some((rcal) => lcal.externalId == rcal.externalId))
+      .map(async (calendar) => {
+        return (await this.getExchangeService())
           .FindAppointments(
-            calendarFolderId,
+            new FolderId(calendar.externalId),
             new CalendarView(DateTime.Parse(dateFrom), DateTime.Parse(dateTo))
           )
-          .then(function (params) {
-            const ret: EventBusyDate[] = [];
-
-            for (let k = 0; k < params.Items.length; k++) {
-              if (params.Items[k].LegacyFreeBusyStatus != LegacyFreeBusyStatus.Free) {
-                //Dont use this appointment if "ShowAs" was set to "free"
-                ret.push({
-                  start: new Date(params.Items[k].Start.ToISOString()),
-                  end: new Date(params.Items[k].End.ToISOString()),
-                });
-              }
-            }
-            return ret;
+          .then((results: FindItemsResults<Appointment>) => {
+            return results.Items.filter((appointment: Appointment) => {
+              return appointment.LegacyFreeBusyStatus != LegacyFreeBusyStatus.Free;
+            }).map((appointment: Appointment) => {
+              return {
+                start: new Date(appointment.Start.ToISOString()),
+                end: new Date(appointment.End.ToISOString()),
+              };
+            });
+          })
+          .catch((reason) => {
+            this.log.error(reason);
+            throw reason;
           });
-        finaleRet.push(...localReturn);
-      }
-
-      return finaleRet;
-    } catch (reason) {
-      this.log.error(reason);
-      throw reason;
-    }
+      });
+    return Promise.all(promises).then((x) => x.flat());
   }
 
   async listCalendars(): Promise<IntegrationCalendar[]> {
-    try {
-      const allFolders: IntegrationCalendar[] = [];
-      return this.getExchangeService()
-        .FindFolders(WellKnownFolderName.MsgFolderRoot, new FolderView(1000))
-        .then(async (res) => {
-          for (const k in res.Folders) {
-            const f = res.Folders[k];
-            if (f.FolderClass == "IPF.Appointment") {
-              //Select parent folder for all calendars
-              allFolders.push({
-                externalId: f.Id.UniqueId,
-                name: f.DisplayName ?? "",
-                primary: true, //The first one is prime
-                integration: this.integrationName,
-              });
-              return await this.getExchangeService()
-                .FindFolders(f.Id, new FolderView(1000))
-                .then((res) => {
-                  //Find all calendars inside calendar folder
-                  res.Folders.forEach((fs) => {
-                    allFolders.push({
-                      externalId: fs.Id.UniqueId,
-                      name: fs.DisplayName ?? "",
-                      primary: false,
-                      integration: this.integrationName,
-                    });
-                  });
-                  return allFolders;
-                });
-            }
-          }
-          return allFolders;
-        }) as Promise<IntegrationCalendar[]>;
-    } catch (reason) {
-      this.log.error(reason);
-      throw reason;
-    }
+    const service: ExchangeService = await this.getExchangeService();
+    const view: FolderView = new FolderView(1000);
+    view.PropertySet = new PropertySet(BasePropertySet.IdOnly);
+    view.PropertySet.Add(FolderSchema.ParentFolderId);
+    view.PropertySet.Add(FolderSchema.DisplayName);
+    view.PropertySet.Add(FolderSchema.ChildFolderCount);
+    view.Traversal = FolderTraversal.Deep;
+    const deletedItemsFolder: Folder = await Folder.Bind(service, WellKnownFolderName.DeletedItems);
+    const searchFilterCollection = new SearchFilter.SearchFilterCollection(LogicalOperator.And);
+    searchFilterCollection.Add(new SearchFilter.IsEqualTo(FolderSchema.FolderClass, "IPF.Appointment"));
+    return service
+      .FindFolders(WellKnownFolderName.MsgFolderRoot, searchFilterCollection, view)
+      .then((res: FindFoldersResults) => {
+        return res.Folders.filter((folder: Folder) => {
+          return folder.ParentFolderId.UniqueId != deletedItemsFolder.Id.UniqueId;
+        }).map((folder: Folder) => {
+          return {
+            externalId: folder.Id.UniqueId,
+            name: folder.DisplayName ?? "",
+            primary: folder.ChildFolderCount > 0,
+            integration: this.integrationName,
+          };
+        });
+      })
+      .catch((reason) => {
+        this.log.error(reason);
+        throw reason;
+      });
   }
 
-  private getExchangeService(): ExchangeService {
-    const exch1 = new ExchangeService(this.exchangeVersion);
-    exch1.Credentials = new WebCredentials(this.credentials.username, this.credentials.password);
-    exch1.Url = new Uri(this.url);
-    return exch1;
+  private async getExchangeService(): Promise<ExchangeService> {
+    const service: ExchangeService = new ExchangeService(this.payload.exchangeVersion);
+    service.Credentials = new WebCredentials(this.payload.username, this.payload.password);
+    service.Url = new Uri(this.payload.url);
+    if (this.payload.authenticationMethod === ExchangeAuthentication.NTLM) {
+      const { XhrApi } = await import("@ewsjs/xhr");
+      const xhr = new XhrApi({
+        rejectUnauthorized: false,
+      }).useNtlmAuthentication(this.payload.username, this.payload.password);
+      service.XHRApi = xhr;
+    }
+    return service;
   }
 }
 

--- a/packages/app-store/exchange2016calendar/package.json
+++ b/packages/app-store/exchange2016calendar/package.json
@@ -8,6 +8,7 @@
     "@calcom/lib": "workspace:*",
     "@calcom/prisma": "workspace:*",
     "@calcom/ui": "workspace:*",
+    "@ewsjs/xhr": "3.1.3",
     "ews-javascript-api": "0.11.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
Add full NTLM authentication support for Exchange Server 2016 on-premise deployments. This resolves the issue where users could not connect to on-premise Exchange servers due to authentication failures.

Closes #8123

## Problem
On-premise Exchange 2016 servers typically use NTLM (Windows) authentication rather than basic authentication. The existing exchange2016calendar integration only supported basic authentication, causing connection failures for enterprise users.

## Solution
- Added `@ewsjs/xhr` dependency which provides XhrApi with NTLM authentication support
- Added `ExchangeAuthentication` enum (STANDARD vs NTLM)
- Added `ExchangeVersion` enum for all supported Exchange versions
- Updated `api/add.ts` to accept `authenticationMethod` and `exchangeVersion` parameters
- **Default to NTLM authentication** for on-premise compatibility
- Updated `CalendarService.ts` to conditionally use NTLM authentication via XhrApi
- Set `rejectUnauthorized: false` for self-signed certificates common in on-premise deployments

## Changes
| File | Change |
|------|--------|
| `package.json` | Added `@ewsjs/xhr` dependency |
| `enums.ts` | Added `ExchangeAuthentication` and `ExchangeVersion` enums |
| `api/add.ts` | Added authenticationMethod (default: NTLM) and exchangeVersion parameters |
| `lib/CalendarService.ts` | Full refactor with NTLM support via `@ewsjs/xhr` |

## Test plan
- [ ] Configure Exchange 2016 on-premise server with NTLM authentication
- [ ] Test adding Exchange 2016 calendar integration
- [ ] Verify calendar listing works correctly
- [ ] Test availability/busy time fetching
- [ ] Test event creation, update, and deletion
- [ ] Verify works with self-signed certificates

## Bounty
This PR addresses the $40 bounty for issue #8123.