### PR TITLE
fix: return 400 instead of 500 for invalid eventTypeId in booking flow

### DIFF
--- a/packages/features/bot-detection/BotDetectionService.test.ts
+++ b/packages/features/bot-detection/BotDetectionService.test.ts
@@ -75,6 +75,41 @@ describe("BotDetectionService", () => {
       expect(mockEventTypeRepository.getTeamIdByEventTypeId).not.toHaveBeenCalled();
     });
 
+    it("should throw HttpError with 400 status for invalid eventTypeId", async () => {
+      process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "1";
+
+      await expect(
+        botDetectionService.checkBotDetection({
+          eventTypeId: "3823346KiEg1Zk6') OR 370=(SELECT 370 FROM PG_SLEEP(15))--" as unknown as number,
+          headers: mockHeaders,
+        })
+      ).rejects.toThrow(HttpError);
+
+      await expect(
+        botDetectionService.checkBotDetection({
+          eventTypeId: -1,
+          headers: mockHeaders,
+        })
+      ).rejects.toThrow(HttpError);
+
+      await expect(
+        botDetectionService.checkBotDetection({
+          eventTypeId: 1.5,
+          headers: mockHeaders,
+        })
+      ).rejects.toThrow(HttpError);
+
+      try {
+        await botDetectionService.checkBotDetection({
+          eventTypeId: -1,
+          headers: mockHeaders,
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpError);
+        expect((error as HttpError).statusCode).toBe(400);
+      }
+    });
+
     it("should return early if event type has no teamId", async () => {
       process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "1";
       vi.mocked(mockEventTypeRepository.getTeamIdByEventTypeId).mockResolvedValue({

--- a/packages/features/bot-detection/BotDetectionService.test.ts
+++ b/packages/features/bot-detection/BotDetectionService.test.ts
@@ -1,5 +1,5 @@
 import type { IncomingHttpHeaders } from "node:http";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import type { FeaturesRepository } from "@calcom/features/flags/features.repository";
@@ -32,10 +32,8 @@ describe("BotDetectionService", () => {
   let mockHeaders: IncomingHttpHeaders;
 
   beforeEach(() => {
-    // Reset all mocks before each test
     vi.clearAllMocks();
 
-    // Setup mock repositories
     mockFeaturesRepository = {
       checkIfTeamHasFeature: vi.fn(),
     } as unknown as FeaturesRepository;
@@ -50,14 +48,15 @@ describe("BotDetectionService", () => {
     };
 
     botDetectionService = new BotDetectionService(mockFeaturesRepository, mockEventTypeRepository);
+  });
 
-    // Reset environment variable
-    delete process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER;
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   describe("checkBotDetection", () => {
     it("should return early if BotID is not enabled at instance level", async () => {
-      process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "0";
+      vi.stubEnv("NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER", "0");
 
       await botDetectionService.checkBotDetection({
         eventTypeId: 123,
@@ -68,7 +67,7 @@ describe("BotDetectionService", () => {
     });
 
     it("should return early if no eventTypeId is provided", async () => {
-      process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "1";
+      vi.stubEnv("NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER", "1");
 
       await botDetectionService.checkBotDetection({
         headers: mockHeaders,
@@ -78,7 +77,7 @@ describe("BotDetectionService", () => {
     });
 
     it("should throw ErrorWithCode for invalid eventTypeId", async () => {
-      process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "1";
+      vi.stubEnv("NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER", "1");
 
       await expect(
         botDetectionService.checkBotDetection({
@@ -113,7 +112,7 @@ describe("BotDetectionService", () => {
     });
 
     it("should return early if event type has no teamId", async () => {
-      process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "1";
+      vi.stubEnv("NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER", "1");
       vi.mocked(mockEventTypeRepository.getTeamIdByEventTypeId).mockResolvedValue({
         teamId: null,
       });
@@ -127,7 +126,7 @@ describe("BotDetectionService", () => {
     });
 
     it("should return early if BotID feature is not enabled for the team", async () => {
-      process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "1";
+      vi.stubEnv("NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER", "1");
       vi.mocked(mockEventTypeRepository.getTeamIdByEventTypeId).mockResolvedValue({
         teamId: 456,
       });
@@ -144,7 +143,7 @@ describe("BotDetectionService", () => {
     });
 
     it("should throw HttpError when a bot is detected", async () => {
-      process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "1";
+      vi.stubEnv("NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER", "1");
       vi.mocked(mockEventTypeRepository.getTeamIdByEventTypeId).mockResolvedValue({
         teamId: 456,
       });
@@ -177,7 +176,7 @@ describe("BotDetectionService", () => {
     });
 
     it("should pass when a human is detected", async () => {
-      process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "1";
+      vi.stubEnv("NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER", "1");
       vi.mocked(mockEventTypeRepository.getTeamIdByEventTypeId).mockResolvedValue({
         teamId: 456,
       });
@@ -204,7 +203,7 @@ describe("BotDetectionService", () => {
 
     it("should check feature flag with correct teamId", async () => {
       const teamId = 789;
-      process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "1";
+      vi.stubEnv("NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER", "1");
       vi.mocked(mockEventTypeRepository.getTeamIdByEventTypeId).mockResolvedValue({
         teamId,
       });

--- a/packages/features/bot-detection/BotDetectionService.test.ts
+++ b/packages/features/bot-detection/BotDetectionService.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import type { FeaturesRepository } from "@calcom/features/flags/features.repository";
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import { HttpError } from "@calcom/lib/http-error";
 
 import { BotDetectionService } from "./BotDetectionService";
@@ -75,7 +77,7 @@ describe("BotDetectionService", () => {
       expect(mockEventTypeRepository.getTeamIdByEventTypeId).not.toHaveBeenCalled();
     });
 
-    it("should throw HttpError with 400 status for invalid eventTypeId", async () => {
+    it("should throw ErrorWithCode for invalid eventTypeId", async () => {
       process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER = "1";
 
       await expect(
@@ -83,21 +85,21 @@ describe("BotDetectionService", () => {
           eventTypeId: "3823346KiEg1Zk6') OR 370=(SELECT 370 FROM PG_SLEEP(15))--" as unknown as number,
           headers: mockHeaders,
         })
-      ).rejects.toThrow(HttpError);
+      ).rejects.toThrow(ErrorWithCode);
 
       await expect(
         botDetectionService.checkBotDetection({
           eventTypeId: -1,
           headers: mockHeaders,
         })
-      ).rejects.toThrow(HttpError);
+      ).rejects.toThrow(ErrorWithCode);
 
       await expect(
         botDetectionService.checkBotDetection({
           eventTypeId: 1.5,
           headers: mockHeaders,
         })
-      ).rejects.toThrow(HttpError);
+      ).rejects.toThrow(ErrorWithCode);
 
       try {
         await botDetectionService.checkBotDetection({
@@ -105,8 +107,8 @@ describe("BotDetectionService", () => {
           headers: mockHeaders,
         });
       } catch (error) {
-        expect(error).toBeInstanceOf(HttpError);
-        expect((error as HttpError).statusCode).toBe(400);
+        expect(error).toBeInstanceOf(ErrorWithCode);
+        expect((error as ErrorWithCode).code).toBe(ErrorCode.BadRequest);
       }
     });
 

--- a/packages/features/bot-detection/BotDetectionService.ts
+++ b/packages/features/bot-detection/BotDetectionService.ts
@@ -3,6 +3,8 @@ import type { IncomingHttpHeaders } from "node:http";
 
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import type { FeaturesRepository } from "@calcom/features/flags/features.repository";
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import { HttpError } from "@calcom/lib/http-error";
 import logger from "@calcom/lib/logger";
 
@@ -34,10 +36,10 @@ export class BotDetectionService {
     }
 
     if (!Number.isInteger(eventTypeId) || eventTypeId <= 0) {
-      throw new HttpError({
-        statusCode: 400,
-        message: `Invalid eventTypeId: ${eventTypeId}. Must be a positive integer.`,
-      });
+      throw new ErrorWithCode(
+        ErrorCode.BadRequest,
+        `Invalid eventTypeId: ${eventTypeId}. Must be a positive integer.`
+      );
     }
 
     // Fetch only the teamId from the event type

--- a/packages/features/bot-detection/BotDetectionService.ts
+++ b/packages/features/bot-detection/BotDetectionService.ts
@@ -34,7 +34,10 @@ export class BotDetectionService {
     }
 
     if (!Number.isInteger(eventTypeId) || eventTypeId <= 0) {
-      throw new Error(`Invalid eventTypeId: ${eventTypeId}. Must be a positive integer.`);
+      throw new HttpError({
+        statusCode: 400,
+        message: `Invalid eventTypeId: ${eventTypeId}. Must be a positive integer.`,
+      });
     }
 
     // Fetch only the teamId from the event type


### PR DESCRIPTION
## What does this PR do?

Fixes SQL injection attempts on the booking endpoint (`/api/book/event`) returning 500 errors instead of 400.

When invalid `eventTypeId` values (like SQL injection strings) are passed to the booking endpoint, the `BotDetectionService.checkBotDetection()` method was throwing a generic `Error`, which resulted in a 500 Internal Server Error. This PR changes it to throw an `HttpError` with statusCode 400, properly indicating a bad request.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Unit tests have been added covering:
- SQL injection strings as eventTypeId
- Negative numbers
- Float numbers
- Verification that the error statusCode is 400
