### PR TITLE
feat(companion): add register=false param to OAuth URL for iOS

### DIFF
--- a/companion/services/oauthService.ts
+++ b/companion/services/oauthService.ts
@@ -133,6 +133,10 @@ export class CalComOAuthService {
       code_challenge_method: "S256",
     });
 
+    if (Platform.OS === "ios") {
+      params.append("register", "false");
+    }
+
     return `${this.config.calcomBaseUrl}/auth/oauth2/authorize?${params.toString()}`;
   }
 


### PR DESCRIPTION
## What does this PR do?

Adds the `register=false` query parameter to the OAuth authorization URL when the companion app is running on iOS. This prevents showing the registration option when iOS users are redirected to the login page during the OAuth flow.

When an iOS user clicks "Continue with Cal.com" and isn't logged in, Cal.com's OAuth server redirects them from `/auth/oauth2/authorize` to `/auth/login`. This change ensures the `register=false` parameter is included in that flow, hiding the registration option for iOS app users.

This change only affects iOS - Android and web/extension users will continue to see the standard login page with registration option.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Build and run the companion iOS app
2. Ensure you are logged out
3. Tap "Continue with Cal.com" on the login screen
4. Verify the OAuth authorization URL includes `register=false` parameter
5. When redirected to the login page, confirm the registration option is not shown

**Note**: This requires testing on an actual iOS device or simulator as it's platform-specific behavior.

## Human Review Checklist

- [ ] Verify that the `register=false` parameter is preserved when Cal.com redirects from `/auth/oauth2/authorize` to `/auth/login`
- [ ] Confirm iOS-only behavior is desired (Android users will still see registration option)

---

Link to Devin run: https://app.devin.ai/sessions/ff0d5df5a44549c980eeb5476279b8bb
Requested by: @PeerRich