### PR TITLE
fix: api v2 imports

### DIFF
--- a/apps/api/v2/src/lib/services/org-membership-lookup.service.ts
+++ b/apps/api/v2/src/lib/services/org-membership-lookup.service.ts
@@ -1,6 +1,9 @@
-import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
-import type { OrgMembershipLookup } from "@calcom/trpc/server/routers/viewer/slots/util";
 import { Injectable } from "@nestjs/common";
+
+import {
+  type OrgMembershipLookup,
+  ProfileRepository,
+} from "@calcom/platform-libraries";
 
 /**
  * NestJS service that implements OrgMembershipLookup interface.
@@ -8,7 +11,11 @@ import { Injectable } from "@nestjs/common";
  */
 @Injectable()
 export class OrgMembershipLookupService implements OrgMembershipLookup {
-  async findFirstOrganizationIdForUser({ userId }: { userId: number }): Promise<number | null> {
+  async findFirstOrganizationIdForUser({
+    userId,
+  }: {
+    userId: number;
+  }): Promise<number | null> {
     return ProfileRepository.findFirstOrganizationIdForUser({ userId });
   }
 }

--- a/packages/platform/libraries/index.ts
+++ b/packages/platform/libraries/index.ts
@@ -19,6 +19,7 @@ import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/crede
 import { paymentDataSelect } from "@calcom/prisma/selects/payment";
 import { createNewUsersConnectToOrgIfExists } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
 
+
 export { slugify } from "@calcom/lib/slugify";
 export { slugifyLenient } from "@calcom/lib/slugify-lenient";
 export { getBookingForReschedule };
@@ -141,3 +142,6 @@ export { validateUrlForSSRFSync } from "@calcom/lib/ssrfProtection";
 export { verifyCodeChallenge } from "@calcom/lib/pkce";
 export { generateSecret } from "@calcom/features/oauth/utils/generateSecret";
 export { OAuthService } from "@calcom/features/oauth/services/OAuthService";
+
+export { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
+export type { OrgMembershipLookup } from "@calcom/trpc/server/routers/viewer/slots/util";


### PR DESCRIPTION
## Summary 
Standardized API v2 imports to use @calcom/platform-libraries, replacing direct imports from @calcom/features and @calcom/trpc. Added re-exports and updated OrgMembershipLookupService. No behavior changes.

- **Refactors**
  - Re-exported ProfileRepository and OrgMembershipLookup from @calcom/platform-libraries.
  - Updated OrgMembershipLookupService to import from @calcom/platform-libraries.



