### PR TITLE
feat: add proration tasker support

### DIFF
--- a/apps/web/app/api/cron/monthly-proration/route.ts
+++ b/apps/web/app/api/cron/monthly-proration/route.ts
@@ -1,10 +1,8 @@
 import process from "node:process";
+import { getMonthlyProrationTasker } from "@calcom/features/ee/billing/di/tasker/MonthlyProrationTasker.container";
 import { formatMonthKey } from "@calcom/features/ee/billing/lib/month-key";
 import { MonthlyProrationTeamRepository } from "@calcom/features/ee/billing/repository/proration/MonthlyProrationTeamRepository";
 import { MONTHLY_PRORATION_BATCH_SIZE } from "@calcom/features/ee/billing/service/proration/tasker/constants";
-import { MonthlyProrationSyncTasker } from "@calcom/features/ee/billing/service/proration/tasker/MonthlyProrationSyncTasker";
-import { MonthlyProrationTasker } from "@calcom/features/ee/billing/service/proration/tasker/MonthlyProrationTasker";
-import { MonthlyProrationTriggerDevTasker } from "@calcom/features/ee/billing/service/proration/tasker/MonthlyProrationTriggerDevTasker";
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { ENABLE_ASYNC_TASKER } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
@@ -55,11 +53,7 @@ async function getHandler(request: NextRequest) {
     });
   }
 
