### PR TITLE
fix(api): correct bookingUrl username and domain for platform orgs

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.spec.ts
@@ -85,22 +85,22 @@ describe("OutputEventTypesService_2024_06_14", () => {
     it("should use cal.com for non-managed users in platform orgs", () => {
       const user = {
         id: 1,
-        name: "Dhairyashil Shinde",
-        username: "dhairyashil", // Public username
+        name: "Test User",
+        username: "platform-user", // Public username
         avatarUrl: null,
         brandColor: null,
         darkBrandColor: null,
         weekStart: "Monday",
         metadata: {},
         organizationId: 1,
-        organization: { slug: "gmail-platform-9041df0e" },
+        organization: { slug: "platform-org-slug" },
         movedToProfile: null,
         profiles: [
           {
             id: 100,
-            username: "dhairyashil10101010-gmail-com", // Platform-generated username
+            username: "platform-user-generated-id", // Platform-generated username
             organizationId: 1,
-            organization: { id: 1, slug: "gmail-platform-9041df0e", isPlatform: true },
+            organization: { id: 1, slug: "platform-org-slug", isPlatform: true },
           },
         ],
       };
@@ -108,8 +108,8 @@ describe("OutputEventTypesService_2024_06_14", () => {
 
       const result = service.buildBookingUrl(user, slug);
 
-      // Should use user.username (dhairyashil), not profile.username (dhairyashil10101010-gmail-com)
-      expect(result).toBe("https://cal.com/dhairyashil/secret");
+      // Should use user.username (platform-user), not profile.username (platform-user-generated-id)
+      expect(result).toBe("https://cal.com/platform-user/secret");
     });
 
     it("should return empty string for managed users", () => {

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.spec.ts
@@ -86,7 +86,7 @@ describe("OutputEventTypesService_2024_06_14", () => {
       const user = {
         id: 1,
         name: "Dhairyashil Shinde",
-        username: "dhairyashil10101010-gmail-com",
+        username: "dhairyashil", // Public username
         avatarUrl: null,
         brandColor: null,
         darkBrandColor: null,
@@ -98,7 +98,7 @@ describe("OutputEventTypesService_2024_06_14", () => {
         profiles: [
           {
             id: 100,
-            username: "dhairyashil",
+            username: "dhairyashil10101010-gmail-com", // Platform-generated username
             organizationId: 1,
             organization: { id: 1, slug: "gmail-platform-9041df0e", isPlatform: true },
           },
@@ -108,6 +108,7 @@ describe("OutputEventTypesService_2024_06_14", () => {
 
       const result = service.buildBookingUrl(user, slug);
 
+      // Should use user.username (dhairyashil), not profile.username (dhairyashil10101010-gmail-com)
       expect(result).toBe("https://cal.com/dhairyashil/secret");
     });
 

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
@@ -448,17 +448,21 @@ export class OutputEventTypesService_2024_06_14 {
     }
 
     const profile = this.usersService.getUserMainProfile(user);
-    const username = profile?.username ?? user.username;
+    const org = profile?.organization;
+    const isPlatformOrg = org?.isPlatform ?? false;
+
+    // For platform orgs, use user.username (public username like 'dhairyashil')
+    // For regular orgs, use profile.username (org-specific username)
+    const username = isPlatformOrg ? user.username : (profile?.username ?? user.username);
 
     if (!username) {
       return "";
     }
 
-    const org = profile?.organization;
     // Don't use org subdomain for platform organizations - they don't have public-facing subdomains
-    const orgSlug = org && !org.isPlatform ? org.slug : null;
-    const webAppUrl = this.configService.get<string>("app.baseUrl", "https://app.cal.com");
-    const baseUrl = orgSlug ? getBookerBaseUrlSync(orgSlug) : webAppUrl;
+    const orgSlug = !isPlatformOrg && org?.slug ? org.slug : null;
+    // getBookerBaseUrlSync(null) returns WEBSITE_URL (https://cal.com)
+    const baseUrl = getBookerBaseUrlSync(orgSlug);
     const normalizedBaseUrl = baseUrl.replace(/\/$/, "");
 
     return `${normalizedBaseUrl}/${username}/${slug}`;


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect `bookingUrl` generation for platform organization users in API v2.

### Changes

1. **Username Fix**: Uses the public `user.username` (e.g. `dhairyashil`) instead of the internal `profile.username` (e.g. `dhairyashil10101010-gmail`).
   - *Why*: Platform orgs generate internal usernames that shouldn't be exposed in booking URLs.

2. **Base URL Fix**: Ensures the URL uses `cal.com` instead of `app.cal.com`.
   - *Why*: Switched to [getBookerBaseUrlSync](cci:1://file:///Users/dhairyashilshinde/work/cal.com/packages/features/ee/organizations/lib/getBookerBaseUrlSync.ts:2:0-9:2) which correctly uses the `WEBSITE_URL` (`https://cal.com`) instead of falling back to `app.baseUrl`.