### PR TITLE
refactor: change conflict resolver from cron to label-based trigger

### DIFF
--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -111,10 +111,13 @@ jobs:
             
             core.setOutput('pr-number', prNumber.toString());
             core.setOutput('has-pr', 'true');
+            core.setOutput('mergeable-status', pr.mergeable || 'UNKNOWN');
+            core.setOutput('has-conflicts', pr.mergeable === 'CONFLICTING' ? 'true' : 'false');
             
             console.log(`PR #${prNumber}: ${pr.title}`);
             console.log(`Mergeable status: ${pr.mergeable}`);
             console.log(`Is fork: ${isFork}`);
+            console.log(`Has conflicts: ${pr.mergeable === 'CONFLICTING'}`);
 
       - name: Request maintainer access for fork PR
         if: steps.get-pr.outputs.needs-maintainer-access == 'true'
@@ -174,8 +177,47 @@ jobs:
             console.log(`Posted comment and updated labels for PR #${prNumber}`);
             core.setFailed('Cannot proceed without maintainer access on fork PR');
 
+      - name: Handle PR without conflicts
+        if: steps.get-pr.outputs.has-pr == 'true' && steps.get-pr.outputs.needs-maintainer-access != 'true' && steps.get-pr.outputs.has-conflicts != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = parseInt('${{ steps.get-pr.outputs.pr-number }}', 10);
+            const mergeableStatus = '${{ steps.get-pr.outputs.mergeable-status }}';
+            
+            console.log(`PR #${prNumber} does not have conflicts (status: ${mergeableStatus})`);
+            
+            let message;
+            if (mergeableStatus === 'MERGEABLE') {
+              message = `### No Conflicts Detected\n\nThis PR does not have any merge conflicts with the base branch. The \`devin-conflict-resolution\` label has been removed.\n\nIf you believe this PR should have conflicts, please check the PR status and try again.`;
+            } else {
+              message = `### Mergeable Status Unknown\n\nGitHub is still computing the mergeable status for this PR (current status: \`${mergeableStatus}\`). The \`devin-conflict-resolution\` label has been removed.\n\nPlease wait a moment and re-add the label if the PR has conflicts.`;
+            }
+            
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body: message
+            });
+            
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: prNumber,
+                name: 'devin-conflict-resolution'
+              });
+            } catch (e) {
+              console.log(`Label may have already been removed: ${e.message}`);
+            }
+            
+            console.log(`Posted comment and removed label for PR #${prNumber}`);
+
       - name: Create Devin session for conflict resolution
-        if: steps.get-pr.outputs.has-pr == 'true' && steps.get-pr.outputs.needs-maintainer-access != 'true'
+        if: steps.get-pr.outputs.has-pr == 'true' && steps.get-pr.outputs.needs-maintainer-access != 'true' && steps.get-pr.outputs.has-conflicts == 'true'
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -1,16 +1,13 @@
 name: Devin PR Conflict Resolver
 
 on:
-  # Run every 5 minutes instead of on push to main.
-  # This saves runner costs by avoiding the 20-second sleep that was needed
-  # to wait for GitHub to compute mergeable status after merges to main.
-  schedule:
-    - cron: '*/5 * * * *'
+  pull_request:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to resolve conflicts for (optional, bypasses maintainer access check for fork PRs)'
-        required: false
+        description: 'PR number to resolve conflicts for'
+        required: true
         type: string
 
 permissions:
@@ -18,12 +15,16 @@ permissions:
   pull-requests: write
 
 jobs:
-  check-conflicts:
-    name: Check Open PRs for Conflicts
+  resolve-conflicts:
+    name: Resolve PR Conflicts with Devin
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    # Only run when devin-conflict-resolution label is added, or on manual dispatch
+    if: |
+      (github.event_name == 'pull_request' && github.event.label.name == 'devin-conflict-resolution') ||
+      github.event_name == 'workflow_dispatch'
     steps:
