### PR TITLE
fix: booking limits with seats not working

### DIFF
--- a/packages/features/busyTimes/lib/getBusyTimesFromLimits.test.ts
+++ b/packages/features/busyTimes/lib/getBusyTimesFromLimits.test.ts
@@ -1,0 +1,247 @@
+import dayjs from "@calcom/dayjs";
+import LimitManager from "@calcom/lib/intervalLimits/limitManager";
+import type { EventBusyDetails } from "@calcom/types/Calendar";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock dependencies
+vi.mock("@calcom/features/di/containers/BookingLimits", () => ({
+  getCheckBookingLimitsService: () => ({
+    checkBookingLimit: vi.fn(),
+  }),
+}));
+
+vi.mock("@calcom/features/di/containers/BusyTimes", () => ({
+  getBusyTimesService: () => ({
+    getStartEndDateforLimitCheck: vi.fn(),
+  }),
+}));
+
+vi.mock("@calcom/prisma", () => ({
+  default: {},
+}));
+
+// Import the function we're testing
+import { getBusyTimesFromBookingLimits } from "./getBusyTimesFromLimits";
+
+const startOfTomorrow = dayjs().add(1, "day").startOf("day");
+
+describe("getBusyTimesFromBookingLimits with seats", () => {
+  describe("seated events", () => {
+    it("should NOT mark slot busy when booking limit is reached but seats remain available", async () => {
+      const limitManager = new LimitManager();
+      const dateFrom = startOfTomorrow;
+      const dateTo = startOfTomorrow.endOf("day");
+
+      // Event type has 5 seats and limit of 1 booking per day
+      // 1 booking exists with 1 attendee - 4 seats should still be available
+      const bookings: EventBusyDetails[] = [
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 1",
+          source: "eventType-1-booking-1",
+          userId: 1,
+          attendeeCount: 1, // Only 1 seat taken
+        },
+      ];
+
+      await getBusyTimesFromBookingLimits({
+        bookings,
+        bookingLimits: { PER_DAY: 1 },
+        dateFrom,
+        dateTo,
+        limitManager,
+        eventTypeId: 1,
+        timeZone: "UTC",
+        seatsPerTimeSlot: 5, // 5 seats available
+      });
+
+      const busyTimes = limitManager.getBusyTimes();
+
+      // Should NOT be marked as busy because 4 seats remain (1 attendee < 5 seats)
+      expect(busyTimes).toHaveLength(0);
+    });
+
+    it("should mark slot busy when all seats are filled", async () => {
+      const limitManager = new LimitManager();
+      const dateFrom = startOfTomorrow;
+      const dateTo = startOfTomorrow.endOf("day");
+
+      // Event type has 3 seats, and all 3 attendees have booked
+      const bookings: EventBusyDetails[] = [
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 1",
+          source: "eventType-1-booking-1",
+          userId: 1,
+          attendeeCount: 3, // All 3 seats taken
+        },
+      ];
+
+      await getBusyTimesFromBookingLimits({
+        bookings,
+        bookingLimits: { PER_DAY: 1 },
+        dateFrom,
+        dateTo,
+        limitManager,
+        eventTypeId: 1,
+        timeZone: "UTC",
+        seatsPerTimeSlot: 3, // Only 3 seats available
+      });
+
+      const busyTimes = limitManager.getBusyTimes();
+
+      // Should be marked as busy because all 3 seats are taken
+      expect(busyTimes).toHaveLength(1);
+    });
+
+    it("should count attendees across multiple bookings for the same slot", async () => {
+      const limitManager = new LimitManager();
+      const dateFrom = startOfTomorrow;
+      const dateTo = startOfTomorrow.endOf("day");
+
+      // Event type has 5 seats, 2 bookings with total 5 attendees
+      const bookings: EventBusyDetails[] = [
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 1",
+          source: "eventType-1-booking-1",
+          userId: 1,
+          attendeeCount: 2,
+        },
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 2",
+          source: "eventType-1-booking-2",
+          userId: 2,
+          attendeeCount: 3,
+        },
+      ];
+
+      await getBusyTimesFromBookingLimits({
+        bookings,
+        bookingLimits: { PER_DAY: 10 }, // High limit - shouldn't matter for seats
+        dateFrom,
+        dateTo,
+        limitManager,
+        eventTypeId: 1,
+        timeZone: "UTC",
+        seatsPerTimeSlot: 5, // 5 seats, all filled (2 + 3)
+      });
+
+      const busyTimes = limitManager.getBusyTimes();
+
+      // Should be marked as busy because 2 + 3 = 5 attendees >= 5 seats
+      expect(busyTimes).toHaveLength(1);
+    });
+  });
+
+  describe("non-seated events (regression)", () => {
+    it("should mark slot busy when booking limit is reached for non-seated event", async () => {
+      const limitManager = new LimitManager();
+      const dateFrom = startOfTomorrow;
+      const dateTo = startOfTomorrow.endOf("day");
+
+      // Regular event with 1 booking per day limit
+      const bookings: EventBusyDetails[] = [
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 1",
+          source: "eventType-1-booking-1",
+          userId: 1,
+          attendeeCount: 1,
+        },
+      ];
+
+      await getBusyTimesFromBookingLimits({
+        bookings,
+        bookingLimits: { PER_DAY: 1 },
+        dateFrom,
+        dateTo,
+        limitManager,
+        eventTypeId: 1,
+        timeZone: "UTC",
+        // No seatsPerTimeSlot - this is a non-seated event
+      });
+
+      const busyTimes = limitManager.getBusyTimes();
+
+      // Should be marked as busy because 1 booking >= 1 limit
+      expect(busyTimes).toHaveLength(1);
+    });
+
+    it("should NOT mark slot busy when booking limit is not reached for non-seated event", async () => {
+      const limitManager = new LimitManager();
+      const dateFrom = startOfTomorrow;
+      const dateTo = startOfTomorrow.endOf("day");
+
+      // Regular event with 2 bookings per day limit, only 1 booking exists
+      const bookings: EventBusyDetails[] = [
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 1",
+          source: "eventType-1-booking-1",
+          userId: 1,
+          attendeeCount: 1,
+        },
+      ];
+
+      await getBusyTimesFromBookingLimits({
+        bookings,
+        bookingLimits: { PER_DAY: 2 }, // Limit is 2, only 1 booking
+        dateFrom,
+        dateTo,
+        limitManager,
+        eventTypeId: 1,
+        timeZone: "UTC",
+        // No seatsPerTimeSlot - this is a non-seated event
+      });
+
+      const busyTimes = limitManager.getBusyTimes();
+
+      // Should NOT be marked as busy because 1 booking < 2 limit
+      expect(busyTimes).toHaveLength(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle attendeeCount defaulting to 1 when not provided", async () => {
+      const limitManager = new LimitManager();
+      const dateFrom = startOfTomorrow;
+      const dateTo = startOfTomorrow.endOf("day");
+
+      // Booking without attendeeCount should default to 1
+      const bookings: EventBusyDetails[] = [
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 1",
+          source: "eventType-1-booking-1",
+          userId: 1,
+          // No attendeeCount - should default to 1
+        },
+      ];
+
+      await getBusyTimesFromBookingLimits({
+        bookings,
+        bookingLimits: { PER_DAY: 1 },
+        dateFrom,
+        dateTo,
+        limitManager,
+        eventTypeId: 1,
+        timeZone: "UTC",
+        seatsPerTimeSlot: 2, // 2 seats, only 1 taken (default)
+      });
+
+      const busyTimes = limitManager.getBusyTimes();
+
+      // Should NOT be marked as busy because 1 (default) < 2 seats
+      expect(busyTimes).toHaveLength(0);
+    });
+  });
+});

