### PR TITLE
fix: address proration implementation flaws

### DIFF
--- a/packages/features/ee/billing/lib/stripe-subscription-utils.ts
+++ b/packages/features/ee/billing/lib/stripe-subscription-utils.ts
@@ -11,9 +11,9 @@ export function extractBillingDataFromStripeSubscription(subscription: Stripe.Su
   const billingPeriod: BillingPeriod =
     subscription.items.data[0]?.price.recurring?.interval === "year" ? "ANNUALLY" : "MONTHLY";
 
-  const pricePerSeat = subscription.items.data[0]?.price.unit_amount;
+  const pricePerSeat = subscription.items.data[0]?.price.unit_amount ?? undefined;
 
-  const paidSeats = subscription.items.data[0]?.quantity;
+  const paidSeats = subscription.items.data[0]?.quantity ?? undefined;
 
   return {
     billingPeriod,

--- a/packages/features/ee/billing/repository/seatChangeLogs/SeatChangeLogRepository.ts
+++ b/packages/features/ee/billing/repository/seatChangeLogs/SeatChangeLogRepository.ts
@@ -10,6 +10,7 @@ export interface CreateSeatChangeLogData {
   userId?: number;
   triggeredBy?: number;
   monthKey: string;
+  operationId?: string;
   metadata?: Prisma.InputJsonValue;
   teamBillingId: string | null;
   organizationBillingId: string | null;
@@ -28,6 +29,20 @@ export class SeatChangeLogRepository {
   }
 
   async create(data: CreateSeatChangeLogData): Promise<SeatChangeLog> {
+    // If operationId is provided, use upsert to prevent duplicates
+    if (data.operationId) {
+      return await this.prisma.seatChangeLog.upsert({
+        where: {
+          teamId_operationId: {
+            teamId: data.teamId,
+            operationId: data.operationId,
+          },
+        },
+        create: data,
+        update: {}, // No update needed - if it exists, we skip
+      });
+    }
+
     return await this.prisma.seatChangeLog.create({
       data,
     });

--- a/packages/features/ee/billing/service/billingProvider/IBillingProviderService.ts
+++ b/packages/features/ee/billing/service/billingProvider/IBillingProviderService.ts
@@ -80,10 +80,13 @@ export interface IBillingProviderService {
     customerId: string;
     autoAdvance: boolean;
     collectionMethod?: "charge_automatically" | "send_invoice";
+    daysUntilDue?: number;
     metadata?: Record<string, string>;
   }): Promise<{ invoiceId: string }>;
 
   finalizeInvoice(invoiceId: string): Promise<void>;
+
+  voidInvoice(invoiceId: string): Promise<void>;
 
   getPaymentIntentFailureReason(paymentIntentId: string): Promise<string | null>;
 

--- a/packages/features/ee/billing/service/proration/MonthlyProrationService.ts
+++ b/packages/features/ee/billing/service/proration/MonthlyProrationService.ts
@@ -193,6 +193,8 @@ export class MonthlyProrationService {
     netSeatIncrease: number;
     monthKey: string;
     teamId: number;
+    subscriptionId: string;
+    invoiceId?: string | null;
   }) {
     const amountInCents = Math.round(proration.proratedAmount);
 
@@ -304,6 +306,11 @@ export class MonthlyProrationService {
 
     if (!proration) throw new Error(`Proration ${prorationId} not found`);
     if (proration.status !== "FAILED") throw new Error(`Proration ${prorationId} is not in FAILED status`);
+
+    // Void the old invoice to prevent double charging
+    if (proration.invoiceId) {
+      await this.billingService.voidInvoice(proration.invoiceId);
+    }
 
     await this.createStripeInvoiceItem(proration);
   }

--- a/packages/features/ee/billing/service/seatTracking/SeatChangeTrackingService.ts
+++ b/packages/features/ee/billing/service/seatTracking/SeatChangeTrackingService.ts
@@ -14,6 +14,9 @@ export interface SeatChangeLogParams {
   seatCount?: number;
   metadata?: Prisma.InputJsonValue;
   monthKey?: string;
+  // Idempotency key to prevent duplicate seat change logs from race conditions
+  // Format: "{source}-{uniqueId}" e.g., "membership-123" or "invite-abc"
+  operationId?: string;
 }
 
 export interface MonthlyChanges {
@@ -32,7 +35,15 @@ export class SeatChangeTrackingService {
   }
 
   async logSeatAddition(params: SeatChangeLogParams): Promise<void> {
-    const { teamId, userId, triggeredBy, seatCount = 1, metadata, monthKey: providedMonthKey } = params;
+    const {
+      teamId,
+      userId,
+      triggeredBy,
+      seatCount = 1,
+      metadata,
+      monthKey: providedMonthKey,
+      operationId,
+    } = params;
     const monthKey = providedMonthKey || this.calculateMonthKey(new Date());
 
     const { teamBillingId, organizationBillingId } = await this.repository.getTeamBillingIds(teamId);
@@ -44,6 +55,7 @@ export class SeatChangeTrackingService {
       userId,
       triggeredBy,
       monthKey,
+      operationId,
       metadata: (metadata || {}) as Prisma.InputJsonValue,
       teamBillingId,
       organizationBillingId,
@@ -51,7 +63,15 @@ export class SeatChangeTrackingService {
   }
 
   async logSeatRemoval(params: SeatChangeLogParams): Promise<void> {
-    const { teamId, userId, triggeredBy, seatCount = 1, metadata, monthKey: providedMonthKey } = params;
+    const {
+      teamId,
+      userId,
+      triggeredBy,
+      seatCount = 1,
+      metadata,
+      monthKey: providedMonthKey,
+      operationId,
+    } = params;
     const monthKey = providedMonthKey || this.calculateMonthKey(new Date());
 
     const { teamBillingId, organizationBillingId } = await this.repository.getTeamBillingIds(teamId);
@@ -63,6 +83,7 @@ export class SeatChangeTrackingService {
       userId,
       triggeredBy,
       monthKey,
+      operationId,
       metadata: (metadata || {}) as Prisma.InputJsonValue,
       teamBillingId,
       organizationBillingId,

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2988,6 +2988,9 @@ model SeatChangeLog {
   changeDate DateTime @default(now())
   monthKey   String
 
+  // Idempotency key to prevent duplicate seat change logs from race conditions
+  operationId String?
+
   processedInProrationId String?
   proration              MonthlyProration? @relation(fields: [processedInProrationId], references: [id])
 
@@ -2999,6 +3002,7 @@ model SeatChangeLog {
   organizationBillingId String?
   organizationBilling   OrganizationBilling? @relation(fields: [organizationBillingId], references: [id])
 
+  @@unique([teamId, operationId])
   @@index([teamId, monthKey])
   @@index([teamId, processedInProrationId])
   @@index([monthKey])


### PR DESCRIPTION
## What does this PR do?

This PR addresses several flaws identified during code review of the custom proration implementation on the `feat/proration` branch:

1. **Idempotency for Seat Tracking** - Adds `operationId` field to `SeatChangeLog` model with a unique constraint to prevent duplicate seat change logs from race conditions when users flow through multiple code paths
2. **Prevent Double Charging on Retry** - Adds `voidInvoice` method that voids/deletes old invoices before creating new ones when retrying failed prorations
3. **Due Date for Send Invoice** - Adds `daysUntilDue` parameter (defaults to 30 days) for invoices using `send_invoice` collection method
4. **Type Fix** - Fixes type error in `stripe-subscription-utils.ts` (null to undefined conversion)

Link to Devin run: https://app.devin.ai/sessions/e1373fed6b8442b18a8344f6ae9c8353
Requested by: @sean-brydon

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal billing changes only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Idempotency**: Call `logSeatAddition` or `logSeatRemoval` multiple times with the same `operationId` - should only create one record
2. **Invoice Voiding**: Trigger a failed proration retry and verify the old invoice is voided before creating a new one
3. **Due Date**: Create an invoice with `send_invoice` collection method and verify it has a 30-day due date

Note: The idempotency infrastructure is in place, but callers of `logSeatAddition`/`logSeatRemoval` will need to be updated to pass `operationId` values for the protection to be active.

## Checklist for Human Review

- [ ] Verify Prisma migration is created for the new `operationId` field and unique constraint
- [ ] Review whether callers should be updated now to pass `operationId` values
- [ ] Check `voidInvoice` logic handles all invoice status edge cases appropriately
- [ ] Consider if unit tests should be added for the new functionality