-      - name: Get open PRs and check for conflicts
-        id: check-prs
+      - name: Get PR details
+        id: get-pr
         uses: actions/github-script@v7
         env:
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
@@ -31,202 +32,150 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            const manualPrNumber = process.env.INPUT_PR_NUMBER ? parseInt(process.env.INPUT_PR_NUMBER, 10) : null;
-
+            let prNumber;
+            
+            if (context.eventName === 'workflow_dispatch') {
+              prNumber = parseInt(process.env.INPUT_PR_NUMBER, 10);
+              if (!prNumber) {
+                core.setFailed('PR number is required for manual dispatch');
+                return;
+              }
+            } else {
+              prNumber = context.payload.pull_request.number;
+            }
+            
+            console.log(`Processing PR #${prNumber}`);
+            
+            // Get PR details via GraphQL for complete info
             const query = `
-              query($owner: String!, $repo: String!, $cursor: String) {
+              query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
-                  pullRequests(states: OPEN, first: 100, after: $cursor) {
-                    pageInfo {
-                      hasNextPage
-                      endCursor
-                    }
-                    nodes {
-                      number
-                      title
-                      mergeable
-                      isDraft
-                      headRefName
-                      baseRefName
-                      url
-                      headRepository {
-                        owner {
-                          login
-                        }
-                        name
+                  pullRequest(number: $number) {
+                    number
+                    title
+                    mergeable
+                    isDraft
+                    headRefName
+                    baseRefName
+                    url
+                    body
+                    headRepository {
+                      owner {
+                        login
                       }
-                      maintainerCanModify
-                      labels(first: 10) {
-                        nodes {
-                          name
-                        }
-                      }
+                      name
                     }
+                    maintainerCanModify
                   }
                 }
               }
             `;
