### PR TITLE
chore: remove explicity json check as it is already in included files

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -7,6 +7,5 @@ export default {
     skipWarnings
       ? `biome lint --config-path=biome-staged.json ${files.join(" ")}`
       : `biome lint --config-path=biome-staged.json --error-on-warnings ${files.join(" ")}`,
-      "*.json": (files) => `biome format --config-path=biome-staged.json ${files.join(" ")}`,
   "packages/prisma/schema.prisma": ["prisma format"],
 };


### PR DESCRIPTION
## What does this PR do?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant JSON formatting rule from lint-staged since the Biome config already includes JSON files. This simplifies the config and avoids duplicate formatting steps.

<sup>Written for commit 163bc2267b5c9163f8319a9efd0837d65cf062e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

