### PR TITLE
fix: Check for existing Devin sessions from conflict resolver in cubic workflow

### DIFF
--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -89,6 +89,13 @@ jobs:
             }
             
             // PR was not created through Devin - check for existing Devin session from PR comments
+            // Look for any Devin session comment (cubic review, conflict resolution, stale PR completion, etc.)
+            const devinSessionPatterns = [
+              'Devin AI is addressing Cubic AI',
+              'Devin AI is resolving merge conflicts',
+              'Devin AI is completing this stale PR'
+            ];
+            
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -97,10 +104,12 @@ jobs:
             
             let sessionId = null;
             for (const comment of comments.data.reverse()) {
-              if (comment.body.includes('Devin AI is addressing Cubic AI')) {
+              const hasDevinSession = devinSessionPatterns.some(pattern => comment.body.includes(pattern));
+              if (hasDevinSession) {
                 const match = comment.body.match(/app\.devin\.ai\/sessions\/([a-f0-9-]+)/);
                 if (match) {
                   sessionId = match[1];
+                  console.log(`Found existing Devin session from comment: ${sessionId}`);
                   break;
                 }
               }


### PR DESCRIPTION
## What does this PR do?

When the Cubic AI review workflow triggers Devin to address code review feedback, it now also checks for existing Devin sessions from other workflows (conflict resolver, stale PR completion) - not just previous Cubic review sessions.

Previously, if a Devin session was already working on a PR (e.g., fixing merge conflicts), the Cubic workflow would create a new session instead of sending feedback to the existing one. This change ensures new Cubic feedback is sent to any active Devin session already working on the PR.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow

## How should this be tested?

This workflow triggers when Cubic AI submits a review on a PR. To test:

1. Have a PR with an existing Devin session from the conflict resolver (comment containing "Devin AI is resolving merge conflicts")
2. Trigger a Cubic AI review on that PR
3. Verify the workflow sends the feedback to the existing session instead of creating a new one

## Human Review Checklist

- [ ] Verify the pattern strings match exactly what the other workflows post in their comments:
  - `devin-conflict-resolver.yml` posts "Devin AI is resolving merge conflicts"
  - `stale-pr-devin-completion.yml` posts "Devin AI is completing this stale PR"

<!-- Link to Devin run: https://app.devin.ai/sessions/8e77cdcb52ac42809c7c3c9d893afa16 -->
<!-- Requested by: keith@cal.com (@keithwillcode) -->