-
-            const allPRs = [];
-            let cursor = null;
-
-            do {
-              const result = await github.graphql(query, { owner, repo, cursor });
-              const { nodes, pageInfo } = result.repository.pullRequests;
-              allPRs.push(...nodes);
-              cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
-            } while (cursor);
-
-            console.log(`Found ${allPRs.length} open PRs via GraphQL`);
-
-            if (manualPrNumber) {
-              console.log(`Manual PR number provided: ${manualPrNumber}`);
+            
+            const result = await github.graphql(query, { owner, repo, number: prNumber });
+            const pr = result.repository.pullRequest;
+            
+            if (!pr) {
+              core.setFailed(`PR #${prNumber} not found`);
+              return;
             }
-
-            const conflictingPRs = [];
-            const unknownPRs = [];
-
-            const forksNeedingMaintainerAccess = [];
-
-            function processPR(pr, mergeableStatus) {
-              const isTargetPR = manualPrNumber && pr.number === manualPrNumber;
-              const isFork = pr.headRepository?.owner?.login !== owner;
-
-              if (!isTargetPR && pr.isDraft) {
-                console.log(`PR #${pr.number} is a draft, skipping`);
-                return { skip: true };
-              }
-
-              if (!isTargetPR && isFork) {
-                if (!pr.maintainerCanModify) {
-                  const hasRequestedLabel = pr.labels.nodes.some(label => label.name === 'maintainer-access-requested');
-                  if (!hasRequestedLabel) {
-                    console.log(`PR #${pr.number} is from a fork without maintainer access, will request access`);
-                    forksNeedingMaintainerAccess.push({
-                      number: pr.number,
-                      title: pr.title,
-                      author: pr.headRepository?.owner?.login,
-                      html_url: pr.url
-                    });
-                  } else {
-                    console.log(`PR #${pr.number} already has maintainer-access-requested label, skipping`);
-                  }
-                  return { skip: true };
-                }
-                console.log(`PR #${pr.number} is from a fork with maintainer access enabled`);
-              }
-
-              if (!isTargetPR) {
-                const hasDevinLabel = pr.labels.nodes.some(label => label.name === 'devin-conflict-resolution');
-                if (hasDevinLabel) {
-                  console.log(`PR #${pr.number} already has devin-conflict-resolution label, skipping`);
-                  return { skip: true };
-                }
-              }
-
-              if (mergeableStatus === 'CONFLICTING' || (isTargetPR && mergeableStatus !== 'MERGEABLE')) {
-                const headRepoOwner = pr.headRepository?.owner?.login || owner;
-                const headRepoName = pr.headRepository?.name || repo;
-
-                if (isTargetPR) {
-                  console.log(`PR #${pr.number} manually targeted for conflict resolution${isFork ? ' (from fork)' : ''}`);
-                } else {
-                  console.log(`PR #${pr.number} has conflicts`);
-                }
-
-                return {
-                  conflict: true,
-                  data: {
-                    number: pr.number,
-                    title: pr.title,
-                    head_ref: pr.headRefName,
-                    base_ref: pr.baseRefName,
-                    html_url: pr.url,
-                    is_fork: isFork,
-                    head_repo_owner: headRepoOwner,
-                    head_repo_name: headRepoName,
-                    is_manual: isTargetPR
-                  },
-                  isTargetPR
-                };
-              } else if (mergeableStatus === 'UNKNOWN') {
-                return { unknown: true, isTargetPR };
-              } else {
-                console.log(`PR #${pr.number} has no conflicts (mergeable: ${mergeableStatus})`);
-                return { skip: true };
-              }
+            
+            const isFork = pr.headRepository?.owner?.login !== owner;
+            
+            // Check if fork PR has maintainer access
+            if (isFork && !pr.maintainerCanModify) {
+              console.log(`PR #${prNumber} is from a fork without maintainer access`);
+              core.setOutput('needs-maintainer-access', 'true');
+              core.setOutput('fork-author', pr.headRepository?.owner?.login);
+            } else {
+              core.setOutput('needs-maintainer-access', 'false');
             }
-
-            for (const pr of allPRs) {
-              const result = processPR(pr, pr.mergeable);
-
-              if (result.conflict) {
-                conflictingPRs.push(result.data);
-                if (result.isTargetPR) break;
-              } else if (result.unknown) {
-                console.log(`PR #${pr.number} mergeable status is still being computed`);
-                unknownPRs.push(pr);
-              }
-            }
-
-            if (unknownPRs.length > 0) {
-              console.log(`\n${unknownPRs.length} PRs have UNKNOWN mergeable status, retrying via REST API...`);
-
-              for (const pr of unknownPRs) {
-                try {
-                  const { data } = await github.rest.pulls.get({
-                    owner,
-                    repo,
-                    pull_number: pr.number
-                  });
-
-                  let mergeableStatus;
-                  if (data.mergeable === true) {
-                    mergeableStatus = 'MERGEABLE';
-                  } else if (data.mergeable === false) {
-                    mergeableStatus = 'CONFLICTING';
-                  } else {
-                    mergeableStatus = 'UNKNOWN';
-                  }
-
-                  console.log(`PR #${pr.number} retry result: mergeable=${mergeableStatus}`);
-
-                  const result = processPR(pr, mergeableStatus);
-                  if (result.conflict) {
-                    conflictingPRs.push(result.data);
-                    if (result.isTargetPR) break;
-                  } else if (result.unknown) {
-                    console.log(`PR #${pr.number} still has UNKNOWN status, will be checked on next run`);
-                  }
-                } catch (error) {
-                  console.error(`Error retrying PR #${pr.number}: ${error.message}`);
-                }
-              }
-            }
-
-            if (manualPrNumber && conflictingPRs.length === 0) {
-              console.log(`Warning: PR #${manualPrNumber} not found or has no conflicts`);
-            }
-
-            const MAX_PRS = 15;
-            if (conflictingPRs.length > MAX_PRS) {
-              console.log(`Warning: Found ${conflictingPRs.length} PRs with conflicts, limiting to ${MAX_PRS} for safety`);
-              conflictingPRs.length = MAX_PRS;
-            }
-
-            console.log(`Found ${conflictingPRs.length} PRs with conflicts that need Devin sessions`);
-            console.log(`Found ${forksNeedingMaintainerAccess.length} fork PRs needing maintainer access`);
-
+            
+            const headRepoOwner = pr.headRepository?.owner?.login || owner;
+            const headRepoName = pr.headRepository?.name || repo;
+            
+            const prData = {
+              number: pr.number,
+              title: pr.title,
+              head_ref: pr.headRefName,
+              base_ref: pr.baseRefName,
+              html_url: pr.url,
+              body: pr.body,
+              is_fork: isFork,
+              head_repo_owner: headRepoOwner,
+              head_repo_name: headRepoName,
+              mergeable: pr.mergeable
+            };
+            
             const fs = require('fs');
-            fs.writeFileSync('/tmp/conflicting-prs.json', JSON.stringify(conflictingPRs));
-            fs.writeFileSync('/tmp/forks-needing-access.json', JSON.stringify(forksNeedingMaintainerAccess));
+            fs.writeFileSync('/tmp/pr-data.json', JSON.stringify(prData));
+            
+            core.setOutput('pr-number', prNumber.toString());
+            core.setOutput('has-pr', 'true');
+            
+            console.log(`PR #${prNumber}: ${pr.title}`);
+            console.log(`Mergeable status: ${pr.mergeable}`);
+            console.log(`Is fork: ${isFork}`);
 
-            core.setOutput('has-conflicts', conflictingPRs.length > 0 ? 'true' : 'false');
-            core.setOutput('conflict-count', conflictingPRs.length.toString());
-            core.setOutput('has-forks-needing-access', forksNeedingMaintainerAccess.length > 0 ? 'true' : 'false');
+      - name: Request maintainer access for fork PR
+        if: steps.get-pr.outputs.needs-maintainer-access == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = parseInt('${{ steps.get-pr.outputs.pr-number }}', 10);
+            const forkAuthor = '${{ steps.get-pr.outputs.fork-author }}';
+            
+            console.log(`Requesting maintainer access for PR #${prNumber}`);
+            
+            const commentBody = [
+              '### Maintainer Access Needed',
+              '',
+              `Hi @${forkAuthor}! Thanks for your contribution to Cal.com.`,
+              '',
+              'We noticed that this PR doesn\'t have "Allow edits from maintainers" enabled. We\'d love to help keep your PR up to date by resolving merge conflicts and making small fixes when needed.',
+              '',
+              '**Could you please enable this setting?** Here\'s how:',
+              '1. Scroll down to the bottom of this PR page',
+              '2. In the right sidebar, check the box that says **"Allow edits and access to secrets by maintainers"**',
+              '',
+              'This allows us to push commits directly to your PR branch, which helps us:',
+              '- Resolve merge conflicts automatically',
+              '- Make small adjustments to help get your PR merged faster',
+              '',
+              'Once you enable this setting, please remove and re-add the `devin-conflict-resolution` label to trigger conflict resolution.',
+              '',
+              'If you have any concerns about enabling this setting, feel free to let us know!'
+            ].join('\n');
+            
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body: commentBody
+            });
+            
+            // Add label to track that we've requested access
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: ['maintainer-access-requested']
+            });
+            
+            // Remove the devin-conflict-resolution label since we can't proceed
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number: prNumber,
+              name: 'devin-conflict-resolution'
+            });
+            
+            console.log(`Posted comment and updated labels for PR #${prNumber}`);
+            core.setFailed('Cannot proceed without maintainer access on fork PR');
 
