### PR TITLE
fix: sort workflow dropdown to show org before teams

### DIFF
--- a/packages/trpc/server/routers/loggedInViewer/teamsAndUserProfilesQuery.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/teamsAndUserProfilesQuery.handler.ts
@@ -113,6 +113,13 @@ export const teamsAndUserProfilesQuery = async ({ ctx, input }: TeamsAndUserProf
     teamsData = teamsData.filter((_, index) => permissionChecks[index]);
   }
 
+  // Sort teams so organizations come first, followed by other teams
+  teamsData.sort((a, b) => {
+    if (a.team.isOrganization && !b.team.isOrganization) return -1;
+    if (!a.team.isOrganization && b.team.isOrganization) return 1;
+    return 0;
+  });
+
   const rolesWithWriteAccess = [MembershipRole.ADMIN, MembershipRole.OWNER] as MembershipRole[];
 
   return [


### PR DESCRIPTION
## What does this PR do?

Sorts the teams/organization dropdown in the "New Workflow" button so that the organization appears before other teams. The order is now:
1. User profile
2. Organization
3. Teams

Previously, the order was determined by database insertion order, which could result in the organization appearing at the end of the list.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Log in as an org admin who has access to multiple teams
2. Navigate to Workflows page
3. Click the "+ New" dropdown button
4. Verify the order is: Profile, Organization, then Teams

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the sorting logic correctly places organizations before teams
- [ ] Note: This change affects ALL dropdowns using `CreateButtonWithTeamsList` (workflows, routing forms, webhooks), not just the workflow dropdown - confirm this is the desired behavior

---

Link to Devin run: https://app.devin.ai/sessions/01b2faf6da8a4d9ab86b54f85eece1f7
Requested by: @CarinaWolli