### PR TITLE
feat: request maintainer access for fork PRs without edit permissions

### DIFF
--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -86,6 +86,8 @@ jobs:
             const conflictingPRs = [];
             const unknownPRs = [];
 
+            const forksNeedingMaintainerAccess = [];
+
             function processPR(pr, mergeableStatus) {
               const isTargetPR = manualPrNumber && pr.number === manualPrNumber;
               const isFork = pr.headRepository?.owner?.login !== owner;
@@ -96,8 +98,22 @@ jobs:
               }
 
               if (!isTargetPR && isFork) {
-                console.log(`PR #${pr.number} is from a fork, skipping`);
-                return { skip: true };
+                if (!pr.maintainerCanModify) {
+                  const hasRequestedLabel = pr.labels.nodes.some(label => label.name === 'maintainer-access-requested');
+                  if (!hasRequestedLabel) {
+                    console.log(`PR #${pr.number} is from a fork without maintainer access, will request access`);
+                    forksNeedingMaintainerAccess.push({
+                      number: pr.number,
+                      title: pr.title,
+                      author: pr.headRepository?.owner?.login,
+                      html_url: pr.url
+                    });
+                  } else {
+                    console.log(`PR #${pr.number} already has maintainer-access-requested label, skipping`);
+                  }
+                  return { skip: true };
+                }
+                console.log(`PR #${pr.number} is from a fork with maintainer access enabled`);
               }
 
               if (!isTargetPR) {
@@ -199,12 +215,15 @@ jobs:
             }
 
             console.log(`Found ${conflictingPRs.length} PRs with conflicts that need Devin sessions`);
+            console.log(`Found ${forksNeedingMaintainerAccess.length} fork PRs needing maintainer access`);
 
             const fs = require('fs');
             fs.writeFileSync('/tmp/conflicting-prs.json', JSON.stringify(conflictingPRs));
+            fs.writeFileSync('/tmp/forks-needing-access.json', JSON.stringify(forksNeedingMaintainerAccess));
 
             core.setOutput('has-conflicts', conflictingPRs.length > 0 ? 'true' : 'false');
             core.setOutput('conflict-count', conflictingPRs.length.toString());
+            core.setOutput('has-forks-needing-access', forksNeedingMaintainerAccess.length > 0 ? 'true' : 'false');
 
       - name: Handle Devin sessions for conflicting PRs
         if: steps.check-prs.outputs.has-conflicts == 'true'
