### PR TITLE
revert: "fix: add withSentryConfig to enable Sentry tracing in production"

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,17 +1,16 @@
-import process from "node:process";
-import { withSentryConfig } from "@sentry/nextjs";
 import { withBotId } from "botid/next/config";
 import { config as dotenvConfig } from "dotenv";
 import type { NextConfig } from "next";
 import type { RouteHas } from "next/dist/lib/load-custom-routes";
 import { withAxiom } from "next-axiom";
+
 import i18nConfig from "./next-i18next.config";
 import packageJson from "./package.json";
 import {
   nextJsOrgRewriteConfig,
   orgUserRoutePath,
-  orgUserTypeEmbedRoutePath,
   orgUserTypeRoutePath,
+  orgUserTypeEmbedRoutePath,
 } from "./pagesAndRewritePaths";
 
 dotenvConfig({ path: "../../.env" });
@@ -138,25 +137,6 @@ plugins.push(withAxiom);
 
 if (process.env.NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER === "1") {
   plugins.push(withBotId);
-}
-
-const sentryTracesSampleRate = parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE ?? "0.0") || 0.0;
-const isSentryEnabled =
-  process.env.NODE_ENV === "production" &&
-  process.env.NEXT_PUBLIC_SENTRY_DSN &&
-  sentryTracesSampleRate > 0;
-
-if (isSentryEnabled) {
-  plugins.push((config) =>
-    withSentryConfig(config, {
-      silent: !process.env.SENTRY_DEBUG,
-      org: process.env.SENTRY_ORG,
-      project: process.env.SENTRY_PROJECT,
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-      widenClientFileUpload: true,
-      disableLogger: true,
-    })
-  );
 }
 
 interface OrgDomainMatcher {


### PR DESCRIPTION
Reverts calcom/cal.com#26743

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Sentry tracing integration in apps/web/next.config.ts to restore the previous Next.js configuration. Removes the withSentryConfig plugin and related environment checks, so production builds no longer include Sentry tracing.

<sup>Written for commit 38cde5ba069b4296e246d856457b0eb876859af8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

