### PR TITLE
feat(companion): unique extension id for firefox browser extension

### DIFF
--- a/companion/wxt.config.ts
+++ b/companion/wxt.config.ts
@@ -46,6 +46,9 @@ export default defineConfig({
     "build:manifestGenerated": (_wxt, manifest) => {
       manifest.browser_specific_settings ??= {};
       manifest.browser_specific_settings.gecko ??= {};
+      // Stable extension ID for Firefox development - ensures consistent OAuth redirect URL
+      // This must be an email-like string for Firefox to accept it
+      manifest.browser_specific_settings.gecko.id = "companion@cal.com";
       manifest.browser_specific_settings.gecko.data_collection_permissions = {
         required: ["none"],
       };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set a fixed Firefox extension ID in the WXT build so dev builds stay consistent and OAuth redirect URLs don't change.

<sup>Written for commit 15cd5a85b268adf3f20ab97f236d828382434bc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