-  const prorationTasker = new MonthlyProrationTasker({
-    logger: log,
-    asyncTasker: new MonthlyProrationTriggerDevTasker({ logger: log }),
-    syncTasker: new MonthlyProrationSyncTasker(log),
-  });
+  const prorationTasker = getMonthlyProrationTasker();
 
   const batches: number[][] = [];
   for (let index = 0; index < teamIdsList.length; index += MONTHLY_PRORATION_BATCH_SIZE) {

--- a/apps/web/app/api/cron/monthly-proration/route.ts
+++ b/apps/web/app/api/cron/monthly-proration/route.ts
@@ -1,4 +1,5 @@
 import process from "node:process";
+import { formatMonthKey } from "@calcom/features/ee/billing/lib/month-key";
 import { MonthlyProrationService } from "@calcom/features/ee/billing/service/proration/MonthlyProrationService";
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import logger from "@calcom/lib/logger";
@@ -32,9 +33,7 @@ async function getHandler(request: NextRequest) {
   const now = new Date();
   const startOfCurrentMonthUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
   const previousMonthUtc = subMonths(startOfCurrentMonthUtc, 1);
-  const defaultMonthKey = `${previousMonthUtc.getUTCFullYear()}-${String(
-    previousMonthUtc.getUTCMonth() + 1
-  ).padStart(2, "0")}`;
+  const defaultMonthKey = formatMonthKey(previousMonthUtc);
   const monthKey = requestedMonthKey || defaultMonthKey;
 
   log.info(`Processing monthly prorations for ${monthKey}`);

--- a/packages/features/ee/billing/api/webhook/_invoice.payment_failed.test.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.payment_failed.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { buildMonthlyProrationMetadata } from "../../lib/proration-utils";
 import type { SWHMap } from "./__handler";
 import handler from "./_invoice.payment_failed";
 
@@ -31,10 +32,7 @@ describe("invoice.payment_failed webhook", () => {
         lines: {
           data: [
             {
-              metadata: {
-                type: "monthly_proration",
-                prorationId: "pr_123",
-              },
+              metadata: buildMonthlyProrationMetadata({ prorationId: "pr_123" }),
             },
           ],
         },

--- a/packages/features/ee/billing/api/webhook/_invoice.payment_failed.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.payment_failed.ts
@@ -1,6 +1,7 @@
 import { getBillingProviderService } from "@calcom/ee/billing/di/containers/Billing";
 import logger from "@calcom/lib/logger";
 
+import { findMonthlyProrationLineItem } from "../../lib/proration-utils";
 import { MonthlyProrationService } from "../../service/proration/MonthlyProrationService";
 import type { SWHMap } from "./__handler";
 
@@ -11,7 +12,7 @@ type Data = SWHMap["invoice.payment_failed"]["data"];
 const handler = async (data: Data) => {
   const invoice = data.object;
 
-  const prorationLineItem = invoice.lines.data.find((line) => line.metadata?.type === "monthly_proration");
+  const prorationLineItem = findMonthlyProrationLineItem(invoice.lines.data);
 
   if (!prorationLineItem) {
     return { success: true, message: "no proration line items in invoice" };

--- a/packages/features/ee/billing/api/webhook/_invoice.payment_succeeded.test.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.payment_succeeded.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { buildMonthlyProrationMetadata } from "../../lib/proration-utils";
 import type { SWHMap } from "./__handler";
 import handler from "./_invoice.payment_succeeded";
 
@@ -22,10 +23,7 @@ describe("invoice.payment_succeeded webhook", () => {
         lines: {
           data: [
             {
-              metadata: {
-                type: "monthly_proration",
-                prorationId: "pr_123",
-              },
+              metadata: buildMonthlyProrationMetadata({ prorationId: "pr_123" }),
             },
           ],
         },

--- a/packages/features/ee/billing/api/webhook/_invoice.payment_succeeded.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.payment_succeeded.ts
@@ -1,5 +1,6 @@
 import logger from "@calcom/lib/logger";
 
+import { findMonthlyProrationLineItem } from "../../lib/proration-utils";
 import { MonthlyProrationService } from "../../service/proration/MonthlyProrationService";
 import type { SWHMap } from "./__handler";
 
@@ -10,7 +11,7 @@ type Data = SWHMap["invoice.payment_succeeded"]["data"];
 const handler = async (data: Data) => {
   const invoice = data.object;
 
-  const prorationLineItem = invoice.lines.data.find((line) => line.metadata?.type === "monthly_proration");
+  const prorationLineItem = findMonthlyProrationLineItem(invoice.lines.data);
 
   if (!prorationLineItem) {
     return { success: true, message: "no proration line items in invoice" };

--- a/packages/features/ee/billing/di/tasker/MonthlyProrationSyncTasker.module.ts
+++ b/packages/features/ee/billing/di/tasker/MonthlyProrationSyncTasker.module.ts
@@ -1,0 +1,21 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as loggerServiceModule } from "@calcom/features/di/shared/services/logger.service";
+import { MonthlyProrationSyncTasker } from "@calcom/features/ee/billing/service/proration/tasker/MonthlyProrationSyncTasker";
+
+import { MONTHLY_PRORATION_TASKER_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = MONTHLY_PRORATION_TASKER_DI_TOKENS.MONTHLY_PRORATION_SYNC_TASKER;
+const moduleToken = MONTHLY_PRORATION_TASKER_DI_TOKENS.MONTHLY_PRORATION_SYNC_TASKER_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: MonthlyProrationSyncTasker,
+  dep: loggerServiceModule,
+});
+
+export const moduleLoader = {
+  token,
+  loadModule,
+} satisfies ModuleLoader;

--- a/packages/features/ee/billing/di/tasker/MonthlyProrationTasker.container.ts
+++ b/packages/features/ee/billing/di/tasker/MonthlyProrationTasker.container.ts
@@ -1,0 +1,13 @@
+import { createContainer } from "@calcom/features/di/di";
+
+import type { MonthlyProrationTasker } from "@calcom/features/ee/billing/service/proration/tasker/MonthlyProrationTasker";
+
+import { moduleLoader as monthlyProrationTaskerModule } from "./MonthlyProrationTasker.module";
+import { MONTHLY_PRORATION_TASKER_DI_TOKENS } from "./tokens";
+
+const container = createContainer();
+
+export function getMonthlyProrationTasker(): MonthlyProrationTasker {
+  monthlyProrationTaskerModule.loadModule(container);
+  return container.get<MonthlyProrationTasker>(MONTHLY_PRORATION_TASKER_DI_TOKENS.MONTHLY_PRORATION_TASKER);
+}

--- a/packages/features/ee/billing/di/tasker/MonthlyProrationTasker.module.ts
+++ b/packages/features/ee/billing/di/tasker/MonthlyProrationTasker.module.ts
@@ -1,0 +1,27 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as loggerServiceModule } from "@calcom/features/di/shared/services/logger.service";
+import { MonthlyProrationTasker } from "@calcom/features/ee/billing/service/proration/tasker/MonthlyProrationTasker";
+
+import { moduleLoader as monthlyProrationSyncTaskerModule } from "./MonthlyProrationSyncTasker.module";
+import { moduleLoader as monthlyProrationTriggerTaskerModule } from "./MonthlyProrationTriggerDevTasker.module";
+import { MONTHLY_PRORATION_TASKER_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = MONTHLY_PRORATION_TASKER_DI_TOKENS.MONTHLY_PRORATION_TASKER;
+const moduleToken = MONTHLY_PRORATION_TASKER_DI_TOKENS.MONTHLY_PRORATION_TASKER_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: MonthlyProrationTasker,
+  depsMap: {
+    logger: loggerServiceModule,
+    asyncTasker: monthlyProrationTriggerTaskerModule,
+    syncTasker: monthlyProrationSyncTaskerModule,
+  },
+});
+
+export const moduleLoader = {
+  token,
+  loadModule,
+} satisfies ModuleLoader;

--- a/packages/features/ee/billing/di/tasker/MonthlyProrationTriggerDevTasker.module.ts
+++ b/packages/features/ee/billing/di/tasker/MonthlyProrationTriggerDevTasker.module.ts
@@ -1,0 +1,23 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as loggerServiceModule } from "@calcom/features/di/shared/services/logger.service";
+import { MonthlyProrationTriggerDevTasker } from "@calcom/features/ee/billing/service/proration/tasker/MonthlyProrationTriggerDevTasker";
+
+import { MONTHLY_PRORATION_TASKER_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = MONTHLY_PRORATION_TASKER_DI_TOKENS.MONTHLY_PRORATION_TRIGGER_TASKER;
+const moduleToken = MONTHLY_PRORATION_TASKER_DI_TOKENS.MONTHLY_PRORATION_TRIGGER_TASKER_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: MonthlyProrationTriggerDevTasker,
+  depsMap: {
+    logger: loggerServiceModule,
+  },
+});
+
+export const moduleLoader = {
+  token,
+  loadModule,
+} satisfies ModuleLoader;

--- a/packages/features/ee/billing/di/tasker/tokens.ts
+++ b/packages/features/ee/billing/di/tasker/tokens.ts
@@ -1,0 +1,8 @@
+export const MONTHLY_PRORATION_TASKER_DI_TOKENS = {
+  MONTHLY_PRORATION_TASKER: Symbol("MonthlyProrationTasker"),
+  MONTHLY_PRORATION_TASKER_MODULE: Symbol("MonthlyProrationTaskerModule"),
+  MONTHLY_PRORATION_SYNC_TASKER: Symbol("MonthlyProrationSyncTasker"),
+  MONTHLY_PRORATION_SYNC_TASKER_MODULE: Symbol("MonthlyProrationSyncTaskerModule"),
+  MONTHLY_PRORATION_TRIGGER_TASKER: Symbol("MonthlyProrationTriggerTasker"),
+  MONTHLY_PRORATION_TRIGGER_TASKER_MODULE: Symbol("MonthlyProrationTriggerTaskerModule"),
+};

--- a/packages/features/ee/billing/lib/month-key.ts
+++ b/packages/features/ee/billing/lib/month-key.ts
@@ -1,0 +1,5 @@
+export function formatMonthKey(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}

--- a/packages/features/ee/billing/lib/proration-utils.ts
+++ b/packages/features/ee/billing/lib/proration-utils.ts
@@ -1,0 +1,30 @@
+export const MONTHLY_PRORATION_METADATA_TYPE = "monthly_proration";
+
+type MetadataContainer = {
+  metadata?: Record<string, string | null | undefined> | null;
+};
+
+export function buildMonthlyProrationMetadata(params: {
+  prorationId: string;
+  teamId?: number;
+  monthKey?: string;
+}): Record<string, string> {
+  const metadata: Record<string, string> = {
+    type: MONTHLY_PRORATION_METADATA_TYPE,
+    prorationId: params.prorationId,
+  };
+
+  if (typeof params.teamId === "number") {
+    metadata.teamId = params.teamId.toString();
+  }
+
+  if (params.monthKey) {
+    metadata.monthKey = params.monthKey;
+  }
+
+  return metadata;
+}
+
+export function findMonthlyProrationLineItem<T extends MetadataContainer>(lineItems: T[]): T | undefined {
+  return lineItems.find((line) => line.metadata?.type === MONTHLY_PRORATION_METADATA_TYPE);
+}

--- a/packages/features/ee/billing/lib/stripe-subscription-utils.ts
+++ b/packages/features/ee/billing/lib/stripe-subscription-utils.ts
@@ -1,23 +1,62 @@
-import type Stripe from "stripe";
 import type { BillingPeriod } from "@calcom/prisma/enums";
+
+type SubscriptionItemLike = {
+  id: string;
+  quantity: number | null;
+  price: {
+    unit_amount: number | null;
+    recurring: { interval: string } | null;
+  };
+};
+
+type SubscriptionItems = SubscriptionItemLike[] | { data: SubscriptionItemLike[] };
+
+export interface StripeSubscriptionLike {
+  items: SubscriptionItems;
+  current_period_start: number;
+  current_period_end: number;
+  trial_end: number | null;
+}
 
 export interface BillingData {
   billingPeriod: BillingPeriod;
   pricePerSeat: number | undefined;
   paidSeats: number | undefined;
+  subscriptionStart: Date | null;
+  subscriptionEnd: Date | null;
+  subscriptionTrialEnd: Date | null;
 }
 
-export function extractBillingDataFromStripeSubscription(subscription: Stripe.Subscription): BillingData {
+const getSubscriptionItems = (subscription: StripeSubscriptionLike) =>
+  Array.isArray(subscription.items) ? subscription.items : subscription.items.data;
+
+export function extractBillingDataFromStripeSubscription(subscription: StripeSubscriptionLike): BillingData {
+  const subscriptionItems = getSubscriptionItems(subscription);
+  const primaryItem = subscriptionItems[0];
+
   const billingPeriod: BillingPeriod =
-    subscription.items.data[0]?.price.recurring?.interval === "year" ? "ANNUALLY" : "MONTHLY";
+    primaryItem?.price.recurring?.interval === "year" ? "ANNUALLY" : "MONTHLY";
 
-  const pricePerSeat = subscription.items.data[0]?.price.unit_amount ?? undefined;
+  const pricePerSeat = primaryItem?.price.unit_amount ?? undefined;
 
-  const paidSeats = subscription.items.data[0]?.quantity ?? undefined;
+  const paidSeats = primaryItem?.quantity ?? undefined;
+
+  const subscriptionStart = subscription.current_period_start
+    ? new Date(subscription.current_period_start * 1000)
+    : null;
+
+  const subscriptionEnd = subscription.current_period_end
+    ? new Date(subscription.current_period_end * 1000)
+    : null;
+
+  const subscriptionTrialEnd = subscription.trial_end ? new Date(subscription.trial_end * 1000) : null;
 
   return {
     billingPeriod,
     pricePerSeat,
     paidSeats,
+    subscriptionStart,
+    subscriptionEnd,
+    subscriptionTrialEnd,
   };
 }

--- a/packages/features/ee/billing/lib/subscription-updates.ts
+++ b/packages/features/ee/billing/lib/subscription-updates.ts
@@ -1,0 +1,30 @@
+import type { Logger } from "tslog";
+
+import type { IBillingProviderService } from "../service/billingProvider/IBillingProviderService";
+
+type ProrationBehavior = "none" | "create_prorations" | "always_invoice";
+
+export async function updateSubscriptionQuantity(params: {
+  billingService: IBillingProviderService;
+  subscriptionId: string;
+  subscriptionItemId: string;
+  quantity: number;
+  prorationBehavior?: ProrationBehavior;
+  logger?: Logger<unknown>;
+}): Promise<void> {
+  const { billingService, subscriptionId, subscriptionItemId, quantity, prorationBehavior, logger } = params;
+
+  try {
+    await billingService.handleSubscriptionUpdate({
+      subscriptionId,
+      subscriptionItemId,
+      membershipCount: quantity,
+      ...(prorationBehavior ? { prorationBehavior } : {}),
+    });
+  } catch (error) {
+    if (logger) {
+      logger.error(`Failed to update subscription ${subscriptionId} quantity to ${quantity}:`, error);
+    }
+    throw error;
+  }
+}

--- a/packages/features/ee/billing/service/proration/__tests__/MonthlyProrationService.integration-test.ts
+++ b/packages/features/ee/billing/service/proration/__tests__/MonthlyProrationService.integration-test.ts
@@ -4,6 +4,7 @@ import type { Team, User } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
 import { createMemberships } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildMonthlyProrationMetadata } from "../../../lib/proration-utils";
 import type { IBillingProviderService } from "../../billingProvider/IBillingProviderService";
 import { SeatChangeTrackingService } from "../../seatTracking/SeatChangeTrackingService";
 import { MonthlyProrationService } from "../MonthlyProrationService";
@@ -167,10 +168,7 @@ describe("MonthlyProrationService Integration Tests", () => {
       autoAdvance: true,
       collectionMethod: "charge_automatically",
       subscriptionId: proration!.subscriptionId,
-      metadata: {
-        type: "monthly_proration",
-        prorationId: proration!.id,
-      },
+      metadata: buildMonthlyProrationMetadata({ prorationId: proration!.id }),
     });
 
     const seatChanges = await prisma.seatChangeLog.findMany({

--- a/packages/features/ee/billing/service/proration/__tests__/MonthlyProrationService.test.ts
+++ b/packages/features/ee/billing/service/proration/__tests__/MonthlyProrationService.test.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@calcom/prisma";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildMonthlyProrationMetadata } from "../../../lib/proration-utils";
 import type { IBillingProviderService } from "../../billingProvider/IBillingProviderService";
-
 import { MonthlyProrationService } from "../MonthlyProrationService";
 
 vi.mock("@calcom/prisma", () => ({
@@ -365,10 +365,7 @@ describe("MonthlyProrationService", () => {
         autoAdvance: true,
         collectionMethod: "send_invoice",
         subscriptionId: "sub_789",
-        metadata: {
-          type: "monthly_proration",
-          prorationId: "proration-789",
-        },
+        metadata: buildMonthlyProrationMetadata({ prorationId: "proration-789" }),
       });
       expect(mockProrationRepository.updateProrationStatus).toHaveBeenCalledWith("proration-789", "PENDING", {
         invoiceItemId: "ii_test_123",

--- a/packages/features/ee/billing/service/proration/tasker/MonthlyProrationSyncTasker.ts
+++ b/packages/features/ee/billing/service/proration/tasker/MonthlyProrationSyncTasker.ts
@@ -1,0 +1,16 @@
+import { nanoid } from "nanoid";
+import type { Logger } from "tslog";
+
+import { MonthlyProrationService } from "../MonthlyProrationService";
+import type { IMonthlyProrationTasker } from "./types";
+
+export class MonthlyProrationSyncTasker implements IMonthlyProrationTasker {
+  constructor(private readonly logger: Logger<unknown>) {}
+
+  async processBatch(payload: Parameters<IMonthlyProrationTasker["processBatch"]>[0]) {
+    const runId = `sync_${nanoid(10)}`;
+    const prorationService = new MonthlyProrationService(this.logger);
+    await prorationService.processMonthlyProrations(payload);
+    return { runId };
+  }
+}

--- a/packages/features/ee/billing/service/proration/tasker/MonthlyProrationTasker.ts
+++ b/packages/features/ee/billing/service/proration/tasker/MonthlyProrationTasker.ts
@@ -1,0 +1,22 @@
+import { Tasker } from "@calcom/lib/tasker/Tasker";
+import type { Logger } from "tslog";
+
+import type { MonthlyProrationSyncTasker } from "./MonthlyProrationSyncTasker";
+import type { MonthlyProrationTriggerDevTasker } from "./MonthlyProrationTriggerDevTasker";
+import type { IMonthlyProrationTasker, MonthlyProrationBatchPayload } from "./types";
+
+export interface MonthlyProrationTaskerDependencies {
+  asyncTasker: MonthlyProrationTriggerDevTasker;
+  syncTasker: MonthlyProrationSyncTasker;
+  logger: Logger<unknown>;
+}
+
+export class MonthlyProrationTasker extends Tasker<IMonthlyProrationTasker> {
+  constructor(dependencies: MonthlyProrationTaskerDependencies) {
+    super(dependencies);
+  }
+
+  async processBatch(payload: MonthlyProrationBatchPayload): Promise<{ runId: string }> {
+    return await this.dispatch("processBatch", payload);
+  }
+}

--- a/packages/features/ee/billing/service/proration/tasker/MonthlyProrationTriggerDevTasker.ts
+++ b/packages/features/ee/billing/service/proration/tasker/MonthlyProrationTriggerDevTasker.ts
@@ -1,0 +1,13 @@
+import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
+
+import type { IMonthlyProrationTasker } from "./types";
+
+export class MonthlyProrationTriggerDevTasker implements IMonthlyProrationTasker {
+  constructor(public readonly dependencies: ITaskerDependencies) {}
+
+  async processBatch(payload: Parameters<IMonthlyProrationTasker["processBatch"]>[0]) {
+    const { processMonthlyProrationBatch } = await import("./trigger/processMonthlyProrationBatch");
+    const handle = await processMonthlyProrationBatch.trigger(payload);
+    return { runId: handle.id };
+  }
+}

--- a/packages/features/ee/billing/service/proration/tasker/constants.ts
+++ b/packages/features/ee/billing/service/proration/tasker/constants.ts
@@ -1,0 +1,1 @@
+export const MONTHLY_PRORATION_BATCH_SIZE = 10;

--- a/packages/features/ee/billing/service/proration/tasker/trigger/config.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/config.ts
@@ -1,0 +1,20 @@
+import { queue, type schemaTask } from "@trigger.dev/sdk";
+
+type MonthlyProrationTaskConfig = Pick<Parameters<typeof schemaTask>[0], "machine" | "retry" | "queue">;
+
+export const monthlyProrationQueue = queue({
+  name: "monthly-proration",
+  concurrencyLimit: 5,
+});
+
+export const monthlyProrationTaskConfig: MonthlyProrationTaskConfig = {
+  queue: monthlyProrationQueue,
+  machine: "small-2x",
+  retry: {
+    maxAttempts: 3,
+    factor: 2,
+    minTimeoutInMs: 1_000,
+    maxTimeoutInMs: 30_000,
+    randomize: true,
+  },
+};

--- a/packages/features/ee/billing/service/proration/tasker/trigger/processMonthlyProrationBatch.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/processMonthlyProrationBatch.ts
@@ -1,0 +1,23 @@
+import { schemaTask } from "@trigger.dev/sdk";
+
+import { monthlyProrationTaskConfig } from "./config";
+import { monthlyProrationBatchSchema } from "./schema";
+
+export const processMonthlyProrationBatch = schemaTask({
+  id: "billing.monthly-proration.batch",
+  ...monthlyProrationTaskConfig,
+  schema: monthlyProrationBatchSchema,
+  run: async (payload) => {
+    const { TriggerDevLogger } = await import("@calcom/lib/triggerDevLogger");
+    const { MonthlyProrationService } = await import("../../MonthlyProrationService");
+
+    const triggerDevLogger = new TriggerDevLogger();
+    const taskLogger = triggerDevLogger.getSubLogger({ name: "MonthlyProrationTask" });
+    const prorationService = new MonthlyProrationService(taskLogger);
+
+    await prorationService.processMonthlyProrations({
+      monthKey: payload.monthKey,
+      teamIds: payload.teamIds,
+    });
+  },
+});

--- a/packages/features/ee/billing/service/proration/tasker/trigger/schema.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+import { MONTHLY_PRORATION_BATCH_SIZE } from "../constants";
+
+const monthKeyRegex = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+export const monthlyProrationBatchSchema = z.object({
+  monthKey: z.string().regex(monthKeyRegex),
+  teamIds: z.array(z.number()).min(1).max(MONTHLY_PRORATION_BATCH_SIZE),
+});

--- a/packages/features/ee/billing/service/proration/tasker/types.ts
+++ b/packages/features/ee/billing/service/proration/tasker/types.ts
@@ -1,0 +1,8 @@
+export type MonthlyProrationBatchPayload = {
+  monthKey: string;
+  teamIds: number[];
+};
+
+export interface IMonthlyProrationTasker {
+  processBatch(payload: MonthlyProrationBatchPayload): Promise<{ runId: string }>;
+}

--- a/packages/features/ee/billing/service/seatTracking/SeatChangeTrackingService.ts
+++ b/packages/features/ee/billing/service/seatTracking/SeatChangeTrackingService.ts
@@ -1,9 +1,9 @@
-import type { Logger } from "tslog";
-
+import { formatMonthKey } from "@calcom/features/ee/billing/lib/month-key";
 import { SeatChangeLogRepository } from "@calcom/features/ee/billing/repository/seatChangeLogs/SeatChangeLogRepository";
 import logger from "@calcom/lib/logger";
 import type { Prisma } from "@calcom/prisma/client";
 import type { SeatChangeType } from "@calcom/prisma/enums";
+import type { Logger } from "tslog";
 
 const log = logger.getSubLogger({ prefix: ["SeatChangeTrackingService"] });
 
@@ -44,7 +44,7 @@ export class SeatChangeTrackingService {
       monthKey: providedMonthKey,
       operationId,
     } = params;
-    const monthKey = providedMonthKey || this.calculateMonthKey(new Date());
+    const monthKey = providedMonthKey || formatMonthKey(new Date());
 
     const { teamBillingId, organizationBillingId } = await this.repository.getTeamBillingIds(teamId);
 
@@ -72,7 +72,7 @@ export class SeatChangeTrackingService {
       monthKey: providedMonthKey,
       operationId,
     } = params;
-    const monthKey = providedMonthKey || this.calculateMonthKey(new Date());
+    const monthKey = providedMonthKey || formatMonthKey(new Date());
 
     const { teamBillingId, organizationBillingId } = await this.repository.getTeamBillingIds(teamId);
 
@@ -114,11 +114,5 @@ export class SeatChangeTrackingService {
     const { teamId, monthKey, prorationId } = params;
 
     return await this.repository.markAsProcessed({ teamId, monthKey, prorationId });
-  }
-
-  private calculateMonthKey(date: Date): string {
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    return `${year}-${month}`;
   }
 }

--- a/packages/features/ee/billing/service/teams/TeamBillingService.ts
+++ b/packages/features/ee/billing/service/teams/TeamBillingService.ts
@@ -9,6 +9,7 @@ import { prisma } from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import { teamMetadataStrictSchema } from "@calcom/prisma/zod-utils";
 import type { z } from "zod";
+import { updateSubscriptionQuantity } from "../../lib/subscription-updates";
 // import billing from "../..";
 import type {
   IBillingRepository,
@@ -172,10 +173,11 @@ export class TeamBillingService implements ITeamBillingService {
         return;
       }
 
-      await this.billingProviderService.handleSubscriptionUpdate({
+      await updateSubscriptionQuantity({
+        billingService: this.billingProviderService,
         subscriptionId,
         subscriptionItemId,
-        membershipCount,
+        quantity: membershipCount,
       });
       log.info(`Updated subscription ${subscriptionId} for team ${teamId} to ${membershipCount} seats.`);
     } catch (error) {

--- a/packages/features/trigger.config.ts
+++ b/packages/features/trigger.config.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { defineConfig } from "@trigger.dev/sdk";
 import dotEnv from "dotenv";
 
@@ -8,7 +9,7 @@ export default defineConfig({
   project: process.env.TRIGGER_DEV_PROJECT_REF ?? "", // e.g., "proj_abc123"
 
   // Directories containing your tasks
-  dirs: ["./bookings/lib/tasker/trigger/notifications"], // Customize based on your project structure
+  dirs: ["./bookings/lib/tasker/trigger/notifications", "./ee/billing/service/proration/tasker/trigger"],
 
   // Retry configuration
   retries: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds tasker-based batching for monthly proration so we queue and process teams asynchronously (with a sync fallback). Refactors billing/proration code with small utilities to simplify subscription updates and metadata handling.

- New Features
  - Cron endpoint now schedules proration batches and returns scheduledTeams, scheduledBatches, and batchSize.
  - Async processing via Trigger.dev queue; falls back to in-process execution when async is off.
  - Fixed-size batches (10) with schema validation.
  - Helpers added: month key formatter, proration metadata builder/finder, and a Trigger task for batch runs.

- Refactors
  - MonthlyProrationService uses shared updateSubscriptionQuantity and a Stripe subscription extractor for period, seats, and dates.
  - Webhooks and tests use the proration metadata helpers.
  - SeatChangeTrackingService and TeamBillingService now use shared utilities.
  - Trigger config updated to include proration task directory.

<sup>Written for commit 0957d03879d72ee365efc51e99cbdd9e3bef217e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

