### PR TITLE
fix: add noValidate to routing form to suppress native browser tooltips

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/RoutingLink.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/RoutingLink.tsx
@@ -181,7 +181,7 @@ function RoutingForm({ form, profile, ...restProps }: Props) {
                 <div className="main border-booker md:border-booker-width dark:bg-cal-muted bg-default mx-0 rounded-md p-4 py-6 sm:-mx-4 sm:px-8 ">
                   <Toaster position="bottom-right" />
 
-                  <form onSubmit={handleOnSubmit}>
+                  <form noValidate onSubmit={handleOnSubmit}>
                     <div className="mb-8">
                       <h1 className="font-cal text-emphasis mb-1 text-xl font-semibold tracking-wide">
                         {form.name}


### PR DESCRIPTION
- Fixes #26467

This PR adds the `noValidate` attribute to the `<form>` element in `RoutingLink.tsx`.

**Reasoning:**
Currently, depending on the browser (e.g., Chrome), native HTML5 validation tooltips can appear and overlap with the custom Cal.com error UI when a user attempts to submit an empty form. Adding `noValidate` suppresses this native behavior, ensuring that only the intended Cal.com validation styling is displayed.