### PR TITLE
feat(api-v2): add GET /v2/bookings/{bookingUid}/seats/{seatUid} endpoint

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -8,6 +8,7 @@ import { CreateBookingOutput_2024_08_13 } from "@/ee/bookings/2024-08-13/outputs
 import { MarkAbsentBookingOutput_2024_08_13 } from "@/ee/bookings/2024-08-13/outputs/mark-absent.output";
 import { ReassignBookingOutput_2024_08_13 } from "@/ee/bookings/2024-08-13/outputs/reassign-booking.output";
 import { RescheduleBookingOutput_2024_08_13 } from "@/ee/bookings/2024-08-13/outputs/reschedule-booking.output";
+import { GetBookingSeatOutput_2024_08_13 } from "@/ee/bookings/2024-08-13/outputs/get-booking-seat.output";
 import { BookingReferencesService_2024_08_13 } from "@/ee/bookings/2024-08-13/services/booking-references.service";
 import { BookingsService_2024_08_13 } from "@/ee/bookings/2024-08-13/services/bookings.service";
 import { CalVideoService } from "@/ee/bookings/2024-08-13/services/cal-video.service";
@@ -208,6 +209,33 @@ export class BookingsController_2024_08_13 {
     return {
       status: SUCCESS_STATUS,
       data: booking,
+    };
+  }
+
+  @Get("/:bookingUid/seats/:seatUid")
+  @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
+  @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
+  @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
+  @ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiOperation({
+    summary: "Get a booking seat",
+    description: `Get seat data for a specific seat within a seated booking.
+
+    If the event type has 'show attendees' disabled, you must authenticate as the event type owner, host, team admin or org admin/owner to view seat details.
+
+    <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>
+    `,
+  })
+  async getBookingSeat(
+    @Param("bookingUid") bookingUid: string,
+    @Param("seatUid") seatUid: string,
+    @GetOptionalUser() user: AuthOptionalUser
+  ): Promise<GetBookingSeatOutput_2024_08_13> {
+    const seat = await this.bookingsService.getBookingSeat(bookingUid, seatUid, user);
+
+    return {
+      status: SUCCESS_STATUS,
+      data: seat,
     };
   }
 

--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/seated-bookings.e2e-spec.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/seated-bookings.e2e-spec.ts
@@ -364,6 +364,47 @@ describe("Bookings Endpoints 2024-08-13", () => {
         });
     });
 
