### PR TITLE
fix: resolve type errors in attribute sync feature

### DIFF
--- a/packages/features/credentials/repositories/CredentialRepository.ts
+++ b/packages/features/credentials/repositories/CredentialRepository.ts
@@ -330,7 +330,7 @@ export class CredentialRepository {
     });
   }
 
-  async findByAppIdAndKeyValue<T>({
+  async findByAppIdAndKeyValue({
     appId,
     keyPath,
     value,
@@ -338,7 +338,7 @@ export class CredentialRepository {
   }: {
     appId: string;
     keyPath: string[];
-    value: T;
+    value: Prisma.InputJsonValue;
     keyFields?: string[];
   }) {
     const credential = await prisma.credential.findFirst({

--- a/packages/features/ee/integration-attribute-sync/repositories/IIntegrationAttributeSyncRepository.ts
+++ b/packages/features/ee/integration-attribute-sync/repositories/IIntegrationAttributeSyncRepository.ts
@@ -130,6 +130,14 @@ export interface IIntegrationAttributeSyncRepository {
   getSyncFieldMappings(
     integrationAttributeSyncId: string
   ): Promise<AttributeSyncFieldMapping[]>;
+  getMappedAttributeIdsByOrganization(
+    organizationId: number,
+    excludeSyncId?: string
+  ): Promise<string[]>;
+  getAttributeIdsByOrganization(
+    organizationId: number,
+    attributeIds: string[]
+  ): Promise<string[]>;
   create(
     params: IIntegrationAttributeSyncCreateParams
   ): Promise<IntegrationAttributeSync>;

--- a/packages/trpc/server/routers/viewer/featureOptIn/_router.ts
+++ b/packages/trpc/server/routers/viewer/featureOptIn/_router.ts
@@ -19,13 +19,14 @@ const featureStateSchema: ZodEnum<["enabled", "disabled", "inherit"]> = z.enum([
 const featureOptInService = getFeatureOptInService();
 const featuresRepository = new FeaturesRepository(prisma);
 const teamRepository = new TeamRepository(prisma);
+const membershipRepository = new MembershipRepository(prisma);
 
 /**
  * Helper to get user's org and team IDs from their memberships.
  * Returns orgId (if user belongs to an org) and teamIds (non-org teams).
  */
 async function getUserOrgAndTeamIds(userId: number): Promise<{ orgId: number | null; teamIds: number[] }> {
-  const memberships = await MembershipRepository.findAllByUserId({
+  const memberships = await membershipRepository.findAllByUserId({
     userId,
     filters: { accepted: true },
   });


### PR DESCRIPTION
## What does this PR do?

Fixes CI type check failures in PR #26517 by resolving three TypeScript errors:

1. **IIntegrationAttributeSyncRepository interface** - Added missing method signatures (`getMappedAttributeIdsByOrganization` and `getAttributeIdsByOrganization`) that were implemented in `PrismaIntegrationAttributeSyncRepository` but not declared in the interface.

2. **featureOptIn/_router.ts** - Fixed `MembershipRepository.findAllByUserId` being called as a static method when it's actually an instance method. Created a `membershipRepository` instance to call the method correctly.

3. **CredentialRepository.ts** - Changed the generic type `<T>` to `Prisma.InputJsonValue` for the `findByAppIdAndKeyValue` method to satisfy Prisma's JSON filtering type requirements.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - type fixes only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run `yarn prisma generate && cd packages/trpc && yarn build` - should complete without type errors
2. Run `yarn type-check:ci --force` - the files modified in this PR should pass type checking (note: there are pre-existing embed-react type errors unrelated to this PR)

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the interface method signatures match the implementation in `PrismaIntegrationAttributeSyncRepository`
- [ ] Confirm the `MembershipRepository` instantiation pattern is consistent with other repositories in the file (e.g., `TeamRepository`)
- [ ] Check that removing the generic type from `findByAppIdAndKeyValue` doesn't break any callers

---
**Link to Devin run:** https://app.devin.ai/sessions/ecbe675bbe0e4a8ba2de987e8bcbd0ae
**Requested by:** @hariombalhara