### PR TITLE
fix: fix email exclusion validation for full emails and and @-prefixed domains

### DIFF
--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -1616,6 +1616,46 @@ describe("excluded email/domain validation", () => {
       })
     );
   });
+
+  test("should block emails with domain when excluded email is just the domain without @", async () => {
+    const excludedEmails = "gmail.com";
+
+    const schema = getBookingResponsesSchema({
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+          excludeEmails: excludedEmails,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+      view: "ALL_VIEWS",
+    });
+
+    // test@gmail.com should be blocked when gmail.com is excluded
+    const parsedResponses = await schema.safeParseAsync({
+      name: "test",
+      email: "test@gmail.com",
+    });
+
+    expect(parsedResponses.success).toBe(false);
+
+    if (parsedResponses.success) {
+      throw new Error("Should not reach here");
+    }
+
+    expect(parsedResponses.error.issues[0]).toEqual(
+      expect.objectContaining({
+        code: "custom",
+        message: `{email}${CUSTOM_EMAIL_EXCLUDED_ERROR_MSG}`,
+      })
+    );
+  });
 });
 
 describe("require email/domain validation", () => {

--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -1536,6 +1536,86 @@ describe("excluded email/domain validation", () => {
       email: "blocked.com@allowed.com",
     });
   });
+
+  test("should block full email match when exact email is excluded", async () => {
+    const excludedEmails = "anik@cal.com";
+
+    const schema = getBookingResponsesSchema({
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+          excludeEmails: excludedEmails,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+      view: "ALL_VIEWS",
+    });
+
+    // anik@cal.com should be blocked
+    const parsedResponses = await schema.safeParseAsync({
+      name: "test",
+      email: "anik@cal.com",
+    });
+
+    expect(parsedResponses.success).toBe(false);
+
+    if (parsedResponses.success) {
+      throw new Error("Should not reach here");
+    }
+
+    expect(parsedResponses.error.issues[0]).toEqual(
+      expect.objectContaining({
+        code: "custom",
+        message: `{email}${CUSTOM_EMAIL_EXCLUDED_ERROR_MSG}`,
+      })
+    );
+  });
+
+  test("should block emails with domain when domain starts with @", async () => {
+    const excludedEmails = "@gmail.com";
+
+    const schema = getBookingResponsesSchema({
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+          excludeEmails: excludedEmails,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+      view: "ALL_VIEWS",
+    });
+
+    // anik@gmail.com should be blocked when @gmail.com is excluded
+    const parsedResponses = await schema.safeParseAsync({
+      name: "test",
+      email: "anik@gmail.com",
+    });
+
+    expect(parsedResponses.success).toBe(false);
+
+    if (parsedResponses.success) {
+      throw new Error("Should not reach here");
+    }
+
+    expect(parsedResponses.error.issues[0]).toEqual(
+      expect.objectContaining({
+        code: "custom",
+        message: `{email}${CUSTOM_EMAIL_EXCLUDED_ERROR_MSG}`,
+      })
+    );
+  });
 });
 
 describe("require email/domain validation", () => {

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -33,16 +33,18 @@ const ensureValidPhoneNumber = (value: string) => {
  * - Domain without @ prefix: "example.com" - matches any email ending with "@example.com"
  */
 const doesEmailMatchEntry = (bookerEmail: string, entry: string): boolean => {
+  const bookerEmailLower = bookerEmail.toLowerCase();
+
   if (entry.startsWith("@")) {
-    const domain = entry.slice(1);
-    return bookerEmail.endsWith("@" + domain);
+    const domain = entry.slice(1).toLowerCase();
+    return bookerEmailLower.endsWith("@" + domain);
   }
 
   if (entry.includes("@")) {
-    return bookerEmail.toLowerCase() === entry.toLowerCase();
+    return bookerEmailLower === entry.toLowerCase();
   }
 
-  return bookerEmail.endsWith("@" + entry);
+  return bookerEmailLower.endsWith("@" + entry.toLowerCase());
 };
 export const getBookingResponsesPartialSchema = ({ bookingFields, view, translateFn }: CommonParams) => {
   const schema = bookingResponses.unwrap().partial().and(catchAllSchema);

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -208,7 +208,19 @@ function preprocess<T extends z.ZodType>({
             const excludedEmails =
               bookingField.excludeEmails?.split(",").map((domain) => domain.trim()) || [];
 
-            const match = excludedEmails.find((email) => bookerEmail.endsWith("@" + email));
+            const match = excludedEmails.find((excludedEntry) => {
+              // If starts with "@", treat as domain (e.g., "@gmail.com")
+              if (excludedEntry.startsWith("@")) {
+                const domain = excludedEntry.slice(1);
+                return bookerEmail.endsWith("@" + domain);
+              }
+              // If contains "@" but doesn't start with "@", treat as full email (e.g., "anik@cal.com")
+              if (excludedEntry.includes("@")) {
+                return bookerEmail.toLowerCase() === excludedEntry.toLowerCase();
+              }
+              // Otherwise, treat as domain (e.g., "gmail.com")
+              return bookerEmail.endsWith("@" + excludedEntry);
+            });
             if (match) {
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,
@@ -220,7 +232,19 @@ function preprocess<T extends z.ZodType>({
                 ?.split(",")
                 .map((domain) => domain.trim())
                 .filter(Boolean) || [];
-            const requiredEmailsMatch = requiredEmails.find((email) => bookerEmail.endsWith("@" + email));
+            const requiredEmailsMatch = requiredEmails.find((requiredEntry) => {
+              // If starts with "@", treat as domain (e.g., "@gmail.com")
+              if (requiredEntry.startsWith("@")) {
+                const domain = requiredEntry.slice(1);
+                return bookerEmail.endsWith("@" + domain);
+              }
+              // If contains "@" but doesn't start with "@", treat as full email (e.g., "user@hotmail.com")
+              if (requiredEntry.includes("@")) {
+                return bookerEmail.toLowerCase() === requiredEntry.toLowerCase();
+              }
+              // Otherwise, treat as domain (e.g., "gmail.com")
+              return bookerEmail.endsWith("@" + requiredEntry);
+            });
             if (requiredEmails.length > 0 && !requiredEmailsMatch) {
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -33,16 +33,18 @@ const ensureValidPhoneNumber = (value: string) => {
  * - Domain without @ prefix: "example.com" - matches any email ending with "@example.com"
  */
 const doesEmailMatchEntry = (bookerEmail: string, entry: string): boolean => {
+  const normalizedEmail = bookerEmail.toLowerCase();
+
   if (entry.startsWith("@")) {
-    const domain = entry.slice(1);
-    return bookerEmail.endsWith("@" + domain);
+    const domain = entry.slice(1).toLowerCase();
+    return normalizedEmail.endsWith("@" + domain);
   }
 
   if (entry.includes("@")) {
-    return bookerEmail.toLowerCase() === entry.toLowerCase();
+    return normalizedEmail === entry.toLowerCase();
   }
 
-  return bookerEmail.endsWith("@" + entry);
+  return normalizedEmail.endsWith("@" + entry.toLowerCase());
 };
 export const getBookingResponsesPartialSchema = ({ bookingFields, view, translateFn }: CommonParams) => {
   const schema = bookingResponses.unwrap().partial().and(catchAllSchema);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated booking email validation to correctly handle exact email exclusions and "@-prefixed" domains. The same logic is applied to required emails for consistency.

- **Bug Fixes**
  - Support three formats in exclude/require lists: "@domain.com", "user@domain.com", "domain.com".
  - Case-insensitive matching for emails and domains.
  - Added tests for full email exclusion and "@domain" handling.

<sup>Written for commit 26552df1d9d4c0bcd2dd559d569266e8ea41199a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

