### PR TITLE
chore: Biome increase line numbers per function

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -124,7 +124,13 @@
             "noNestedTernary": "warn"
           },
           "complexity": {
-            "noExcessiveLinesPerFunction": "warn"
+            "noExcessiveLinesPerFunction": {
+              "level": "warn",
+              "options": {
+                "maxLines": 100,
+                "skipBlankLines": true
+              }
+            }
           },
           "performance": {
             "noImgElement": "warn"


### PR DESCRIPTION
## What does this PR do?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised Biome’s lines-per-function threshold to 100 and set it to ignore blank lines. This reduces unnecessary warnings for longer functions while keeping the rule at warn level.

<sup>Written for commit f77eacff051879c144d58ed806289a6dd1cb2a77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

