### PR TITLE
docs: add Platform deprecation notice and hide from navigation

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -207,7 +207,6 @@
     {
       "group": "Getting Started",
       "pages": [
-        "platform/introduction",
         "platform/setup",
         "platform/quickstart",
         {

--- a/docs/platform/introduction.mdx
+++ b/docs/platform/introduction.mdx
@@ -3,6 +3,10 @@ title: Introduction
 icon: "presentation-screen"
 ---
 
+<Warning>
+**Platform is being deprecated and will be discontinued on January 1, 2027.**
+</Warning>
+
 <img src="/images/Platform_banner.png" width="800" height="800" />
 
 <a href="https://app.cal.com/signup?redirect=https://app.cal.com/settings/platform/new" heading="">

--- a/docs/platform/introduction.mdx
+++ b/docs/platform/introduction.mdx
@@ -4,7 +4,7 @@ icon: "presentation-screen"
 ---
 
 <Warning>
-**Platform is being deprecated and will be discontinued on January 1, 2027.**
+**Platform is being deprecated and will be discontinued on October 1, 2027.**
 </Warning>
 
 <img src="/images/Platform_banner.png" width="800" height="800" />


### PR DESCRIPTION
## What does this PR do?

Adds a deprecation warning to the Platform introduction page at `/docs/platform/introduction`, similar to the existing API v1 deprecation notice. The warning informs users that Platform will be discontinued on October 1, 2027.

Additionally, hides the Platform introduction page from the navigation menu in `mint.json`. The page remains accessible via direct URL but will no longer appear in the sidebar navigation.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). This PR is the documentation change itself.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - documentation only change.

## How should this be tested?

1. View the Platform introduction page directly at `/docs/platform/introduction`
2. Verify the warning message appears at the top of the page
3. Confirm the message reads: "Platform is being deprecated and will be discontinued on October 1, 2027."
4. Verify the Platform introduction page no longer appears in the sidebar navigation menu
5. Confirm other Platform pages (setup, quickstart, atoms, etc.) still appear in the navigation

## Human Review Checklist

- [ ] Verify the deprecation date (October 1, 2027) is correct per business requirements
- [ ] Verify the wording is appropriate
- [ ] Confirm hiding the introduction page from navigation is the intended behavior (page still accessible via direct URL)

## Updates since last revision

- Updated deprecation date from January 1, 2027 to October 1, 2027 based on PR feedback

---

> Requested by @Ryukemeister
> [Link to Devin run](https://app.devin.ai/sessions/c9354886699244089d69db1aebb0341e)