### PR TITLE
docs: Fix Cal.com brand casing inconsistencies

### DIFF
--- a/docs/api-reference/v2/oauth.mdx
+++ b/docs/api-reference/v2/oauth.mdx
@@ -3,7 +3,7 @@ title: "OAuth"
 description: "Authorize apps with Cal.com accounts using OAuth"
 ---
 
-As an example, you can view our OAuth flow in action on Zapier. Try to connect your cal.com account [here](https://zapier.com/apps/calcom/integrations). To enable OAuth in one of your apps, you will need a Client ID, Client Secret, Authorization URL, Access Token Request URL, and Refresh Token Request URL.
+As an example, you can view our OAuth flow in action on Zapier. Try to connect your Cal.com account [here](https://zapier.com/apps/calcom/integrations). To enable OAuth in one of your apps, you will need a Client ID, Client Secret, Authorization URL, Access Token Request URL, and Refresh Token Request URL.
 
 <Frame>
   ![](/images/oauth-zapier.png)

--- a/docs/api-reference/v2/oauth.mdx
+++ b/docs/api-reference/v2/oauth.mdx
@@ -22,7 +22,7 @@ As an example, you can view our OAuth flow in action on Zapier. Try to connect y
 
 ### OAuth Client Credentials
 
-Only the cal.com team can create new OAuth clients. Please fill out [this form](https://i.cal.com/forms/4052adda-bc79-4a8d-9f63-5bc3bead4cd3) and book us to get started.
+Only the Cal.com team can create new OAuth clients. Please fill out [this form](https://i.cal.com/forms/4052adda-bc79-4a8d-9f63-5bc3bead4cd3) and book us to get started.
 
 The Cal.com team will register the app and provide you with the Client ID and Client Secret. Keep these credentials confidential and secure.
 

--- a/docs/api-reference/v2/oauth.mdx
+++ b/docs/api-reference/v2/oauth.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OAuth"
-description: "Authorize apps with cal.com accounts using OAuth"
+description: "Authorize apps with Cal.com accounts using OAuth"
 ---
 
 As an example, you can view our OAuth flow in action on Zapier. Try to connect your cal.com account [here](https://zapier.com/apps/calcom/integrations). To enable OAuth in one of your apps, you will need a Client ID, Client Secret, Authorization URL, Access Token Request URL, and Refresh Token Request URL.

--- a/docs/self-hosting/deployments/gcp.mdx
+++ b/docs/self-hosting/deployments/gcp.mdx
@@ -110,7 +110,7 @@ In this guide, we will go over the steps to deploy Cal.com on Google Cloud Platf
 
         ### Access Cal.com
 
-        Open a web browser and navigate to `http://localhost`. You should now be able to access the cal.com homepage.
+        Open a web browser and navigate to `http://localhost`. You should now be able to access the Cal.com homepage.
     </Step>
 </Steps>
 

--- a/docs/self-hosting/deployments/gcp.mdx
+++ b/docs/self-hosting/deployments/gcp.mdx
@@ -106,7 +106,7 @@ In this guide, we will go over the steps to deploy Cal.com on Google Cloud Platf
         ```bash
         docker run -d -p 80:80 cal/cal.com
         ```
-        This command maps port 80 on your local machine to port 80 inside the container, so you can access cal.com from outside the container.
+        This command maps port 80 on your local machine to port 80 inside the container, so you can access Cal.com from outside the container.
 
         ### Access Cal.com
 

--- a/docs/self-hosting/deployments/gcp.mdx
+++ b/docs/self-hosting/deployments/gcp.mdx
@@ -5,7 +5,7 @@ icon: "google"
 
 Deploying Cal.com on Google Cloud Platform (GCP)
 
-In this guide, we will go over the steps to deploy cal.com on Google Cloud Platform (GCP). We will cover how to create a virtual machine, configure it, install Docker, and finally deploy the Cal.com application.
+In this guide, we will go over the steps to deploy Cal.com on Google Cloud Platform (GCP). We will cover how to create a virtual machine, configure it, install Docker, and finally deploy the cal.com application.
 
 ## One Click Deployment
 
@@ -92,7 +92,7 @@ In this guide, we will go over the steps to deploy cal.com on Google Cloud Platf
         ```
     </Step>
     <Step title="Deploying Cal.com">
-        Now that Docker is installed and running, you can deploy cal.com on your virtual machine.
+        Now that Docker is installed and running, you can deploy Cal.com on your virtual machine.
 
         ### Pull the Docker Image
 

--- a/docs/self-hosting/deployments/gcp.mdx
+++ b/docs/self-hosting/deployments/gcp.mdx
@@ -5,7 +5,7 @@ icon: "google"
 
 Deploying Cal.com on Google Cloud Platform (GCP)
 
-In this guide, we will go over the steps to deploy cal.com on Google Cloud Platform (GCP). We will cover how to create a virtual machine, configure it, install Docker, and finally deploy the cal.com application.
+In this guide, we will go over the steps to deploy Cal.com on Google Cloud Platform (GCP). We will cover how to create a virtual machine, configure it, install Docker, and finally deploy the cal.com application.
 
 ## One Click Deployment
 

--- a/docs/self-hosting/deployments/gcp.mdx
+++ b/docs/self-hosting/deployments/gcp.mdx
@@ -5,7 +5,7 @@ icon: "google"
 
 Deploying Cal.com on Google Cloud Platform (GCP)
 
-In this guide, we will go over the steps to deploy Cal.com on Google Cloud Platform (GCP). We will cover how to create a virtual machine, configure it, install Docker, and finally deploy the cal.com application.
+In this guide, we will go over the steps to deploy Cal.com on Google Cloud Platform (GCP). We will cover how to create a virtual machine, configure it, install Docker, and finally deploy the Cal.com application.
 
 ## One Click Deployment
 

--- a/docs/self-hosting/deployments/gcp.mdx
+++ b/docs/self-hosting/deployments/gcp.mdx
@@ -114,4 +114,4 @@ In this guide, we will go over the steps to deploy Cal.com on Google Cloud Platf
     </Step>
 </Steps>
 
-Congratulations! You have successfully deployed cal.com on Google Cloud Platform.
+Congratulations! You have successfully deployed Cal.com on Google Cloud Platform.

--- a/docs/self-hosting/deployments/gcp.mdx
+++ b/docs/self-hosting/deployments/gcp.mdx
@@ -96,7 +96,7 @@ In this guide, we will go over the steps to deploy Cal.com on Google Cloud Platf
 
         ### Pull the Docker Image
 
-        Use the following command to pull the cal.com Docker image from Docker Hub:
+        Use the following command to pull the Cal.com Docker image from Docker Hub:
         ```bash
         docker pull cal/calcom
         ```

--- a/docs/self-hosting/deployments/gcp.mdx
+++ b/docs/self-hosting/deployments/gcp.mdx
@@ -5,7 +5,7 @@ icon: "google"
 
 Deploying Cal.com on Google Cloud Platform (GCP)
 
-In this guide, we will go over the steps to deploy Cal.com on Google Cloud Platform (GCP). We will cover how to create a virtual machine, configure it, install Docker, and finally deploy the cal.com application.
+In this guide, we will go over the steps to deploy cal.com on Google Cloud Platform (GCP). We will cover how to create a virtual machine, configure it, install Docker, and finally deploy the Cal.com application.
 
 ## One Click Deployment
 


### PR DESCRIPTION
Fixed inconsistent casing of "Cal.com" brand name throughout documentation. Updated lowercase "cal.com" references to proper "Cal.com" casing in open text while preserving technical identifiers like URLs and Docker image names.

Files changed:
- docs/api-reference/v2/oauth.mdx
- docs/self-hosting/deployments/gcp.mdx

---

Created by Mintlify agent