### PR TITLE
ci: only auto-fix Cubic suggestions with confidence >= 9/10

### DIFF
--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -150,7 +150,9 @@ jobs:
           
           MESSAGE="New Cubic AI review feedback has been submitted on PR #${{ github.event.pull_request.number }}.
 
-          Please address the following additional issues:
+          IMPORTANT: Before fixing any issue, check the individual Cubic comment on the PR for that issue's confidence score. The confidence score appears as 'Fix confidence (alpha): X/10' in each comment. Only fix issues where the confidence score is 9/10 or higher. If you cannot find a confidence score for an issue, skip it.
+
+          Here are the issues identified by Cubic AI:
 
           ${CUBIC_PROMPT}
 
@@ -181,8 +183,8 @@ jobs:
           Your tasks:
           1. Clone the repository ${{ github.repository }} locally.
           2. Check out the PR branch and review the current code.
-          3. Read and understand the Cubic AI review feedback below.
-          4. Address each issue identified by Cubic AI by making the necessary code changes.
+          3. Read the Cubic AI review feedback below AND check each individual Cubic comment on the PR for the confidence score.
+          4. IMPORTANT: Only fix issues where the confidence score is 9/10 or higher. The confidence score appears as 'Fix confidence (alpha): X/10' in each Cubic comment. If you cannot find a confidence score for an issue, skip it.
           5. Commit your changes with clear commit messages referencing the issues fixed.
           6. Push your changes to the PR branch.
 

--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -150,7 +150,7 @@ jobs:
           
           MESSAGE="New Cubic AI review feedback has been submitted on PR #${{ github.event.pull_request.number }}.
 
-          IMPORTANT: Before fixing any issue, check the individual Cubic comment on the PR for that issue's confidence score. The confidence score appears as 'Fix confidence (alpha): X/10' in each comment. Only fix issues where the confidence score is 9/10 or higher. If you cannot find a confidence score for an issue, skip it.
+          IMPORTANT: Before fixing any issue, check the individual Cubic comment on the PR for that issue's confidence score. The confidence score appears as 'Fix confidence (alpha): X/10' in each comment. Note that the (alpha) may or not be there. Don't be picky about that text. But only fix issues where the confidence score is 9/10 or higher. If you cannot find a confidence score for an issue, skip it.
 
           Here are the issues identified by Cubic AI:
 


### PR DESCRIPTION
## What does this PR do?

Updates the Cubic-to-Devin review workflow to instruct Devin to only fix Cubic AI suggestions that have a confidence score of 9/10 or higher. Issues without a confidence score are skipped.

The change updates the instructions sent to Devin (both for existing sessions and new sessions) to:
1. Check each individual Cubic comment on the PR for the confidence score
2. Only fix issues where the confidence score is 9/10 or higher
3. Skip issues if no confidence score can be found

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - workflow behavior will be validated when Cubic submits reviews on future PRs.

## How should this be tested?

This workflow change will be validated when Cubic AI submits a review on a PR:
1. Cubic submits a review with issues that have varying confidence scores
2. Devin should only address issues with confidence >= 9/10
3. Issues with lower confidence or no confidence score should be skipped

## Checklist for Human Review

- [ ] Verify the instruction wording is clear enough for Devin to parse confidence scores from Cubic comments
- [ ] Confirm both the existing session message (line 153) and new session prompt (lines 186-187) are updated consistently

---

Link to Devin run: https://app.devin.ai/sessions/b69c0a39ba16425f9a18dd37f42e464b
Requested by: Keith Williams (@keithwillcode)