### PR TITLE
feat: enable Stale Community PR workflow for fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/stale-pr-devin-completion.yml
+++ b/.github/workflows/stale-pr-devin-completion.yml
@@ -1,7 +1,7 @@
 name: Stale Community PR Devin Completion
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
   workflow_dispatch:
     inputs:
@@ -59,10 +59,6 @@ jobs:
             }
 
             const isFork = pr.head.repo.fork || pr.head.repo.full_name !== pr.base.repo.full_name;
-            const maintainerCanModify = pr.maintainer_can_modify;
-            const canProceed = !isFork || maintainerCanModify;
-            const needsMaintainerAccess = isFork && !maintainerCanModify;
-
             const headRepoFullName = pr.head.repo.full_name;
             const headRepoCloneUrl = pr.head.repo.clone_url;
 
@@ -73,77 +69,14 @@ jobs:
             core.setOutput('is_fork', isFork);
             core.setOutput('head_repo_full_name', headRepoFullName);
             core.setOutput('head_repo_clone_url', headRepoCloneUrl);
-            core.setOutput('maintainer_can_modify', maintainerCanModify);
-            core.setOutput('can_proceed', canProceed);
-            core.setOutput('needs_maintainer_access', needsMaintainerAccess);
 
             console.log(`PR #${prNumber}: "${pr.title}"`);
             console.log(`Author: ${pr.user.login}`);
             console.log(`Branch: ${pr.head.ref}`);
             console.log(`Is fork: ${isFork}`);
             console.log(`Head repo: ${headRepoFullName}`);
-            console.log(`Maintainer can modify: ${maintainerCanModify}`);
-            console.log(`Needs maintainer access: ${needsMaintainerAccess}`);
-
-      - name: Request maintainer access for fork PR
-        if: steps.pr.outputs.needs_maintainer_access == 'true'
-        uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-          PR_AUTHOR: ${{ steps.pr.outputs.pr_author }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = parseInt(process.env.PR_NUMBER);
-            const prAuthor = process.env.PR_AUTHOR;
-            const { owner, repo } = context.repo;
-
-            const comments = await github.rest.issues.listComments({
-              owner,
-              repo,
-              issue_number: prNumber
-            });
-
-            const alreadyRequested = comments.data.some(comment => 
-              comment.body?.includes('### Maintainer Access Needed')
-            );
-
-            if (!alreadyRequested) {
-              const commentBody = [
-                '### Maintainer Access Needed',
-                '',
-                `Hi @${prAuthor}! Thanks for your contribution to Cal.com.`,
-                '',
-                `We'd like to help complete this stale PR, but we noticed that "Allow edits from maintainers" isn't enabled. We need this setting to push updates to your PR branch.`,
-                '',
-                '**Could you please enable this setting?** Here\'s how:',
-                '1. Scroll down to the bottom of this PR page',
-                '2. In the right sidebar, check the box that says **"Allow edits and access to secrets by maintainers"**',
-                '',
-                'This allows us to push commits directly to your PR branch, which helps us:',
-                '- Complete any remaining work on your PR',
-                '- Fix merge conflicts and make small adjustments',
-                '- Get your contribution merged faster',
-                '',
-                'Once you\'ve enabled this setting, we\'ll be able to help finish up this PR. If you have any concerns about enabling this setting, feel free to let us know!'
-              ].join('\n');
-
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: prNumber,
-                body: commentBody
-              });
-
-              console.log(`Posted maintainer access request comment on PR #${prNumber}`);
-            } else {
-              console.log(`Maintainer access already requested on PR #${prNumber}`);
-            }
-
-            core.setFailed(`Cannot complete this fork PR: the fork owner has not enabled "Allow edits from maintainers". A comment has been posted requesting access.`);
 
       - name: Create Devin session
-        if: steps.pr.outputs.can_proceed == 'true'
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}

--- a/.github/workflows/stale-pr-devin-completion.yml
+++ b/.github/workflows/stale-pr-devin-completion.yml
@@ -59,6 +59,9 @@ jobs:
             }
 
             const isFork = pr.head.repo.fork || pr.head.repo.full_name !== pr.base.repo.full_name;
+            const maintainerCanModify = pr.maintainer_can_modify;
+            const needsMaintainerAccess = isFork && !maintainerCanModify;
+
             const headRepoFullName = pr.head.repo.full_name;
             const headRepoCloneUrl = pr.head.repo.clone_url;
 
