### PR TITLE
fix(companion): wrong event type link for org user with same username

### DIFF
--- a/companion/extension/entrypoints/background/index.ts
+++ b/companion/extension/entrypoints/background/index.ts
@@ -947,10 +947,15 @@ async function fetchEventTypes(): Promise<unknown[]> {
 
   const userData = await userResponse.json();
   const username = userData?.data?.username as string | undefined;
+  // For org users, include org slug to avoid username collisions across orgs
+  const orgSlug = userData?.data?.organization?.slug as string | undefined;
 
   const params = new URLSearchParams();
   if (username) {
     params.append("username", username);
+  }
+  if (orgSlug) {
+    params.append("orgSlug", orgSlug);
   }
   const queryString = params.toString();
   const endpoint = `${API_BASE_URL}/event-types${queryString ? `?${queryString}` : ""}`;

--- a/companion/services/calcom.ts
+++ b/companion/services/calcom.ts
@@ -862,20 +862,28 @@ async function getTranscripts(bookingUid: string): Promise<BookingTranscript[]> 
 }
 
 async function getEventTypes(): Promise<EventType[]> {
-  // Get cached user profile to extract username (uses in-flight deduplication)
+  // Get cached user profile to extract username and org slug (uses in-flight deduplication)
   let username: string | undefined;
+  let orgSlug: string | undefined;
   try {
     const userProfile = await getUserProfile();
     // Extract username from response
     if (userProfile?.username) {
       username = userProfile.username;
     }
+    // For org users, include org slug to avoid username collisions across orgs
+    if (userProfile?.organization?.slug) {
+      orgSlug = userProfile.organization.slug;
+    }
   } catch (_error) {}
 
-  // Build query string with username and sorting
+  // Build query string with username, orgSlug, and sorting
   const params = new URLSearchParams();
   if (username) {
     params.append("username", username);
+  }
+  if (orgSlug) {
+    params.append("orgSlug", orgSlug);
   }
   // Sort by creation date descending (newer first) to match main codebase behavior
   // Main codebase uses position: "desc", id: "desc" - since API doesn't expose position,

--- a/companion/services/types/users.types.ts
+++ b/companion/services/types/users.types.ts
@@ -13,6 +13,8 @@ export interface UserProfile {
   organizationId?: number;
   organization?: {
     id: number;
+    slug?: string;
+    name?: string;
     isPlatform: boolean;
   };
   metadata?: Record<string, unknown>;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes wrong event type links for org users when the same username exists in multiple orgs. Event-type queries are now scoped with org slug to resolve the correct links.

- **Bug Fixes**
  - Add orgSlug to event-types requests in background and service layers.
  - Extract organization.slug from the user profile and include it with username in query params.
  - Extend UserProfile types with organization.slug (and name) for safer lookups.

<sup>Written for commit a981d65e7a62bca4f849f6fd64e774fb7e80767a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

