### PR TITLE
fix: re-throw error in voidInvoice to prevent silent failures

### DIFF
--- a/packages/features/ee/billing/service/billingProvider/StripeBillingService.ts
+++ b/packages/features/ee/billing/service/billingProvider/StripeBillingService.ts
@@ -290,6 +290,7 @@ export class StripeBillingService implements IBillingProviderService {
       // If paid or void, no action needed
     } catch (error) {
       log.warn("Failed to void invoice", { invoiceId, error });
+      throw error;
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Addresses Cubic AI feedback from PR #26823: the `voidInvoice` method was silently catching and logging errors without re-throwing them. This could lead to double charging if the Stripe API call fails - the caller wouldn't know the void operation failed and might proceed to create a new invoice anyway.

Now the error is logged for debugging purposes and then re-thrown so callers can handle failures appropriately.

Link to Devin run: https://app.devin.ai/sessions/e1373fed6b8442b18a8344f6ae9c8353
Requested by: @sean-brydon

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal billing change only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Trigger a failed proration retry where the old invoice cannot be voided (e.g., Stripe API error)
2. Verify the error propagates to the caller instead of being silently swallowed
3. Confirm the caller can handle the error appropriately (e.g., not proceeding to create a duplicate invoice)

## Checklist for Human Review

- [ ] Verify that `retryFailedProration` in `MonthlyProrationService.ts` handles the thrown error appropriately, or that it's acceptable for the error to propagate up and abort the retry