+    describe("Get booking seat by seatUid", () => {
+      it("should get a specific seat by seatUid when seatsShowAttendees is enabled", async () => {
+        const seatUid = createdSeatedBooking.attendees[0].seatUid;
+
+        return request(app.getHttpServer())
+          .get(`/v2/bookings/${createdSeatedBooking.uid}/seats/${seatUid}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
+          .expect(200)
+          .then(async (response) => {
+            const responseBody = response.body;
+            expect(responseBody.status).toEqual(SUCCESS_STATUS);
+            expect(responseBody.data).toBeDefined();
+            expect(responseBody.data.seatUid).toEqual(seatUid);
+            expect(responseBody.data.name).toEqual(createdSeatedBooking.attendees[0].name);
+            expect(responseBody.data.email).toEqual(createdSeatedBooking.attendees[0].email);
+            expect(responseBody.data.timeZone).toEqual(createdSeatedBooking.attendees[0].timeZone);
+            expect(responseBody.data.language).toEqual(createdSeatedBooking.attendees[0].language);
+            expect(responseBody.data.bookingFieldsResponses).toBeDefined();
+          });
+      });
+
+      it("should return 404 when seatUid does not exist", async () => {
+        const nonExistentSeatUid = "non-existent-seat-uid";
+
+        return request(app.getHttpServer())
+          .get(`/v2/bookings/${createdSeatedBooking.uid}/seats/${nonExistentSeatUid}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
+          .expect(404);
+      });
+
+      it("should return 404 when seatUid does not belong to the booking", async () => {
+        const seatUid = createdSeatedBooking.attendees[0].seatUid;
+        const wrongBookingUid = "wrong-booking-uid";
+
+        return request(app.getHttpServer())
+          .get(`/v2/bookings/${wrongBookingUid}/seats/${seatUid}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
+          .expect(404);
+      });
+    });
+
     it("should not be able to reschedule seated booking if seatUid is not provided", async () => {
       const body = {
         start: new Date(Date.UTC(2030, 0, 8, 15, 0, 0)).toISOString(),

--- a/apps/api/v2/src/ee/bookings/2024-08-13/outputs/get-booking-seat.output.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/outputs/get-booking-seat.output.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { IsEnum, ValidateNested } from "class-validator";
+
+import { SUCCESS_STATUS, ERROR_STATUS } from "@calcom/platform-constants";
+import { SeatedAttendee } from "@calcom/platform-types";
+
+export class GetBookingSeatOutput_2024_08_13 {
+  @ApiProperty({ example: SUCCESS_STATUS, enum: [SUCCESS_STATUS, ERROR_STATUS] })
+  @IsEnum([SUCCESS_STATUS, ERROR_STATUS])
+  status!: typeof SUCCESS_STATUS | typeof ERROR_STATUS;
+
+  @ValidateNested()
+  @ApiProperty({
+    type: SeatedAttendee,
+    description: "Seat data including attendee information",
+  })
+  @Type(() => SeatedAttendee)
+  data!: SeatedAttendee;
+}

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/output.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/output.service.ts
@@ -551,4 +551,42 @@ export class OutputBookingsService_2024_08_13 {
       },
     };
   }
+
+  getOutputSeatAttendee(seat: {
+    referenceUid: string;
+    data: unknown;
+    metadata: unknown;
+    attendee: {
+      name: string;
+      email: string;
+      timeZone: string;
+      locale: string | null;
+      noShow: boolean | null;
+    };
+  }) {
+    const { responses } = safeParse(seatedBookingDataSchema, seat.data, defaultSeatedBookingData, false);
+
+    const attendeeData = {
+      name: seat.attendee.name,
+      email: seat.attendee.email,
+      displayEmail: this.getDisplayEmail(seat.attendee.email),
+      timeZone: seat.attendee.timeZone,
+      language: seat.attendee.locale,
+      absent: !!seat.attendee.noShow,
+      seatUid: seat.referenceUid,
+      bookingFieldsResponses: {},
+    };
+
+    const attendeeParsed = plainToClass(SeatedAttendee, attendeeData, { strategy: "excludeAll" });
+    attendeeParsed.bookingFieldsResponses = responses || {};
+    attendeeParsed.metadata = safeParse(
+      seatedBookingMetadataSchema,
+      seat.metadata,
+      defaultSeatedBookingMetadata,
+      false
+    );
+    delete attendeeParsed.bookingFieldsResponses.email;
+
+    return attendeeParsed;
+  }
 }

--- a/apps/api/v2/src/modules/booking-seat/booking-seat.repository.ts
+++ b/apps/api/v2/src/modules/booking-seat/booking-seat.repository.ts
@@ -16,4 +16,28 @@ export class BookingSeatRepository {
       },
     });
   }
+
+  async getByReferenceUidIncludeAttendee(referenceUid: string) {
+    return this.dbRead.prisma.bookingSeat.findUnique({
+      where: {
+        referenceUid,
+      },
+      include: {
+        booking: {
+          select: {
+            uid: true,
+            eventType: {
+              select: {
+                id: true,
+                teamId: true,
+                userId: true,
+                seatsShowAttendees: true,
+              },
+            },
+          },
+        },
+        attendee: true,
+      },
+    });
+  }
 }

--- a/apps/api/v2/src/modules/booking-seat/booking-seat.repository.ts
+++ b/apps/api/v2/src/modules/booking-seat/booking-seat.repository.ts
@@ -36,7 +36,15 @@ export class BookingSeatRepository {
             },
           },
         },
-        attendee: true,
+        attendee: {
+          select: {
+            name: true,
+            email: true,
+            timeZone: true,
+            locale: true,
+            noShow: true,
+          },
+        },
       },
     });
   }

--- a/apps/api/v2/src/modules/event-types/services/event-type-access.service.ts
+++ b/apps/api/v2/src/modules/event-types/services/event-type-access.service.ts
@@ -7,6 +7,8 @@ import { Injectable } from "@nestjs/common";
 
 import type { EventType } from "@calcom/prisma/client";
 
+type EventTypeForAccessCheck = Pick<EventType, "id" | "teamId" | "userId">;
+
 @Injectable()
 export class EventTypeAccessService {
   constructor(
@@ -16,7 +18,10 @@ export class EventTypeAccessService {
     private readonly teamsRepository: TeamsRepository
   ) {}
 
-  async userIsEventTypeAdminOrOwner(authUser: ApiAuthGuardUser, eventType: EventType): Promise<boolean> {
+  async userIsEventTypeAdminOrOwner(
+    authUser: ApiAuthGuardUser,
+    eventType: EventType | EventTypeForAccessCheck
+  ): Promise<boolean> {
     const authUserId = authUser.id;
     const eventTypeId = eventType.id;
     const teamId = eventType.teamId;


### PR DESCRIPTION
## What does this PR do?

Adds a new API v2 endpoint to retrieve seat data for a specific seat within a seated booking at `GET /v2/bookings/{bookingUid}/seats/{seatUid}`.

This endpoint returns the attendee information for a specific seat, including name, email, timezone, language, booking field responses, and metadata.

**Authorization**: If the event type has `seatsShowAttendees` disabled, the user must authenticate as the event type owner, host, team admin, or org admin/owner to view seat details.

## Updates since last revision

- Addressed Cubic AI feedback (confidence 9/10): Changed `attendee: true` to use explicit `select` with only the required fields (name, email, timeZone, locale, noShow) in `getByReferenceUidIncludeAttendee` repository method for better performance and security

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. N/A - OpenAPI docs are auto-generated from NestJS decorators.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a seated event type with `seatsShowAttendees: true`
2. Create a booking for that event type
3. Call `GET /v2/bookings/{bookingUid}/seats/{seatUid}` with the booking UID and seat UID from the attendees array
4. Verify the response contains the seat attendee data

**Test cases covered in e2e tests**:
- Successfully retrieving a seat by seatUid when seatsShowAttendees is enabled
- Returns 404 when seatUid does not exist
- Returns 404 when seatUid does not belong to the specified booking

## Human Review Checklist

- [ ] Verify the authorization logic in `bookings.service.ts:getBookingSeat` correctly checks `seatsShowAttendees` OR user is event type admin/owner
- [ ] Verify the type change in `event-type-access.service.ts` (accepting `EventType | EventTypeForAccessCheck`) is backward compatible
- [ ] Verify the output format from `getOutputSeatAttendee` matches the `SeatedAttendee` type expectations

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/0bf254eda7fe4a2cb52d1f62b43ef92d
Requested by: @ThyMinimalDev