### PR TITLE
refactor: migrate MembershipRole usages to PBAC permission checks

### DIFF
--- a/apps/web/modules/settings/outOfOffice/CreateNewOutOfOfficeEntryButton.tsx
+++ b/apps/web/modules/settings/outOfOffice/CreateNewOutOfOfficeEntryButton.tsx
@@ -23,7 +23,7 @@ const CreateNewOutOfOfficeEntryButton = ({
   const me = useMeQuery();
   const { data: orgData } = trpc.viewer.organizations.listCurrent.useQuery();
   const isOrgAdminOrOwner = orgData && checkAdminOrOwner(orgData.user.role);
-  const hasTeamOOOAdminAccess = isOrgAdminOrOwner || me?.data?.isTeamAdminOrOwner;
+  const hasTeamOOOAdminAccess = isOrgAdminOrOwner || me?.data?.canUpdateTeams;
 
   const params = useCompatSearchParams();
   const selectedTab = params?.get("type") ?? OutOfOfficeTab.MINE;

--- a/packages/features/ee/organizations/pages/organization.tsx
+++ b/packages/features/ee/organizations/pages/organization.tsx
@@ -29,7 +29,7 @@ export const getServerSideProps = async ({ req }: GetServerSidePropsContext) => 
   const canManageOrganization = await permissionCheckService.checkPermission({
     userId: session.user.id,
     teamId: session.user.profile.organizationId,
-    permission: "team.update",
+    permission: "organization.update",
     fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
   });
 

--- a/packages/features/ee/organizations/pages/organization.tsx
+++ b/packages/features/ee/organizations/pages/organization.tsx
@@ -2,6 +2,7 @@ import type { GetServerSidePropsContext } from "next";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { MembershipRole } from "@calcom/prisma/enums";
 
 export const getServerSideProps = async ({ req }: GetServerSidePropsContext) => {
@@ -24,19 +25,15 @@ export const getServerSideProps = async ({ req }: GetServerSidePropsContext) => 
     } as const;
   }
 
-  // Check if logged in user has OWNER/ADMIN role in organization
-  const membership = await prisma.membership.findUnique({
-    where: {
-      userId_teamId: {
-        userId: session?.user.id,
-        teamId: session?.user.profile.organizationId,
-      },
-    },
-    select: {
-      role: true,
-    },
+  const permissionCheckService = new PermissionCheckService();
+  const canManageOrganization = await permissionCheckService.checkPermission({
+    userId: session.user.id,
+    teamId: session.user.profile.organizationId,
+    permission: "team.update",
+    fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
   });
-  if (!membership?.role || membership?.role === MembershipRole.MEMBER) {
+
+  if (!canManageOrganization) {
     return {
       notFound: true,
     } as const;

--- a/packages/features/eventtypes/lib/getEventTypesByViewer.ts
+++ b/packages/features/eventtypes/lib/getEventTypesByViewer.ts
@@ -53,7 +53,7 @@ export const getEventTypesByViewer = async (user: User, filters?: Filters, forRo
   }
 
   const permissionCheckService = new PermissionCheckService();
-  const [teamsWithEventTypeReadPermission, teamsWithEventTypeManagePermission] = await Promise.all([
+  const [teamsWithEventTypeReadPermission, teamsWithEventTypeUpdatePermission] = await Promise.all([
     permissionCheckService.getTeamIdsWithPermission({
       userId: user.id,
       permission: "eventType.read",
@@ -301,7 +301,7 @@ export const getEventTypesByViewer = async (user: User, filters?: Filters, forRo
                 return res;
               })
               .filter((evType) =>
-                !teamsWithEventTypeManagePermission.includes(team.id)
+                !teamsWithEventTypeUpdatePermission.includes(team.id)
                   ? evType.schedulingType !== SchedulingType.MANAGED
                   : true
               )

--- a/packages/features/eventtypes/lib/getEventTypesByViewer.ts
+++ b/packages/features/eventtypes/lib/getEventTypesByViewer.ts
@@ -52,13 +52,19 @@ export const getEventTypesByViewer = async (user: User, filters?: Filters, forRo
     shouldListUserEvents = true;
   }
 
-  // Get teams where user has eventType.read permission for PBAC readonly check
   const permissionCheckService = new PermissionCheckService();
-  const teamsWithEventTypeReadPermission = await permissionCheckService.getTeamIdsWithPermission({
-    userId: user.id,
-    permission: "eventType.read",
-    fallbackRoles: [MembershipRole.MEMBER, MembershipRole.ADMIN, MembershipRole.OWNER],
-  });
+  const [teamsWithEventTypeReadPermission, teamsWithEventTypeManagePermission] = await Promise.all([
+    permissionCheckService.getTeamIdsWithPermission({
+      userId: user.id,
+      permission: "eventType.read",
+      fallbackRoles: [MembershipRole.MEMBER, MembershipRole.ADMIN, MembershipRole.OWNER],
+    }),
+    permissionCheckService.getTeamIdsWithPermission({
+      userId: user.id,
+      permission: "eventType.update",
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+    }),
+  ]);
 
   const eventTypeRepo = new EventTypeRepository(prisma);
   const [profileMemberships, profileEventTypes] = await Promise.all([
@@ -295,7 +301,7 @@ export const getEventTypesByViewer = async (user: User, filters?: Filters, forRo
                 return res;
               })
               .filter((evType) =>
-                membership.role === MembershipRole.MEMBER
+                !teamsWithEventTypeManagePermission.includes(team.id)
                   ? evType.schedulingType !== SchedulingType.MANAGED
                   : true
               )

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -7,7 +7,9 @@ import { getBookingFieldsWithSystemFields } from "@calcom/features/bookings/lib/
 import { getBookerBaseUrlSync } from "@calcom/features/ee/organizations/lib/getBookerBaseUrlSync";
 import { getSlugOrRequestedSlug } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { getDefaultEvent, getUsernameList } from "@calcom/features/eventtypes/lib/defaultEvents";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+import { MembershipRole } from "@calcom/prisma/enums";
 import { getOrgOrTeamAvatar } from "@calcom/lib/defaultAvatarImage";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
@@ -517,25 +519,27 @@ export const getPublicEvent = async (
       length: eventWithUserProfiles.length,
     });
   }
-  const isTeamAdminOrOwner = await prisma.membership.findFirst({
-    where: {
-      userId: currentUserId ?? -1,
-      teamId: event.teamId ?? -1,
-      accepted: true,
-      role: { in: ["ADMIN", "OWNER"] },
-    },
-  });
+  let canViewPrivateTeamMembers = false;
+  if (currentUserId && event.teamId) {
+    const permissionCheckService = new PermissionCheckService();
+    canViewPrivateTeamMembers = await permissionCheckService.checkPermission({
+      userId: currentUserId,
+      teamId: event.teamId,
+      permission: "team.read",
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
 
-  const isOrgAdminOrOwner = await prisma.membership.findFirst({
-    where: {
-      userId: currentUserId ?? -1,
-      teamId: event.team?.parentId ?? -1,
-      accepted: true,
-      role: { in: ["ADMIN", "OWNER"] },
-    },
-  });
+    if (!canViewPrivateTeamMembers && event.team?.parentId) {
+      canViewPrivateTeamMembers = await permissionCheckService.checkPermission({
+        userId: currentUserId,
+        teamId: event.team.parentId,
+        permission: "team.read",
+        fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+      });
+    }
+  }
 
-  if (event.team?.isPrivate && !isTeamAdminOrOwner && !isOrgAdminOrOwner) {
+  if (event.team?.isPrivate && !canViewPrivateTeamMembers) {
     users = [];
   }
 

--- a/packages/trpc/server/routers/viewer/eventTypes/getActiveOnOptions.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getActiveOnOptions.handler.ts
@@ -1,5 +1,6 @@
 import { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import { MembershipRepository } from "@calcom/features/membership/repositories/MembershipRepository";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { PrismaRoutingFormRepository } from "@calcom/features/routing-forms/repositories/PrismaRoutingFormRepository";
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
@@ -55,12 +56,14 @@ const fetchEventTypeGroups = async ({
   parentOrgHasLockedEventTypes,
   skipEventTypes,
   teamId,
+  teamIdsWithEventTypeManagePermission,
 }: {
   ctx: { user: NonNullable<TrpcSessionUser>; prisma: PrismaClient };
   profile: NonNullable<Awaited<ReturnType<typeof ProfileRepository.findByUpIdWithAuth>>>;
   parentOrgHasLockedEventTypes: boolean | undefined;
   skipEventTypes: boolean;
   teamId?: number;
+  teamIdsWithEventTypeManagePermission: number[];
 }): Promise<EventTypeGroup[]> => {
   const user = ctx.user;
   const userProfile = ctx.user.profile;
@@ -132,12 +135,11 @@ const fetchEventTypeGroups = async ({
           metadata: teamMetadataSchema.parse(membership.team.metadata),
         };
 
+        const canManageEventTypes = teamIdsWithEventTypeManagePermission.includes(team.id);
         const eventTypes = team.eventTypes
           ?.filter((evType) => evType.userId === null || evType.userId === user.id)
           ?.filter((evType) =>
-            membership.role === MembershipRole.MEMBER
-              ? evType.schedulingType !== SchedulingType.MANAGED
-              : true
+            !canManageEventTypes ? evType.schedulingType !== SchedulingType.MANAGED : true
           );
 
         return {
@@ -222,12 +224,20 @@ export const getActiveOnOptions = async ({ ctx, input }: GetActiveOnOptions) => 
     throw new TRPCError({ code: "INTERNAL_SERVER_ERROR" });
   }
 
+  const permissionCheckService = new PermissionCheckService();
+  const teamIdsWithEventTypeManagePermission = await permissionCheckService.getTeamIdsWithPermission({
+    userId: user.id,
+    permission: "eventType.update",
+    fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+  });
+
   const eventTypeGroups = await fetchEventTypeGroups({
     ctx,
     profile,
     parentOrgHasLockedEventTypes,
     skipEventTypes: shouldSkipEventTypes,
     teamId,
+    teamIdsWithEventTypeManagePermission,
   });
 
   const teamOptions = await fetchTeamOptions({

--- a/packages/trpc/server/routers/viewer/eventTypes/getActiveOnOptions.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getActiveOnOptions.handler.ts
@@ -56,14 +56,14 @@ const fetchEventTypeGroups = async ({
   parentOrgHasLockedEventTypes,
   skipEventTypes,
   teamId,
-  teamIdsWithEventTypeManagePermission,
+  teamIdsWithEventTypeUpdatePermission,
 }: {
   ctx: { user: NonNullable<TrpcSessionUser>; prisma: PrismaClient };
   profile: NonNullable<Awaited<ReturnType<typeof ProfileRepository.findByUpIdWithAuth>>>;
   parentOrgHasLockedEventTypes: boolean | undefined;
   skipEventTypes: boolean;
   teamId?: number;
-  teamIdsWithEventTypeManagePermission: number[];
+  teamIdsWithEventTypeUpdatePermission: number[];
 }): Promise<EventTypeGroup[]> => {
   const user = ctx.user;
   const userProfile = ctx.user.profile;
@@ -135,11 +135,11 @@ const fetchEventTypeGroups = async ({
           metadata: teamMetadataSchema.parse(membership.team.metadata),
         };
 
-        const canManageEventTypes = teamIdsWithEventTypeManagePermission.includes(team.id);
+        const canUpdateEventTypes = teamIdsWithEventTypeUpdatePermission.includes(team.id);
         const eventTypes = team.eventTypes
           ?.filter((evType) => evType.userId === null || evType.userId === user.id)
           ?.filter((evType) =>
-            !canManageEventTypes ? evType.schedulingType !== SchedulingType.MANAGED : true
+            !canUpdateEventTypes ? evType.schedulingType !== SchedulingType.MANAGED : true
           );
 
         return {
@@ -225,7 +225,7 @@ export const getActiveOnOptions = async ({ ctx, input }: GetActiveOnOptions) => 
   }
 
   const permissionCheckService = new PermissionCheckService();
-  const teamIdsWithEventTypeManagePermission = await permissionCheckService.getTeamIdsWithPermission({
+  const teamIdsWithEventTypeUpdatePermission = await permissionCheckService.getTeamIdsWithPermission({
     userId: user.id,
     permission: "eventType.update",
     fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
@@ -237,7 +237,7 @@ export const getActiveOnOptions = async ({ ctx, input }: GetActiveOnOptions) => 
     parentOrgHasLockedEventTypes,
     skipEventTypes: shouldSkipEventTypes,
     teamId,
-    teamIdsWithEventTypeManagePermission,
+    teamIdsWithEventTypeUpdatePermission,
   });
 
   const teamOptions = await fetchTeamOptions({

--- a/packages/trpc/server/routers/viewer/ooo/outOfOffice.utils.ts
+++ b/packages/trpc/server/routers/viewer/ooo/outOfOffice.utils.ts
@@ -1,21 +1,18 @@
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import prisma from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
 
 export const isAdminForUser = async (adminUserId: number, memberUserId: number) => {
-  const adminTeams = await prisma.membership.findMany({
-    where: {
-      userId: adminUserId,
-      accepted: true,
-      role: {
-        in: [MembershipRole.ADMIN, MembershipRole.OWNER],
-      },
-    },
-    select: {
-      teamId: true,
-    },
+  const permissionCheckService = new PermissionCheckService();
+  const adminTeamIds = await permissionCheckService.getTeamIdsWithPermission({
+    userId: adminUserId,
+    permission: "ooo.update",
+    fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
   });
 
-  const adminTeamIds = adminTeams?.map((team) => team.teamId);
+  if (adminTeamIds.length === 0) {
+    return false;
+  }
 
   const member = await prisma.membership.findFirst({
     where: {

--- a/packages/trpc/server/routers/viewer/organizations/checkIfOrgNeedsUpgrade.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/checkIfOrgNeedsUpgrade.handler.ts
@@ -1,3 +1,4 @@
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { IS_TEAM_BILLING_ENABLED } from "@calcom/lib/constants";
 import { prisma } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
@@ -14,16 +15,22 @@ type GetUpgradeableOptions = {
 export async function checkIfOrgNeedsUpgradeHandler({ ctx }: GetUpgradeableOptions) {
   if (!IS_TEAM_BILLING_ENABLED) return [];
 
-  // Get all teams/orgs where the user is an owner
+  const permissionCheckService = new PermissionCheckService();
+  const teamIdsWithBillingPermission = await permissionCheckService.getTeamIdsWithPermission({
+    userId: ctx.user.id,
+    permission: "organization.manageBilling",
+    fallbackRoles: [MembershipRole.OWNER],
+  });
+
+  if (teamIdsWithBillingPermission.length === 0) return [];
+
   let teams = await prisma.membership.findMany({
     where: {
-      user: {
-        id: ctx.user.id,
-      },
-      role: MembershipRole.OWNER,
+      userId: ctx.user.id,
+      teamId: { in: teamIdsWithBillingPermission },
       team: {
         isPlatform: false,
-        parentId: null, // Since ORGS relay on their parent's subscription, we don't need to return them
+        parentId: null,
       },
     },
     include: {


### PR DESCRIPTION
## What does this PR do?

Refactors direct `MembershipRole` checks throughout the codebase to use the PBAC (Permission-Based Access Control) system via `PermissionCheckService`. This is part of the ongoing effort to centralize permission logic and enable fine-grained access control.

**Changes include:**
- `get.handler.ts`: Renamed `isTeamAdminOrOwner` → `canUpdateTeams` using PBAC
- `checkForInvalidAppCredentials.ts`: Uses `getTeamIdsWithPermission` for team credential access
- `outOfOffice.utils.ts`: Uses `ooo.update` permission for admin checks
- `checkIfOrgNeedsUpgrade.handler.ts`: Uses `organization.manageBilling` permission
- `getActiveOnOptions.handler.ts`: Pre-fetches teams with `eventType.update` permission
- `WorkflowRepository.ts`: Uses `workflow.update` permission for readOnly determination
- `organization.tsx`: Uses `organization.update` permission for org management access
- `getEventTypesByViewer.ts`: Uses `eventType.update` for managed event type filtering
- `getPublicEvent.ts`: Uses `team.read` permission for private team member visibility

### Updates since last revision
- Fixed variable naming to match permission strings: renamed `teamsWithEventTypeManagePermission` → `teamsWithEventTypeUpdatePermission` and `canManageEventTypes` → `canUpdateEventTypes` to align with the `eventType.update` permission being checked

Link to Devin run: https://app.devin.ai/sessions/b006afc07b43408e9ecd92da851aaff2
Requested by: @sean-brydon

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal refactoring only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **API Response Change**: The `/api/trpc/viewer.me` endpoint now returns `canUpdateTeams` instead of `isTeamAdminOrOwner`. Verify this doesn't break any frontend functionality.

2. **Permission Checks**: Test the following scenarios with both PBAC enabled and disabled (fallback mode):
   - Out of office entry creation for team members
   - Workflow list filtering (readOnly status)
   - Event type management (managed event types visibility)
   - Organization settings page access
   - Private team member visibility on public event pages

3. **Fallback Behavior**: When PBAC is not enabled for a team, the `fallbackRoles` should maintain the same behavior as the previous direct role checks.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Items for Human Review

- **Breaking Change**: `isTeamAdminOrOwner` renamed to `canUpdateTeams` in me endpoint - verify no other consumers depend on old name
- **Permission Strings**: Verify `team.read` is the correct permission for private team member visibility (vs `team.listMembersPrivate`)
- **Fallback Roles**: Confirm the fallback roles match the original role requirements in each case