### PR TITLE
fix: cancel email notification workflow did not get sent to the secondary host

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -402,6 +402,7 @@ async function handler(input: CancelBookingInput, dependencies?: Dependencies) {
     platformBookingUrl,
     customReplyToEmail: bookingToDelete.eventType?.customReplyToEmail,
     organizationId: ownerProfile?.organizationId ?? null,
+    schedulingType: bookingToDelete.eventType?.schedulingType,
   };
 
   const dataForWebhooks = { evt, webhooks, eventTypeInfo };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes cancel email notifications so the secondary host is included by adding schedulingType to the cancel workflow payload.

- **Bug Fixes**
  - Pass eventType.schedulingType in handleCancelBooking when building eventTypeInfo, enabling the workflow to email the secondary host.

<sup>Written for commit 281c54a1845050279ceb6a029aef141d9e39416f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

