### PR TITLE
feat(companion): manifest id for safari extension & add delete account link 

### DIFF
--- a/companion/app/(tabs)/(more)/index.ios.tsx
+++ b/companion/app/(tabs)/(more)/index.ios.tsx
@@ -138,8 +138,24 @@ export default function More() {
           ))}
         </View>
 
-        {/* Sign Out Button */}
+        {/* Delete Account Link */}
         <View className="mt-6 overflow-hidden rounded-lg border border-[#E5E5EA] bg-white">
+          <TouchableOpacity
+            onPress={() =>
+              openInAppBrowser("https://app.cal.com/settings/my-account/profile", "Delete Account")
+            }
+            className="flex-row items-center justify-between bg-white px-5 py-4 active:bg-red-50"
+          >
+            <View className="flex-1 flex-row items-center">
+              <Ionicons name="trash-outline" size={20} color="#991B1B" />
+              <Text className="ml-3 text-base font-medium text-[#991B1B]">Delete Account</Text>
+            </View>
+            <Ionicons name="open-outline" size={20} color="#C7C7CC" />
+          </TouchableOpacity>
+        </View>
+
+        {/* Sign Out Button */}
+        <View className="mt-4 overflow-hidden rounded-lg border border-[#E5E5EA] bg-white">
           <TouchableOpacity
             onPress={handleSignOut}
             className="flex-row items-center justify-center bg-white px-5 py-4 active:bg-red-50"

--- a/companion/app/(tabs)/(more)/index.tsx
+++ b/companion/app/(tabs)/(more)/index.tsx
@@ -112,8 +112,24 @@ export default function More() {
           ))}
         </View>
 
-        {/* Sign Out Button */}
+        {/* Delete Account Link */}
         <View className="mt-6 overflow-hidden rounded-lg border border-[#E5E5EA] bg-white">
+          <TouchableOpacity
+            onPress={() =>
+              openInAppBrowser("https://app.cal.com/settings/my-account/profile", "Delete Account")
+            }
+            className="flex-row items-center justify-between bg-white px-5 py-4 active:bg-red-50"
+          >
+            <View className="flex-1 flex-row items-center">
+              <Ionicons name="trash-outline" size={20} color="#991B1B" />
+              <Text className="ml-3 text-base font-medium text-[#991B1B]">Delete Account</Text>
+            </View>
+            <Ionicons name="open-outline" size={20} color="#C7C7CC" />
+          </TouchableOpacity>
+        </View>
+
+        {/* Sign Out Button */}
+        <View className="mt-4 overflow-hidden rounded-lg border border-[#E5E5EA] bg-white">
           <TouchableOpacity
             onPress={handleSignOut}
             className="flex-row items-center justify-center bg-white px-5 py-4 active:bg-red-50"

--- a/companion/wxt.config.ts
+++ b/companion/wxt.config.ts
@@ -59,7 +59,7 @@ export default defineConfig({
   publicDir: "extension/public",
   outDir: ".output",
   manifest: {
-    name: "Cal.com Companion",
+    name: browserTarget === "safari" ? "Cal.com" : "Cal.com Companion",
     version: "1.7.5",
     description: "Your calendar companion for quick booking and scheduling",
     permissions: [


### PR DESCRIPTION


https://github.com/user-attachments/assets/426b26af-c13a-4695-822b-2946092d8a03





<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Safari builds now use "Cal.com" as the extension name to match platform requirements; the More tab now includes a Delete Account link. Other browsers keep "Cal.com Companion".

<sup>Written for commit b6c15c021a611de2a7da3cb802ba830d1193a155. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