-      - name: Handle Devin sessions for conflicting PRs
-        if: steps.check-prs.outputs.has-conflicts == 'true'
+      - name: Create Devin session for conflict resolution
+        if: steps.get-pr.outputs.has-pr == 'true' && steps.get-pr.outputs.needs-maintainer-access != 'true'
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -235,7 +184,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const conflictingPRs = JSON.parse(fs.readFileSync('/tmp/conflicting-prs.json', 'utf8'));
+            const pr = JSON.parse(fs.readFileSync('/tmp/pr-data.json', 'utf8'));
             const { owner, repo } = context.repo;
             
             async function checkSessionStatus(sessionId) {
@@ -303,18 +252,11 @@ jobs:
               return null;
             }
             
-            for (const pr of conflictingPRs) {
-              console.log(`Processing PR #${pr.number}: ${pr.title}${pr.is_fork ? ' (fork)' : ''}`);
-              
-              const { data: prDetails } = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: pr.number
-              });
-              
-              const existingSession = await findExistingSession(pr.number, prDetails.body);
-              
-              const forkInstructions = pr.is_fork ? `
+            console.log(`Processing PR #${pr.number}: ${pr.title}${pr.is_fork ? ' (fork)' : ''}`);
+            
+            const existingSession = await findExistingSession(pr.number, pr.body);
+            
+            const forkInstructions = pr.is_fork ? `
             IMPORTANT: This PR is from a fork. The contributor has enabled "Allow edits from maintainers".
             - Clone the FORK repository: ${pr.head_repo_owner}/${pr.head_repo_name}
             - The branch to work on is: ${pr.head_ref}
@@ -323,8 +265,8 @@ jobs:
             - Clone the repository: ${owner}/${repo}
             - Check out the PR branch: ${pr.head_ref}
             - Merge the base branch (${pr.base_ref}) using standard git merge`;
