### PR TITLE
fix(api): use cal.com for bookingUrl in platform organizations

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.spec.ts
@@ -82,6 +82,35 @@ describe("OutputEventTypesService_2024_06_14", () => {
       expect(result).toBe("https://acme.cal.com/owner1/30min");
     });
 
+    it("should use cal.com for non-managed users in platform orgs", () => {
+      const user = {
+        id: 1,
+        name: "Dhairyashil Shinde",
+        username: "dhairyashil10101010-gmail-com",
+        avatarUrl: null,
+        brandColor: null,
+        darkBrandColor: null,
+        weekStart: "Monday",
+        metadata: {},
+        organizationId: 1,
+        organization: { slug: "gmail-platform-9041df0e" },
+        movedToProfile: null,
+        profiles: [
+          {
+            id: 100,
+            username: "dhairyashil",
+            organizationId: 1,
+            organization: { id: 1, slug: "gmail-platform-9041df0e", isPlatform: true },
+          },
+        ],
+      };
+      const slug = "secret";
+
+      const result = service.buildBookingUrl(user, slug);
+
+      expect(result).toBe("https://cal.com/dhairyashil/secret");
+    });
+
     it("should fall back to user username when profile has no username", () => {
       const user = {
         id: 1,

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
@@ -53,7 +53,7 @@ type EventTypeUser = {
   weekStart: string;
   metadata: Prisma.JsonValue;
   organizationId: number | null;
-  organization?: { slug: string | null } | null;
+  organization?: { slug: string | null; isPlatform?: boolean } | null;
   movedToProfile?: ProfileMinimal | null;
   profiles?: ProfileMinimal[];
 };
@@ -448,7 +448,9 @@ export class OutputEventTypesService_2024_06_14 {
       return "";
     }
 
-    const orgSlug = profile?.organization?.slug ?? null;
+    const org = profile?.organization;
+    // Don't use org subdomain for platform organizations - they don't have public-facing subdomains
+    const orgSlug = org && !org.isPlatform ? org.slug : null;
     const webAppUrl = this.configService.get<string>("app.baseUrl", "https://app.cal.com");
     const baseUrl = orgSlug ? getBookerBaseUrlSync(orgSlug) : webAppUrl;
     const normalizedBaseUrl = baseUrl.replace(/\/$/, "");

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -2936,7 +2936,9 @@
                   "watchlist.create",
                   "watchlist.read",
                   "watchlist.update",
-                  "watchlist.delete"
+                  "watchlist.delete",
+                  "featureOptIn.read",
+                  "featureOptIn.update"
                 ]
               }
             }
@@ -6659,7 +6661,9 @@
                   "webhook.create",
                   "webhook.read",
                   "webhook.update",
-                  "webhook.delete"
+                  "webhook.delete",
+                  "featureOptIn.read",
+                  "featureOptIn.update"
                 ]
               }
             }
@@ -29645,7 +29649,9 @@
                 "watchlist.create",
                 "watchlist.read",
                 "watchlist.update",
-                "watchlist.delete"
+                "watchlist.delete",
+                "featureOptIn.read",
+                "featureOptIn.update"
               ]
             }
           },
@@ -29758,7 +29764,9 @@
                 "watchlist.create",
                 "watchlist.read",
                 "watchlist.update",
-                "watchlist.delete"
+                "watchlist.delete",
+                "featureOptIn.read",
+                "featureOptIn.update"
               ]
             }
           },
@@ -29920,7 +29928,9 @@
                 "watchlist.create",
                 "watchlist.read",
                 "watchlist.update",
-                "watchlist.delete"
+                "watchlist.delete",
+                "featureOptIn.read",
+                "featureOptIn.update"
               ]
             }
           },
@@ -30039,7 +30049,9 @@
                 "watchlist.create",
                 "watchlist.read",
                 "watchlist.update",
-                "watchlist.delete"
+                "watchlist.delete",
+                "featureOptIn.read",
+                "featureOptIn.update"
               ]
             }
           }
@@ -30123,7 +30135,9 @@
                 "webhook.create",
                 "webhook.read",
                 "webhook.update",
-                "webhook.delete"
+                "webhook.delete",
+                "featureOptIn.read",
+                "featureOptIn.update"
               ]
             }
           },
@@ -30215,7 +30229,9 @@
                 "webhook.create",
                 "webhook.read",
                 "webhook.update",
-                "webhook.delete"
+                "webhook.delete",
+                "featureOptIn.read",
+                "featureOptIn.update"
               ]
             }
           },
@@ -30356,7 +30372,9 @@
                 "webhook.create",
                 "webhook.read",
                 "webhook.update",
-                "webhook.delete"
+                "webhook.delete",
+                "featureOptIn.read",
+                "featureOptIn.update"
               ]
             }
           },
@@ -30454,7 +30472,9 @@
                 "webhook.create",
                 "webhook.read",
                 "webhook.update",
-                "webhook.delete"
+                "webhook.delete",
+                "featureOptIn.read",
+                "featureOptIn.update"
               ]
             }
           }
@@ -33058,10 +33078,6 @@
               "error"
             ]
           },
-          "message": {
-            "type": "string",
-            "example": "This endpoint will require authentication in a future release."
-          },
           "error": {
             "type": "object"
           },
@@ -33097,10 +33113,6 @@
             "items": {
               "type": "string"
             }
-          },
-          "message": {
-            "type": "string",
-            "example": "This endpoint will require authentication in a future release."
           },
           "error": {
             "type": "object"


### PR DESCRIPTION
## What does this PR do?

Fixes the `bookingUrl` field in API v2 event types response for non-managed users in platform organizations.

### Problem

Non-managed users in platform orgs were getting incorrect booking URLs that used the platform org's subdomain:

- ❌ `https://gmail-platform-9041df0e-a16d-46b2-a.cal.com/dhairyashil10101010-gmail/secret`
- ✅ `https://cal.com/dhairyashil/secret`

Platform organizations (`isPlatform: true`) don't have public-facing subdomains - they're internal containers for API developers. Only regular organizations should have subdomain-based booking URLs.

### Solution

Updated [buildBookingUrl](cci:1://file:///Users/dhairyashilshinde/work/cal.com/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts:438:2-456:3) in [OutputEventTypesService_2024_06_14](cci:2://file:///Users/dhairyashilshinde/work/cal.com/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts:130:0-517:1) to check if the organization is a platform org before using the slug for the subdomain.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes incorrect booking URLs in companion app for platform org users (follow-up to #26195)