### PR TITLE
feat: add Biome rule to restrict @calcom imports in API v2

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -355,6 +355,41 @@
           }
         }
       }
+    },
+    {
+      "includes": ["apps/api/v2/**/*.{ts,tsx,js,jsx,mts,mjs,cjs,cts}"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": [
+                      "@calcom/*",
+                      "@calcom/**",
+                      "!@calcom/platform-constants",
+                      "!@calcom/platform-constants/**",
+                      "!@calcom/platform-enums",
+                      "!@calcom/platform-enums/**",
+                      "!@calcom/platform-libraries",
+                      "!@calcom/platform-libraries/**",
+                      "!@calcom/platform-types",
+                      "!@calcom/platform-types/**",
+                      "!@calcom/platform-utils",
+                      "!@calcom/platform-utils/**",
+                      "!@calcom/prisma",
+                      "!@calcom/prisma/**"
+                    ],
+                    "message": "API v2 should only import from @calcom/platform-constants, @calcom/platform-enums, @calcom/platform-libraries, @calcom/platform-types, @calcom/platform-utils, and @calcom/prisma. Other @calcom packages are not allowed."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Adds a Biome lint rule that restricts `@calcom/*` imports in API v2 to only the allowed platform packages. This prevents developers from accidentally importing directly from packages like `@calcom/features` or `@calcom/trpc`, which can cause module resolution issues since API v2's tsconfig.json doesn't have path mappings for those packages.

**Allowed packages:**
- `@calcom/platform-constants`
- `@calcom/platform-enums`
- `@calcom/platform-libraries`
- `@calcom/platform-types`
- `@calcom/platform-utils`
- `@calcom/prisma`

This addresses the architectural constraint discussed in [#26746](https://github.com/calcom/cal.com/pull/26746) where importing from `@calcom/features` directly caused API v2 to break.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - this is a lint configuration change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - lint rule tested manually.

## How should this be tested?

1. Run `yarn biome lint apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts` - should show an error for the `@calcom/features` import
2. Run `yarn biome lint` on a file that only imports from allowed packages (e.g., `@calcom/platform-libraries`) - should not show any `noRestrictedImports` errors

## Human Review Checklist

- [ ] Verify the Biome negation pattern syntax (`!@calcom/...`) works correctly
- [ ] Note: There are existing violations in the codebase that will now trigger lint errors - these should be fixed in follow-up PRs
- [ ] Verify the allowed packages list matches the API v2 package.json dependencies

---

Requested by: @keithwillcode
Link to Devin run: https://app.devin.ai/sessions/d808c7c50b5d4177aa4835b28acc8881