### PR TITLE
ci: use HEAD^2 and relative threshold in conflict resolver

### DIFF
--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -316,7 +316,7 @@ jobs:
             Base Branch: ${pr.base_ref}
             ${pr.is_fork ? `Fork Repository: ${pr.head_repo_owner}/${pr.head_repo_name}` : ''}
 
-            IMPORTANT WARNING: If your merge commit shows more than 50 files changed, DO NOT PUSH. This indicates the merge was done incorrectly. Abort and leave a comment instead.
+            IMPORTANT WARNING: If your merge commit shows significantly more files than the original PR, DO NOT PUSH. This indicates the merge was done incorrectly. Abort and leave a comment instead.
 
             Your tasks:
             ${forkInstructions}
@@ -330,25 +330,35 @@ jobs:
             2. Test that the code still works after resolving conflicts (run lint/type checks).
             3. Commit the merge resolution with a clear commit message.
             4. CRITICAL VALIDATION BEFORE PUSHING - YOU MUST RUN THESE EXACT COMMANDS:
-               
-               Step A: Count files changed in your merge commit:
+
+               Step A: Get original PR file count and count files in your merge commit:
                \`\`\`
-               FILE_COUNT=$(git diff --name-only HEAD^1...HEAD | wc -l)
-               echo "Files changed in merge commit: $FILE_COUNT"
+               # Get original PR file count
+               ORIGINAL_FILES=$(gh pr view ${pr.number} --json files -q '.files | length')
+               echo "Original PR files: $ORIGINAL_FILES"
+
+               # Count files in merge commit (what the PR contributes)
+               # HEAD^2 = base branch parent, so HEAD^2...HEAD shows the PR's contribution
+               MERGE_FILES=$(git diff --name-only HEAD^2...HEAD | wc -l)
+               echo "Files in merge commit: $MERGE_FILES"
+
+               # Calculate threshold (original PR files + 10 buffer)
+               THRESHOLD=$((ORIGINAL_FILES + 10))
+               echo "Threshold: $THRESHOLD"
                \`\`\`
-               
-               Step B: If FILE_COUNT > 50, STOP IMMEDIATELY. DO NOT PUSH.
-               - A proper merge commit should only contain conflict resolutions
-               - If you see 50+ files changed, the merge was done INCORRECTLY
+
+               Step B: If MERGE_FILES > THRESHOLD, STOP IMMEDIATELY. DO NOT PUSH.
+               - A proper merge commit should show approximately the same files as the original PR
+               - If you see significantly more files, the merge was done INCORRECTLY
                - This usually means you accidentally reproduced changes from ${pr.base_ref} instead of just resolving conflicts
-               
+
                Step C: Compare your merge to the original PR:
                \`\`\`
-               git diff --stat HEAD^1...HEAD
+               git diff --stat HEAD^2...HEAD
                \`\`\`
-               - This should show ONLY the files that had conflicts, plus any files from ${pr.base_ref} that were merged in
-               - If you see hundreds of files or files unrelated to the original PR conflicts, STOP
-               
+               - This should show approximately the same files as the original PR (the PR's contribution to the base branch)
+               - If you see many more files or files unrelated to the original PR, STOP
+
                Step D: If validation fails:
                - DO NOT PUSH under any circumstances
                - DO NOT attempt to fix it
@@ -367,7 +377,7 @@ jobs:
             5. Never ask for user confirmation. Never wait for user messages.
             6. CRITICAL: If this is a fork PR and you encounter ANY error when pushing (permission denied, authentication failure, etc.), you MUST fail the task immediately. Do NOT attempt to push to a new branch in the main ${owner}/${repo} repository as a workaround. Simply report the error and stop.
             7. CRITICAL: Never reproduce or recreate changes from the target branch. Your merge commit should ONLY contain conflict resolutions. If you find yourself manually copying file contents from ${pr.base_ref} or creating changes that mirror what's already in ${pr.base_ref}, you are doing it wrong. Use git's merge functionality properly - it handles bringing in changes automatically.
-            8. CRITICAL: If your merge commit shows a large number of files changed (more than 50), DO NOT PUSH UNDER ANY CIRCUMSTANCES. This is a sign that the merge was done incorrectly. Abort the task and leave a comment explaining the issue. A bad merge commit in the git history is worse than leaving the PR with conflicts.`;
+            8. CRITICAL: If your merge commit shows significantly more files than the original PR (more than original PR files + 10), DO NOT PUSH UNDER ANY CIRCUMSTANCES. This is a sign that the merge was done incorrectly. Abort the task and leave a comment explaining the issue. A bad merge commit in the git history is worse than leaving the PR with conflicts.`;
 
             try {
               let sessionUrl;


### PR DESCRIPTION
 ## What does this PR do?

Follow-up to #26754, improving the merge commit validation logic in the Devin conflict resolver.

### Changes

| Change | Before | After |
|--------|--------|-------|
| Git diff target | `HEAD^1...HEAD` | `HEAD^2...HEAD` |
| Threshold | Fixed 50 files | Relative: original PR files + 10 |

**Why `HEAD^2`?**
- `HEAD^1...HEAD` shows what main brought in (commit view)
- `HEAD^2...HEAD` shows what the PR contributed (matches GitHub's "Files changed" view)

**Why relative threshold?**
- Scales with PR size: a 100-file PR with 108 files in merge is fine
- More dynamic than a fixed number

## Validation

Tested locally with real merge commit:
```bash
# HEAD^1: 8 files — what main brought in
# HEAD^2: 1 file — what the PR contributed
```

## How should this be tested?

1. Trigger conflict resolver on a PR with conflicts
2. Verify Devin runs the updated validation commands
3. Check that threshold is calculated relative to original PR size

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs)
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.