### PR TITLE
fix: load .env file in vitest config and update integration test docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,10 @@ yarn vitest run path/to/file.test.ts
 yarn vitest run path/to/file.test.ts --testNamePattern="specific test name"
 
 # Integration test specific file
-yarn test path/to/file.integration-test.ts -- --integrationTestsOnly
+VITEST_MODE=integration yarn test path/to/file.integration-test.ts
 
 # Integration test specific file + specific test
-yarn test path/to/file.integration-test.ts --testNamePattern="specific test name" -- --integrationTestsOnly
+VITEST_MODE=integration yarn test path/to/file.integration-test.ts --testNamePattern="specific test name"
 
 # E2E test specific file
 PLAYWRIGHT_HEADLESS=1 yarn e2e path/to/file.e2e.ts

--- a/agents/commands.md
+++ b/agents/commands.md
@@ -34,9 +34,9 @@
 
 ### Integration Tests
 
-- `yarn test -- --integrationTestsOnly` - Run integration tests (vitest)
-- `yarn test <filename> -- --integrationTestsOnly` - Run integration tests for specific file
-- `yarn test <filename> -t "<testName>" -- --integrationTestsOnly` - Run specific integration test by name for specific file
+- `VITEST_MODE=integration yarn test` - Run integration tests (vitest)
+- `VITEST_MODE=integration yarn test <filename>` - Run integration tests for specific file
+- `VITEST_MODE=integration yarn test <filename> -t "<testName>"` - Run specific integration test by name for specific file
 
 
 ### End-to-End Tests
@@ -73,7 +73,7 @@
 yarn vitest run packages/lib/some-file.test.ts
 
 # Integration test specific file
-yarn test routing-form-response-denormalized.integration-test.ts -- --integrationTestsOnly
+VITEST_MODE=integration yarn test routing-form-response-denormalized.integration-test.ts
 
 # E2E test specific file
 yarn e2e tests/booking-flow.e2e.ts

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -3,8 +3,6 @@ import react from "@vitejs/plugin-react";
 import { loadEnv } from "vite";
 import { defineConfig } from "vitest/config";
 
-// Load .env file for integration tests (DATABASE_URL, etc.)
-// This is needed because Vitest 4.0 doesn't automatically load .env into process.env
 const env = loadEnv("", process.cwd(), "");
 Object.assign(process.env, env);
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,7 +4,11 @@ import { loadEnv } from "vite";
 import { defineConfig } from "vitest/config";
 
 const env = loadEnv("", process.cwd(), "");
-Object.assign(process.env, env);
+for (const [key, value] of Object.entries(env)) {
+  if (process.env[key] === undefined) {
+    process.env[key] = value;
+  }
+}
 
 const vitestMode = process.env.VITEST_MODE;
 // Support both new VITEST_MODE env var and legacy CLI flags for backwards compatibility

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,12 @@
 import path from "node:path";
 import react from "@vitejs/plugin-react";
+import { loadEnv } from "vite";
 import { defineConfig } from "vitest/config";
+
+// Load .env file for integration tests (DATABASE_URL, etc.)
+// This is needed because Vitest 4.0 doesn't automatically load .env into process.env
+const env = loadEnv("", process.cwd(), "");
+Object.assign(process.env, env);
 
 const vitestMode = process.env.VITEST_MODE;
 // Support both new VITEST_MODE env var and legacy CLI flags for backwards compatibility


### PR DESCRIPTION
## What does this PR do?

This PR addresses two issues with integration tests after the Vitest 4.0 upgrade (#26351):

1. **Documentation update**: Updates docs to reflect the new `VITEST_MODE=integration` environment variable syntax (the old `--integrationTestsOnly` CLI flag no longer works)

2. **Fix .env loading**: Adds `loadEnv` from Vite to load `.env` file into `process.env` at vitest config initialization. This fixes `ECONNREFUSED` errors when running integration tests because `DATABASE_URL` was not being loaded.

**Old syntax (no longer works):**
```bash
yarn test path/to/file.integration-test.ts -- --integrationTestsOnly
```

**New syntax:**
```bash
VITEST_MODE=integration yarn test path/to/file.integration-test.ts
```

## Updates since last revision

- Fixed env var loading to only set variables if they're not already defined in the shell/CI environment. This prevents `.env` values from overwriting existing environment variables like `DATABASE_URL` that may be set differently in CI.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - this PR is the documentation update itself.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - verified manually.

## How should this be tested?

Run an integration test with the new syntax to verify it works:
```bash
VITEST_MODE=integration yarn test packages/features/insights/services/InsightsBookingService.integration-test.ts
```

All 16 tests should pass without needing to manually set `DATABASE_URL`.

## Human Review Checklist

- [ ] Verify the `loadEnv("", process.cwd(), "")` with empty prefix is intentional - this loads ALL env vars (not just `VITE_` prefixed) which is needed for `DATABASE_URL`
- [x] ~~Confirm `Object.assign(process.env, env)` doesn't cause issues by overwriting existing shell env vars~~ - Fixed: now only sets env vars if `process.env[key] === undefined`
- [ ] Check that regular unit tests still work after this change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run:** https://app.devin.ai/sessions/2af10e82fd50463abda9beb727528437
**Requested by:** @eunjae-lee