### PR TITLE
fix: resolve useLiteralKeys biome lint issues

### DIFF
--- a/packages/embeds/embed-core/src/FloatingButton/FloatingButton.ts
+++ b/packages/embeds/embed-core/src/FloatingButton/FloatingButton.ts
@@ -96,10 +96,10 @@ export class FloatingButton extends HTMLElement {
   constructor() {
     super();
     const dataset = this.dataset as FloatingButtonDataset;
-    const buttonText = dataset["buttonText"];
-    const buttonPosition = dataset["buttonPosition"];
-    const buttonColor = dataset["buttonColor"];
-    const buttonTextColor = dataset["buttonTextColor"];
+    const buttonText = dataset.buttonText;
+    const buttonPosition = dataset.buttonPosition;
+    const buttonColor = dataset.buttonColor;
+    const buttonTextColor = dataset.buttonTextColor;
 
     //TODO: Logic is duplicated over HTML generation and attribute change, keep it at one place
     const buttonHtml = `<style>${window.Cal.__css}</style> ${getFloatingButtonHtml({

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -1018,11 +1018,11 @@ class CalApi {
       el = existingEl as FloatingButton;
     }
     const dataset = el.dataset;
-    dataset["buttonText"] = buttonText;
-    dataset["hideButtonIcon"] = `${hideButtonIcon}`;
-    dataset["buttonPosition"] = `${buttonPosition}`;
-    dataset["buttonColor"] = `${buttonColor}`;
-    dataset["buttonTextColor"] = `${buttonTextColor}`;
+    dataset.buttonText = buttonText;
+    dataset.hideButtonIcon = `${hideButtonIcon}`;
+    dataset.buttonPosition = `${buttonPosition}`;
+    dataset.buttonColor = `${buttonColor}`;
+    dataset.buttonTextColor = `${buttonTextColor}`;
   }
 
   async modal({

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -393,6 +393,7 @@ export default abstract class BaseCalendarService implements Calendar {
         const dtstartProperty = vevent.getFirstProperty("dtstart");
         const tzidFromDtstart = dtstartProperty ? (dtstartProperty as any).jCal[1].tzid : undefined;
         const dtstart: { [key: string]: string } | undefined = vevent?.getFirstPropertyValue("dtstart");
+        // biome-ignore lint/complexity/useLiteralKeys: accessing dynamic property from ICAL.js object
         const timezone = dtstart ? dtstart["timezone"] : undefined;
         // We check if the dtstart timezone is in UTC which is actually represented by Z instead, but not recognized as that in ICAL.js as UTC
         const isUTC = timezone === "Z";

--- a/packages/lib/dayjs/index.ts
+++ b/packages/lib/dayjs/index.ts
@@ -177,7 +177,7 @@ export const weekdayToWeekIndex = (weekday: WeekDays | string | number | undefin
  * @returns Time Zone name
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const getTimeZone = (date: Dayjs): string => (date as any)["$x"]["$timezone"];
+export const getTimeZone = (date: Dayjs): string => (date as any).$x.$timezone;
 
 /**
  * Verify if timeZone has Daylight Saving Time (DST).

--- a/packages/lib/getBooking.tsx
+++ b/packages/lib/getBooking.tsx
@@ -79,7 +79,7 @@ async function getBooking(prisma: PrismaClient, uid: string) {
   if (booking) {
     // @NOTE: had to do this because Server side cant return [Object objects]
     // probably fixable with json.stringify -> json.parse
-    booking["startTime"] = (booking?.startTime as Date)?.toISOString() as unknown as Date;
+    booking.startTime = (booking?.startTime as Date)?.toISOString() as unknown as Date;
   }
 
   return booking;

--- a/packages/lib/server/checkCfTurnstileToken.ts
+++ b/packages/lib/server/checkCfTurnstileToken.ts
@@ -29,7 +29,7 @@ export async function checkCfTurnstileToken({ token, remoteIp }: { token?: strin
 
   const data = await result.json();
 
-  if (!data["success"]) {
+  if (!data.success) {
     throw new HttpError({ statusCode: 401, message: INVALID_CLOUDFLARE_TOKEN_ERROR });
   }
 

--- a/packages/trpc/server/routers/viewer/bookings/editLocation.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/bookings/editLocation.handler.test.ts
@@ -177,6 +177,7 @@ describe.skip("editLocation.handler", () => {
             ],
           },
         ],
+        // biome-ignore lint/complexity/useLiteralKeys: app keys contain hyphens
         apps: [TestData.apps["zoom"], TestData.apps["google-meet"]],
       };
 

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -480,16 +480,16 @@ export async function getBookings({
               eb
                 .case()
                 .when("Booking.status", "=", "cancelled")
-                .then(BookingStatus["CANCELLED"])
+                .then(BookingStatus.CANCELLED)
                 .when("Booking.status", "=", "accepted")
-                .then(BookingStatus["ACCEPTED"])
+                .then(BookingStatus.ACCEPTED)
                 .when("Booking.status", "=", "rejected")
-                .then(BookingStatus["REJECTED"])
+                .then(BookingStatus.REJECTED)
                 .when("Booking.status", "=", "pending")
-                .then(BookingStatus["PENDING"])
+                .then(BookingStatus.PENDING)
                 .when("Booking.status", "=", "awaiting_host")
-                .then(BookingStatus["AWAITING_HOST"])
-                .else(BookingStatus["PENDING"])
+                .then(BookingStatus.AWAITING_HOST)
+                .else(BookingStatus.PENDING)
                 .end(), // End of CASE expression
               "varchar"
             )
@@ -539,11 +539,11 @@ export async function getBookings({
                     eb
                       .case()
                       .when("EventType.schedulingType", "=", "roundRobin")
-                      .then(SchedulingType["ROUND_ROBIN"])
+                      .then(SchedulingType.ROUND_ROBIN)
                       .when("EventType.schedulingType", "=", "collective")
-                      .then(SchedulingType["COLLECTIVE"])
+                      .then(SchedulingType.COLLECTIVE)
                       .when("EventType.schedulingType", "=", "managed")
-                      .then(SchedulingType["MANAGED"])
+                      .then(SchedulingType.MANAGED)
                       .else(null)
                       .end(),
                     "varchar" // Or 'text' - use the actual SQL data type

--- a/packages/trpc/server/routers/viewer/calVideo/getMeetingInformation.handler.ts
+++ b/packages/trpc/server/routers/viewer/calVideo/getMeetingInformation.handler.ts
@@ -16,7 +16,7 @@ export const getMeetingInformationHandler = async ({ ctx: _ctx, input }: GetMeet
   const { roomName } = input;
 
   try {
-    const dailyVideoAdapterImport = VideoApiAdapterMap["dailyvideo"];
+    const dailyVideoAdapterImport = VideoApiAdapterMap.dailyvideo;
     if (!dailyVideoAdapterImport) {
       throw new TRPCError({
         code: "BAD_REQUEST",

--- a/packages/trpc/server/routers/viewer/oAuth/generateAuthCode.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/generateAuthCode.handler.test.ts
@@ -86,7 +86,7 @@ describe("generateAuthCodeHandler", () => {
       await expect(generateAuthCodeHandler({ ctx: mockCtx, input })).rejects.toThrow(
         new TRPCError({
           code: "BAD_REQUEST",
-          message: OAUTH_ERROR_REASONS["pkce_required"],
+          message: OAUTH_ERROR_REASONS.pkce_required,
         })
       );
 
@@ -108,7 +108,7 @@ describe("generateAuthCodeHandler", () => {
       await expect(generateAuthCodeHandler({ ctx: mockCtx, input })).rejects.toThrow(
         new TRPCError({
           code: "BAD_REQUEST",
-          message: OAUTH_ERROR_REASONS["invalid_code_challenge_method"],
+          message: OAUTH_ERROR_REASONS.invalid_code_challenge_method,
         })
       );
 
@@ -131,7 +131,7 @@ describe("generateAuthCodeHandler", () => {
       await expect(generateAuthCodeHandler({ ctx: mockCtx, input: inputMD5 })).rejects.toThrow(
         new TRPCError({
           code: "BAD_REQUEST",
-          message: OAUTH_ERROR_REASONS["invalid_code_challenge_method"],
+          message: OAUTH_ERROR_REASONS.invalid_code_challenge_method,
         })
       );
 
@@ -148,7 +148,7 @@ describe("generateAuthCodeHandler", () => {
       await expect(generateAuthCodeHandler({ ctx: mockCtx, input: inputPlain })).rejects.toThrow(
         new TRPCError({
           code: "BAD_REQUEST",
-          message: OAUTH_ERROR_REASONS["invalid_code_challenge_method"],
+          message: OAUTH_ERROR_REASONS.invalid_code_challenge_method,
         })
       );
 
@@ -266,7 +266,7 @@ describe("generateAuthCodeHandler", () => {
       await expect(generateAuthCodeHandler({ ctx: mockCtx, input })).rejects.toThrow(
         new TRPCError({
           code: "BAD_REQUEST",
-          message: OAUTH_ERROR_REASONS["invalid_code_challenge_method"],
+          message: OAUTH_ERROR_REASONS.invalid_code_challenge_method,
         })
       );
 
@@ -290,7 +290,7 @@ describe("generateAuthCodeHandler", () => {
       await expect(generateAuthCodeHandler({ ctx: mockCtx, input })).rejects.toThrow(
         new TRPCError({
           code: "UNAUTHORIZED",
-          message: OAUTH_ERROR_REASONS["client_not_found"],
+          message: OAUTH_ERROR_REASONS.client_not_found,
         })
       );
 
@@ -349,7 +349,7 @@ describe("generateAuthCodeHandler", () => {
       await expect(generateAuthCodeHandler({ ctx: mockCtx, input: inputInvalid })).rejects.toThrow(
         new TRPCError({
           code: "BAD_REQUEST",
-          message: OAUTH_ERROR_REASONS["invalid_code_challenge_method"],
+          message: OAUTH_ERROR_REASONS.invalid_code_challenge_method,
         })
       );
 
@@ -366,7 +366,7 @@ describe("generateAuthCodeHandler", () => {
       await expect(generateAuthCodeHandler({ ctx: mockCtx, input: inputPlain })).rejects.toThrow(
         new TRPCError({
           code: "BAD_REQUEST",
-          message: OAUTH_ERROR_REASONS["invalid_code_challenge_method"],
+          message: OAUTH_ERROR_REASONS.invalid_code_challenge_method,
         })
       );
     });


### PR DESCRIPTION
## What does this PR do?

Fixes all 33 `lint/complexity/useLiteralKeys` biome lint issues across the codebase. This rule prefers dot notation (`obj.key`) over bracket notation (`obj["key"]`) for object property access when the key is a valid identifier.

**Changes:**
- Converted bracket notation to dot notation where possible (e.g., `dataset["buttonText"]` → `dataset.buttonText`)
- Added `// biome-ignore` comments where bracket notation is required (hyphenated keys like `"google-meet"` or dynamic properties from external libraries)

**Files modified:** 10 files across embed-core, lib, and trpc packages

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - lint fixes only
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run `yarn turbo run lint -- --max-diagnostics=10000` and verify no `useLiteralKeys` errors remain
2. Run `yarn type-check:ci` to verify no type errors were introduced
3. The changes are purely syntactic and don't affect runtime behavior

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify enum access changes are correct (`BookingStatus.CANCELLED` vs `BookingStatus["CANCELLED"]`)
- [ ] Verify biome-ignore comments have appropriate explanations
- [ ] Confirm no functional changes were introduced

---

Link to Devin run: https://app.devin.ai/sessions/674bbf5e35ff4394a0af3bbff07a2033
Requested by: Volnei Munhoz (@volnei)