### PR TITLE
fix(api): return empty bookingUrl for managed users in API v2

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/event-types.repository.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/event-types.repository.ts
@@ -65,6 +65,7 @@ export class EventTypesRepository_2024_06_14 {
       id: true,
       name: true,
       username: true,
+      isPlatformManaged: true,
       avatarUrl: true,
       brandColor: true,
       darkBrandColor: true,

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.spec.ts
@@ -111,6 +111,29 @@ describe("OutputEventTypesService_2024_06_14", () => {
       expect(result).toBe("https://cal.com/dhairyashil/secret");
     });
 
+    it("should return empty string for managed users", () => {
+      const user = {
+        id: 1,
+        name: "Managed User",
+        username: "managed-user-abc123",
+        isPlatformManaged: true,
+        avatarUrl: null,
+        brandColor: null,
+        darkBrandColor: null,
+        weekStart: "Monday",
+        metadata: {},
+        organizationId: 1,
+        organization: { slug: "platform-org" },
+        movedToProfile: null,
+        profiles: [],
+      };
+      const slug = "30min";
+
+      const result = service.buildBookingUrl(user, slug);
+
+      expect(result).toBe("");
+    });
+
     it("should fall back to user username when profile has no username", () => {
       const user = {
         id: 1,

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
@@ -47,6 +47,7 @@ type EventTypeUser = {
   id: number;
   name: string | null;
   username: string | null;
+  isPlatformManaged?: boolean;
   avatarUrl: string | null;
   brandColor: string | null;
   darkBrandColor: string | null;
@@ -438,6 +439,11 @@ export class OutputEventTypesService_2024_06_14 {
 
   buildBookingUrl(user: EventTypeUser | undefined, slug: string): string {
     if (!user) {
+      return "";
+    }
+
+    // Managed users don't have public booking pages
+    if (user.isPlatformManaged) {
       return "";
     }
 


### PR DESCRIPTION
## What does this PR do?

Returns an empty `bookingUrl` for managed users in the API v2 event types response.

### Background

Managed users (`isPlatformManaged: true`) are users created via the Platform API. They don't have public Cal.com booking pages - their scheduling is handled entirely through the platform's app. Returning a `bookingUrl` for them is misleading and incorrect.

### Changes

- **[event-types.repository.ts](cci:7://file:///Users/dhairyashilshinde/work/cal.com/apps/api/v2/src/ee/event-types/event-types_2024_06_14/event-types.repository.ts:0:0-0:0)**: Fetch `isPlatformManaged` field for users
- **[output-event-types.service.ts](cci:7://file:///Users/dhairyashilshinde/work/cal.com/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts:0:0-0:0)**: Return empty string `""` for managed users in [buildBookingUrl](cci:1://file:///Users/dhairyashilshinde/work/cal.com/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts:439:2-464:3)
- **[output-event-types.service.spec.ts](cci:7://file:///Users/dhairyashilshinde/work/cal.com/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.spec.ts:0:0-0:0)**: Added unit test for managed users case

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Follow-up to #26195 - addresses feedback about managed users not needing booking URLs