### PR TITLE
feat(feature-opt-in): refactor FeatureOptInService to use cached repositories

### DIFF
--- a/packages/features/di/modules/FeatureOptInService.ts
+++ b/packages/features/di/modules/FeatureOptInService.ts
@@ -1,8 +1,10 @@
 import { FEATURE_OPT_IN_DI_TOKENS } from "@calcom/features/feature-opt-in/di/tokens";
 import { FeatureOptInService } from "@calcom/features/feature-opt-in/services/FeatureOptInService";
+import { moduleLoader as cachedFeatureRepositoryModuleLoader } from "@calcom/features/flags/di/CachedFeatureRepository.module";
+import { moduleLoader as cachedTeamFeatureRepositoryModuleLoader } from "@calcom/features/flags/di/CachedTeamFeatureRepository.module";
+import { moduleLoader as cachedUserFeatureRepositoryModuleLoader } from "@calcom/features/flags/di/CachedUserFeatureRepository.module";
 
 import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "../di";
-import { moduleLoader as featuresRepositoryModuleLoader } from "./FeaturesRepository";
 
 const thisModule = createModule();
 const token = FEATURE_OPT_IN_DI_TOKENS.FEATURE_OPT_IN_SERVICE;
@@ -13,7 +15,11 @@ const loadModule = bindModuleToClassOnToken({
   moduleToken,
   token,
   classs: FeatureOptInService,
-  dep: featuresRepositoryModuleLoader,
+  depsMap: {
+    featureRepo: cachedFeatureRepositoryModuleLoader,
+    teamFeatureRepo: cachedTeamFeatureRepositoryModuleLoader,
+    userFeatureRepo: cachedUserFeatureRepositoryModuleLoader,
+  },
 });
 
 export const moduleLoader: ModuleLoader = {

--- a/packages/features/flags/di/CachedTeamFeatureRepository.container.ts
+++ b/packages/features/flags/di/CachedTeamFeatureRepository.container.ts
@@ -1,0 +1,12 @@
+import type { ICachedTeamFeatureRepository } from "../repositories/CachedTeamFeatureRepository";
+import { createContainer } from "../../di/di";
+import { moduleLoader as cachedTeamFeatureRepositoryModuleLoader } from "./CachedTeamFeatureRepository.module";
+
+const cachedTeamFeatureRepositoryContainer = createContainer();
+
+export function getCachedTeamFeatureRepository(): ICachedTeamFeatureRepository {
+  cachedTeamFeatureRepositoryModuleLoader.loadModule(cachedTeamFeatureRepositoryContainer);
+  return cachedTeamFeatureRepositoryContainer.get<ICachedTeamFeatureRepository>(
+    cachedTeamFeatureRepositoryModuleLoader.token
+  );
+}

--- a/packages/features/flags/di/CachedUserFeatureRepository.container.ts
+++ b/packages/features/flags/di/CachedUserFeatureRepository.container.ts
@@ -1,0 +1,12 @@
+import type { ICachedUserFeatureRepository } from "../repositories/CachedUserFeatureRepository";
+import { createContainer } from "../../di/di";
+import { moduleLoader as cachedUserFeatureRepositoryModuleLoader } from "./CachedUserFeatureRepository.module";
+
+const cachedUserFeatureRepositoryContainer = createContainer();
+
+export function getCachedUserFeatureRepository(): ICachedUserFeatureRepository {
+  cachedUserFeatureRepositoryModuleLoader.loadModule(cachedUserFeatureRepositoryContainer);
+  return cachedUserFeatureRepositoryContainer.get<ICachedUserFeatureRepository>(
+    cachedUserFeatureRepositoryModuleLoader.token
+  );
+}


### PR DESCRIPTION
## What does this PR do?

This is a **stacked PR** on top of #26798. It refactors `FeatureOptInService` to use the new cached repositories instead of the monolithic `FeaturesRepository`.

**Changes:**
- Update `FeatureOptInService` to accept `IFeatureOptInServiceDeps` with 3 cached repositories (`featureRepo`, `teamFeatureRepo`, `userFeatureRepo`)
- Update DI module to use `depsMap` pattern for multiple dependencies
- Update tRPC router to use cached repositories for auto-opt-in methods
- Add container files for `CachedTeamFeatureRepository` and `CachedUserFeatureRepository`

Cache invalidation now happens automatically on write operations through the cached repository layer.

## Updates since last revision

- Rebased on top of updated #26798 which now returns full `TeamFeatures`/`UserFeatures` objects instead of `FeatureState` values
- Added helper functions `teamFeatureToState()` and `userFeatureToState()` to transform full objects to `FeatureState` values ("enabled" | "disabled" | "inherit")
- Updated type signatures in `resolveFeatureState()`, `getOrgState()`, and `getOrgStateForTeam()` to handle the new return types

**Link to Devin run:** https://app.devin.ai/sessions/386ce63f8189493e8c66c35d42db9b16
**Requested by:** @eunjae-lee

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Ensure PR #26798 is merged first (this PR depends on it)
2. Run type checks: `yarn type-check:ci --force`
3. Run unit tests: `TZ=UTC yarn test`
4. Test feature opt-in functionality:
   - User feature state changes should invalidate user cache
   - Team feature state changes should invalidate team cache
   - Auto-opt-in preference changes should work correctly

## Checklist for Reviewers

- [ ] Verify method signature mappings from `FeaturesRepository` to cached repositories are correct
- [ ] Verify the `depsMap` DI pattern is wired correctly
- [ ] Check if existing `FeatureOptInService` tests need updates for new dependency injection pattern
- [ ] Verify `upsert()` and `delete()` calls match the cached repository interfaces
- [ ] Verify the type transformation logic in `teamFeatureToState()` and `userFeatureToState()` correctly maps `enabled: true` → "enabled", `enabled: false` → "disabled", `undefined` → "inherit"