### PR TITLE
fix: remove trpc build dependency from turbo dev command

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -495,7 +495,7 @@
       "outputs": ["dist/**", "build/**"]
     },
     "@calcom/web#dev": {
-      "dependsOn": ["@calcom/trpc#build", "//#env-check:common", "//#env-check:app-store"],
+      "dependsOn": ["//#env-check:common", "//#env-check:app-store"],
       "cache": false
     },
     "dev": {


### PR DESCRIPTION
## What does this PR do?

Removes the `@calcom/trpc#build` dependency from the `@calcom/web#dev` task in turbo.json. This speeds up the `yarn dev` command startup by not requiring trpc to build first.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - configuration change.

## How should this be tested?

1. Run `yarn dev` and verify the web app starts without waiting for trpc build
2. Verify development workflow still works correctly

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> **Requested by:** @sean-brydon
> **Link to Devin run:** https://app.devin.ai/sessions/1418f4088f4441a6afff96c7555a4e79