@@ -440,6 +459,58 @@ jobs:
                 }
               } catch (error) {
                 console.error(`Error handling Devin session for PR #${pr.number}: ${error.message}`);
+              }
+
+              await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+
+      - name: Request maintainer access for fork PRs
+        if: steps.check-prs.outputs.has-forks-needing-access == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const forksNeedingAccess = JSON.parse(fs.readFileSync('/tmp/forks-needing-access.json', 'utf8'));
+            const { owner, repo } = context.repo;
+
+            for (const pr of forksNeedingAccess) {
+              console.log(`Requesting maintainer access for PR #${pr.number}: ${pr.title}`);
+
+              try {
+                const commentBody = `### Maintainer Access Needed
+
+            Hi @${pr.author}! Thanks for your contribution to Cal.com.
+
+            We noticed that this PR doesn't have "Allow edits from maintainers" enabled. We'd love to help keep your PR up to date by resolving merge conflicts and making small fixes when needed.
+
+            **Could you please enable this setting?** Here's how:
+            1. Scroll down to the bottom of this PR page
+            2. In the right sidebar, check the box that says **"Allow edits and access to secrets by maintainers"**
+
+            This allows us to push commits directly to your PR branch, which helps us:
+            - Resolve merge conflicts automatically
+            - Make small adjustments to help get your PR merged faster
+
+            If you have any concerns about enabling this setting, feel free to let us know!`;
+
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  body: commentBody
+                });
+
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  labels: ['maintainer-access-requested']
+                });
+
+                console.log(`Posted comment and added label to PR #${pr.number}`);
+              } catch (error) {
+                console.error(`Error requesting maintainer access for PR #${pr.number}: ${error.message}`);
               }
 
               await new Promise(resolve => setTimeout(resolve, 1000));

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -478,21 +478,23 @@ jobs:
               console.log(`Requesting maintainer access for PR #${pr.number}: ${pr.title}`);
 
               try {
-                const commentBody = `### Maintainer Access Needed
-
-            Hi @${pr.author}! Thanks for your contribution to Cal.com.
-
-            We noticed that this PR doesn't have "Allow edits from maintainers" enabled. We'd love to help keep your PR up to date by resolving merge conflicts and making small fixes when needed.
-
-            **Could you please enable this setting?** Here's how:
-            1. Scroll down to the bottom of this PR page
-            2. In the right sidebar, check the box that says **"Allow edits and access to secrets by maintainers"**
-
-            This allows us to push commits directly to your PR branch, which helps us:
-            - Resolve merge conflicts automatically
-            - Make small adjustments to help get your PR merged faster
-
-            If you have any concerns about enabling this setting, feel free to let us know!`;
+                const commentBody = [
+                  '### Maintainer Access Needed',
+                  '',
+                  `Hi @${pr.author}! Thanks for your contribution to Cal.com.`,
+                  '',
+                  'We noticed that this PR doesn\'t have "Allow edits from maintainers" enabled. We\'d love to help keep your PR up to date by resolving merge conflicts and making small fixes when needed.',
+                  '',
+                  '**Could you please enable this setting?** Here\'s how:',
+                  '1. Scroll down to the bottom of this PR page',
+                  '2. In the right sidebar, check the box that says **"Allow edits and access to secrets by maintainers"**',
+                  '',
+                  'This allows us to push commits directly to your PR branch, which helps us:',
+                  '- Resolve merge conflicts automatically',
+                  '- Make small adjustments to help get your PR merged faster',
+                  '',
+                  'If you have any concerns about enabling this setting, feel free to let us know!'
+                ].join('\n');
 
                 await github.rest.issues.createComment({
                   owner,

--- a/.github/workflows/stale-pr-devin-completion.yml
+++ b/.github/workflows/stale-pr-devin-completion.yml
@@ -61,11 +61,7 @@ jobs:
             const isFork = pr.head.repo.fork || pr.head.repo.full_name !== pr.base.repo.full_name;
             const maintainerCanModify = pr.maintainer_can_modify;
             const canProceed = !isFork || maintainerCanModify;
-
-            if (!canProceed) {
-              core.setFailed(`Cannot complete this fork PR: the fork owner has not enabled "Allow edits from maintainers". PR author needs to enable this setting.`);
-              return;
-            }
+            const needsMaintainerAccess = isFork && !maintainerCanModify;
 
             const headRepoFullName = pr.head.repo.full_name;
             const headRepoCloneUrl = pr.head.repo.clone_url;
@@ -79,6 +75,7 @@ jobs:
             core.setOutput('head_repo_clone_url', headRepoCloneUrl);
             core.setOutput('maintainer_can_modify', maintainerCanModify);
             core.setOutput('can_proceed', canProceed);
+            core.setOutput('needs_maintainer_access', needsMaintainerAccess);
 
             console.log(`PR #${prNumber}: "${pr.title}"`);
             console.log(`Author: ${pr.user.login}`);
@@ -86,6 +83,62 @@ jobs:
             console.log(`Is fork: ${isFork}`);
             console.log(`Head repo: ${headRepoFullName}`);
             console.log(`Maintainer can modify: ${maintainerCanModify}`);
+            console.log(`Needs maintainer access: ${needsMaintainerAccess}`);
+
+      - name: Request maintainer access for fork PR
+        if: steps.pr.outputs.needs_maintainer_access == 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_AUTHOR: ${{ steps.pr.outputs.pr_author }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            const prAuthor = process.env.PR_AUTHOR;
+            const { owner, repo } = context.repo;
+
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: prNumber
+            });
+
+            const alreadyRequested = comments.data.some(comment => 
+              comment.body?.includes('### Maintainer Access Needed')
+            );
+
+            if (!alreadyRequested) {
+              const commentBody = `### Maintainer Access Needed
+
+            Hi @${prAuthor}! Thanks for your contribution to Cal.com.
+
+            We'd like to help complete this stale PR, but we noticed that "Allow edits from maintainers" isn't enabled. We need this setting to push updates to your PR branch.
+
+            **Could you please enable this setting?** Here's how:
+            1. Scroll down to the bottom of this PR page
+            2. In the right sidebar, check the box that says **"Allow edits and access to secrets by maintainers"**
+
+            This allows us to push commits directly to your PR branch, which helps us:
+            - Complete any remaining work on your PR
+            - Fix merge conflicts and make small adjustments
+            - Get your contribution merged faster
+
+            Once you've enabled this setting, we'll be able to help finish up this PR. If you have any concerns about enabling this setting, feel free to let us know!`;
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+
+              console.log(`Posted maintainer access request comment on PR #${prNumber}`);
+            } else {
+              console.log(`Maintainer access already requested on PR #${prNumber}`);
+            }
+
+            core.setFailed(`Cannot complete this fork PR: the fork owner has not enabled "Allow edits from maintainers". A comment has been posted requesting access.`);
 
       - name: Create Devin session
         if: steps.pr.outputs.can_proceed == 'true'

--- a/.github/workflows/stale-pr-devin-completion.yml
+++ b/.github/workflows/stale-pr-devin-completion.yml
@@ -109,22 +109,24 @@ jobs:
             );
 
             if (!alreadyRequested) {
-              const commentBody = `### Maintainer Access Needed
-
-            Hi @${prAuthor}! Thanks for your contribution to Cal.com.
-
-            We'd like to help complete this stale PR, but we noticed that "Allow edits from maintainers" isn't enabled. We need this setting to push updates to your PR branch.
-
-            **Could you please enable this setting?** Here's how:
-            1. Scroll down to the bottom of this PR page
-            2. In the right sidebar, check the box that says **"Allow edits and access to secrets by maintainers"**
-
-            This allows us to push commits directly to your PR branch, which helps us:
-            - Complete any remaining work on your PR
-            - Fix merge conflicts and make small adjustments
-            - Get your contribution merged faster
-
-            Once you've enabled this setting, we'll be able to help finish up this PR. If you have any concerns about enabling this setting, feel free to let us know!`;
+              const commentBody = [
+                '### Maintainer Access Needed',
+                '',
+                `Hi @${prAuthor}! Thanks for your contribution to Cal.com.`,
+                '',
+                `We'd like to help complete this stale PR, but we noticed that "Allow edits from maintainers" isn't enabled. We need this setting to push updates to your PR branch.`,
+                '',
+                '**Could you please enable this setting?** Here\'s how:',
+                '1. Scroll down to the bottom of this PR page',
+                '2. In the right sidebar, check the box that says **"Allow edits and access to secrets by maintainers"**',
+                '',
+                'This allows us to push commits directly to your PR branch, which helps us:',
+                '- Complete any remaining work on your PR',
+                '- Fix merge conflicts and make small adjustments',
+                '- Get your contribution merged faster',
+                '',
+                'Once you\'ve enabled this setting, we\'ll be able to help finish up this PR. If you have any concerns about enabling this setting, feel free to let us know!'
+              ].join('\n');
 
               await github.rest.issues.createComment({
                 owner,


### PR DESCRIPTION
## What does this PR do?

Updates the Devin stale PR updater and conflict resolver workflows to check if forked PRs have "Allow edits from maintainers" enabled. When this setting is disabled, the workflows now post a friendly comment asking the contributor to enable it, rather than silently skipping or failing.

**Changes:**
- **devin-conflict-resolver.yml**: Instead of skipping all fork PRs, now checks `maintainerCanModify`. If disabled, posts a comment and adds `maintainer-access-requested` label to avoid duplicate requests.
- **stale-pr-devin-completion.yml**: Instead of failing silently, now posts a helpful comment explaining how to enable the setting before failing the workflow.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow changes only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflows are tested via manual trigger.

## How should this be tested?

1. **For devin-conflict-resolver.yml**: Trigger the workflow manually or wait for the scheduled run. Check that fork PRs without maintainer access receive a comment and the `maintainer-access-requested` label.

2. **For stale-pr-devin-completion.yml**: Add the `stale` label to a fork PR that doesn't have "Allow edits from maintainers" enabled. Verify a friendly comment is posted before the workflow fails.

## Human Review Checklist

- [x] Verify the comment text renders correctly on GitHub (check for unintended leading whitespace)
- [x] Confirm the `maintainer-access-requested` label will be created if it doesn't exist
- [x] In conflict-resolver, `pr.headRepository?.owner?.login` is used as author - verify this correctly identifies the PR author vs fork owner

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---
Link to Devin run: https://app.devin.ai/sessions/033ae1fc47c848f689e9923496fd4c28
Requested by: @keithwillcode