--- a/packages/features/busyTimes/lib/getBusyTimesFromLimits.ts
+++ b/packages/features/busyTimes/lib/getBusyTimesFromLimits.ts
@@ -116,7 +116,8 @@ const _getBusyTimesFromBookingLimits = async (params: {
         : LimitSources.eventBookingLimit({ limit, unit });
 
       // special handling of yearly limits to improve performance
-      if (unit === "year") {
+      // For seated events, we need to use the regular seat-aware counting logic
+      if (unit === "year" && !seatsPerTimeSlot) {
         try {
           const checkBookingLimitsService = getCheckBookingLimitsService();
           await checkBookingLimitsService.checkBookingLimit({

--- a/packages/features/busyTimes/lib/getBusyTimesFromLimits.ts
+++ b/packages/features/busyTimes/lib/getBusyTimesFromLimits.ts
@@ -42,6 +42,7 @@ const _getBusyTimesFromLimits = async (
       limitManager,
       rescheduleUid,
       timeZone,
+      seatsPerTimeSlot: eventType.seatsPerTimeSlot,
     });
     performance.mark("bookingLimitsEnd");
     performance.measure(`checking booking limits took $1'`, "bookingLimitsStart", "bookingLimitsEnd");
@@ -83,6 +84,7 @@ const _getBusyTimesFromBookingLimits = async (params: {
   user?: { id: number; email: string };
   includeManagedEvents?: boolean;
   timeZone?: string | null;
+  seatsPerTimeSlot?: number | null;
 }) => {
   const {
     bookings,
@@ -96,6 +98,7 @@ const _getBusyTimesFromBookingLimits = async (params: {
     rescheduleUid,
     includeManagedEvents = false,
     timeZone,
+    seatsPerTimeSlot,
   } = params;
 
   for (const key of descendingLimitKeys) {
@@ -143,6 +146,7 @@ const _getBusyTimesFromBookingLimits = async (params: {
 
       const periodEnd = periodStart.endOf(unit);
       let totalBookings = 0;
+      let totalAttendees = 0;
 
       for (const booking of bookings) {
         // consider booking part of period independent of end date
@@ -150,7 +154,20 @@ const _getBusyTimesFromBookingLimits = async (params: {
           continue;
         }
         totalBookings++;
-        if (totalBookings >= limit) {
+        totalAttendees += booking.attendeeCount || 1;
+
+        // For seated events, check if all seats are filled
+        if (seatsPerTimeSlot) {
+          if (totalAttendees >= seatsPerTimeSlot) {
+            limitManager.addBusyTime({
+              start: periodStart,
+              unit,
+              title,
+              source,
+            });
+            break;
+          }
+        } else if (totalBookings >= limit) {
           limitManager.addBusyTime({
             start: periodStart,
             unit,

--- a/packages/features/busyTimes/services/getBusyTimes.ts
+++ b/packages/features/busyTimes/services/getBusyTimes.ts
@@ -493,9 +493,30 @@ export class BusyTimesService {
         eventTypeId: true,
         title: true,
         userId: true,
+        _count: {
+          select: {
+            attendees: true,
+          },
+        },
       },
     });
 
-    return bookings;
+    busyTimes = bookings.map(({ id, startTime, endTime, title, userId, _count }) => ({
+      start: dayjs(startTime).toDate(),
+      end: dayjs(endTime).toDate(),
+      title,
+      source: `eventType-${eventTypeId}-booking-${id}`,
+      userId,
+      attendeeCount: _count?.attendees || 1,
+    }));
+
+    logger.silly(`Fetch limit checks bookings for eventId: ${eventTypeId} ${JSON.stringify(busyTimes)}`);
+    performance.mark("getBusyTimesForLimitChecksEnd");
+    performance.measure(
+      `prisma booking get for limits took $1'`,
+      "getBusyTimesForLimitChecksStart",
+      "getBusyTimesForLimitChecksEnd"
+    );
+    return busyTimes;
   }
 }

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -443,6 +443,7 @@ export class AvailableSlotsService {
 
           const periodEnd = periodStart.endOf(unit);
           let totalBookings = 0;
+          let totalAttendees = 0;
 
           const { title, source } = LimitSources.eventBookingLimit({ limit, unit });
 
@@ -452,7 +453,21 @@ export class AvailableSlotsService {
             }
 
             totalBookings++;
-            if (totalBookings >= limit) {
+            totalAttendees += booking.attendeeCount || 1;
+
+            // For seated events, check if all seats are filled
+            if (eventType.seatsPerTimeSlot) {
+              if (totalAttendees >= eventType.seatsPerTimeSlot) {
+                globalLimitManager.addBusyTime({
+                  start: periodStart,
+                  unit,
+                  timeZone,
+                  title,
+                  source,
+                });
+                break;
+              }
+            } else if (totalBookings >= limit) {
               globalLimitManager.addBusyTime({
                 start: periodStart,
                 unit,
@@ -543,6 +558,7 @@ export class AvailableSlotsService {
 
             const periodEnd = periodStart.endOf(unit);
             let totalBookings = 0;
+            let totalAttendees = 0;
 
             for (const booking of userBookings) {
               if (!isBookingWithinPeriod(booking, periodStart, periodEnd, timeZone)) {
@@ -550,7 +566,21 @@ export class AvailableSlotsService {
               }
 
               totalBookings++;
-              if (totalBookings >= limit) {
+              totalAttendees += booking.attendeeCount || 1;
+
+              // For seated events, check if all seats are filled
+              if (eventType.seatsPerTimeSlot) {
+                if (totalAttendees >= eventType.seatsPerTimeSlot) {
+                  limitManager.addBusyTime({
+                    start: periodStart,
+                    unit,
+                    timeZone,
+                    title,
+                    source,
+                  });
+                  break;
+                }
+              } else if (totalBookings >= limit) {
                 limitManager.addBusyTime({
                   start: periodStart,
                   unit,

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -64,6 +64,7 @@ export type EventBusyDetails = EventBusyDate & {
   title?: string;
   source: string;
   userId?: number | null;
+  attendeeCount?: number;
 };
 
 export type AdditionalInfo = Record<string, unknown> & { calWarnings?: string[] };


### PR DESCRIPTION
## Summary

When an event has seats enabled AND booking limits (e.g., 5 seats + 1 booking/week limit), the first booking was blocking the **entire period** for everyone instead of just counting toward the seat limit.

**Before:** 1 person books 1 seat → entire week blocked
**After:** 1 person books 1 seat → 4 seats remain available

### Changes Made

- **Type Update**: Added `attendeeCount` to `EventBusyDetails` type
- **Query Update**: Include `_count.attendees` in booking query for limit checks
- **Core Logic**: Add seat-aware logic - only mark period busy when `totalAttendees >= seatsPerTimeSlot`
- **Backward Compatible**: Non-seated events continue to use booking count as before
- **Tests**: Added 6 unit tests covering seated and non-seated scenarios

### Technical Details

The fix works by:
1. Querying attendee count when fetching bookings for limit checks
2. For seated events: checking if `totalAttendees >= seatsPerTimeSlot` before marking busy
3. For non-seated events: using the existing `totalBookings >= limit` check

### Files Modified

| File | Change |
|------|--------|
| `packages/types/Calendar.d.ts` | Add `attendeeCount` to type |
| `packages/features/busyTimes/services/getBusyTimes.ts` | Include attendee count in query |
| `packages/features/busyTimes/lib/getBusyTimesFromLimits.ts` | Add seat-aware logic |
| `packages/trpc/server/routers/viewer/slots/util.ts` | Add seat-aware limit checking |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

- [x] Seated event with limit - remaining seats stay available after first booking
- [x] Seated event with all seats filled - slot correctly blocked
- [x] Multiple bookings counted correctly (total attendees across bookings)
- [x] Non-seated events work as before (regression test)
- [x] Default attendeeCount to 1 when not provided

Fixes #17221