### PR TITLE
fix: replace @ts-ignore with @ts-expect-error to fix biome lint errors

### DIFF
--- a/packages/embeds/embed-core/src/FloatingButton/FloatingButton.ts
+++ b/packages/embeds/embed-core/src/FloatingButton/FloatingButton.ts
@@ -44,8 +44,7 @@ export class FloatingButton extends HTMLElement {
   // Button added here triggers the modal on click. So, it has to have the same data attributes as the modal target as well
   dataset!: DOMStringMap & FloatingButtonDataset & ModalTargetDatasetProps;
   buttonWrapperStyleDisplay!: HTMLElement["style"]["display"];
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
+  // @ts-expect-error
   static get observedAttributes() {
     return dataAttributes;
   }

--- a/packages/embeds/embed-core/src/FloatingButton/FloatingButton.ts
+++ b/packages/embeds/embed-core/src/FloatingButton/FloatingButton.ts
@@ -44,7 +44,7 @@ export class FloatingButton extends HTMLElement {
   // Button added here triggers the modal on click. So, it has to have the same data attributes as the modal target as well
   dataset!: DOMStringMap & FloatingButtonDataset & ModalTargetDatasetProps;
   buttonWrapperStyleDisplay!: HTMLElement["style"]["display"];
-  // @ts-expect-error
+
   static get observedAttributes() {
     return dataAttributes;
   }

--- a/packages/embeds/embed-core/src/ModalBox/ModalBox.ts
+++ b/packages/embeds/embed-core/src/ModalBox/ModalBox.ts
@@ -12,8 +12,7 @@ export class ModalBox extends EmbedElement {
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
+  // @ts-expect-error
   static get observedAttributes() {
     return ["state"];
   }

--- a/packages/embeds/embed-core/src/ModalBox/ModalBox.ts
+++ b/packages/embeds/embed-core/src/ModalBox/ModalBox.ts
@@ -12,7 +12,6 @@ export class ModalBox extends EmbedElement {
     }
   };
 
-  // @ts-expect-error
   static get observedAttributes() {
     return ["state"];
   }

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -266,8 +266,7 @@ export class Cal {
       error(`Instruction ${method} not FOUND`);
     }
     try {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore There can be any method which can have any number of arguments.
+      // @ts-expect-error There can be any method which can have any number of arguments.
       this.api[method](...args);
     } catch (e) {
       // Instead of throwing error, log and move forward in the queue
@@ -283,8 +282,7 @@ export class Cal {
 
     queue.splice(0);
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    /** @ts-ignore */ // We changed the definition of push here.
+    // @ts-expect-error We changed the definition of push here.
     queue.push = (instruction) => {
       this.processInstruction(instruction);
     };
@@ -363,8 +361,7 @@ export class Cal {
     }
 
     // Merge searchParams from config onto the URL which might have query params already
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
+    // @ts-expect-error
     for (const [key, value] of searchParams) {
       urlInstance.searchParams.append(key, value);
     }
@@ -1565,8 +1562,7 @@ window.addEventListener("message", (e) => {
   if (!actionManager) {
     throw new Error(`Unhandled Action ${parsedAction}`);
   }
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   actionManager.fire(parsedAction.type, detail.data);
 });
 

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -361,6 +361,7 @@ export class Cal {
     }
 
     // Merge searchParams from config onto the URL which might have query params already
+    // @ts-ignore TS2802: URLSearchParams iteration requires downlevelIteration
     for (const [key, value] of searchParams) {
       urlInstance.searchParams.append(key, value);
     }

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -361,7 +361,6 @@ export class Cal {
     }
 
     // Merge searchParams from config onto the URL which might have query params already
-    // @ts-expect-error
     for (const [key, value] of searchParams) {
       urlInstance.searchParams.append(key, value);
     }

--- a/packages/embeds/embed-core/src/lib/utils.ts
+++ b/packages/embeds/embed-core/src/lib/utils.ts
@@ -33,6 +33,7 @@ export function fromEntriesWithDuplicateKeys(entries: IterableIterator<[string, 
   }
 
   // Consider setting atleast ES2015 as target
+  // @ts-ignore TS2802: IterableIterator iteration requires downlevelIteration
   for (const [key, value] of entries) {
     if (result.hasOwnProperty(key)) {
       let currentValue = result[key];

--- a/packages/embeds/embed-core/src/lib/utils.ts
+++ b/packages/embeds/embed-core/src/lib/utils.ts
@@ -33,7 +33,6 @@ export function fromEntriesWithDuplicateKeys(entries: IterableIterator<[string, 
   }
 
   // Consider setting atleast ES2015 as target
-  // @ts-expect-error
   for (const [key, value] of entries) {
     if (result.hasOwnProperty(key)) {
       let currentValue = result[key];

--- a/packages/embeds/embed-core/src/lib/utils.ts
+++ b/packages/embeds/embed-core/src/lib/utils.ts
@@ -33,8 +33,7 @@ export function fromEntriesWithDuplicateKeys(entries: IterableIterator<[string, 
   }
 
   // Consider setting atleast ES2015 as target
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   for (const [key, value] of entries) {
     if (result.hasOwnProperty(key)) {
       let currentValue = result[key];

--- a/packages/embeds/embed-core/src/preview.ts
+++ b/packages/embeds/embed-core/src/preview.ts
@@ -70,8 +70,7 @@ if (!calLink) {
 // TODO: Reuse the embed code snippet from the embed-snippet package - Not able to use it because of circular dependency
 // Install Cal Embed Code Snippet
 (function (C, A, L) {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
+  // @ts-expect-error
   const p = function (a, ar) {
     a.q.push(ar);
   };
@@ -95,8 +94,7 @@ if (!calLink) {
           p(api, arguments);
         };
         const namespace = ar[1];
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
+        // @ts-expect-error
         api.q = api.q || [];
         if (typeof namespace === "string") {
           // Make sure that even after re-execution of the snippet, the namespace is not overridden

--- a/packages/embeds/embed-snippet/src/index.ts
+++ b/packages/embeds/embed-snippet/src/index.ts
@@ -43,7 +43,7 @@ export default function EmbedSnippet(url = EMBED_LIB_URL) {
           cal.ns = {};
           cal.q = cal.q || [];
 
-          //@ts-ignore
+          // @ts-expect-error
           d.head.appendChild(d.createElement("script")).src = A;
           cal.loaded = true;
         }

--- a/packages/embeds/embed-snippet/src/index.ts
+++ b/packages/embeds/embed-snippet/src/index.ts
@@ -43,7 +43,6 @@ export default function EmbedSnippet(url = EMBED_LIB_URL) {
           cal.ns = {};
           cal.q = cal.q || [];
 
-          // @ts-expect-error
           d.head.appendChild(d.createElement("script")).src = A;
           cal.loaded = true;
         }

--- a/packages/lib/__mocks__/constants.ts
+++ b/packages/lib/__mocks__/constants.ts
@@ -33,19 +33,16 @@ beforeEach(() => {
 
 export const constantsScenarios = {
   enableTeamBilling: () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error - mockedConstants is typed as Partial but we need to set this value
     mockedConstants.IS_TEAM_BILLING_ENABLED = true;
   },
   setWebsiteUrl: (url: string) => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     mockedConstants.WEBSITE_URL = url;
   },
   set: (envVariables: Record<string, string>) => {
     Object.entries(envVariables).forEach(([key, value]) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error
       mockedConstants[key] = value;
     });
   },

--- a/packages/lib/__mocks__/constants.ts
+++ b/packages/lib/__mocks__/constants.ts
@@ -33,16 +33,13 @@ beforeEach(() => {
 
 export const constantsScenarios = {
   enableTeamBilling: () => {
-    // @ts-expect-error - mockedConstants is typed as Partial but we need to set this value
     mockedConstants.IS_TEAM_BILLING_ENABLED = true;
   },
   setWebsiteUrl: (url: string) => {
-    // @ts-expect-error
     mockedConstants.WEBSITE_URL = url;
   },
   set: (envVariables: Record<string, string>) => {
     Object.entries(envVariables).forEach(([key, value]) => {
-      // @ts-expect-error
       mockedConstants[key] = value;
     });
   },

--- a/packages/lib/__mocks__/constants.ts
+++ b/packages/lib/__mocks__/constants.ts
@@ -40,6 +40,7 @@ export const constantsScenarios = {
   },
   set: (envVariables: Record<string, string>) => {
     Object.entries(envVariables).forEach(([key, value]) => {
+      // @ts-expect-error - dynamic key access on Partial type
       mockedConstants[key] = value;
     });
   },

--- a/packages/lib/__tests__/buildCalEventFromBooking.test.ts
+++ b/packages/lib/__tests__/buildCalEventFromBooking.test.ts
@@ -60,8 +60,7 @@ const createBooking = (overrides = {}) => ({
 describe("buildCalEventFromBooking", () => {
   beforeEach(() => {
     // vi.resetAllMocks();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     getTranslation.mockImplementation((locale: string, namespace: string) => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       const translate = () => {};

--- a/packages/lib/errors.ts
+++ b/packages/lib/errors.ts
@@ -46,7 +46,7 @@ export function getErrorFromUnknown(cause: unknown): Error & { statusCode?: numb
     return cause;
   }
   if (typeof cause === "string") {
-    // @ts-ignore https://github.com/tc39/proposal-error-cause
+    // @ts-expect-error https://github.com/tc39/proposal-error-cause
     return new Error(cause, { cause });
   }
 

--- a/packages/lib/errors.ts
+++ b/packages/lib/errors.ts
@@ -46,7 +46,7 @@ export function getErrorFromUnknown(cause: unknown): Error & { statusCode?: numb
     return cause;
   }
   if (typeof cause === "string") {
-    // @ts-expect-error https://github.com/tc39/proposal-error-cause
+    // @ts-ignore https://github.com/tc39/proposal-error-cause - must use @ts-ignore because different packages have different TS lib targets
     return new Error(cause, { cause });
   }
 

--- a/packages/lib/errors.ts
+++ b/packages/lib/errors.ts
@@ -46,7 +46,6 @@ export function getErrorFromUnknown(cause: unknown): Error & { statusCode?: numb
     return cause;
   }
   if (typeof cause === "string") {
-    // @ts-expect-error https://github.com/tc39/proposal-error-cause
     return new Error(cause, { cause });
   }
 

--- a/packages/lib/errors.ts
+++ b/packages/lib/errors.ts
@@ -46,6 +46,7 @@ export function getErrorFromUnknown(cause: unknown): Error & { statusCode?: numb
     return cause;
   }
   if (typeof cause === "string") {
+    // @ts-ignore https://github.com/tc39/proposal-error-cause
     return new Error(cause, { cause });
   }
 

--- a/packages/lib/errors.ts
+++ b/packages/lib/errors.ts
@@ -46,8 +46,7 @@ export function getErrorFromUnknown(cause: unknown): Error & { statusCode?: numb
     return cause;
   }
   if (typeof cause === "string") {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore https://github.com/tc39/proposal-error-cause
+    // @ts-expect-error https://github.com/tc39/proposal-error-cause
     return new Error(cause, { cause });
   }
 

--- a/packages/lib/fromEntriesWithDuplicateKeys.ts
+++ b/packages/lib/fromEntriesWithDuplicateKeys.ts
@@ -6,8 +6,7 @@ export function fromEntriesWithDuplicateKeys(entries: IterableIterator<[string, 
   }
 
   // Consider setting atleast ES2015 as target
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   for (const [key, value] of entries) {
     if (result.hasOwnProperty(key)) {
       let currentValue = result[key];

--- a/packages/lib/hooks/useRouterQuery.ts
+++ b/packages/lib/hooks/useRouterQuery.ts
@@ -12,8 +12,7 @@ function fromEntriesWithDuplicateKeys(entries: IterableIterator<[string, string]
   }
 
   // Consider setting atleast ES2015 as target
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   for (const [key, value] of entries) {
     if (result.hasOwnProperty(key)) {
       let currentValue = result[key];

--- a/packages/lib/hooks/useTraceUpdate.ts
+++ b/packages/lib/hooks/useTraceUpdate.ts
@@ -4,11 +4,9 @@ export function useTraceUpdate(props: { [s: string]: unknown } | ArrayLike<unkno
   const prev = useRef(props);
   useEffect(() => {
     const changedProps = Object.entries(props).reduce((ps, [k, v]) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore TODO: fix this
+      // @ts-expect-error TODO: fix this
       if (prev.current[k] !== v) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore TODO: fix this
+        // @ts-expect-error TODO: fix this
         ps[k] = [prev.current[k], v];
       }
       return ps;

--- a/packages/lib/http-error.ts
+++ b/packages/lib/http-error.ts
@@ -37,8 +37,7 @@ export class HttpError<TCode extends number = number> extends Error {
       url: response.url,
       method: request.method,
       statusCode: response.status,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore the data property is a custom one from ErrorWithCode
+      // @ts-expect-error the data property is a custom one from ErrorWithCode
       data: parsedError.data as Record<string, unknown>,
     });
   }

--- a/packages/lib/http-error.ts
+++ b/packages/lib/http-error.ts
@@ -37,7 +37,6 @@ export class HttpError<TCode extends number = number> extends Error {
       url: response.url,
       method: request.method,
       statusCode: response.status,
-      // @ts-expect-error the data property is a custom one from ErrorWithCode
       data: parsedError.data as Record<string, unknown>,
     });
   }

--- a/packages/lib/server/__mocks__/serviceAccountKey.ts
+++ b/packages/lib/server/__mocks__/serviceAccountKey.ts
@@ -1,7 +1,6 @@
 import { vi } from "vitest";
 
 vi.mock("@calcom/lib/server/serviceAccountKey", async (importOriginal) => {
-  // @ts-expect-error
   const actual = await importOriginal<any>();
   return {
     ...actual,

--- a/packages/lib/server/__mocks__/serviceAccountKey.ts
+++ b/packages/lib/server/__mocks__/serviceAccountKey.ts
@@ -1,8 +1,7 @@
 import { vi } from "vitest";
 
 vi.mock("@calcom/lib/server/serviceAccountKey", async (importOriginal) => {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   const actual = await importOriginal<any>();
   return {
     ...actual,

--- a/packages/lib/server/repository/selectedCalendar.ts
+++ b/packages/lib/server/repository/selectedCalendar.ts
@@ -177,10 +177,7 @@ export class SelectedCalendarRepository {
                 error: { not: null },
                 watchAttempts: {
                   lt: {
-                    // Using ts-ignore instead of ts-expect-error because I am seeing conflicting errors in CI. In one case ts-expect-error fails with `Unused '@ts-expect-error' directive.`
-                    // Removing ts-expect-error fails in another case that _ref isn't defined
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
+                    // @ts-expect-error - _ref is a Prisma extension field
                     _ref: "maxAttempts",
                     _container: "SelectedCalendar",
                   },
@@ -220,10 +217,7 @@ export class SelectedCalendarRepository {
               error: { not: null },
               unwatchAttempts: {
                 lt: {
-                  // Using ts-ignore instead of ts-expect-error because I am seeing conflicting errors in CI. In one case ts-expect-error fails with `Unused '@ts-expect-error' directive.`
-                  // Removing ts-expect-error fails in another case that _ref isn't defined
-                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                  // @ts-ignore
+                  // @ts-expect-error - _ref is a Prisma extension field
                   _ref: "maxAttempts",
                   _container: "SelectedCalendar",
                 },

--- a/packages/lib/server/username.test.ts
+++ b/packages/lib/server/username.test.ts
@@ -6,13 +6,11 @@ import { usernameCheckForSignup } from "./username";
 
 describe("usernameCheckForSignup ", async () => {
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
+    // @ts-expect-error
     prismaMock.user.findUnique.mockImplementation(() => {
       return null;
     });
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
+    // @ts-expect-error
     prismaMock.user.findMany.mockImplementation(() => {
       return [];
     });
@@ -60,8 +58,7 @@ describe("usernameCheckForSignup ", async () => {
 });
 
 function mockUserInDB({ id, email, username }: { id: number; email: string; username: string }) {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
+  // @ts-expect-error
   prismaMock.user.findUnique.mockImplementation((arg) => {
     if (arg.where.email === email) {
       return {
@@ -75,12 +72,10 @@ function mockUserInDB({ id, email, username }: { id: number; email: string; user
 }
 
 function mockMembership({ userId }: { userId: number }) {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
+  // @ts-expect-error
   prismaMock.membership.findFirst.mockImplementation((arg) => {
     const isOrganizationWhereClause =
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
+      // @ts-expect-error
       arg?.where?.team?.metadata?.path[0] === "isOrganization" && arg?.where?.team?.metadata?.equals === true;
     if (arg?.where?.userId === userId && isOrganizationWhereClause) {
       return {

--- a/packages/lib/slugify.ts
+++ b/packages/lib/slugify.ts
@@ -10,7 +10,9 @@ export const slugify = (str: string, forDisplayingInput?: boolean) => {
     .toLowerCase() // Convert to lowercase
     .trim() // Remove whitespace from both sides
     .normalize("NFD") // Normalize to decomposed form for handling accents
+    // @ts-ignore - Unicode property escapes require ES6+ target in some TS configs
     .replace(/\p{Diacritic}/gu, "") // Remove any diacritics (accents) from characters
+    // @ts-ignore - Unicode property escapes require ES6+ target in some TS configs
     .replace(/[^.\p{L}\p{N}\p{Zs}\p{Emoji}]+/gu, "-") // Replace any non-alphanumeric characters (including Unicode and except "." period) with a dash
     .replace(/[\s_#]+/g, "-") // Replace whitespace, # and underscores with a single dash
     .replace(/^-+/, "") // Remove dashes from start

--- a/packages/lib/slugify.ts
+++ b/packages/lib/slugify.ts
@@ -10,11 +10,9 @@ export const slugify = (str: string, forDisplayingInput?: boolean) => {
     .toLowerCase() // Convert to lowercase
     .trim() // Remove whitespace from both sides
     .normalize("NFD") // Normalize to decomposed form for handling accents
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     .replace(/\p{Diacritic}/gu, "") // Remove any diacritics (accents) from characters
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     .replace(/[^.\p{L}\p{N}\p{Zs}\p{Emoji}]+/gu, "-") // Replace any non-alphanumeric characters (including Unicode and except "." period) with a dash
     .replace(/[\s_#]+/g, "-") // Replace whitespace, # and underscores with a single dash
     .replace(/^-+/, "") // Remove dashes from start

--- a/packages/lib/slugify.ts
+++ b/packages/lib/slugify.ts
@@ -10,9 +10,7 @@ export const slugify = (str: string, forDisplayingInput?: boolean) => {
     .toLowerCase() // Convert to lowercase
     .trim() // Remove whitespace from both sides
     .normalize("NFD") // Normalize to decomposed form for handling accents
-    // @ts-expect-error
     .replace(/\p{Diacritic}/gu, "") // Remove any diacritics (accents) from characters
-    // @ts-expect-error
     .replace(/[^.\p{L}\p{N}\p{Zs}\p{Emoji}]+/gu, "-") // Replace any non-alphanumeric characters (including Unicode and except "." period) with a dash
     .replace(/[\s_#]+/g, "-") // Replace whitespace, # and underscores with a single dash
     .replace(/^-+/, "") // Remove dashes from start

--- a/packages/trpc/server/routers/viewer/apps/toggle.handler.ts
+++ b/packages/trpc/server/routers/viewer/apps/toggle.handler.ts
@@ -131,11 +131,9 @@ export const toggleHandler = async ({ input, ctx }: ToggleOptions) => {
                 ...(eventType.metadata as object),
                 apps: {
                   // From this comment we can not type JSON fields in Prisma https://github.com/prisma/prisma/issues/3219#issuecomment-670202980
-                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                  //@ts-ignore
+                  // @ts-expect-error
                   ...eventType.metadata?.apps,
-                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                  //@ts-ignore
+                  // @ts-expect-error
                   [app.slug]: { ...eventType.metadata?.apps[app.slug], enabled: false },
                 },
               },

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/duplicate.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/duplicate.handler.ts
@@ -101,8 +101,7 @@ export const duplicateHandler = async ({ ctx, input }: DuplicateOptions) => {
       webhooks: _webhooks,
 
       schedule: _schedule,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore - descriptionAsSafeHTML is added on the fly using a prisma middleware it shouldn't be used to create event type. Such a property doesn't exist on schema
+      // @ts-expect-error - descriptionAsSafeHTML is added on the fly using a prisma middleware it shouldn't be used to create event type. Such a property doesn't exist on schema
       descriptionAsSafeHTML: _descriptionAsSafeHTML,
       secondaryEmailId,
       instantMeetingScheduleId: _instantMeetingScheduleId,

--- a/packages/trpc/server/routers/viewer/organizations/__tests__/createTeams.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/organizations/__tests__/createTeams.handler.test.ts
@@ -42,8 +42,7 @@ async function createTestTeam(data: {
       slug: data.slug || slugify(data.name),
       parentId: data.parentId,
       isOrganization: data.isOrganization ?? false,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error
       metadata: data.metadata || {},
       isPlatform: data.isPlatform ?? false,
     },

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/__mocks__/inviteMemberUtils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/__mocks__/inviteMemberUtils.ts
@@ -17,8 +17,7 @@ const inviteMemberUtilsMock = mockDeep<typeof inviteMemberUtils>();
 export const inviteMemberutilsScenarios = {
   checkPermissions: {
     fakePassed: () =>
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
+      // @ts-expect-error
       inviteMemberUtilsMock.checkPermissions.mockResolvedValue(undefined),
   },
   getTeamOrThrow: {
@@ -29,8 +28,7 @@ export const inviteMemberutilsScenarios = {
         parentId: null,
         ...team,
       };
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
+      // @ts-expect-error
       inviteMemberUtilsMock.getTeamOrThrow.mockImplementation((teamId) => {
         if (forInput.teamId === teamId) {
           return fakedVal;
@@ -49,8 +47,7 @@ export const inviteMemberutilsScenarios = {
     useActual: async function () {
       const actualImport = await vi.importActual<typeof inviteMemberUtils>("../utils");
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
+      // @ts-expect-error
       return inviteMemberUtilsMock.getOrgState.mockImplementation(actualImport.getOrgState);
     },
   },
@@ -58,8 +55,7 @@ export const inviteMemberutilsScenarios = {
     useActual: async function () {
       const actualImport = await vi.importActual<typeof inviteMemberUtils>("../utils");
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
+      // @ts-expect-error
       return inviteMemberUtilsMock.getUniqueInvitationsOrThrowIfEmpty.mockImplementation(
         actualImport.getUniqueInvitationsOrThrowIfEmpty
       );
@@ -90,8 +86,7 @@ export const inviteMemberutilsScenarios = {
     useActual: async function () {
       const actualImport = await vi.importActual<typeof inviteMemberUtils>("../utils");
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
+      // @ts-expect-error
       return inviteMemberUtilsMock.getOrgConnectionInfo.mockImplementation(actualImport.getOrgConnectionInfo);
     },
   },

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/__mocks__/inviteMemberUtils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/__mocks__/inviteMemberUtils.ts
@@ -47,7 +47,6 @@ export const inviteMemberutilsScenarios = {
     useActual: async function () {
       const actualImport = await vi.importActual<typeof inviteMemberUtils>("../utils");
 
-      // @ts-expect-error
       return inviteMemberUtilsMock.getOrgState.mockImplementation(actualImport.getOrgState);
     },
   },
@@ -55,7 +54,6 @@ export const inviteMemberutilsScenarios = {
     useActual: async function () {
       const actualImport = await vi.importActual<typeof inviteMemberUtils>("../utils");
 
-      // @ts-expect-error
       return inviteMemberUtilsMock.getUniqueInvitationsOrThrowIfEmpty.mockImplementation(
         actualImport.getUniqueInvitationsOrThrowIfEmpty
       );
@@ -86,7 +84,6 @@ export const inviteMemberutilsScenarios = {
     useActual: async function () {
       const actualImport = await vi.importActual<typeof inviteMemberUtils>("../utils");
 
-      // @ts-expect-error
       return inviteMemberUtilsMock.getOrgConnectionInfo.mockImplementation(actualImport.getOrgConnectionInfo);
     },
   },


### PR DESCRIPTION
## What does this PR do?

Replaces all `@ts-ignore` directives with `@ts-expect-error` across the codebase to fix biome's `lint/suspicious/noTsIgnore` rule violations.

`@ts-expect-error` is preferred because it will cause a TypeScript error if the suppressed line no longer has an error, making it safer for code maintenance. `@ts-ignore` silently suppresses errors forever, even after the underlying issue is fixed.

This PR also removes the now-unnecessary `eslint-disable-next-line @typescript-eslint/ban-ts-comment` comments that were paired with the old directives.

### Updates since initial revision

**Files where `@ts-ignore` is intentionally kept:**
- `slugify.ts`: Two `@ts-ignore` comments for Unicode property escapes (`\p{Diacritic}`, `\p{L}`, etc.) that require ES6+ target in some TS configs
- `embed.ts` and `lib/utils.ts`: Two `@ts-ignore` comments for TS2802 iteration errors that only appear when the trpc package builds
- `errors.ts`: One `@ts-ignore` for Error cause option - must use `@ts-ignore` because different packages have different TS lib targets (some support ES2022 Error cause natively, others don't)

**Removed unnecessary suppressions:**
- `FloatingButton.ts` and `ModalBox.ts`: Removed `@ts-ignore` directives that were suppressing non-existent errors
- `http-error.ts`: Removed `@ts-expect-error` for accessing `parsedError.data` (valid on `Record<string, unknown>`)
- `inviteMemberUtils.ts`: Removed unnecessary `@ts-expect-error` directives for vitest mock implementations
- `embed-snippet/src/index.ts`: Removed unnecessary `@ts-ignore` directive
- `__mocks__/constants.ts`: Removed 2 unused suppressions for literal key access (`enableTeamBilling`, `setWebsiteUrl`); kept `@ts-expect-error` for dynamic key access in `set` function
- `server/__mocks__/serviceAccountKey.ts`: Removed unused `@ts-expect-error` directive

**Changes:** 23 files modified

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - lint-only changes, verified by biome lint passing.

## How should this be tested?

Run biome lint and verify no `noTsIgnore` violations:
```bash
yarn turbo run lint -- --max-diagnostics=10000 2>&1 | grep -E "noTsIgnore"
```

Should return 0 results (the remaining `@ts-ignore` comments have explanatory comments which biome accepts).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the `@ts-ignore` kept in `slugify.ts` (lines 13, 15) are necessary for Unicode regex patterns
- [ ] Verify the `@ts-ignore` kept in embed-core (`embed.ts:364`, `lib/utils.ts:36`) are necessary for TS2802 iteration errors
- [ ] Verify `errors.ts` `@ts-ignore` is necessary due to different TS lib targets across packages
- [ ] Verify `@ts-expect-error` in `__mocks__/constants.ts` `set` function is necessary for dynamic key access
- [ ] Verify CI type-check and build jobs pass

---

### Link to Devin run
https://app.devin.ai/sessions/674bbf5e35ff4394a0af3bbff07a2033

### Requested by
Volnei Munhoz (@volnei)