### PR TITLE
feat: hide "Don't have an account?" button when register=false query param is set

### DIFF
--- a/apps/web/modules/auth/login-view.tsx
+++ b/apps/web/modules/auth/login-view.tsx
@@ -186,7 +186,7 @@ export default function Login({
             ? !totpEmail
               ? TwoFactorFooter
               : ExternalTotpFooter
-            : process.env.NEXT_PUBLIC_DISABLE_SIGNUP !== "true"
+            : process.env.NEXT_PUBLIC_DISABLE_SIGNUP !== "true" && searchParams?.get("register") !== "false"
             ? LoginFooter
             : null
         }>


### PR DESCRIPTION
## What does this PR do?

Hides the "Don't have an account?" signup link on the login page when the `?register=false` query parameter is present in the URL.

This allows embedding or linking to the login page without showing the signup option, useful for scenarios where registration should be disabled for specific users or contexts.

**Example URL:** `https://app.cal.com/auth/login?register=false`

## Visual Demo

#### Without `?register=false` - Link visible:
![Login page with signup link visible](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2NzZmMmQyOTMyMWE5NmU4OGU1MTg0ZTciLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi8zNzQ0ZmU5Ny0zNGE5LTRhZDAtOGM2NS05NWIyZmYyMzFmYWEiLCJpYXQiOjE3Njg1MDcwNzQsImV4cCI6MTc2OTExMTg3NH0.kNQnH9sazcEm4M759g5RuZuAdRz-wViiqhuH3-f5q_Y)

#### With `?register=false` - Link hidden:
![Login page with signup link hidden](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2NzZmMmQyOTMyMWE5NmU4OGU1MTg0ZTciLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi83Nzk3NTk0Zi0yZTJhLTRjMmItYWZhMS04Y2RiOGYyNzg4N2MiLCJpYXQiOjE3Njg1MDcwNzQsImV4cCI6MTc2OTExMTg3NH0.50jN8jD-86zHrlyHnJI3FnzjZ1xrVziQE95JIa1fwvU)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to `/auth/login` - the "Don't have an account?" link should be visible
2. Navigate to `/auth/login?register=false` - the "Don't have an account?" link should be hidden
3. Navigate to `/auth/login?register=true` or any other value - the link should still be visible

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> **Reviewer note:** The condition uses strict string comparison (`!== "false"`), so only the exact value `false` will hide the link. Values like `FALSE`, `0`, or empty string will not hide it.

<!-- Link to Devin run: https://app.devin.ai/sessions/edd4e8d5705a491fb1b86755eefb6f85 -->
<!-- Requested by: @PeerRich -->