### PR TITLE
fix: send correct cancellation email to previous round robin host

### DIFF
--- a/packages/emails/src/templates/OrganizerCancelledEmail.tsx
+++ b/packages/emails/src/templates/OrganizerCancelledEmail.tsx
@@ -4,12 +4,12 @@ import { OrganizerScheduledEmail } from "./OrganizerScheduledEmail";
 
 export const OrganizerCancelledEmail = (props: React.ComponentProps<typeof OrganizerScheduledEmail>) => {
   const t = props.teamMember?.language.translate || props.calEvent.organizer.language.translate;
-  const title = props.reassigned ? "event_request_reassigned" : "event_request_cancelled";
+  const title = "event_request_cancelled";
+  const subject = "event_cancelled_subject";
   const isRoundRobin = props.calEvent.schedulingType === SchedulingType.ROUND_ROBIN;
   const subtitle = props.reassigned 
     ? (isRoundRobin ? t("event_reassigned_subtitle") : t("event_reassigned_subtitle_generic"))
     : "";
-  const subject = props.reassigned ? "event_reassigned_subject" : "event_cancelled_subject";
   return (
     <OrganizerScheduledEmail
       title={title}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Send the correct cancellation email to the previous round-robin host by always using the cancellation title and subject in OrganizerCancelledEmail. Keep the reassigned subtitle only when applicable for context.

<sup>Written for commit 8210e85540210713b6e16ce61c92576e7a21f415. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

