### PR TITLE
fix: show only first assignment reason on insights page

### DIFF
--- a/apps/web/modules/insights/hooks/useInsightsColumns.tsx
+++ b/apps/web/modules/insights/hooks/useInsightsColumns.tsx
@@ -254,9 +254,7 @@ export const useInsightsColumns = ({
           filter: { type: ColumnFilterType.TEXT },
         },
         cell: (info) => {
-          const assignmentReason = info.getValue();
-          const firstReason = assignmentReason?.split(",")[0]?.trim() || "";
-          return <div className="max-w-[250px]">{firstReason}</div>;
+          return <div className="max-w-[250px]">{info.getValue()}</div>;
         },
       }),
       columnHelper.accessor("utm_source", {

--- a/apps/web/modules/insights/hooks/useInsightsColumns.tsx
+++ b/apps/web/modules/insights/hooks/useInsightsColumns.tsx
@@ -1,28 +1,26 @@
-import { createColumnHelper } from "@tanstack/react-table";
-import startCase from "lodash/startCase";
-import { useMemo } from "react";
-import { z } from "zod";
-
 import dayjs from "@calcom/dayjs";
 import { ColumnFilterType } from "@calcom/features/data-table";
+import type { HeaderRow, RoutingFormTableRow } from "@calcom/features/insights/lib/types";
+import {
+  ZResponseMultipleValues,
+  ZResponseNumericValue,
+  ZResponseSingleValue,
+  ZResponseTextValue,
+} from "@calcom/features/insights/lib/types";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useCopy } from "@calcom/lib/hooks/useCopy";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { RoutingFormFieldType } from "@calcom/routing-forms/lib/FieldTypes";
 import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
-
+import { createColumnHelper } from "@tanstack/react-table";
+import startCase from "lodash/startCase";
+import { useMemo } from "react";
+import { z } from "zod";
 import { BookedByCell } from "../components/BookedByCell";
 import { BookingAtCell } from "../components/BookingAtCell";
 import { BookingStatusBadge } from "../components/BookingStatusBadge";
 import { ResponseValueCell } from "../components/ResponseValueCell";
-import type { HeaderRow, RoutingFormTableRow } from "@calcom/features/insights/lib/types";
-import {
-  ZResponseMultipleValues,
-  ZResponseSingleValue,
-  ZResponseTextValue,
-  ZResponseNumericValue,
-} from "@calcom/features/insights/lib/types";
 
 export const useInsightsColumns = ({
   headers,
@@ -165,18 +163,21 @@ export const useInsightsColumns = ({
         const filterType = isSingleSelect
           ? ColumnFilterType.SINGLE_SELECT
           : isNumber
-          ? ColumnFilterType.NUMBER
-          : isText
-          ? ColumnFilterType.TEXT
-          : ColumnFilterType.MULTI_SELECT;
+            ? ColumnFilterType.NUMBER
+            : isText
+              ? ColumnFilterType.TEXT
+              : ColumnFilterType.MULTI_SELECT;
 
         const optionMap =
-          fieldHeader.options?.reduce((acc, option) => {
-            if (option.id) {
-              acc[option.id] = option.label;
-            }
-            return acc;
-          }, {} as Record<string, string>) ?? {};
+          fieldHeader.options?.reduce(
+            (acc, option) => {
+              if (option.id) {
+                acc[option.id] = option.label;
+              }
+              return acc;
+            },
+            {} as Record<string, string>
+          ) ?? {};
 
         return columnHelper.accessor((row) => row.fields.find((field) => field.fieldId === fieldHeader.id), {
           id: fieldHeader.id,
@@ -254,7 +255,8 @@ export const useInsightsColumns = ({
         },
         cell: (info) => {
           const assignmentReason = info.getValue();
-          return <div className="max-w-[250px]">{assignmentReason}</div>;
+          const firstReason = assignmentReason?.split(",")[0]?.trim() || "";
+          return <div className="max-w-[250px]">{firstReason}</div>;
         },
       }),
       columnHelper.accessor("utm_source", {

--- a/packages/features/insights/services/InsightsRoutingBaseService.ts
+++ b/packages/features/insights/services/InsightsRoutingBaseService.ts
@@ -294,7 +294,7 @@ export class InsightsRoutingBaseService {
         rfrd."bookingUserName",
         rfrd."bookingUserEmail",
         rfrd."bookingUserAvatarUrl",
-        rfrd."bookingAssignmentReason",
+        SPLIT_PART(rfrd."bookingAssignmentReason", ',', 1) as "bookingAssignmentReason",
         rfrd."bookingStartTime",
         rfrd."bookingEndTime",
         rfrd."eventTypeId",


### PR DESCRIPTION
## What does this PR do?

On the insights page, the assignment reason column now displays only the first reason (split by comma) instead of showing the full comma-separated list of reasons.

The assignment reason string can contain multiple attribute values joined by commas (e.g., `"Region: US, Language: English"`). This change extracts and displays only the first value for a cleaner presentation.

### Implementation Approach

The filtering is done at the SQL query level using PostgreSQL's `SPLIT_PART` function rather than in the UI. This is more efficient as it reduces data transfer and avoids client-side string manipulation.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to the Insights page (routing form responses table)
2. Find a row with an assignment reason that contains multiple comma-separated values
3. Verify that only the first reason is displayed in the Assignment Reason column

## Human Review Checklist

- [ ] Verify the comma delimiter assumption is correct for all assignment reason types (check `AssignmentReasonRecorder.ts` for how reasons are formatted)
- [ ] Confirm `SPLIT_PART` handles NULL values correctly (should return empty string)
- [ ] Note: The text filter for assignment reason still searches the full value in the database, not just the first part - verify this is acceptable behavior
- [ ] Consider if there are edge cases where a single reason might legitimately contain a comma

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/ba488bc7e6094c2b9c5c8ce6d6cf24dd
Requested by: @joeauyeung