### PR TITLE
fix: sync team members as hosts when assignAllTeamMembers is enabled

### DIFF
--- a/packages/features/eventtypes/lib/schemas.ts
+++ b/packages/features/eventtypes/lib/schemas.ts
@@ -1,8 +1,7 @@
-import { z } from "zod";
-
 import { eventTypeLocations, eventTypeSlug } from "@calcom/lib/zod/eventType";
 import { SchedulingType } from "@calcom/prisma/enums";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
+import { z } from "zod";
 
 type CalVideoSettings =
   | {
@@ -82,6 +81,7 @@ export type TCreateEventTypeInput = {
   afterEventBuffer?: number;
   scheduleId?: number;
   calVideoSettings?: CalVideoSettings;
+  assignAllTeamMembers?: boolean;
 };
 
 export const createEventTypeInput: z.ZodType<TCreateEventTypeInput> = z
@@ -102,6 +102,7 @@ export const createEventTypeInput: z.ZodType<TCreateEventTypeInput> = z
     afterEventBuffer: z.number().int().min(0).optional(),
     scheduleId: z.number().int().optional(),
     calVideoSettings: calVideoSettingsSchema,
+    assignAllTeamMembers: z.boolean().optional(),
   })
   .partial({ hidden: true, locations: true })
   .refine((data) => (data.teamId ? data.teamId && data.schedulingType : true), {


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where toggling `assignAllTeamMembers` to `true` on an existing event type (or creating a new one with this flag) would only update the flag but NOT sync existing team members as hosts. This was causing "missing hosts" issues during booking.

**Changes:**
1. **Update handler**: When `assignAllTeamMembers` is toggled from `false` to `true` and hosts are not explicitly provided, automatically sync all accepted team members as hosts
2. **Create handler**: When creating a team event type with `assignAllTeamMembers: true`, automatically create hosts for all accepted team members
3. **Schema**: Added `assignAllTeamMembers` field to the create event type input schema

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Update flow**: 
   - Create a team event type with `assignAllTeamMembers: false` and no hosts
   - Toggle `assignAllTeamMembers` to `true`
   - Verify all team members are now added as hosts

2. **Create flow**:
   - Create a new team event type with `assignAllTeamMembers: true`
   - Verify all team members are automatically added as hosts

3. **Edge cases to verify**:
   - Existing hosts should preserve their priority/weight settings when toggling
   - COLLECTIVE scheduling type should set `isFixed: true` for all hosts
   - ROUND_ROBIN scheduling type should set `isFixed: false` for all hosts

## Human Review Checklist

- [ ] Verify the condition `assignAllTeamMembers === true && !eventType.assignAllTeamMembers && !hosts` correctly handles all edge cases
- [ ] Check if MANAGED scheduling type needs special handling (currently excluded since it's handled by child event types)
- [ ] Verify host creation logic matches API v2 behavior in `input.service.ts`

---

Link to Devin run: https://app.devin.ai/sessions/62a1ad2234c74630b609316f771819e0
Requested by: @hariombalhara