### PR TITLE
test: Set Vitest pool to "forks" to fix flakes

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -99,6 +99,7 @@ export default defineConfig({
     setupFiles: ["./packages/testing/src/setupVitest.ts"],
     include: getTestInclude(),
     exclude: getTestExclude(),
+    pool: "forks",
     server: {
       deps: {
         inline: [/@calcom\/.*/],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set Vitest pool to "forks" to isolate test workers and stabilize flaky tests in CI and local runs. This reduces intermittent failures caused by shared state across threads.

<sup>Written for commit 384f2ab890505e197200663532bee7e926947d54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