-              
-              const conflictResolutionInstructions = `You are resolving merge conflicts on PR #${pr.number} in repository ${owner}/${repo}.
+            
+            const conflictResolutionInstructions = `You are resolving merge conflicts on PR #${pr.number} in repository ${owner}/${repo}.
 
             PR Title: ${pr.title}
             PR URL: ${pr.html_url}
@@ -363,78 +305,71 @@ jobs:
             6. CRITICAL: If this is a fork PR and you encounter ANY error when pushing (permission denied, authentication failure, etc.), you MUST fail the task immediately. Do NOT attempt to push to a new branch in the main ${owner}/${repo} repository as a workaround. Simply report the error and stop.
             7. CRITICAL: Never reproduce or recreate changes from the target branch. Your merge commit should ONLY contain conflict resolutions. If you find yourself manually copying file contents from ${pr.base_ref} or creating changes that mirror what's already in ${pr.base_ref}, you are doing it wrong. Use git's merge functionality properly - it handles bringing in changes automatically.`;
 
-              try {
-                let sessionUrl;
-                let isNewSession = false;
+            try {
+              let sessionUrl;
+              let isNewSession = false;
+              
+              if (existingSession) {
+                console.log(`Sending message to existing session ${existingSession.sessionId} for PR #${pr.number}`);
                 
-                if (existingSession) {
-                  console.log(`Sending message to existing session ${existingSession.sessionId} for PR #${pr.number}`);
-                  
-                  const message = `PR #${pr.number} has new merge conflicts that need to be resolved.
+                const message = `PR #${pr.number} has merge conflicts that need to be resolved.
 
             ${conflictResolutionInstructions}
 
             Continue working on the same PR branch and push your fixes.`;
-                  
-                  const response = await fetch(`https://api.devin.ai/v1/sessions/${existingSession.sessionId}/message`, {
-                    method: 'POST',
-                    headers: {
-                      'Authorization': `Bearer ${process.env.DEVIN_API_KEY}`,
-                      'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({ message })
-                  });
-                  
-                  if (!response.ok) {
-                    console.error(`Failed to send message to session ${existingSession.sessionId}: ${response.status}`);
-                    continue;
-                  }
-                  
-                  sessionUrl = existingSession.sessionUrl;
-                  console.log(`Message sent to existing session for PR #${pr.number}`);
-                } else {
-                  console.log(`Creating new Devin session for PR #${pr.number}`);
-                  
-                  const response = await fetch('https://api.devin.ai/v1/sessions', {
-                    method: 'POST',
-                    headers: {
-                      'Authorization': `Bearer ${process.env.DEVIN_API_KEY}`,
-                      'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({
-                      prompt: conflictResolutionInstructions,
-                      title: `Resolve Conflicts: PR #${pr.number}`,
-                      tags: ['conflict-resolution', `pr-${pr.number}`]
-                    })
-                  });
-                  
-                  if (!response.ok) {
-                    console.error(`Devin API error for PR #${pr.number}: ${response.status} ${response.statusText}`);
-                    continue;
-                  }
-                  
-                  const data = await response.json();
-                  sessionUrl = data.url || data.session_url;
-                  isNewSession = true;
+                
+                const response = await fetch(`https://api.devin.ai/v1/sessions/${existingSession.sessionId}/message`, {
+                  method: 'POST',
+                  headers: {
+                    'Authorization': `Bearer ${process.env.DEVIN_API_KEY}`,
+                    'Content-Type': 'application/json'
+                  },
+                  body: JSON.stringify({ message })
+                });
+                
+                if (!response.ok) {
+                  console.error(`Failed to send message to session ${existingSession.sessionId}: ${response.status}`);
+                  throw new Error(`Failed to send message to existing session: ${response.status}`);
                 }
                 
