### PR TITLE
fix: add withSentryConfig to enable Sentry tracing in production

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -140,10 +140,11 @@ if (process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER === "1") {
   plugins.push(withBotId);
 }
 
+const sentryTracesSampleRate = parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE ?? "0.0");
 const isSentryEnabled =
   process.env.NODE_ENV === "production" &&
   process.env.NEXT_PUBLIC_SENTRY_DSN &&
-  process.env.SENTRY_TRACES_SAMPLE_RATE;
+  sentryTracesSampleRate > 0;
 
 if (isSentryEnabled) {
   plugins.push((config) =>

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,16 +1,17 @@
+import process from "node:process";
+import { withSentryConfig } from "@sentry/nextjs";
 import { withBotId } from "botid/next/config";
 import { config as dotenvConfig } from "dotenv";
 import type { NextConfig } from "next";
 import type { RouteHas } from "next/dist/lib/load-custom-routes";
 import { withAxiom } from "next-axiom";
-
 import i18nConfig from "./next-i18next.config";
 import packageJson from "./package.json";
 import {
   nextJsOrgRewriteConfig,
   orgUserRoutePath,
-  orgUserTypeRoutePath,
   orgUserTypeEmbedRoutePath,
+  orgUserTypeRoutePath,
 } from "./pagesAndRewritePaths";
 
 dotenvConfig({ path: "../../.env" });
@@ -137,6 +138,24 @@ plugins.push(withAxiom);
 
 if (process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER === "1") {
   plugins.push(withBotId);
+}
+
+const isSentryEnabled =
+  process.env.NODE_ENV === "production" &&
+  process.env.NEXT_PUBLIC_SENTRY_DSN &&
+  process.env.SENTRY_TRACES_SAMPLE_RATE;
+
+if (isSentryEnabled) {
+  plugins.push((config) =>
+    withSentryConfig(config, {
+      silent: !process.env.SENTRY_DEBUG,
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      widenClientFileUpload: true,
+      disableLogger: true,
+    })
+  );
 }
 
 interface OrgDomainMatcher {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -140,7 +140,7 @@ if (process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER === "1") {
   plugins.push(withBotId);
 }
 
-const sentryTracesSampleRate = parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE ?? "0.0");
+const sentryTracesSampleRate = parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE ?? "0.0") || 0.0;
 const isSentryEnabled =
   process.env.NODE_ENV === "production" &&
   process.env.NEXT_PUBLIC_SENTRY_DSN &&


### PR DESCRIPTION
## What does this PR do?

Adds the `withSentryConfig` wrapper to the Next.js configuration, which is required for Sentry tracing/performance monitoring to work properly.

**Root cause:** Despite having `NEXT_PUBLIC_SENTRY_DSN` and `SENTRY_TRACES_SAMPLE_RATE` environment variables set, and the `instrumentation.ts` file initializing Sentry, no spans were being recorded to Sentry. This is because `withSentryConfig` was missing from the Next.js config - without it, Sentry cannot properly instrument the build for performance monitoring.

The wrapper is conditionally applied only in production when:
- `NEXT_PUBLIC_SENTRY_DSN` is set
- `SENTRY_TRACES_SAMPLE_RATE` is set and greater than 0

## Updates since last revision

- Updated conditional logic to only enable Sentry when `SENTRY_TRACES_SAMPLE_RATE > 0`, not just when the env var is set (per reviewer feedback)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Deploy to a production environment with the following env vars set:
   - `NEXT_PUBLIC_SENTRY_DSN`
   - `SENTRY_TRACES_SAMPLE_RATE` (e.g., `0.2` for 20% sampling - must be > 0)
   - Optionally: `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` for source map uploads
2. Trigger some calendar operations (e.g., fetch availability)
3. Check Sentry Performance/Traces section for spans with `op:calendar.*`

**Note:** This cannot be tested locally as the wrapper only activates when `NODE_ENV === "production"`.

## Checklist for Human Review

- [ ] Verify the conditional logic (`isSentryEnabled`) is correct for your production setup
- [ ] Confirm the required Sentry env vars (`SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`) are available in production if source map uploads are desired
- [ ] The `import process from "node:process"` was added by the linter - verify this doesn't cause issues

---

Link to Devin run: https://app.devin.ai/sessions/4cb81492c7d94bf79c3b617ba8668b1c
Requested by: Volnei Munhoz (@volnei)