### PR TITLE
fix: disable booking actions for cancelled/rejected/past bookings

### DIFF
--- a/apps/web/components/booking/actions/bookingActions.test.ts
+++ b/apps/web/components/booking/actions/bookingActions.test.ts
@@ -374,6 +374,87 @@ describe("Booking Actions", () => {
       expect(rescheduleAction?.disabled).toBe(true);
       expect(rescheduleRequestAction?.disabled).toBe(true);
     });
+
+    it("should disable change_location for past bookings", () => {
+      const context = createMockContext({ isBookingInPast: true });
+      const actions = getEditEventActions(context);
+
+      const changeLocationAction = actions.find((a) => a.id === "change_location");
+      expect(changeLocationAction?.disabled).toBe(true);
+    });
+
+    it("should disable change_location for cancelled bookings", () => {
+      const context = createMockContext({ isCancelled: true });
+      const actions = getEditEventActions(context);
+
+      const changeLocationAction = actions.find((a) => a.id === "change_location");
+      expect(changeLocationAction?.disabled).toBe(true);
+    });
+
+    it("should disable add_members for rejected bookings", () => {
+      const context = createMockContext({ isRejected: true });
+      const actions = getEditEventActions(context);
+
+      const addMembersAction = actions.find((a) => a.id === "add_members");
+      expect(addMembersAction?.disabled).toBe(true);
+    });
+
+    it("should disable reroute for past bookings from routing form", () => {
+      const context = createMockContext({
+        isBookingFromRoutingForm: true,
+        isBookingInPast: true,
+      });
+      const actions = getEditEventActions(context);
+
+      const rerouteAction = actions.find((a) => a.id === "reroute");
+      expect(rerouteAction?.disabled).toBe(true);
+    });
+
+    it("should disable reassign for cancelled round robin bookings", () => {
+      const context = createMockContext({
+        isCancelled: true,
+        booking: {
+          ...createMockContext().booking,
+          eventType: {
+            ...createMockContext().booking.eventType,
+            schedulingType: SchedulingType.ROUND_ROBIN,
+            hostGroups: [],
+          },
+        },
+      });
+      const actions = getEditEventActions(context);
+
+      const reassignAction = actions.find((a) => a.id === "reassign");
+      expect(reassignAction?.disabled).toBe(true);
+    });
+
+    it("should enable edit actions for upcoming active bookings", () => {
+      const context = createMockContext({
+        isBookingInPast: false,
+        isCancelled: false,
+        isRejected: false,
+        isBookingFromRoutingForm: true,
+        booking: {
+          ...createMockContext().booking,
+          eventType: {
+            ...createMockContext().booking.eventType,
+            schedulingType: SchedulingType.ROUND_ROBIN,
+            hostGroups: [],
+          },
+        },
+      });
+      const actions = getEditEventActions(context);
+
+      const changeLocationAction = actions.find((a) => a.id === "change_location");
+      const addMembersAction = actions.find((a) => a.id === "add_members");
+      const rerouteAction = actions.find((a) => a.id === "reroute");
+      const reassignAction = actions.find((a) => a.id === "reassign");
+
+      expect(changeLocationAction?.disabled).toBe(false);
+      expect(addMembersAction?.disabled).toBe(false);
+      expect(rerouteAction?.disabled).toBe(false);
+      expect(reassignAction?.disabled).toBe(false);
+    });
   });
 
   describe("getAfterEventActions", () => {
@@ -522,6 +603,134 @@ describe("Booking Actions", () => {
       const context = createMockContext({ cardCharged: true });
 
       expect(isActionDisabled("charge_card", context)).toBe(true);
+    });
+
+    describe("change_location action", () => {
+      it("should be disabled for past bookings", () => {
+        const context = createMockContext({ isBookingInPast: true });
+        expect(isActionDisabled("change_location", context)).toBe(true);
+      });
+
+      it("should be disabled for cancelled bookings", () => {
+        const context = createMockContext({ isCancelled: true });
+        expect(isActionDisabled("change_location", context)).toBe(true);
+      });
+
+      it("should be disabled for rejected bookings", () => {
+        const context = createMockContext({ isRejected: true });
+        expect(isActionDisabled("change_location", context)).toBe(true);
+      });
+
+      it("should be enabled for upcoming active bookings", () => {
+        const context = createMockContext({
+          isBookingInPast: false,
+          isCancelled: false,
+          isRejected: false,
+        });
+        expect(isActionDisabled("change_location", context)).toBe(false);
+      });
+    });
+
+    describe("add_members action", () => {
+      it("should be disabled for past bookings", () => {
+        const context = createMockContext({ isBookingInPast: true });
+        expect(isActionDisabled("add_members", context)).toBe(true);
+      });
+
+      it("should be disabled for cancelled bookings", () => {
+        const context = createMockContext({ isCancelled: true });
+        expect(isActionDisabled("add_members", context)).toBe(true);
+      });
+
+      it("should be disabled for rejected bookings", () => {
+        const context = createMockContext({ isRejected: true });
+        expect(isActionDisabled("add_members", context)).toBe(true);
+      });
+
+      it("should be enabled for upcoming active bookings", () => {
+        const context = createMockContext({
+          isBookingInPast: false,
+          isCancelled: false,
+          isRejected: false,
+        });
+        expect(isActionDisabled("add_members", context)).toBe(false);
+      });
+    });
+
+    describe("reroute action", () => {
+      it("should be disabled for past bookings", () => {
+        const context = createMockContext({ isBookingInPast: true });
+        expect(isActionDisabled("reroute", context)).toBe(true);
+      });
+
+      it("should be disabled for cancelled bookings", () => {
+        const context = createMockContext({ isCancelled: true });
+        expect(isActionDisabled("reroute", context)).toBe(true);
+      });
+
+      it("should be disabled for rejected bookings", () => {
+        const context = createMockContext({ isRejected: true });
+        expect(isActionDisabled("reroute", context)).toBe(true);
+      });
+
+      it("should be enabled for upcoming active bookings", () => {
+        const context = createMockContext({
+          isBookingInPast: false,
+          isCancelled: false,
+          isRejected: false,
+        });
+        expect(isActionDisabled("reroute", context)).toBe(false);
+      });
+    });
+
+    describe("reassign action", () => {
+      it("should be disabled for past bookings", () => {
+        const context = createMockContext({ isBookingInPast: true });
+        expect(isActionDisabled("reassign", context)).toBe(true);
+      });
+
+      it("should be disabled for cancelled bookings", () => {
+        const context = createMockContext({ isCancelled: true });
+        expect(isActionDisabled("reassign", context)).toBe(true);
+      });
+
+      it("should be disabled for rejected bookings", () => {
+        const context = createMockContext({ isRejected: true });
+        expect(isActionDisabled("reassign", context)).toBe(true);
+      });
+
+      it("should be enabled for upcoming active bookings", () => {
+        const context = createMockContext({
+          isBookingInPast: false,
+          isCancelled: false,
+          isRejected: false,
+        });
+        expect(isActionDisabled("reassign", context)).toBe(false);
+      });
+    });
+
+    describe("cancel action with cancelled/rejected states", () => {
+      it("should be disabled for already cancelled bookings", () => {
+        const context = createMockContext({ isCancelled: true });
+        expect(isActionDisabled("cancel", context)).toBe(true);
+      });
+
+      it("should be disabled for rejected bookings", () => {
+        const context = createMockContext({ isRejected: true });
+        expect(isActionDisabled("cancel", context)).toBe(true);
+      });
+    });
+
+    describe("reschedule_request action with cancelled/rejected states", () => {
+      it("should be disabled for cancelled bookings", () => {
+        const context = createMockContext({ isCancelled: true });
+        expect(isActionDisabled("reschedule_request", context)).toBe(true);
+      });
+
+      it("should be disabled for rejected bookings", () => {
+        const context = createMockContext({ isRejected: true });
+        expect(isActionDisabled("reschedule_request", context)).toBe(true);
+      });
     });
   });
 


### PR DESCRIPTION
## What does this PR do?

Fixes inconsistent disabled state for booking actions. Several actions (`Edit location `, `Add Guests`, `Reroute`, `Reassign`) were hardcoded to `disabled: false`, allowing users to see enabled buttons on cancelled, rejected, or past bookings.

Users could see enabled "Edit Location" or "Add Guests" buttons on bookings that were already cancelled/rejected/past, which doesn't make sense functionally.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Changes - 
- `change_location`, `add_members`, `reroute`, `reassign` now use `isActionDisabled()` instead of hardcoded `disabled: false`
- `cancel` action now properly checks for `isCancelled` and `isRejected` states
- reschedule and  `reschedule_request` now checks for `isCancelled` and `isRejected` states

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):

- before: 

https://github.com/user-attachments/assets/3327f32d-3cac-4382-9825-b77b86d7678c

- after:

https://github.com/user-attachments/assets/50f62adb-7d9d-4c3f-a6f7-9139b88b9850

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Tested locally and verified with before/after screen recordings.