-                if (sessionUrl) {
-                  if (isNewSession) {
-                    console.log(`Devin session created for PR #${pr.number}: ${sessionUrl}`);
-                  }
-                  
-                  await github.rest.issues.addLabels({
-                    owner,
-                    repo,
-                    issue_number: pr.number,
-                    labels: ['devin-conflict-resolution']
-                  });
-                  
-                  const sessionStatusMessage = isNewSession
-                    ? 'A Devin session has been created to automatically resolve them.'
-                    : 'The existing Devin session has been notified to resolve them.';
-                  
-                  const commentBody = `### Devin AI is resolving merge conflicts
+                sessionUrl = existingSession.sessionUrl;
+                console.log(`Message sent to existing session for PR #${pr.number}`);
+              } else {
+                console.log(`Creating new Devin session for PR #${pr.number}`);
+                
+                const response = await fetch('https://api.devin.ai/v1/sessions', {
+                  method: 'POST',
+                  headers: {
+                    'Authorization': `Bearer ${process.env.DEVIN_API_KEY}`,
+                    'Content-Type': 'application/json'
+                  },
+                  body: JSON.stringify({
+                    prompt: conflictResolutionInstructions,
+                    title: `Resolve Conflicts: PR #${pr.number}`,
+                    tags: ['conflict-resolution', `pr-${pr.number}`]
+                  })
+                });
+                
+                if (!response.ok) {
+                  console.error(`Devin API error for PR #${pr.number}: ${response.status} ${response.statusText}`);
+                  throw new Error(`Failed to create Devin session: ${response.status}`);
+                }
+                
+                const data = await response.json();
+                sessionUrl = data.url || data.session_url;
+                isNewSession = true;
+              }
+              
+              if (sessionUrl) {
+                if (isNewSession) {
+                  console.log(`Devin session created for PR #${pr.number}: ${sessionUrl}`);
+                }
+                
+                const sessionStatusMessage = isNewSession
+                  ? 'A Devin session has been created to automatically resolve them.'
+                  : 'The existing Devin session has been notified to resolve them.';
+                
+                const commentBody = `### Devin AI is resolving merge conflicts
 
             This PR has merge conflicts with the \`${pr.base_ref}\` branch. ${sessionStatusMessage}
 
@@ -447,73 +382,19 @@ jobs:
             4. Push the resolved changes
 
             If you prefer to resolve conflicts manually, you can close the Devin session and handle it yourself.`;
-                  
-                  await github.rest.issues.createComment({
-                    owner,
-                    repo,
-                    issue_number: pr.number,
-                    body: commentBody
-                  });
-                } else {
-                  console.log(`Failed to get session URL for PR #${pr.number}`);
-                }
-              } catch (error) {
-                console.error(`Error handling Devin session for PR #${pr.number}: ${error.message}`);
-              }
-
-              await new Promise(resolve => setTimeout(resolve, 1000));
-            }
-
-      - name: Request maintainer access for fork PRs
-        if: steps.check-prs.outputs.has-forks-needing-access == 'true'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const forksNeedingAccess = JSON.parse(fs.readFileSync('/tmp/forks-needing-access.json', 'utf8'));
-            const { owner, repo } = context.repo;
-
-            for (const pr of forksNeedingAccess) {
-              console.log(`Requesting maintainer access for PR #${pr.number}: ${pr.title}`);
-
-              try {
-                const commentBody = [
-                  '### Maintainer Access Needed',
-                  '',
-                  `Hi @${pr.author}! Thanks for your contribution to Cal.com.`,
-                  '',
-                  'We noticed that this PR doesn\'t have "Allow edits from maintainers" enabled. We\'d love to help keep your PR up to date by resolving merge conflicts and making small fixes when needed.',
-                  '',
-                  '**Could you please enable this setting?** Here\'s how:',
-                  '1. Scroll down to the bottom of this PR page',
-                  '2. In the right sidebar, check the box that says **"Allow edits and access to secrets by maintainers"**',
-                  '',
-                  'This allows us to push commits directly to your PR branch, which helps us:',
-                  '- Resolve merge conflicts automatically',
-                  '- Make small adjustments to help get your PR merged faster',
-                  '',
-                  'If you have any concerns about enabling this setting, feel free to let us know!'
-                ].join('\n');
-
+                
                 await github.rest.issues.createComment({
                   owner,
                   repo,
                   issue_number: pr.number,
                   body: commentBody
                 });
-
-                await github.rest.issues.addLabels({
-                  owner,
-                  repo,
-                  issue_number: pr.number,
-                  labels: ['maintainer-access-requested']
-                });
-
-                console.log(`Posted comment and added label to PR #${pr.number}`);
-              } catch (error) {
-                console.error(`Error requesting maintainer access for PR #${pr.number}: ${error.message}`);
+                
+                console.log(`Posted comment to PR #${pr.number}`);
+              } else {
+                throw new Error(`Failed to get session URL for PR #${pr.number}`);
               }
-
-              await new Promise(resolve => setTimeout(resolve, 1000));
+            } catch (error) {
+              console.error(`Error handling Devin session for PR #${pr.number}: ${error.message}`);
+              core.setFailed(error.message);
             }


