### PR TITLE
fix: add integration-test.ts pattern to biome test file overrides

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -179,7 +179,7 @@
       }
     },
     {
-      "includes": ["**/*.test.ts", "**/*.test.tsx", "**/*.e2e-spec.ts"],
+      "includes": ["**/*.test.ts", "**/*.test.tsx", "**/*.e2e-spec.ts", "**/*.integration-test.ts"],
       "linter": {
         "rules": {
           "complexity": {


### PR DESCRIPTION
## What does this PR do?

Adds `**/*.integration-test.ts` to the Biome configuration's test file overrides so that integration test files are properly excluded from the `noExcessiveLinesPerFunction` rule.

The existing override at line 181 only matched `**/*.test.ts`, `**/*.test.tsx`, and `**/*.e2e-spec.ts`, but the codebase has 35+ files using the `.integration-test.ts` naming pattern (e.g., `InsightsRoutingService.integration-test.ts`). This caused Biome to incorrectly flag `describe` blocks as functions exceeding the 50-line limit.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - config change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - verified locally by running `npx biome lint` on the affected file.

## How should this be tested?

Run biome lint on an integration test file before and after this change:
```bash
npx biome lint packages/features/insights/services/InsightsRoutingService.integration-test.ts 2>&1 | grep noExcessiveLinesPerFunction
```

Before: Shows warning about function having too many lines (1086)
After: No `noExcessiveLinesPerFunction` warnings

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Requested by: @eunjae-lee
Link to Devin run: https://app.devin.ai/sessions/e98e82fa66aa49bb9c16c96bd6df6f1f