### PR TITLE
feat: pass register param directly to login page from OAuth authorize

### DIFF
--- a/apps/web/modules/auth/oauth2/authorize-view.tsx
+++ b/apps/web/modules/auth/oauth2/authorize-view.tsx
@@ -111,6 +111,11 @@ export default function Authorize() {
       const urlSearchParams = new URLSearchParams({
         callbackUrl: `auth/oauth2/authorize?${queryString}`,
       });
+      // Pass register param directly so login page can hide "Don't have an account" link
+      const registerParam = searchParams?.get("register");
+      if (registerParam) {
+        urlSearchParams.set("register", registerParam);
+      }
       router.replace(`/auth/login?${urlSearchParams.toString()}`);
     }
   }, [status]);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pass the register query param from /auth/oauth2/authorize to /auth/login. This lets the login page hide the "Don't have an account" link during OAuth sign-up flows.

<sup>Written for commit f1ea0dd43fa14d6e2854fd8c1e79dcd9875932be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

