### PR TITLE
fix: increase type-check memory limit to 12GB

### DIFF
--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -2,7 +2,7 @@ name: Check types
 on:
   workflow_call:
 env:
-  NODE_OPTIONS: --max-old-space-size=6144
+  NODE_OPTIONS: --max-old-space-size=12288
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 permissions:
@@ -22,16 +22,4 @@ jobs:
         run: |
           echo "::remove-matcher owner=tsc::"
           echo "::add-matcher::.github/matchers/tsc-absolute.json"
-      - name: Run type check
-        run: |
-          # Workaround for https://github.com/vercel/turbo/issues/4227
-          set -o pipefail
-          yarn type-check:ci 2>&1 | tee /tmp/type-check-output.log
-          TYPE_CHECK_EXIT_CODE=${PIPESTATUS[0]}
-          
-          if grep -q "FATAL ERROR:.*heap.*out of memory" /tmp/type-check-output.log; then
-            echo "::error::Type check failed due to out of memory error"
-            exit 1
-          fi
-          
-          exit $TYPE_CHECK_EXIT_CODE
+      - run: yarn type-check:ci

--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -22,4 +22,19 @@ jobs:
         run: |
           echo "::remove-matcher owner=tsc::"
           echo "::add-matcher::.github/matchers/tsc-absolute.json"
-      - run: yarn type-check:ci
+      - name: Run type check
+        run: |
+          # Run type-check and capture output to detect OOM errors
+          # Turborepo bug: OOM-killed tasks are incorrectly marked as successful
+          # See: https://github.com/vercel/turbo/issues/4227
+          set -o pipefail
+          yarn type-check:ci 2>&1 | tee /tmp/type-check-output.log
+          TYPE_CHECK_EXIT_CODE=${PIPESTATUS[0]}
+          
+          # Check for OOM error pattern in output
+          if grep -q "FATAL ERROR:.*heap.*out of memory" /tmp/type-check-output.log; then
+            echo "::error::Type check failed due to out of memory error"
+            exit 1
+          fi
+          
+          exit $TYPE_CHECK_EXIT_CODE

--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -2,7 +2,7 @@ name: Check types
 on:
   workflow_call:
 env:
-  NODE_OPTIONS: --max-old-space-size=4096
+  NODE_OPTIONS: --max-old-space-size=6144
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 permissions:
@@ -24,14 +24,11 @@ jobs:
           echo "::add-matcher::.github/matchers/tsc-absolute.json"
       - name: Run type check
         run: |
-          # Run type-check and capture output to detect OOM errors
-          # Turborepo bug: OOM-killed tasks are incorrectly marked as successful
-          # See: https://github.com/vercel/turbo/issues/4227
+          # Workaround for https://github.com/vercel/turbo/issues/4227
           set -o pipefail
           yarn type-check:ci 2>&1 | tee /tmp/type-check-output.log
           TYPE_CHECK_EXIT_CODE=${PIPESTATUS[0]}
           
-          # Check for OOM error pattern in output
           if grep -q "FATAL ERROR:.*heap.*out of memory" /tmp/type-check-output.log; then
             echo "::error::Type check failed due to out of memory error"
             exit 1


### PR DESCRIPTION
## What does this PR do?

Fixes OOM (Out of Memory) errors in the type-check CI workflow by increasing the Node.js heap memory limit from 4096 MB (4GB) to 12288 MB (12GB).

The OOM errors started appearing around v5.9.9 after the Next.js CVE-2025-55182 patch increased memory requirements. The current 4GB limit was insufficient, causing type-check to crash with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`.

Example of the issue: https://github.com/calcom/cal.com/actions/runs/21008439542/job/60396952631?pr=26849

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - This will be validated when type-check CI runs successfully without OOM.

## How should this be tested?

The memory increase should prevent OOM errors from occurring during type-check CI runs. The `blacksmith-4vcpu-ubuntu-2404` runner typically has 16GB RAM, so 12GB heap allocation should be well within available memory.

## Human Review Checklist

- [ ] Verify 12GB (12288 MB) is appropriate for the blacksmith-4vcpu-ubuntu-2404 runner's available memory
- [ ] Monitor type-check CI runs after merge to confirm OOM errors are resolved

---

### Link to Devin run
https://app.devin.ai/sessions/ba15288cccc54f14a5449ea4f254f537

### Requested by
Volnei Munhoz (@volnei)