### PR TITLE
ci: use pull_request_target for conflict resolver label trigger

### DIFF
--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     # Only run when devin-conflict-resolution label is added, or on manual dispatch
     if: |
-      (github.event_name == 'pull_request' && github.event.label.name == 'devin-conflict-resolution') ||
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'devin-conflict-resolution') ||
       github.event_name == 'workflow_dispatch'
     steps:
       - name: Get PR details

--- a/.github/workflows/devin-conflict-resolver.yml
+++ b/.github/workflows/devin-conflict-resolver.yml
@@ -1,7 +1,7 @@
 name: Devin PR Conflict Resolver
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What does this PR do?

Changes the Devin PR Conflict Resolver workflow trigger from `pull_request` to `pull_request_target` for the `labeled` event type, and updates the job's `if` condition to match the new event name.

The `pull_request` event with `types: [labeled]` was not reliably triggering when labels were added to PRs (e.g., PR #25912). The `pull_request_target` event is more reliable for label-based triggers because:

1. It always runs in the context of the base branch (main), avoiding workflow file caching issues
2. It has consistent access to secrets (needed for `DEVIN_API_KEY`)
3. It's the recommended approach for workflows that react to PR events but don't need to execute code from the PR

This is safe because the workflow only reads PR metadata and calls the Devin API - it doesn't checkout or execute any code from the PR.

### Changes made:
- Changed trigger from `pull_request` to `pull_request_target`
- Updated `if` condition from `github.event_name == 'pull_request'` to `github.event_name == 'pull_request_target'`

## Visual Demo (For contributors especially)

N/A - This is a CI workflow change with no UI impact.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - workflow triggers cannot be unit tested; manual verification required.

## How should this be tested?

1. Merge this PR
2. Add the `devin-conflict-resolution` label to a PR with merge conflicts
3. Verify the workflow triggers automatically (check the Actions tab)

Previously, adding the label would not trigger the workflow, requiring manual `workflow_dispatch`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run:** https://app.devin.ai/sessions/10665846ee964a2fada72f2edfe09494
**Requested by:** @keithwillcode