### PR TITLE
feat: store utm tags in stripe on signup

### DIFF
--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -35,7 +35,7 @@ import {
 
 const log = logger.getSubLogger({ prefix: ["signupCalcomHandler"] });
 
-const handler: CustomNextApiHandler = async (body, usernameStatus) => {
+const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
   const {
     email: _email,
     password,
@@ -122,7 +122,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
   // Create the customer in Stripe with ad tracking metadata
   const cookieStore = await cookies();
   const cookiesObj = Object.fromEntries(cookieStore.getAll().map((c) => [c.name, c.value]));
-  const tracking = getTrackingFromCookies(cookiesObj);
+  const tracking = getTrackingFromCookies(cookiesObj, query);
 
   const customer = await billingService.createCustomer({
     email,
@@ -179,7 +179,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
       },
     });
     if (team) {
-      const organizationId = team.isOrganization ? team.id : team.parent?.id ?? null;
+      const organizationId = team.isOrganization ? team.id : (team.parent?.id ?? null);
 
       if (username) {
         const existingUserByUsername = await prisma.user.findFirst({
@@ -272,10 +272,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
       if (isPrismaError(error) && error.code === "P2002") {
         const target = String(error.meta?.target ?? "");
         if (target.includes("email") || target.includes("username")) {
-          return NextResponse.json(
-            { message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS },
-            { status: 409 }
-          );
+          return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
         }
       }
       throw error;

--- a/apps/web/app/api/auth/signup/route.ts
+++ b/apps/web/app/api/auth/signup/route.ts
@@ -47,6 +47,7 @@ async function handler(req: NextRequest) {
     });
 
     const body = await parseRequestData(req);
+    const query = Object.fromEntries(req.nextUrl.searchParams.entries());
     await checkCfTurnstileToken({
       token: req.headers.get("cf-access-token") as string,
       remoteIp,
@@ -62,7 +63,7 @@ async function handler(req: NextRequest) {
      * @zomars: We need to be able to test this with E2E. They way it's done RN it will never run on CI.
      */
     if (IS_PREMIUM_USERNAME_ENABLED) {
-      return await calcomSignupHandler(body);
+      return await calcomSignupHandler(body, query);
     }
 
     return await selfHostedSignupHandler(body);

--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -11,7 +11,7 @@ const handler = (req: NextApiRequest, res: NextApiResponse) =>
     res,
     getOptions({
       getDubId: () => req.cookies.dub_id || req.cookies.dclid,
-      getTrackingData: () => getTrackingFromCookies(req.cookies),
+      getTrackingData: () => getTrackingFromCookies(req.cookies, req.query),
     })
   );
 

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -1202,6 +1202,7 @@ export const getOptions = ({
                       liFatId: tracking.linkedInAds.liFatId,
                       linkedInCampaignId: tracking.linkedInAds.campaignId,
                     }),
+                    ...(tracking.utmData && tracking.utmData),
                   },
                 });
                 await prisma.user.update({

--- a/packages/features/auth/signup/lib/fetchSignup.ts
+++ b/packages/features/auth/signup/lib/fetchSignup.ts
@@ -25,7 +25,10 @@ export type SignupResult =
   | { ok: false; status: number; error: SignupErrorResponse };
 
 export async function fetchSignup(data: SignupData, cfToken?: string): Promise<SignupResult> {
-  const response = await fetch("/api/auth/signup", {
+  const searchParams = new URLSearchParams(window.location.search);
+  const url = searchParams.toString() ? `/api/auth/signup?${searchParams.toString()}` : "/api/auth/signup";
+
+  const response = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -60,9 +63,13 @@ export async function fetchSignup(data: SignupData, cfToken?: string): Promise<S
 }
 
 export function isUserAlreadyExistsError(result: SignupResult): boolean {
-  return !result.ok && result.status === 409 && result.error.message === SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS;
+  return (
+    !result.ok && result.status === 409 && result.error.message === SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS
+  );
 }
 
-export function hasCheckoutSession(result: SignupResult): result is { ok: false; status: number; error: SignupErrorResponse & { checkoutSessionId: string } } {
+export function hasCheckoutSession(
+  result: SignupResult
+): result is { ok: false; status: number; error: SignupErrorResponse & { checkoutSessionId: string } } {
   return !result.ok && !!result.error.checkoutSessionId;
 }

--- a/packages/features/auth/signup/lib/fetchSignup.ts
+++ b/packages/features/auth/signup/lib/fetchSignup.ts
@@ -25,8 +25,26 @@ export type SignupResult =
   | { ok: false; status: number; error: SignupErrorResponse };
 
 export async function fetchSignup(data: SignupData, cfToken?: string): Promise<SignupResult> {
-  const searchParams = new URLSearchParams(window.location.search);
-  const url = searchParams.toString() ? `/api/auth/signup?${searchParams.toString()}` : "/api/auth/signup";
+  const allParams = new URLSearchParams(window.location.search);
+
+  const utmParams = new URLSearchParams();
+  const utmKeys = [
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "utm_id",
+    "utm_referral",
+    "landing_page",
+  ];
+
+  utmKeys.forEach((key) => {
+    const value = allParams.get(key);
+    if (value) utmParams.set(key, value);
+  });
+
+  const url = utmParams.toString() ? `/api/auth/signup?${utmParams.toString()}` : "/api/auth/signup";
 
   const response = await fetch(url, {
     method: "POST",

--- a/packages/lib/tracking/server.ts
+++ b/packages/lib/tracking/server.ts
@@ -63,7 +63,9 @@ export function getTrackingFromCookies(
 
   if (query && Object.keys(query).length > 0) {
     utmData = parseUtm(query);
-  } else if (cookies?.utm_data) {
+  }
+
+  if (!utmData && cookies?.utm_data) {
     try {
       utmData = parseUtm(JSON.parse(cookies.utm_data));
     } catch {

--- a/packages/lib/tracking/server.ts
+++ b/packages/lib/tracking/server.ts
@@ -1,4 +1,16 @@
 import type { NextApiRequest } from "next";
+import { z } from "zod";
+
+const utmTrackingDataSchema = z.object({
+  utm_source: z.string().optional(),
+  utm_medium: z.string().optional(),
+  utm_campaign: z.string().optional(),
+  utm_term: z.string().optional(),
+  utm_content: z.string().optional(),
+  utm_id: z.string().optional(),
+  utm_referral: z.string().optional(),
+  landing_page: z.string().optional(),
+});
 
 export type GoogleAdsTrackingData = {
   gclid: string;
@@ -10,29 +22,57 @@ export type LinkedInAdsTrackingData = {
   campaignId?: string;
 };
 
+export type UtmTrackingData = z.infer<typeof utmTrackingDataSchema>;
+
 export type TrackingData = {
   googleAds?: GoogleAdsTrackingData;
   linkedInAds?: LinkedInAdsTrackingData;
+  utmData?: UtmTrackingData;
 };
 
-
-export function getTrackingFromCookies(cookies?: NextApiRequest["cookies"]): TrackingData {
+export function getTrackingFromCookies(
+  cookies?: NextApiRequest["cookies"],
+  query?: NextApiRequest["query"]
+): TrackingData {
   const tracking: TrackingData = {};
 
-  if (!cookies) return tracking;
-
-  if (process.env.GOOGLE_ADS_ENABLED === "1" && cookies.gclid) {
+  if (process.env.GOOGLE_ADS_ENABLED === "1" && cookies?.gclid) {
     tracking.googleAds = {
       gclid: cookies.gclid,
       ...(cookies.gad_campaignId && { campaignId: cookies.gad_campaignId }),
     };
   }
 
-  if (process.env.LINKEDIN_ADS_ENABLED === "1" && cookies.li_fat_id) {
+  if (process.env.LINKEDIN_ADS_ENABLED === "1" && cookies?.li_fat_id) {
     tracking.linkedInAds = {
       liFatId: cookies.li_fat_id,
       ...(cookies.li_campaignId && { campaignId: cookies.li_campaignId }),
     };
+  }
+
+  const parseUtm = (input: unknown): UtmTrackingData | null => {
+    const parsed = utmTrackingDataSchema.safeParse(input);
+    if (!parsed.success) return null;
+
+    return Object.fromEntries(
+      Object.entries(parsed.data).filter(([_, value]) => value !== undefined)
+    ) as UtmTrackingData;
+  };
+
+  let utmData: UtmTrackingData | null = null;
+
+  if (query && Object.keys(query).length > 0) {
+    utmData = parseUtm(query);
+  } else if (cookies?.utm_data) {
+    try {
+      utmData = parseUtm(JSON.parse(cookies.utm_data));
+    } catch {
+      console.debug("Failed to parse utm_data cookie");
+    }
+  }
+
+  if (utmData) {
+    tracking.utmData = utmData;
   }
 
   return tracking;


### PR DESCRIPTION
## What does this PR do?

Store utm tags during signup either from url or from utm_data cookie (set using framer on cal.com)

The `getTrackingFromCookies` function now accepts query params and extracts UTM data (utm_source, utm_medium, utm_campaign, utm_term, utm_content, utm_id, utm_referral, landing_page) from either:
1. URL query parameters (preferred)
2. `utm_data` cookie as fallback

UTM data is then stored in Stripe customer metadata during signup.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Updates since last revision

- Fixed cookie fallback logic: Changed from `else if` to separate `if (!utmData && ...)` so that when query params exist but don't contain valid UTM data, the cookie fallback is still tried. Previously, any request with non-UTM query params would skip the stored cookie data entirely.

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Visit signup page with UTM query params (e.g., `?utm_source=google&utm_medium=cpc`)
2. Complete signup flow
3. Verify UTM data is stored in Stripe customer metadata

Alternative flow:
1. Set `utm_data` cookie with JSON UTM data
2. Visit signup page without UTM query params (or with non-UTM params like `?ref=test`)
3. Complete signup flow
4. Verify UTM data from cookie is stored in Stripe customer metadata

## Human Review Checklist

- [ ] Verify cookie fallback works when query has non-UTM params (e.g., `?ref=test` should still read from cookie)
- [ ] Verify UTM data structure in Stripe customer metadata is correct
- [ ] Confirm Zod schema covers all expected UTM parameters