### PR TITLE
feat(vscode): add Biome auto-fix on save configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,8 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "biomejs.biome",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.biome": "explicit",
+    "source.organizeImports.biome": "explicit"
   },
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "spellright.language": ["en"],


### PR DESCRIPTION
## What does this PR do?

Updates VS Code settings to use Biome's code actions on save instead of ESLint, aligning with the repo's use of Biome as the default formatter.

Changes:
- Replaces `source.fixAll.eslint` with `source.fixAll.biome` - applies safe lint fixes automatically (e.g., removing unused imports, style fixes)
- Adds `source.organizeImports.biome` - sorts and organizes imports/exports on save

Both settings are needed separately because they serve different purposes in VS Code's LSP - `fixAll` handles lint rule auto-fixes while `organizeImports` handles import sorting/ordering. This follows [Biome's official documentation](https://biomejs.dev/assist/actions/organize-imports/).

## Visual Demo (For contributors especially)

N/A - This is a VS Code configuration change with no visual UI changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - VS Code settings only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - Configuration file change.

## How should this be tested?

1. Open VS Code with the [Biome extension](https://marketplace.visualstudio.com/items?itemName=biomejs.biome) installed
2. Open a TypeScript/JavaScript file
3. Add an unused import or unsort existing imports
4. Save the file
5. Verify the unused import is removed and imports are sorted automatically

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

### Notes

Link to Devin run: https://app.devin.ai/sessions/b853bd202a6d40f6856b582c8a13ee11
Requested by: @hariombalhara