### PR TITLE
fix: improve BookingReferenceRepository integration test isolation

### DIFF
--- a/packages/features/bookingReference/repositories/BookingReferenceRepository.integration-test.ts
+++ b/packages/features/bookingReference/repositories/BookingReferenceRepository.integration-test.ts
@@ -1,82 +1,103 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
-
-import prisma from "@calcom/prisma";
-import type { Booking, Credential, User } from "@calcom/prisma/client";
+import { prisma } from "@calcom/prisma";
+import type { Booking, Credential } from "@calcom/prisma/client";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { BookingReferenceRepository } from "./BookingReferenceRepository";
 
 const testRunId = `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
 
+let testUserId: number;
+let testCredential: Credential;
+let testBooking: Booking;
+const createdBookingReferenceIds: number[] = [];
+const createdBookingIds: number[] = [];
+
+async function clearTestBookingReferences() {
+  if (createdBookingReferenceIds.length > 0) {
+    await prisma.bookingReference.deleteMany({
+      where: {
+        id: {
+          in: createdBookingReferenceIds,
+        },
+      },
+    });
+    createdBookingReferenceIds.length = 0;
+  }
+}
+
+async function clearTestBookings() {
+  if (createdBookingIds.length > 0) {
+    await prisma.bookingReference.deleteMany({
+      where: {
+        bookingId: {
+          in: createdBookingIds,
+        },
+      },
+    });
+    await prisma.booking.deleteMany({
+      where: {
+        id: {
+          in: createdBookingIds,
+        },
+      },
+    });
+    createdBookingIds.length = 0;
+  }
+}
+
 describe("BookingReferenceRepository Integration Tests", () => {
-  let testUser: User;
-  let testCredential: Credential;
-  let testBooking: Booking;
-  const createdBookingReferenceIds: number[] = [];
-
   beforeAll(async () => {
-    testUser = await prisma.user.create({
-      data: {
-        email: `bookingreference-test-${testRunId}@example.com`,
-        username: `bookingreference-test-${testRunId}`,
-      },
+    let testUser = await prisma.user.findFirst({
+      where: { email: "member0-acme@example.com" },
     });
 
-    testCredential = await prisma.credential.create({
-      data: {
-        type: "google_calendar",
-        key: {},
-        userId: testUser.id,
-      },
+    if (!testUser) {
+      testUser = await prisma.user.create({
+        data: {
+          email: `bookingreference-test-${testRunId}@example.com`,
+          username: `bookingreference-test-${testRunId}`,
+        },
+      });
+    }
+    testUserId = testUser.id;
+
+    let credential = await prisma.credential.findFirst({
+      where: { userId: testUserId, type: "google_calendar" },
     });
 
+    if (!credential) {
+      credential = await prisma.credential.create({
+        data: {
+          type: "google_calendar",
+          key: {},
+          userId: testUserId,
+        },
+      });
+    }
+    testCredential = credential;
+  });
+
+  beforeEach(async () => {
     testBooking = await prisma.booking.create({
       data: {
-        uid: `test-booking-uid-${testRunId}`,
+        uid: `test-booking-uid-${testRunId}-${Date.now()}`,
         title: "Test Booking",
         startTime: new Date(),
         endTime: new Date(),
-        userId: testUser.id,
+        userId: testUserId,
       },
     });
+    createdBookingIds.push(testBooking.id);
   });
 
   afterEach(async () => {
-    if (createdBookingReferenceIds.length > 0) {
-      await prisma.bookingReference.deleteMany({
-        where: {
-          id: {
-            in: createdBookingReferenceIds,
-          },
-        },
-      });
-      createdBookingReferenceIds.splice(0, createdBookingReferenceIds.length);
-    }
+    await clearTestBookingReferences();
+    await clearTestBookings();
   });
 
   afterAll(async () => {
-    await prisma.bookingReference.deleteMany({
-      where: {
-        bookingId: testBooking.id,
-      },
-    });
-
-    await prisma.booking.deleteMany({
-      where: {
-        id: testBooking.id,
-      },
-    });
-
-    await prisma.credential.deleteMany({
-      where: {
-        id: testCredential.id,
-      },
-    });
-
-    await prisma.user.deleteMany({
-      where: {
-        id: testUser.id,
-      },
-    });
+    await clearTestBookingReferences();
+    await clearTestBookings();
   });
 
   describe("replaceBookingReferences", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes flaky integration tests in `BookingReferenceRepository.integration-test.ts` that were introduced by commit eecf9e1ab9. The tests were failing with `ForeignKeyConstraintViolation` errors (Prisma error P2003) on the `BookingReference_bookingId_fkey` constraint.

**Root cause**: The tests created a single booking in `beforeAll` that was shared across all tests. This caused race conditions when tests run in parallel - one test's cleanup could delete the booking while another test was still trying to use it.

**Fix**:
- Use seed user (`member0-acme@example.com`) when available in CI, with fallback to creating a test user for local development
- Move booking creation from `beforeAll` to `beforeEach` so each test gets a fresh, isolated booking
- Track created bookings and clean them up properly in `afterEach`
- Fix import organization to satisfy linter

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - test-only changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. CI should pass - the integration tests that were previously flaky should now pass consistently
2. Run the integration tests locally multiple times to verify stability:
   ```bash
   set -a && source .env && set +a
   VITEST_MODE=integration TZ=UTC yarn test packages/features/bookingReference/repositories/BookingReferenceRepository.integration-test.ts
   ```
3. All 9 tests in the file should pass consistently across multiple runs

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> **Reviewer notes**: 
> - Verify the import change from `import prisma from "@calcom/prisma"` to `import { prisma } from "@calcom/prisma"` is correct
> - The seed user fallback creates a test user that isn't explicitly cleaned up if the seed user doesn't exist - this is acceptable since it only happens in local dev

Requested by: @keithwillcode
Link to Devin run: https://app.devin.ai/sessions/a4fb71e0632041b28f8ed19205b96cf9