@@ -69,12 +72,73 @@ jobs:
             core.setOutput('is_fork', isFork);
             core.setOutput('head_repo_full_name', headRepoFullName);
             core.setOutput('head_repo_clone_url', headRepoCloneUrl);
+            core.setOutput('maintainer_can_modify', maintainerCanModify);
+            core.setOutput('needs_maintainer_access', needsMaintainerAccess);
 
             console.log(`PR #${prNumber}: "${pr.title}"`);
             console.log(`Author: ${pr.user.login}`);
             console.log(`Branch: ${pr.head.ref}`);
             console.log(`Is fork: ${isFork}`);
             console.log(`Head repo: ${headRepoFullName}`);
+            console.log(`Maintainer can modify: ${maintainerCanModify}`);
+            console.log(`Needs maintainer access: ${needsMaintainerAccess}`);
+
+      - name: Request maintainer access for fork PR
+        if: steps.pr.outputs.needs_maintainer_access == 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_AUTHOR: ${{ steps.pr.outputs.pr_author }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            const prAuthor = process.env.PR_AUTHOR;
+            const { owner, repo } = context.repo;
+
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: prNumber
+            });
+
+            const alreadyRequested = comments.data.some(comment => 
+              comment.body?.includes('### Maintainer Access Needed')
+            );
+
+            if (!alreadyRequested) {
+              const commentBody = [
+                '### Maintainer Access Needed',
+                '',
+                `Hi @${prAuthor}! Thanks for your contribution to Cal.com.`,
+                '',
+                `We'd like to help complete this stale PR, but we noticed that "Allow edits from maintainers" isn't enabled. We need this setting to push updates to your PR branch.`,
+                '',
+                '**Could you please enable this setting?** Here\'s how:',
+                '1. Scroll down to the bottom of this PR page',
+                '2. In the right sidebar, check the box that says **"Allow edits and access to secrets by maintainers"**',
+                '',
+                'This allows us to push commits directly to your PR branch, which helps us:',
+                '- Complete any remaining work on your PR',
+                '- Fix merge conflicts and make small adjustments',
+                '- Get your contribution merged faster',
+                '',
+                'Once you\'ve enabled this setting, we\'ll be able to help finish up this PR. If you have any concerns about enabling this setting, feel free to let us know!'
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+
+              console.log(`Posted maintainer access request comment on PR #${prNumber}`);
+            } else {
+              console.log(`Maintainer access already requested on PR #${prNumber}`);
+            }
+
+            core.setFailed(`Cannot complete this fork PR: the fork owner has not enabled "Allow edits from maintainers". A comment has been posted requesting access.`);
 
       - name: Create Devin session
         env:


### PR DESCRIPTION
## What does this PR do?

This PR updates the `Stale Community PR Devin Completion` workflow to properly support fork PRs by changing the trigger from `pull_request` to `pull_request_target`. This allows the workflow to access repository secrets (like `DEVIN_API_KEY` and `DEVIN_ACTIONS_PAT`) when triggered by fork PRs.

Changes:
1. Changed the trigger from `pull_request` to `pull_request_target` for the `stale` label event
2. Simplified the workflow logic by removing the `canProceed` variable (the workflow will fail naturally if maintainer access is needed due to `core.setFailed()` in the "Request maintainer access" step)

The "Request maintainer access for fork PR" step is preserved - it will still post a comment asking fork owners to enable "Allow edits from maintainers" if that setting isn't enabled.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow.

## How should this be tested?

1. Add the `stale` label to a fork PR without "Allow edits from maintainers" enabled - verify the workflow posts a comment requesting access and fails
2. Add the `stale` label to a fork PR with "Allow edits from maintainers" enabled - verify the Devin session is created
3. Add the `stale` label to a non-fork PR - verify the workflow works as before

## Human Review Checklist

- [ ] Verify `DEVIN_ACTIONS_PAT` secret has appropriate permissions for pushing to forks
- [ ] Confirm the security implications of using `pull_request_target` are understood (runs in base repo context with access to secrets)
- [ ] Verify the workflow correctly fails when maintainer access is not enabled on fork PRs

---

Link to Devin run: https://app.devin.ai/sessions/c1cbd90d70754cf38f1c02d2fe2dde5f
Requested by: @keithwillcode