### PR TITLE
fix: block member addition to sub-team when user not in parent org

### DIFF
--- a/apps/api/v2/src/modules/organizations/organizations.module.ts
+++ b/apps/api/v2/src/modules/organizations/organizations.module.ts
@@ -184,6 +184,7 @@ import { Module } from "@nestjs/common";
     OrganizationsEventTypesService,
     OrganizationsConferencingService,
     OrganizationsStripeService,
+    OrganizationMembershipService,
   ],
   controllers: [
     OrganizationsTeamsController,

--- a/apps/api/v2/src/modules/teams/memberships/controllers/teams-memberships.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/teams/memberships/controllers/teams-memberships.controller.e2e-spec.ts
@@ -505,6 +505,226 @@ describe("Teams Memberships Endpoints", () => {
         .expect(400);
     });
 
+    // Auto-accept tests for sub-teams of organizations
+    describe("auto-accept based on email domain for org sub-teams", () => {
+      let orgWithAutoAccept: Team;
+      let subteamWithAutoAccept: Team;
+      let subteamEventType: EventType;
+      let userWithMatchingEmail: User;
+      let userWithUppercaseEmail: User;
+      let userWithMatchingEmailForOverride: User;
+      let userWithNonMatchingEmail: User;
+
+      beforeAll(async () => {
+        // Create org with auto-accept settings
+        orgWithAutoAccept = await teamsRepositoryFixture.create({
+          name: `auto-accept-org-${randomString()}`,
+          isOrganization: true,
+        });
+
+        // Create organization settings with orgAutoAcceptEmail
+        await teamsRepositoryFixture.createOrgSettings(orgWithAutoAccept.id, {
+          orgAutoAcceptEmail: "acme.com",
+          isOrganizationVerified: true,
+          isOrganizationConfigured: true,
+          isAdminAPIEnabled: true,
+        });
+
+        // Create subteam
+        subteamWithAutoAccept = await teamsRepositoryFixture.create({
+          name: `auto-accept-subteam-${randomString()}`,
+          isOrganization: false,
+          parent: { connect: { id: orgWithAutoAccept.id } },
+        });
+
+        // Create event type with assignAllTeamMembers
+        subteamEventType = await eventTypesRepositoryFixture.createTeamEventType({
+          schedulingType: "COLLECTIVE",
+          team: { connect: { id: subteamWithAutoAccept.id } },
+          title: "Auto Accept Event Type",
+          slug: "auto-accept-event-type",
+          length: 30,
+          assignAllTeamMembers: true,
+          bookingFields: [],
+          locations: [],
+        });
+
+        // Create users with different email domains
+        userWithMatchingEmail = await userRepositoryFixture.create({
+          email: `alice-${randomString()}@acme.com`,
+          username: `alice-${randomString()}`,
+        });
+
+        userWithUppercaseEmail = await userRepositoryFixture.create({
+          email: `bob-${randomString()}@ACME.COM`,
+          username: `bob-${randomString()}`,
+        });
+
+        userWithMatchingEmailForOverride = await userRepositoryFixture.create({
+          email: `david-${randomString()}@acme.com`,
+          username: `david-${randomString()}`,
+        });
+
+        userWithNonMatchingEmail = await userRepositoryFixture.create({
+          email: `charlie-${randomString()}@external.com`,
+          username: `charlie-${randomString()}`,
+        });
+
+        // Add users to org
+        await membershipsRepositoryFixture.create({
+          role: "MEMBER",
+          accepted: true,
+          user: { connect: { id: userWithMatchingEmail.id } },
+          team: { connect: { id: orgWithAutoAccept.id } },
+        });
+
+        await membershipsRepositoryFixture.create({
+          role: "MEMBER",
+          accepted: true,
+          user: { connect: { id: userWithUppercaseEmail.id } },
+          team: { connect: { id: orgWithAutoAccept.id } },
+        });
+
+        await membershipsRepositoryFixture.create({
+          role: "MEMBER",
+          accepted: true,
+          user: { connect: { id: userWithMatchingEmailForOverride.id } },
+          team: { connect: { id: orgWithAutoAccept.id } },
+        });
+
+        await membershipsRepositoryFixture.create({
+          role: "MEMBER",
+          accepted: true,
+          user: { connect: { id: userWithNonMatchingEmail.id } },
+          team: { connect: { id: orgWithAutoAccept.id } },
+        });
+
+        // Create profiles for users
+        await profileRepositoryFixture.create({
+          uid: `usr-${userWithMatchingEmail.id}`,
+          username: userWithMatchingEmail.username || `user-${userWithMatchingEmail.id}`,
+          organization: { connect: { id: orgWithAutoAccept.id } },
+          user: { connect: { id: userWithMatchingEmail.id } },
+        });
+
+        await profileRepositoryFixture.create({
+          uid: `usr-${userWithUppercaseEmail.id}`,
+          username: userWithUppercaseEmail.username || `user-${userWithUppercaseEmail.id}`,
+          organization: { connect: { id: orgWithAutoAccept.id } },
+          user: { connect: { id: userWithUppercaseEmail.id } },
+        });
+
+        await profileRepositoryFixture.create({
+          uid: `usr-${userWithMatchingEmailForOverride.id}`,
+          username:
+            userWithMatchingEmailForOverride.username || `user-${userWithMatchingEmailForOverride.id}`,
+          organization: { connect: { id: orgWithAutoAccept.id } },
+          user: { connect: { id: userWithMatchingEmailForOverride.id } },
+        });
+
+        await profileRepositoryFixture.create({
+          uid: `usr-${userWithNonMatchingEmail.id}`,
+          username: userWithNonMatchingEmail.username || `user-${userWithNonMatchingEmail.id}`,
+          organization: { connect: { id: orgWithAutoAccept.id } },
+          user: { connect: { id: userWithNonMatchingEmail.id } },
+        });
+
+        // Make teamAdmin an admin of the org and subteam for API access
+        await membershipsRepositoryFixture.create({
+          role: "ADMIN",
+          accepted: true,
+          user: { connect: { id: teamAdmin.id } },
+          team: { connect: { id: orgWithAutoAccept.id } },
+        });
+
+        await membershipsRepositoryFixture.create({
+          role: "ADMIN",
+          accepted: true,
+          user: { connect: { id: teamAdmin.id } },
+          team: { connect: { id: subteamWithAutoAccept.id } },
+        });
+
+        await profileRepositoryFixture.create({
+          uid: `usr-org-${teamAdmin.id}`,
+          username: teamAdmin.username || `admin-${teamAdmin.id}`,
+          organization: { connect: { id: orgWithAutoAccept.id } },
+          user: { connect: { id: teamAdmin.id } },
+        });
+      });
+
+      it("should auto-accept when email matches orgAutoAcceptEmail for sub-team", async () => {
+        const response = await request(app.getHttpServer())
+          .post(`/v2/teams/${subteamWithAutoAccept.id}/memberships`)
+          .send({
+            userId: userWithMatchingEmail.id,
+            role: "MEMBER",
+          } satisfies CreateTeamMembershipInput)
+          .expect(201);
+
+        const responseBody: CreateTeamMembershipOutput = response.body;
+        expect(responseBody.data.accepted).toBe(true);
+
+        // Verify EventTypes assignment
+        const eventTypes = await eventTypesRepositoryFixture.getAllTeamEventTypes(subteamWithAutoAccept.id);
+        const eventTypeWithAssignAll = eventTypes.find((et) => et.assignAllTeamMembers);
+        expect(eventTypeWithAssignAll).toBeTruthy();
+        const userIsHost = eventTypeWithAssignAll?.hosts.some((h) => h.userId === userWithMatchingEmail.id);
+        expect(userIsHost).toBe(true);
+      });
+
+      it("should handle case-insensitive email domain matching for sub-team", async () => {
+        // User with email="bob@ACME.COM" should match orgAutoAcceptEmail="acme.com"
+        const response = await request(app.getHttpServer())
+          .post(`/v2/teams/${subteamWithAutoAccept.id}/memberships`)
+          .send({
+            userId: userWithUppercaseEmail.id,
+            role: "MEMBER",
+          } satisfies CreateTeamMembershipInput)
+          .expect(201);
+
+        const responseBody: CreateTeamMembershipOutput = response.body;
+        expect(responseBody.data.accepted).toBe(true);
+      });
+
+      it("should ALWAYS auto-accept when email matches, even if accepted:false for sub-team", async () => {
+        const response = await request(app.getHttpServer())
+          .post(`/v2/teams/${subteamWithAutoAccept.id}/memberships`)
+          .send({
+            userId: userWithMatchingEmailForOverride.id,
+            role: "MEMBER",
+            accepted: false,
+          } satisfies CreateTeamMembershipInput)
+          .expect(201);
+
+        const responseBody: CreateTeamMembershipOutput = response.body;
+        // Should override to true because email matches
+        expect(responseBody.data.accepted).toBe(true);
+      });
+
+      it("should NOT auto-accept when email does not match orgAutoAcceptEmail for sub-team", async () => {
+        const response = await request(app.getHttpServer())
+          .post(`/v2/teams/${subteamWithAutoAccept.id}/memberships`)
+          .send({
+            userId: userWithNonMatchingEmail.id,
+            role: "MEMBER",
+          } satisfies CreateTeamMembershipInput)
+          .expect(201);
+
+        const responseBody: CreateTeamMembershipOutput = response.body;
+        expect(responseBody.data.accepted).toBe(false);
+      });
+
+      afterAll(async () => {
+        await userRepositoryFixture.deleteByEmail(userWithMatchingEmail.email);
+        await userRepositoryFixture.deleteByEmail(userWithUppercaseEmail.email);
+        await userRepositoryFixture.deleteByEmail(userWithMatchingEmailForOverride.email);
+        await userRepositoryFixture.deleteByEmail(userWithNonMatchingEmail.email);
+        await teamsRepositoryFixture.deleteOrgSettings(orgWithAutoAccept.id);
+        await teamsRepositoryFixture.delete(subteamWithAutoAccept.id);
+        await teamsRepositoryFixture.delete(orgWithAutoAccept.id);
+      });
+    });
+
     afterAll(async () => {
       await userRepositoryFixture.deleteByEmail(teamAdmin.email);
       await userRepositoryFixture.deleteByEmail(teammateInvitedViaApi.email);

--- a/apps/api/v2/src/modules/teams/memberships/services/teams-memberships.service.ts
+++ b/apps/api/v2/src/modules/teams/memberships/services/teams-memberships.service.ts
@@ -1,7 +1,10 @@
+import { OrganizationMembershipService } from "@/lib/services/organization-membership.service";
 import { OAuthClientRepository } from "@/modules/oauth-clients/oauth-client.repository";
 import { CreateTeamMembershipInput } from "@/modules/teams/memberships/inputs/create-team-membership.input";
 import { UpdateTeamMembershipInput } from "@/modules/teams/memberships/inputs/update-team-membership.input";
 import { TeamsMembershipsRepository } from "@/modules/teams/memberships/teams-memberships.repository";
+import { TeamsRepository } from "@/modules/teams/teams/teams.repository";
+import { UsersRepository } from "@/modules/users/users.repository";
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 
 import { TeamService } from "@calcom/platform-libraries";
@@ -14,11 +17,33 @@ export const PLATFORM_USER_AND_PLATFORM_TEAM_CREATED_WITH_DIFFERENT_OAUTH_CLIENT
 export class TeamsMembershipsService {
   constructor(
     private readonly teamsMembershipsRepository: TeamsMembershipsRepository,
-    private readonly oAuthClientsRepository: OAuthClientRepository
+    private readonly oAuthClientsRepository: OAuthClientRepository,
+    private readonly teamsRepository: TeamsRepository,
+    private readonly usersRepository: UsersRepository,
+    private readonly orgMembershipService: OrganizationMembershipService
   ) {}
 
   async createTeamMembership(teamId: number, data: CreateTeamMembershipInput) {
     await this.canUserBeAddedToTeam(data.userId, teamId);
+
+    // Check if team is a sub-team of an organization and apply auto-accept logic
+    const team = await this.teamsRepository.getById(teamId);
+    if (team?.parentId) {
+      const user = await this.usersRepository.findById(data.userId);
+      if (user) {
+        const shouldAutoAccept = await this.orgMembershipService.shouldAutoAccept({
+          organizationId: team.parentId,
+          userEmail: user.email,
+        });
+
+        // ALWAYS override when email matches - prevents pending memberships
+        // Organizations expect added team member to automatically start receiving bookings for the team event
+        if (shouldAutoAccept) {
+          data = { ...data, accepted: true };
+        }
+      }
+    }
+
     const teamMembership = await this.teamsMembershipsRepository.createTeamMembership(teamId, data);
     return teamMembership;
   }

--- a/apps/api/v2/src/modules/teams/memberships/services/teams-memberships.service.ts
+++ b/apps/api/v2/src/modules/teams/memberships/services/teams-memberships.service.ts
@@ -1,26 +1,52 @@
+import { TeamService } from "@calcom/platform-libraries";
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  UnprocessableEntityException,
+} from "@nestjs/common";
 import { OAuthClientRepository } from "@/modules/oauth-clients/oauth-client.repository";
+import { OrganizationsRepository } from "@/modules/organizations/index/organizations.repository";
 import { CreateTeamMembershipInput } from "@/modules/teams/memberships/inputs/create-team-membership.input";
 import { UpdateTeamMembershipInput } from "@/modules/teams/memberships/inputs/update-team-membership.input";
 import { TeamsMembershipsRepository } from "@/modules/teams/memberships/teams-memberships.repository";
-import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
-
-import { TeamService } from "@calcom/platform-libraries";
 
 export const PLATFORM_USER_BEING_ADDED_TO_REGULAR_TEAM_ERROR = `Can't add user to team - the user is platform managed user but team is not because team probably was not created using OAuth credentials.`;
 export const REGULAR_USER_BEING_ADDED_TO_PLATFORM_TEAM_ERROR = `Can't add user to team - the user is not platform managed user but team is platform managed. Both have to be created using OAuth credentials.`;
 export const PLATFORM_USER_AND_PLATFORM_TEAM_CREATED_WITH_DIFFERENT_OAUTH_CLIENTS_ERROR = `Can't add user to team - managed user and team were created using different OAuth clients.`;
+export const USER_NOT_IN_PARENT_ORGANIZATION_ERROR = `User is not part of the Organization`;
 
 @Injectable()
 export class TeamsMembershipsService {
   constructor(
     private readonly teamsMembershipsRepository: TeamsMembershipsRepository,
-    private readonly oAuthClientsRepository: OAuthClientRepository
+    private readonly oAuthClientsRepository: OAuthClientRepository,
+    private readonly organizationsRepository: OrganizationsRepository
   ) {}
 
   async createTeamMembership(teamId: number, data: CreateTeamMembershipInput) {
     await this.canUserBeAddedToTeam(data.userId, teamId);
+    await this.ensureUserIsInParentOrganization(data.userId, teamId);
     const teamMembership = await this.teamsMembershipsRepository.createTeamMembership(teamId, data);
     return teamMembership;
+  }
+
+  private async ensureUserIsInParentOrganization(userId: number, teamId: number) {
+    const team = await this.teamsMembershipsRepository.findTeamById(teamId);
+
+    if (!team) {
+      throw new NotFoundException(`Team with id ${teamId} not found`);
+    }
+
+    if (!team.parentId) {
+      return;
+    }
+
+    const user = await this.organizationsRepository.findOrgUser(team.parentId, userId);
+
+    if (!user) {
+      throw new UnprocessableEntityException(USER_NOT_IN_PARENT_ORGANIZATION_ERROR);
+    }
   }
 
   async getPaginatedTeamMemberships(teamId: number, emails?: string[], skip = 0, take = 250) {

--- a/apps/api/v2/src/modules/teams/memberships/teams-memberships.module.ts
+++ b/apps/api/v2/src/modules/teams/memberships/teams-memberships.module.ts
@@ -6,10 +6,20 @@ import { TeamsEventTypesModule } from "@/modules/teams/event-types/teams-event-t
 import { TeamsMembershipsController } from "@/modules/teams/memberships/controllers/teams-memberships.controller";
 import { TeamsMembershipsService } from "@/modules/teams/memberships/services/teams-memberships.service";
 import { TeamsMembershipsRepository } from "@/modules/teams/memberships/teams-memberships.repository";
+import { TeamsModule } from "@/modules/teams/teams/teams.module";
+import { UsersModule } from "@/modules/users/users.module";
 import { Module } from "@nestjs/common";
 
 @Module({
-  imports: [PrismaModule, RedisModule, OrganizationsModule, MembershipsModule, TeamsEventTypesModule],
+  imports: [
+    PrismaModule,
+    RedisModule,
+    OrganizationsModule,
+    MembershipsModule,
+    TeamsEventTypesModule,
+    TeamsModule,
+    UsersModule,
+  ],
   providers: [TeamsMembershipsRepository, TeamsMembershipsService],
   controllers: [TeamsMembershipsController],
   exports: [TeamsMembershipsService],

--- a/apps/api/v2/src/modules/teams/memberships/teams-memberships.repository.ts
+++ b/apps/api/v2/src/modules/teams/memberships/teams-memberships.repository.ts
@@ -1,10 +1,9 @@
+import type { Prisma } from "@calcom/prisma/client";
+import { Injectable } from "@nestjs/common";
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { CreateTeamMembershipInput } from "@/modules/teams/memberships/inputs/create-team-membership.input";
 import { UpdateTeamMembershipInput } from "@/modules/teams/memberships/inputs/update-team-membership.input";
-import { Injectable } from "@nestjs/common";
-
-import type { Prisma } from "@calcom/prisma/client";
 
 export interface TeamMembershipFilters {
   emails?: string[];
@@ -21,7 +20,10 @@ export const MembershipUserSelect: Prisma.UserSelect = {
 
 @Injectable()
 export class TeamsMembershipsRepository {
-  constructor(private readonly dbRead: PrismaReadService, private readonly dbWrite: PrismaWriteService) {}
+  constructor(
+    private readonly dbRead: PrismaReadService,
+    private readonly dbWrite: PrismaWriteService
+  ) {}
 
   async createTeamMembership(teamId: number, data: CreateTeamMembershipInput) {
     return this.dbWrite.prisma.membership.create({
@@ -107,6 +109,19 @@ export class TeamsMembershipsRepository {
         teamId: teamId,
       },
       include: { user: { select: MembershipUserSelect } },
+    });
+  }
+
+  async findTeamById(teamId: number) {
+    return this.dbRead.prisma.team.findUnique({
+      where: {
+        id: teamId,
+      },
+      select: {
+        id: true,
+        parentId: true,
+        isOrganization: true,
+      },
     });
   }
 }

--- a/apps/api/v2/src/modules/teams/schedules/teams-schedules.module.ts
+++ b/apps/api/v2/src/modules/teams/schedules/teams-schedules.module.ts
@@ -1,8 +1,10 @@
 import { SchedulesRepository_2024_06_11 } from "@/ee/schedules/schedules_2024_06_11/schedules.repository";
 import { OutputSchedulesService_2024_06_11 } from "@/ee/schedules/schedules_2024_06_11/services/output-schedules.service";
+import { OrganizationMembershipService } from "@/lib/services/organization-membership.service";
 import { AppsRepository } from "@/modules/apps/apps.repository";
 import { CredentialsRepository } from "@/modules/credentials/credentials.repository";
 import { MembershipsModule } from "@/modules/memberships/memberships.module";
+import { OAuthClientRepository } from "@/modules/oauth-clients/oauth-client.repository";
 import { OrganizationsRepository } from "@/modules/organizations/index/organizations.repository";
 import { OrganizationSchedulesRepository } from "@/modules/organizations/schedules/organizations-schedules.repository";
 import { OrganizationsTeamsRepository } from "@/modules/organizations/teams/index/organizations-teams.repository";
@@ -36,6 +38,8 @@ import { Module } from "@nestjs/common";
     TeamsSchedulesService,
     OrganizationsTeamsRepository,
     SchedulesRepository_2024_06_11,
+    OAuthClientRepository,
+    OrganizationMembershipService,
   ],
   controllers: [TeamsController, TeamsSchedulesController],
   exports: [TeamsRepository],

--- a/apps/api/v2/src/modules/teams/teams/teams.module.ts
+++ b/apps/api/v2/src/modules/teams/teams/teams.module.ts
@@ -1,4 +1,7 @@
+import { OrganizationMembershipService } from "@/lib/services/organization-membership.service";
 import { MembershipsModule } from "@/modules/memberships/memberships.module";
+import { OAuthClientRepository } from "@/modules/oauth-clients/oauth-client.repository";
+import { OrganizationsRepository } from "@/modules/organizations/index/organizations.repository";
 import { PrismaModule } from "@/modules/prisma/prisma.module";
 import { RedisModule } from "@/modules/redis/redis.module";
 import { StripeModule } from "@/modules/stripe/stripe.module";
@@ -7,11 +10,21 @@ import { TeamsMembershipsRepository } from "@/modules/teams/memberships/teams-me
 import { TeamsController } from "@/modules/teams/teams/controllers/teams.controller";
 import { TeamsService } from "@/modules/teams/teams/services/teams.service";
 import { TeamsRepository } from "@/modules/teams/teams/teams.repository";
+import { UsersRepository } from "@/modules/users/users.repository";
 import { Module } from "@nestjs/common";
 
 @Module({
   imports: [PrismaModule, MembershipsModule, RedisModule, StripeModule],
-  providers: [TeamsRepository, TeamsService, TeamsMembershipsRepository, TeamsMembershipsService],
+  providers: [
+    TeamsRepository,
+    TeamsService,
+    TeamsMembershipsRepository,
+    TeamsMembershipsService,
+    OAuthClientRepository,
+    UsersRepository,
+    OrganizationsRepository,
+    OrganizationMembershipService,
+  ],
   controllers: [TeamsController],
   exports: [TeamsRepository],
 })

--- a/apps/api/v2/test/fixtures/repository/team.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/team.repository.fixture.ts
@@ -33,4 +33,30 @@ export class TeamRepositoryFixture {
       },
     });
   }
+
+  async createOrgSettings(
+    organizationId: number,
+    settings: {
+      orgAutoAcceptEmail: string;
+      isOrganizationVerified?: boolean;
+      isOrganizationConfigured?: boolean;
+      isAdminAPIEnabled?: boolean;
+    }
+  ) {
+    return this.prismaWriteClient.organizationSettings.create({
+      data: {
+        organizationId,
+        orgAutoAcceptEmail: settings.orgAutoAcceptEmail,
+        isOrganizationVerified: settings.isOrganizationVerified,
+        isOrganizationConfigured: settings.isOrganizationConfigured,
+        isAdminAPIEnabled: settings.isAdminAPIEnabled,
+      },
+    });
+  }
+
+  async deleteOrgSettings(organizationId: number) {
+    return this.prismaWriteClient.organizationSettings.deleteMany({
+      where: { organizationId },
+    });
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Makes the `/teams/{teamId}/memberships` API V2 endpoint consistent with `/organizations/{orgId}/teams/{teamId}/memberships` by blocking member addition when the team is a sub-team and the user is not already a member of the parent organization.

Previously, the `/teams/{teamId}/memberships` endpoint allowed adding a member to a sub-team without checking if they were part of the parent organization, which could lead to data inconsistency where a user is a member of a sub-team but not the parent organization.

### Updates since last revision

This PR has been rebased on top of #26860 (auto-accept logic for team memberships based on org email domain). The combined changes now:
1. First verify the user is in the parent organization (this PR's fix)
2. Then apply auto-accept logic if the user's email matches the org's `orgAutoAcceptEmail` setting

Added E2E test to verify that adding a user who is not in the parent organization returns 422 with message "User is not part of the Organization".

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create an organization with a sub-team
2. Try to add a user to the sub-team via `POST /v2/teams/{teamId}/memberships` where the user is NOT a member of the parent organization
3. Expected: Should return 422 Unprocessable Entity with message "User is not part of the Organization"
4. Add the user to the parent organization first, then retry step 2
5. Expected: Should succeed

Run the E2E tests:
```bash
TZ=UTC yarn test:e2e --testPathPattern="teams-memberships.controller.e2e-spec"
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the order of operations in `createTeamMembership`: blocking check happens before auto-accept logic
- [ ] Confirm the error message "User is not part of the Organization" matches the org endpoint behavior
- [ ] Verify all module dependencies are correctly configured (OrganizationsRepository, TeamsRepository, UsersRepository, OrganizationMembershipService)
- [ ] Review the E2E test `should return 422 when trying to add user who is not in parent organization to sub-team`

---

Link to Devin run: https://app.devin.ai/sessions/f8f3a97df87540c4ac2d8d36e455b144
Requested by: @hariombalhara