### PR DESCRIPTION
## What does this PR do?

Changes the Devin PR Conflict Resolver workflow from a cron-based trigger (running every 5 minutes) to a label-based trigger that runs when the `devin-conflict-resolution` label is added to a PR.

This change:
- Reduces runner costs by only running when explicitly requested via label
- Simplifies the workflow logic since it now handles a single PR at a time instead of scanning all open PRs
- Gives maintainers explicit control over which PRs get conflict resolution

## Key Changes

**Trigger**: `schedule: cron: '*/5 * * * *'` → `pull_request: types: [labeled]` with condition for `devin-conflict-resolution` label

**Logic simplification**: 
- Removed batch processing loop - now handles single PR from event context
- Removed automatic label addition (label is now the trigger)
- Changed error handling from `continue` to `core.setFailed` for proper failure reporting

**Conflict validation**: Before creating a Devin session, the workflow now validates that the PR actually has conflicts (`mergeable === 'CONFLICTING'`). If the PR is mergeable or has unknown status, the label is removed and a comment is posted explaining why.

**Fork PR handling**: If a fork PR lacks maintainer access, the workflow removes the `devin-conflict-resolution` label and instructs the contributor to re-add it after enabling access.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - internal workflow change
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow

## How should this be tested?

1. Add the `devin-conflict-resolution` label to a PR with merge conflicts → should create Devin session
2. Add the `devin-conflict-resolution` label to a PR without conflicts → should remove label and post "No Conflicts Detected" comment
3. Test manual dispatch via `workflow_dispatch` with a PR number
4. Test fork PR handling by labeling a fork PR without maintainer access enabled

## Human Review Checklist

- [ ] Verify the `if` condition correctly filters for the `devin-conflict-resolution` label
- [ ] Verify `has-conflicts` output is correctly set based on `pr.mergeable === 'CONFLICTING'`
- [ ] Verify "Handle PR without conflicts" step runs when PR is MERGEABLE or UNKNOWN
- [ ] Confirm fork PR handling correctly removes the label when maintainer access is missing
- [ ] Verify `workflow_dispatch` still works with the required `pr_number` input

<!-- Link to Devin run: https://app.devin.ai/sessions/2153eb4e792b45ccab177f255100cfca -->
<!-- Requested by: keith@cal.com (@keithwillcode) -->