### PR TITLE
refactor: extract cache tag constants and use revalidateTag for consistency

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/availability/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/availability/actions.ts
@@ -1,7 +1,9 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
+
+import { AVAILABILITY_CACHE_TAG } from "./cache";
 
 export async function revalidateAvailabilityList() {
-  revalidatePath("/availability");
+  revalidateTag(AVAILABILITY_CACHE_TAG, "max");
 }

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/availability/cache.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/availability/cache.ts
@@ -1,0 +1,1 @@
+export const AVAILABILITY_CACHE_TAG = "viewer.availability.list";

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/availability/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/availability/page.tsx
@@ -1,7 +1,7 @@
 import { createRouterCaller, getTRPCContext } from "app/_trpc/context";
 import type { PageProps, ReadonlyHeaders, ReadonlyRequestCookies } from "app/_types";
 import { _generateMetadata, getTranslate } from "app/_utils";
-import { unstable_cache, cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -44,10 +44,6 @@ const getCachedAvailabilities = unstable_cache(
 );
 
 const Page = async ({ searchParams: _searchParams }: PageProps) => {
-  "use cache: private";
-  cacheLife({ stale: 30 });
-  cacheTag(AVAILABILITY_CACHE_TAG);
-
   const searchParams = await _searchParams;
   const t = await getTranslate();
   const _headers = await headers();

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/actions.ts
@@ -1,7 +1,9 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
+
+import { EVENT_TYPES_CACHE_TAG } from "./cache";
 
 export async function revalidateEventTypesList() {
-  revalidatePath("/event-types");
+  revalidateTag(EVENT_TYPES_CACHE_TAG, "max");
 }

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/cache.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/cache.ts
@@ -1,0 +1,1 @@
+export const EVENT_TYPES_CACHE_TAG = "viewer.eventTypes.getUserEventGroups";

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
@@ -11,7 +11,7 @@ import type {
   ReadonlyRequestCookies,
 } from "app/_types";
 import { _generateMetadata } from "app/_utils";
-import { unstable_cache, cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { ReactElement } from "react";
@@ -49,10 +49,6 @@ const getCachedEventGroups: (
   );
 
 const Page = async ({ searchParams }: PageProps): Promise<ReactElement> => {
-  "use cache: private";
-  cacheLife({ stale: 30 });
-  cacheTag(EVENT_TYPES_CACHE_TAG);
-
   const _searchParams = await searchParams;
   const _headers = await headers();
   const _cookies = await cookies();

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
@@ -11,12 +11,13 @@ import type {
   ReadonlyRequestCookies,
 } from "app/_types";
 import { _generateMetadata } from "app/_utils";
-import { unstable_cache } from "next/cache";
+import { unstable_cache, cacheLife, cacheTag } from "next/cache";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { ReactElement } from "react";
 
 import { EventTypesWrapper } from "./EventTypesWrapper";
+import { EVENT_TYPES_CACHE_TAG } from "./cache";
 
 const getCachedEventGroups: (
   headers: ReadonlyHeaders,
@@ -43,11 +44,15 @@ const getCachedEventGroups: (
       );
       return await eventTypesCaller.getUserEventGroups({ filters });
     },
-    ["viewer.eventTypes.getUserEventGroups"],
-    { revalidate: 3600 } // seconds
+    [EVENT_TYPES_CACHE_TAG],
+    { revalidate: 3600, tags: [EVENT_TYPES_CACHE_TAG] }
   );
 
 const Page = async ({ searchParams }: PageProps): Promise<ReactElement> => {
+  "use cache: private";
+  cacheLife({ stale: 30 });
+  cacheTag(EVENT_TYPES_CACHE_TAG);
+
   const _searchParams = await searchParams;
   const _headers = await headers();
   const _cookies = await cookies();

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/actions.ts
@@ -2,6 +2,8 @@
 
 import { revalidateTag } from "next/cache";
 
+import { TEAMS_CACHE_TAG } from "./cache";
+
 export async function revalidateTeamsList() {
-  revalidateTag("viewer.teams.list", "max");
+  revalidateTag(TEAMS_CACHE_TAG, "max");
 }

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/cache.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/cache.ts
@@ -1,0 +1,1 @@
+export const TEAMS_CACHE_TAG = "viewer.teams.list";

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
@@ -12,6 +12,7 @@ import { MembershipRole } from "@calcom/prisma/enums";
 import { TeamsListing } from "~/ee/teams/components/TeamsListing";
 
 import { TeamsCTA } from "./CTA";
+import { TEAMS_CACHE_TAG } from "./cache";
 
 const getCachedTeams = unstable_cache(
   async (userId: number) => {
@@ -22,7 +23,7 @@ const getCachedTeams = unstable_cache(
     });
   },
   undefined,
-  { revalidate: 3600, tags: ["viewer.teams.list"] } // Cache for 1 hour
+  { revalidate: 3600, tags: [TEAMS_CACHE_TAG] }
 );
 
 export const ServerTeamsListing = async ({
@@ -34,7 +35,7 @@ export const ServerTeamsListing = async ({
 }) => {
   "use cache: private";
   cacheLife({ stale: 30 });
-  cacheTag("viewer.teams.list");
+  cacheTag(TEAMS_CACHE_TAG);
   const token = Array.isArray(searchParams?.token) ? searchParams.token[0] : searchParams?.token;
   const autoAccept = Array.isArray(searchParams?.autoAccept)
     ? searchParams.autoAccept[0]

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
@@ -1,6 +1,6 @@
 import type { SearchParams } from "app/_types";
 import type { Session } from "next-auth";
-import { unstable_cache, cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 
 import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { TeamService } from "@calcom/features/ee/teams/services/teamService";
@@ -33,9 +33,6 @@ export const ServerTeamsListing = async ({
   searchParams: SearchParams;
   session: Session;
 }) => {
-  "use cache: private";
-  cacheLife({ stale: 30 });
-  cacheTag(TEAMS_CACHE_TAG);
   const token = Array.isArray(searchParams?.token) ? searchParams.token[0] : searchParams?.token;
   const autoAccept = Array.isArray(searchParams?.autoAccept)
     ? searchParams.autoAccept[0]

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
@@ -1,6 +1,6 @@
 import type { SearchParams } from "app/_types";
 import type { Session } from "next-auth";
-import { unstable_cache } from "next/cache";
+import { unstable_cache, cacheLife, cacheTag } from "next/cache";
 
 import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { TeamService } from "@calcom/features/ee/teams/services/teamService";
@@ -32,6 +32,9 @@ export const ServerTeamsListing = async ({
   searchParams: SearchParams;
   session: Session;
 }) => {
+  "use cache: private";
+  cacheLife({ stale: 30 });
+  cacheTag("viewer.teams.list");
   const token = Array.isArray(searchParams?.token) ? searchParams.token[0] : searchParams?.token;
   const autoAccept = Array.isArray(searchParams?.autoAccept)
     ? searchParams.autoAccept[0]

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/actions.ts
@@ -2,6 +2,8 @@
 
 import { revalidateTag } from "next/cache";
 
+import { API_KEYS_CACHE_TAG } from "./cache";
+
 export async function revalidateApiKeysList() {
-  revalidateTag("viewer.apiKeys.list", "max");
+  revalidateTag(API_KEYS_CACHE_TAG, "max");
 }

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/cache.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/cache.ts
@@ -1,0 +1,1 @@
+export const API_KEYS_CACHE_TAG = "viewer.apiKeys.list";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/page.tsx
@@ -1,5 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { unstable_cache, cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -32,10 +32,6 @@ const getCachedApiKeys = unstable_cache(
 );
 
 const Page = async () => {
-  "use cache: private";
-  cacheLife({ stale: 30 });
-  cacheTag(API_KEYS_CACHE_TAG);
-
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
 
   if (!session) {

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/actions.ts
@@ -2,6 +2,12 @@
 
 import { revalidateTag } from "next/cache";
 
+import { ORG_ATTRIBUTES_CACHE_TAG, ORG_ROLES_CACHE_TAG } from "./cache";
+
 export async function revalidateAttributesList() {
-  revalidateTag("viewer.attributes.list", "max");
+  revalidateTag(ORG_ATTRIBUTES_CACHE_TAG, "max");
+}
+
+export async function revalidateRolesList() {
+  revalidateTag(ORG_ROLES_CACHE_TAG, "max");
 }

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/cache.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/cache.ts
@@ -1,0 +1,2 @@
+export const ORG_ATTRIBUTES_CACHE_TAG = "viewer.attributes.list";
+export const ORG_ROLES_CACHE_TAG = "pbac.roles.list";

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/page.tsx
@@ -1,6 +1,6 @@
 import { createRouterCaller } from "app/_trpc/context";
 import { _generateMetadata } from "app/_utils";
-import { unstable_cache, cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -48,10 +48,6 @@ const getCachedRoles = unstable_cache(
 );
 
 const Page = async () => {
-  "use cache: private";
-  cacheLife({ stale: 30 });
-  cacheTag(ORG_ATTRIBUTES_CACHE_TAG);
-
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
 
   if (!session?.user.id || !session?.user.profile?.organizationId || !session?.user.org) {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -219,6 +219,7 @@ const nextConfig = (phase: string): NextConfig => {
 
   return {
     output: process.env.BUILD_STANDALONE === "true" ? "standalone" : undefined,
+    cacheComponents: true,
     serverExternalPackages: [
       "deasync",
       "http-cookie-agent",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -217,10 +217,9 @@ const nextConfig = (phase: string): NextConfig => {
     );
   }
 
-  return {
-    output: process.env.BUILD_STANDALONE === "true" ? "standalone" : undefined,
-    cacheComponents: true,
-    serverExternalPackages: [
+    return {
+      output: process.env.BUILD_STANDALONE === "true" ? "standalone" : undefined,
+      serverExternalPackages: [
       "deasync",
       "http-cookie-agent",
       "rest-facade",


### PR DESCRIPTION
## What does this PR do?

Refactors cache tag handling across multiple dashboard pages to use shared constants, ensuring consistency between `unstable_cache` tags and `revalidateTag()` calls.

**Note:** This PR originally attempted to implement client-side RSC caching using Next.js's `'use cache: private'` directive with `cacheComponents: true`. However, this was blocked because `cacheComponents` is incompatible with route segment configs (`dynamic`, `runtime`, `revalidate`) used by several API routes (SAML auth, OG images, cron jobs). The client-side caching feature has been removed, and this PR now focuses on the cache tag refactoring only.

### Routes updated:
- `/teams`
- `/event-types`
- `/availability`
- `/settings/developer/api-keys`
- `/settings/organizations/members`

### Changes:
- Created `cache.ts` files with shared constants (e.g., `TEAMS_CACHE_TAG`, `EVENT_TYPES_CACHE_TAG`)
- Updated `unstable_cache` calls to use constants in both the key array and tags option
- Updated revalidation functions to use `revalidateTag()` with shared constants instead of `revalidatePath()`
- Added `revalidateRolesList()` function for org members page

### Why this matters:
Using shared constants ensures that when `revalidateTag()` is called after mutations, it invalidates the correct server-side cache. Previously, some routes used hardcoded strings that could drift out of sync.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. For each route, perform a mutation (create/update/delete)
2. Verify the list refreshes with updated data after the mutation
3. Check that no regressions occur in normal page loading

## Human Review Checklist

- [ ] Verify mutations for each route call the appropriate revalidation function:
  - Teams: `revalidateTeamsList()`
  - Event Types: `revalidateEventTypesList()`
  - Availability: `revalidateAvailabilityList()`
  - API Keys: `revalidateApiKeysList()`
  - Org Members: `revalidateAttributesList()` / `revalidateRolesList()`
- [ ] Verify the cache tag constants match between `cache.ts`, `unstable_cache` tags, and `revalidateTag()` calls
- [ ] **Note**: Org members page has two cache tags (`ORG_ATTRIBUTES_CACHE_TAG`, `ORG_ROLES_CACHE_TAG`) - verify both are invalidated appropriately when data changes

## Future Work

To enable client-side RSC caching with `'use cache: private'`, Next.js would need to support excluding specific routes from `cacheComponents`, or the incompatible API routes would need to be refactored. This is tracked separately.

## Link to Devin run

https://app.devin.ai/sessions/fd7e3d1bd1ad43a182607f3991289222

Requested by: benny@cal.com (@hbjORbj)