### PR TITLE
feat(pbac): use featureOptIn permissions in featureOptIn router and org features page

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/features/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/features/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { _generateMetadata } from "app/_utils";
+
+import { Resource } from "@calcom/features/pbac/domain/types/permission-registry";
+import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permissions";
+import { MembershipRole } from "@calcom/prisma/enums";
+
+import OrganizationFeaturesView from "~/ee/organizations/features-view";
+
+import { validateUserHasOrg } from "../../actions/validateUserHasOrg";
+
+export const generateMetadata = async (): Promise<Metadata> =>
+  await _generateMetadata(
+    (t) => t("features"),
+    (t) => t("feature_opt_in_org_description"),
+    undefined,
+    undefined,
+    "/settings/organizations/features"
+  );
+
+const Page = async () => {
+  const session = await validateUserHasOrg();
+
+  const { canRead } = await getResourcePermissions({
+    userId: session.user.id,
+    teamId: session.user.profile.organizationId,
+    resource: Resource.FeatureOptIn,
+    userRole: session.user.org?.role,
+    fallbackRoles: {
+      read: {
+        roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+      },
+      update: {
+        roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+      },
+    },
+  });
+
+  if (!canRead) {
+    return redirect("/settings/organizations/profile");
+  }
+
+  return <OrganizationFeaturesView />;
+};
+
+export default Page;

--- a/packages/trpc/server/routers/viewer/featureOptIn/_router.ts
+++ b/packages/trpc/server/routers/viewer/featureOptIn/_router.ts
@@ -69,7 +69,7 @@ export const featureOptInRouter = router({
       const hasPermission = await permissionCheckService.checkPermission({
         userId: ctx.user.id,
         teamId: input.teamId,
-        permission: "team.read",
+        permission: "featureOptIn.read",
         fallbackRoles: [MembershipRole.OWNER, MembershipRole.ADMIN],
       });
 
@@ -102,7 +102,7 @@ export const featureOptInRouter = router({
     const hasPermission = await permissionCheckService.checkPermission({
       userId: ctx.user.id,
       teamId: organizationId,
-      permission: "organization.read",
+      permission: "featureOptIn.read",
       fallbackRoles: [MembershipRole.OWNER, MembershipRole.ADMIN],
     });
 
@@ -168,7 +168,7 @@ export const featureOptInRouter = router({
       const hasPermission = await permissionCheckService.checkPermission({
         userId: ctx.user.id,
         teamId: input.teamId,
-        permission: "team.update",
+        permission: "featureOptIn.update",
         fallbackRoles: [MembershipRole.OWNER, MembershipRole.ADMIN],
       });
 
@@ -221,7 +221,7 @@ export const featureOptInRouter = router({
       const hasPermission = await permissionCheckService.checkPermission({
         userId: ctx.user.id,
         teamId: organizationId,
-        permission: "organization.update",
+        permission: "featureOptIn.update",
         fallbackRoles: [MembershipRole.OWNER, MembershipRole.ADMIN],
       });
 


### PR DESCRIPTION
## What does this PR do?

Updates the featureOptIn router and organization features page to use the new `featureOptIn.read` and `featureOptIn.update` permissions from the PBAC permission registry (added in #26761) instead of generic `team.*` and `organization.*` permissions.

**Changes:**
- Updated `packages/trpc/server/routers/viewer/featureOptIn/_router.ts`:
  - `listForTeam`: `team.read` → `featureOptIn.read`
  - `listForOrganization`: `organization.read` → `featureOptIn.read`
  - `setTeamState`: `team.update` → `featureOptIn.update`
  - `setOrganizationState`: `organization.update` → `featureOptIn.update`

- Created `apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/features/page.tsx`:
  - Uses `validateUserHasOrg` + `getResourcePermissions` with `Resource.FeatureOptIn` instead of `validateUserHasOrgAdmin`
  - Redirects to profile page if user lacks `featureOptIn.read` permission

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal permission changes only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Ensure PR #26761 is merged (adds FeatureOptIn resource to permission registry)
2. Verify users with `featureOptIn.read` permission can view team/org feature settings
3. Verify users with `featureOptIn.update` permission can modify team/org feature settings
4. Verify users without permissions are properly denied access

## Human Review Checklist

- [ ] **Dependency check**: The new page imports `OrganizationFeaturesView from "~/ee/organizations/features-view"` - verify this component exists or will be added
- [ ] **i18n keys**: Verify `features` and `feature_opt_in_org_description` translation keys exist
- [ ] **Permission migration**: Confirm the migration in #26761 properly assigns `featureOptIn.*` permissions to admin_role and member_role

## Link to Devin run

https://app.devin.ai/sessions/ca2cb0461b494a0bb217a55c5124e830

Requested by: @eunjae-lee