### PR TITLE
feat: add completion status to Cubic AI review comments

### DIFF
--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -149,6 +149,7 @@ jobs:
 
       - name: Post comment with Devin session link
         if: steps.extract-prompt.outputs.has-prompt == 'true' && env.SESSION_URL != ''
+        id: post-comment
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -160,9 +161,50 @@ jobs:
               ? `### Devin AI is addressing Cubic AI's review feedback\n\nA Devin session has been created to address the issues identified by Cubic AI.\n\n[View Devin Session](${sessionUrl})`
               : `### Devin AI is addressing Cubic AI's review feedback\n\nNew feedback has been sent to the existing Devin session.\n\n[View Devin Session](${sessionUrl})`;
             
-            await github.rest.issues.createComment({
+            const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
               body: message
             });
+            
+            core.setOutput('comment-id', comment.id);
+
+      - name: Send completion instructions to Devin
+        if: steps.extract-prompt.outputs.has-prompt == 'true' && env.SESSION_URL != '' && steps.post-comment.outputs.comment-id != ''
+        env:
+          DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
+        run: |
+          SESSION_ID="${EXISTING_SESSION_ID:-}"
+          if [ -z "$SESSION_ID" ]; then
+            SESSION_ID=$(cat /tmp/devin-response.json | jq -r '.session_id // .id // empty')
+          fi
+          
+          if [ -z "$SESSION_ID" ]; then
+            echo "No session ID found, skipping completion instructions"
+            exit 0
+          fi
+          
+          COMMENT_ID="${{ steps.post-comment.outputs.comment-id }}"
+          
+          MESSAGE="IMPORTANT: When you have finished addressing Cubic AI's feedback (whether you pushed changes or not), you MUST update the GitHub comment to show completion status.
+
+          Use the GitHub API to update comment ID ${COMMENT_ID} on PR #${{ github.event.pull_request.number }} in repository ${{ github.repository }}.
+
+          Add a completion status section at the bottom of the comment:
+          - If you pushed changes: Add '\n\n---\n:white_check_mark: Pushed commit [\`{SHORT_HASH}\`](https://github.com/${{ github.repository }}/commit/{FULL_HASH})' where {SHORT_HASH} is the first 7 characters of the commit hash and {FULL_HASH} is the full commit hash.
+          - If no changes were needed: Add '\n\n---\n:white_check_mark: No changes pushed'
+
+          To update the comment, use: gh api repos/${{ github.repository }}/issues/comments/${COMMENT_ID} -X PATCH -f body='<updated comment body>'"
+
+          HTTP_CODE=$(curl -s -o /tmp/devin-instructions-response.json -w "%{http_code}" -X POST "https://api.devin.ai/v1/sessions/${SESSION_ID}/message" \
+            -H "Authorization: Bearer ${DEVIN_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg message "$MESSAGE" '{message: $message}')")
+          
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "Warning: Failed to send completion instructions to Devin session: HTTP $HTTP_CODE"
+            cat /tmp/devin-instructions-response.json
+          else
+            echo "Completion instructions sent to Devin session successfully"
+          fi


### PR DESCRIPTION
## What does this PR do?

Updates the Cubic AI to Devin review workflow to add a completion status section at the bottom of the PR comment after Devin finishes addressing Cubic AI's feedback. This matches the format Cubic AI uses when it addresses issues (e.g., `:white_check_mark: Addressed in [commit](link)`).

The workflow now:
1. Captures the comment ID when posting the "Devin AI is addressing Cubic AI's review feedback" comment
2. Sends additional instructions to Devin to update that comment when done with either:
   - `:white_check_mark: Pushed commit [{hash}](link)` if changes were pushed
   - `:white_check_mark: No changes pushed` if no changes were needed

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - workflow changes cannot be unit tested.

## How should this be tested?

This workflow change can only be tested when triggered by an actual Cubic AI review on a PR:

1. Create or update a PR that triggers a Cubic AI review
2. Wait for Cubic AI to submit a review with issues
3. Verify the workflow triggers and posts the "Devin AI is addressing Cubic AI's review feedback" comment
4. Wait for Devin to complete addressing the feedback
5. Verify the comment is updated with the completion status (`:white_check_mark: Pushed commit [hash](link)` or `:white_check_mark: No changes pushed`)

## Human Review Checklist

- [ ] Verify the session ID extraction handles both new sessions and existing sessions correctly
- [ ] Verify the completion status format matches the Cubic AI format shown in [this example](https://github.com/calcom/cal.com/pull/26838#discussion_r2690826636)
- [ ] Consider if the workflow should handle cases where the comment creation fails

---

**Link to Devin run**: https://app.devin.ai/sessions/01a484008b054e68a54494e44009fb40
**Requested by**: @keithwillcode