### PR TITLE
feat(companion): add optimistic updates to availability edit screens

### DIFF
--- a/companion/app/edit-availability-hours.ios.tsx
+++ b/companion/app/edit-availability-hours.ios.tsx
@@ -1,11 +1,11 @@
 import { osName } from "expo-device";
 import { isLiquidGlassAvailable } from "expo-glass-effect";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { ActivityIndicator, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import EditAvailabilityHoursScreenComponent from "@/components/screens/EditAvailabilityHoursScreen.ios";
-import { CalComAPIService, type Schedule } from "@/services/calcom";
+import { useScheduleById } from "@/hooks/useSchedules";
 import { showErrorAlert } from "@/utils/alerts";
 
 // Semi-transparent background to prevent black flash while preserving glass effect
@@ -22,25 +22,20 @@ export default function EditAvailabilityHoursIOS() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const [schedule, setSchedule] = useState<Schedule | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
 
+  // Use React Query hook to read from cache (syncs with mutations)
+  const { data: schedule, isLoading, isError } = useScheduleById(id ? Number(id) : undefined);
+
+  // Handle missing ID or error
   useEffect(() => {
-    if (id) {
-      setIsLoading(true);
-      CalComAPIService.getScheduleById(Number(id))
-        .then(setSchedule)
-        .catch(() => {
-          showErrorAlert("Error", "Failed to load schedule details");
-          router.back();
-        })
-        .finally(() => setIsLoading(false));
-    } else {
-      setIsLoading(false);
+    if (!id) {
       showErrorAlert("Error", "Schedule ID is missing");
       router.back();
+    } else if (isError) {
+      showErrorAlert("Error", "Failed to load schedule details");
+      router.back();
     }
-  }, [id, router]);
+  }, [id, isError, router]);
 
   const handleDayPress = useCallback(
     (dayIndex: number) => {

--- a/companion/app/edit-availability-hours.tsx
+++ b/companion/app/edit-availability-hours.tsx
@@ -1,36 +1,31 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { ActivityIndicator, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { HeaderButtonWrapper } from "@/components/HeaderButtonWrapper";
 import EditAvailabilityHoursScreenComponent from "@/components/screens/EditAvailabilityHoursScreen";
-import { CalComAPIService, type Schedule } from "@/services/calcom";
+import { useScheduleById } from "@/hooks/useSchedules";
 import { showErrorAlert } from "@/utils/alerts";
 
 export default function EditAvailabilityHours() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const [schedule, setSchedule] = useState<Schedule | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
 
+  // Use React Query hook to read from cache (syncs with mutations)
+  const { data: schedule, isLoading, isError } = useScheduleById(id ? Number(id) : undefined);
+
+  // Handle missing ID or error
   useEffect(() => {
-    if (id) {
-      setIsLoading(true);
-      CalComAPIService.getScheduleById(Number(id))
-        .then(setSchedule)
-        .catch(() => {
-          showErrorAlert("Error", "Failed to load schedule details");
-          router.back();
-        })
-        .finally(() => setIsLoading(false));
-    } else {
-      setIsLoading(false);
+    if (!id) {
       showErrorAlert("Error", "Schedule ID is missing");
       router.back();
+    } else if (isError) {
+      showErrorAlert("Error", "Failed to load schedule details");
+      router.back();
     }
-  }, [id, router]);
+  }, [id, isError, router]);
 
   const handleClose = useCallback(() => {
     router.back();

--- a/companion/components/screens/AvailabilityDetailScreen.ios.tsx
+++ b/companion/components/screens/AvailabilityDetailScreen.ios.tsx
@@ -376,13 +376,20 @@ export const AvailabilityDetailScreen = forwardRef<
           </View>
         )}
 
-        {/* No Overrides Message */}
+        {/* No Overrides Message - Still navigable to add overrides */}
         {overrides.length === 0 && (
           <View className="mb-4 overflow-hidden rounded-xl bg-white">
-            <View className="px-4 py-3.5">
-              <Text className="text-[17px] text-black">Date Overrides</Text>
-              <Text className="mt-1 text-[15px] text-[#8E8E93]">No date overrides set</Text>
-            </View>
+            <AppPressable
+              onPress={() => router.push(`/edit-availability-override?id=${id}` as never)}
+            >
+              <View className="flex-row items-center justify-between px-4 py-3.5">
+                <View>
+                  <Text className="text-[17px] text-black">Date Overrides</Text>
+                  <Text className="mt-1 text-[15px] text-[#8E8E93]">No date overrides set</Text>
+                </View>
+                <Ionicons name="chevron-forward" size={18} color="#C7C7CC" />
+              </View>
+            </AppPressable>
           </View>
         )}
       </ScrollView>

--- a/companion/components/screens/AvailabilityDetailScreen.ios.tsx
+++ b/companion/components/screens/AvailabilityDetailScreen.ios.tsx
@@ -200,7 +200,7 @@ export const AvailabilityDetailScreen = forwardRef<
   );
 
   // Expose handlers to parent for iOS header menu
-  useMemo(() => {
+  useEffect(() => {
     if (onActionsReady) {
       onActionsReady({
         handleSetAsDefault,
@@ -209,13 +209,19 @@ export const AvailabilityDetailScreen = forwardRef<
     }
   }, [onActionsReady, handleSetAsDefault, handleDelete]);
 
+  // Handle error state - must be in useEffect to avoid side effects during render
+  useEffect(() => {
+    if (error) {
+      showErrorAlert("Error", "Failed to load availability. Please try again.");
+      router.back();
+    }
+  }, [error, router]);
+
   // Count enabled days
   const enabledDaysCount = Object.keys(availability).length;
 
-  // Handle error state
+  // Early return for error state (after useEffect hooks)
   if (error) {
-    showErrorAlert("Error", "Failed to load availability. Please try again.");
-    router.back();
     return null;
   }
 

--- a/companion/components/screens/AvailabilityDetailScreen.ios.tsx
+++ b/companion/components/screens/AvailabilityDetailScreen.ios.tsx
@@ -3,15 +3,16 @@
  *
  * iOS-specific read-only display of availability schedule.
  * Editing is done via separate bottom sheet screens.
+ * Uses React Query for cache synchronization with edit screens.
  */
 
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from "react";
-import { ActivityIndicator, Alert, ScrollView, Text, View } from "react-native";
+import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
+import { ActivityIndicator, Alert, RefreshControl, ScrollView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AppPressable } from "@/components/AppPressable";
-import { CalComAPIService, type Schedule } from "@/services/calcom";
+import { useDeleteSchedule, useScheduleById, useSetScheduleAsDefault } from "@/hooks/useSchedules";
 import type { ScheduleAvailability } from "@/services/types";
 import { showErrorAlert, showInfoAlert, showSuccessAlert } from "@/utils/alerts";
 
@@ -69,137 +70,93 @@ export const AvailabilityDetailScreen = forwardRef<
   const router = useRouter();
   const insets = useSafeAreaInsets();
 
-  const [loading, setLoading] = useState(true);
-  const [_schedule, setSchedule] = useState<Schedule | null>(null);
-  const [scheduleName, setScheduleName] = useState("");
-  const [timeZone, setTimeZone] = useState("");
-  const [isDefault, setIsDefault] = useState(false);
-  const [availability, setAvailability] = useState<Record<number, ScheduleAvailability[]>>({});
-  const [overrides, setOverrides] = useState<
-    {
-      date: string;
-      startTime: string;
-      endTime: string;
-    }[]
-  >([]);
+  // Use React Query hook for data fetching and cache synchronization
+  const { data: schedule, isLoading, error, refetch, isRefetching } = useScheduleById(Number(id));
 
-  const processScheduleData = useCallback(
-    (scheduleData: NonNullable<Awaited<ReturnType<typeof CalComAPIService.getScheduleById>>>) => {
-      const name = scheduleData.name ?? "";
-      const tz = scheduleData.timeZone ?? "UTC";
-      const isDefaultSchedule = scheduleData.isDefault ?? false;
+  // Mutation hooks for actions
+  const { mutate: setAsDefaultMutation } = useSetScheduleAsDefault();
+  const { mutate: deleteScheduleMutation } = useDeleteSchedule();
 
-      setSchedule(scheduleData);
-      setScheduleName(name);
-      setTimeZone(tz);
-      setIsDefault(isDefaultSchedule);
+  // Derive schedule properties from the query data
+  const scheduleName = schedule?.name ?? "";
+  const timeZone = schedule?.timeZone ?? "";
+  const isDefault = schedule?.isDefault ?? false;
 
-      const availabilityMap: Record<number, ScheduleAvailability[]> = {};
+  // Process availability data into a map by day number
+  const availability = useMemo(() => {
+    const availabilityMap: Record<number, ScheduleAvailability[]> = {};
 
-      const availabilityArray = scheduleData.availability;
-      if (availabilityArray && Array.isArray(availabilityArray)) {
-        availabilityArray.forEach((slot) => {
-          let days: number[] = [];
-          if (Array.isArray(slot.days)) {
-            days = slot.days
-              .map((day) => {
-                if (typeof day === "string" && DAY_NAME_TO_NUMBER[day] !== undefined) {
-                  return DAY_NAME_TO_NUMBER[day];
+    const availabilityArray = schedule?.availability;
+    if (availabilityArray && Array.isArray(availabilityArray)) {
+      availabilityArray.forEach((slot) => {
+        let days: number[] = [];
+        if (Array.isArray(slot.days)) {
+          days = slot.days
+            .map((day) => {
+              if (typeof day === "string" && DAY_NAME_TO_NUMBER[day] !== undefined) {
+                return DAY_NAME_TO_NUMBER[day];
+              }
+              if (typeof day === "string") {
+                const parsed = parseInt(day, 10);
+                if (!Number.isNaN(parsed) && parsed >= 0 && parsed <= 6) {
+                  return parsed;
                 }
-                if (typeof day === "string") {
-                  const parsed = parseInt(day, 10);
-                  if (!Number.isNaN(parsed) && parsed >= 0 && parsed <= 6) {
-                    return parsed;
-                  }
-                }
-                if (typeof day === "number" && day >= 0 && day <= 6) {
-                  return day;
-                }
-                return null;
-              })
-              .filter((day): day is number => day !== null);
+              }
+              if (typeof day === "number" && day >= 0 && day <= 6) {
+                return day;
+              }
+              return null;
+            })
+            .filter((day): day is number => day !== null);
+        }
+
+        days.forEach((day) => {
+          if (!availabilityMap[day]) {
+            availabilityMap[day] = [];
           }
-
-          days.forEach((day) => {
-            if (!availabilityMap[day]) {
-              availabilityMap[day] = [];
-            }
-            const startTime = slot.startTime ?? "09:00:00";
-            const endTime = slot.endTime ?? "17:00:00";
-            availabilityMap[day].push({
-              days: [day.toString()],
-              startTime,
-              endTime,
-            });
+          const startTime = slot.startTime ?? "09:00:00";
+          const endTime = slot.endTime ?? "17:00:00";
+          availabilityMap[day].push({
+            days: [day.toString()],
+            startTime,
+            endTime,
           });
         });
-      }
-
-      setAvailability(availabilityMap);
-
-      const overridesArray = scheduleData.overrides;
-      if (overridesArray && Array.isArray(overridesArray)) {
-        const formattedOverrides = overridesArray.map((override) => {
-          const date = override.date ?? "";
-          const startTime = override.startTime ?? "00:00";
-          const endTime = override.endTime ?? "00:00";
-          return { date, startTime, endTime };
-        });
-        setOverrides(formattedOverrides);
-      } else {
-        setOverrides([]);
-      }
-    },
-    []
-  );
-
-  const fetchSchedule = useCallback(async () => {
-    setLoading(true);
-    let scheduleData: Awaited<ReturnType<typeof CalComAPIService.getScheduleById>> = null;
-    try {
-      scheduleData = await CalComAPIService.getScheduleById(Number(id));
-    } catch (error) {
-      console.error("Error fetching schedule");
-      if (__DEV__) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.debug("[AvailabilityDetailScreen.ios] fetchSchedule failed", {
-          message,
-        });
-      }
-      showErrorAlert("Error", "Failed to load availability. Please try again.");
-      router.back();
-      setLoading(false);
-      return;
+      });
     }
 
-    if (scheduleData) {
-      processScheduleData(scheduleData);
-    }
-    setLoading(false);
-  }, [id, router, processScheduleData]);
+    return availabilityMap;
+  }, [schedule?.availability]);
 
-  useEffect(() => {
-    if (id) {
-      fetchSchedule();
+  // Process overrides data
+  const overrides = useMemo(() => {
+    const overridesArray = schedule?.overrides;
+    if (overridesArray && Array.isArray(overridesArray)) {
+      return overridesArray.map((override) => {
+        const date = override.date ?? "";
+        const startTime = override.startTime ?? "00:00";
+        const endTime = override.endTime ?? "00:00";
+        return { date, startTime, endTime };
+      });
     }
-  }, [id, fetchSchedule]);
+    return [];
+  }, [schedule?.overrides]);
 
-  const handleSetAsDefault = useCallback(async () => {
+  const handleSetAsDefault = useCallback(() => {
     if (isDefault) {
       showInfoAlert("Info", "This schedule is already set as default");
       return;
     }
 
-    try {
-      await CalComAPIService.updateSchedule(Number(id), {
-        isDefault: true,
-      });
-      setIsDefault(true);
-      showSuccessAlert("Success", "Availability set as default successfully");
-    } catch {
-      showErrorAlert("Error", "Failed to set availability as default. Please try again.");
-    }
-  }, [isDefault, id]);
+    setAsDefaultMutation(Number(id), {
+      onSuccess: () => {
+        showSuccessAlert("Success", "Availability set as default successfully");
+      },
+      onError: () => {
+        showErrorAlert("Error", "Failed to set availability as default. Please try again.");
+      },
+    });
+  }, [isDefault, id, setAsDefaultMutation]);
 
   const handleDelete = useCallback(() => {
     if (isDefault) {
@@ -215,19 +172,21 @@ export const AvailabilityDetailScreen = forwardRef<
       {
         text: "Delete",
         style: "destructive",
-        onPress: async () => {
-          try {
-            await CalComAPIService.deleteSchedule(Number(id));
-            Alert.alert("Success", "Availability deleted successfully", [
-              { text: "OK", onPress: () => router.back() },
-            ]);
-          } catch {
-            showErrorAlert("Error", "Failed to delete availability. Please try again.");
-          }
+        onPress: () => {
+          deleteScheduleMutation(Number(id), {
+            onSuccess: () => {
+              Alert.alert("Success", "Availability deleted successfully", [
+                { text: "OK", onPress: () => router.back() },
+              ]);
+            },
+            onError: () => {
+              showErrorAlert("Error", "Failed to delete availability. Please try again.");
+            },
+          });
         },
       },
     ]);
-  }, [isDefault, scheduleName, id, router]);
+  }, [isDefault, scheduleName, id, router, deleteScheduleMutation]);
 
   // Expose handlers via ref
   useImperativeHandle(
@@ -235,13 +194,13 @@ export const AvailabilityDetailScreen = forwardRef<
     () => ({
       setAsDefault: handleSetAsDefault,
       delete: handleDelete,
-      refresh: fetchSchedule,
+      refresh: () => refetch(),
     }),
-    [handleSetAsDefault, handleDelete, fetchSchedule]
+    [handleSetAsDefault, handleDelete, refetch]
   );
 
   // Expose handlers to parent for iOS header menu
-  useEffect(() => {
+  useMemo(() => {
     if (onActionsReady) {
       onActionsReady({
         handleSetAsDefault,
@@ -253,7 +212,14 @@ export const AvailabilityDetailScreen = forwardRef<
   // Count enabled days
   const enabledDaysCount = Object.keys(availability).length;
 
-  if (loading) {
+  // Handle error state
+  if (error) {
+    showErrorAlert("Error", "Failed to load availability. Please try again.");
+    router.back();
+    return null;
+  }
+
+  if (isLoading) {
     return (
       <View className="flex-1 items-center justify-center bg-[#f2f2f7]">
         <ActivityIndicator size="large" color="#000000" />
@@ -272,6 +238,7 @@ export const AvailabilityDetailScreen = forwardRef<
           paddingBottom: insets.bottom + 100,
         }}
         showsVerticalScrollIndicator={false}
+        refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={() => refetch()} />}
       >
         {/* Schedule Title Section - iOS Calendar Style */}
         <View className="mb-4">

--- a/companion/components/screens/AvailabilityDetailScreen.tsx
+++ b/companion/components/screens/AvailabilityDetailScreen.tsx
@@ -3,15 +3,16 @@
  *
  * Read-only display of availability schedule.
  * Editing is done via separate modal screens.
+ * Uses React Query for cache synchronization with edit screens.
  */
 
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from "react";
-import { ActivityIndicator, Alert, ScrollView, Text, View } from "react-native";
+import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
+import { ActivityIndicator, Alert, RefreshControl, ScrollView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AppPressable } from "@/components/AppPressable";
-import { CalComAPIService, type Schedule } from "@/services/calcom";
+import { useDeleteSchedule, useScheduleById, useSetScheduleAsDefault } from "@/hooks/useSchedules";
 import type { ScheduleAvailability } from "@/services/types";
 import { showErrorAlert } from "@/utils/alerts";
 
@@ -69,137 +70,93 @@ export const AvailabilityDetailScreen = forwardRef<
   const router = useRouter();
   const insets = useSafeAreaInsets();
 
-  const [loading, setLoading] = useState(true);
-  const [_schedule, setSchedule] = useState<Schedule | null>(null);
-  const [scheduleName, setScheduleName] = useState("");
-  const [timeZone, setTimeZone] = useState("");
-  const [isDefault, setIsDefault] = useState(false);
-  const [availability, setAvailability] = useState<Record<number, ScheduleAvailability[]>>({});
-  const [overrides, setOverrides] = useState<
-    {
-      date: string;
-      startTime: string;
-      endTime: string;
-    }[]
-  >([]);
+  // Use React Query hook for data fetching and cache synchronization
+  const { data: schedule, isLoading, error, refetch, isRefetching } = useScheduleById(Number(id));
 
-  const processScheduleData = useCallback(
-    (scheduleData: NonNullable<Awaited<ReturnType<typeof CalComAPIService.getScheduleById>>>) => {
-      const name = scheduleData.name ?? "";
-      const tz = scheduleData.timeZone ?? "UTC";
-      const isDefaultSchedule = scheduleData.isDefault ?? false;
+  // Mutation hooks for actions
+  const { mutate: setAsDefaultMutation } = useSetScheduleAsDefault();
+  const { mutate: deleteScheduleMutation } = useDeleteSchedule();
 
-      setSchedule(scheduleData);
-      setScheduleName(name);
-      setTimeZone(tz);
-      setIsDefault(isDefaultSchedule);
+  // Derive schedule properties from the query data
+  const scheduleName = schedule?.name ?? "";
+  const timeZone = schedule?.timeZone ?? "";
+  const isDefault = schedule?.isDefault ?? false;
 
-      const availabilityMap: Record<number, ScheduleAvailability[]> = {};
+  // Process availability data into a map by day number
+  const availability = useMemo(() => {
+    const availabilityMap: Record<number, ScheduleAvailability[]> = {};
 
-      const availabilityArray = scheduleData.availability;
-      if (availabilityArray && Array.isArray(availabilityArray)) {
-        availabilityArray.forEach((slot) => {
-          let days: number[] = [];
-          if (Array.isArray(slot.days)) {
-            days = slot.days
-              .map((day) => {
-                if (typeof day === "string" && DAY_NAME_TO_NUMBER[day] !== undefined) {
-                  return DAY_NAME_TO_NUMBER[day];
+    const availabilityArray = schedule?.availability;
+    if (availabilityArray && Array.isArray(availabilityArray)) {
+      availabilityArray.forEach((slot) => {
+        let days: number[] = [];
+        if (Array.isArray(slot.days)) {
+          days = slot.days
+            .map((day) => {
+              if (typeof day === "string" && DAY_NAME_TO_NUMBER[day] !== undefined) {
+                return DAY_NAME_TO_NUMBER[day];
+              }
+              if (typeof day === "string") {
+                const parsed = parseInt(day, 10);
+                if (!Number.isNaN(parsed) && parsed >= 0 && parsed <= 6) {
+                  return parsed;
                 }
-                if (typeof day === "string") {
-                  const parsed = parseInt(day, 10);
-                  if (!Number.isNaN(parsed) && parsed >= 0 && parsed <= 6) {
-                    return parsed;
-                  }
-                }
-                if (typeof day === "number" && day >= 0 && day <= 6) {
-                  return day;
-                }
-                return null;
-              })
-              .filter((day): day is number => day !== null);
+              }
+              if (typeof day === "number" && day >= 0 && day <= 6) {
+                return day;
+              }
+              return null;
+            })
+            .filter((day): day is number => day !== null);
+        }
+
+        days.forEach((day) => {
+          if (!availabilityMap[day]) {
+            availabilityMap[day] = [];
           }
-
-          days.forEach((day) => {
-            if (!availabilityMap[day]) {
-              availabilityMap[day] = [];
-            }
-            const startTime = slot.startTime ?? "09:00:00";
-            const endTime = slot.endTime ?? "17:00:00";
-            availabilityMap[day].push({
-              days: [day.toString()],
-              startTime,
-              endTime,
-            });
+          const startTime = slot.startTime ?? "09:00:00";
+          const endTime = slot.endTime ?? "17:00:00";
+          availabilityMap[day].push({
+            days: [day.toString()],
+            startTime,
+            endTime,
           });
         });
-      }
-
-      setAvailability(availabilityMap);
-
-      const overridesArray = scheduleData.overrides;
-      if (overridesArray && Array.isArray(overridesArray)) {
-        const formattedOverrides = overridesArray.map((override) => {
-          const date = override.date ?? "";
-          const startTime = override.startTime ?? "00:00";
-          const endTime = override.endTime ?? "00:00";
-          return { date, startTime, endTime };
-        });
-        setOverrides(formattedOverrides);
-      } else {
-        setOverrides([]);
-      }
-    },
-    []
-  );
-
-  const fetchSchedule = useCallback(async () => {
-    setLoading(true);
-    let scheduleData: Awaited<ReturnType<typeof CalComAPIService.getScheduleById>> = null;
-    try {
-      scheduleData = await CalComAPIService.getScheduleById(Number(id));
-    } catch (error) {
-      console.error("Error fetching schedule");
-      if (__DEV__) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.debug("[AvailabilityDetailScreen] fetchSchedule failed", {
-          message,
-        });
-      }
-      showErrorAlert("Error", "Failed to load availability. Please try again.");
-      router.back();
-      setLoading(false);
-      return;
+      });
     }
 
-    if (scheduleData) {
-      processScheduleData(scheduleData);
-    }
-    setLoading(false);
-  }, [id, router, processScheduleData]);
+    return availabilityMap;
+  }, [schedule?.availability]);
 
-  useEffect(() => {
-    if (id) {
-      fetchSchedule();
+  // Process overrides data
+  const overrides = useMemo(() => {
+    const overridesArray = schedule?.overrides;
+    if (overridesArray && Array.isArray(overridesArray)) {
+      return overridesArray.map((override) => {
+        const date = override.date ?? "";
+        const startTime = override.startTime ?? "00:00";
+        const endTime = override.endTime ?? "00:00";
+        return { date, startTime, endTime };
+      });
     }
-  }, [id, fetchSchedule]);
+    return [];
+  }, [schedule?.overrides]);
 
-  const handleSetAsDefault = useCallback(async () => {
+  const handleSetAsDefault = useCallback(() => {
     if (isDefault) {
       Alert.alert("Info", "This schedule is already set as default");
       return;
     }
 
-    try {
-      await CalComAPIService.updateSchedule(Number(id), {
-        isDefault: true,
-      });
-      setIsDefault(true);
-      Alert.alert("Success", "Availability set as default successfully");
-    } catch {
-      showErrorAlert("Error", "Failed to set availability as default. Please try again.");
-    }
-  }, [isDefault, id]);
+    setAsDefaultMutation(Number(id), {
+      onSuccess: () => {
+        Alert.alert("Success", "Availability set as default successfully");
+      },
+      onError: () => {
+        showErrorAlert("Error", "Failed to set availability as default. Please try again.");
+      },
+    });
+  }, [isDefault, id, setAsDefaultMutation]);
 
   const handleDelete = useCallback(() => {
     if (isDefault) {
@@ -215,19 +172,21 @@ export const AvailabilityDetailScreen = forwardRef<
       {
         text: "Delete",
         style: "destructive",
-        onPress: async () => {
-          try {
-            await CalComAPIService.deleteSchedule(Number(id));
-            Alert.alert("Success", "Availability deleted successfully", [
-              { text: "OK", onPress: () => router.back() },
-            ]);
-          } catch {
-            showErrorAlert("Error", "Failed to delete availability. Please try again.");
-          }
+        onPress: () => {
+          deleteScheduleMutation(Number(id), {
+            onSuccess: () => {
+              Alert.alert("Success", "Availability deleted successfully", [
+                { text: "OK", onPress: () => router.back() },
+              ]);
+            },
+            onError: () => {
+              showErrorAlert("Error", "Failed to delete availability. Please try again.");
+            },
+          });
         },
       },
     ]);
-  }, [isDefault, scheduleName, id, router]);
+  }, [isDefault, scheduleName, id, router, deleteScheduleMutation]);
 
   // Expose handlers via ref
   useImperativeHandle(
@@ -235,13 +194,13 @@ export const AvailabilityDetailScreen = forwardRef<
     () => ({
       setAsDefault: handleSetAsDefault,
       delete: handleDelete,
-      refresh: fetchSchedule,
+      refresh: () => refetch(),
     }),
-    [handleSetAsDefault, handleDelete, fetchSchedule]
+    [handleSetAsDefault, handleDelete, refetch]
   );
 
   // Expose handlers to parent for header menu
-  useEffect(() => {
+  useMemo(() => {
     if (onActionsReady) {
       onActionsReady({
         handleSetAsDefault,
@@ -253,7 +212,14 @@ export const AvailabilityDetailScreen = forwardRef<
   // Count enabled days
   const enabledDaysCount = Object.keys(availability).length;
 
-  if (loading) {
+  // Handle error state
+  if (error) {
+    showErrorAlert("Error", "Failed to load availability. Please try again.");
+    router.back();
+    return null;
+  }
+
+  if (isLoading) {
     return (
       <View className="flex-1 items-center justify-center bg-[#f2f2f7]">
         <ActivityIndicator size="large" color="#000000" />
@@ -272,6 +238,7 @@ export const AvailabilityDetailScreen = forwardRef<
           paddingBottom: insets.bottom + 100,
         }}
         showsVerticalScrollIndicator={false}
+        refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={() => refetch()} />}
       >
         {/* Schedule Title Section */}
         <View className="mb-4">

--- a/companion/components/screens/AvailabilityDetailScreen.tsx
+++ b/companion/components/screens/AvailabilityDetailScreen.tsx
@@ -376,13 +376,20 @@ export const AvailabilityDetailScreen = forwardRef<
           </View>
         )}
 
-        {/* No Overrides Message */}
+        {/* No Overrides Message - Still navigable to add overrides */}
         {overrides.length === 0 && (
           <View className="mb-4 overflow-hidden rounded-xl bg-white">
-            <View className="px-4 py-3.5">
-              <Text className="text-[17px] text-black">Date Overrides</Text>
-              <Text className="mt-1 text-[15px] text-[#8E8E93]">No date overrides set</Text>
-            </View>
+            <AppPressable
+              onPress={() => router.push(`/edit-availability-override?id=${id}` as never)}
+            >
+              <View className="flex-row items-center justify-between px-4 py-3.5">
+                <View>
+                  <Text className="text-[17px] text-black">Date Overrides</Text>
+                  <Text className="mt-1 text-[15px] text-[#8E8E93]">No date overrides set</Text>
+                </View>
+                <Ionicons name="chevron-forward" size={18} color="#C7C7CC" />
+              </View>
+            </AppPressable>
           </View>
         )}
       </ScrollView>

--- a/companion/components/screens/AvailabilityDetailScreen.tsx
+++ b/companion/components/screens/AvailabilityDetailScreen.tsx
@@ -200,7 +200,7 @@ export const AvailabilityDetailScreen = forwardRef<
   );
 
   // Expose handlers to parent for header menu
-  useMemo(() => {
+  useEffect(() => {
     if (onActionsReady) {
       onActionsReady({
         handleSetAsDefault,
@@ -209,13 +209,19 @@ export const AvailabilityDetailScreen = forwardRef<
     }
   }, [onActionsReady, handleSetAsDefault, handleDelete]);
 
+  // Handle error state - must be in useEffect to avoid side effects during render
+  useEffect(() => {
+    if (error) {
+      showErrorAlert("Error", "Failed to load availability. Please try again.");
+      router.back();
+    }
+  }, [error, router]);
+
   // Count enabled days
   const enabledDaysCount = Object.keys(availability).length;
 
-  // Handle error state
+  // Early return for error state (after useEffect hooks)
   if (error) {
-    showErrorAlert("Error", "Failed to load availability. Please try again.");
-    router.back();
     return null;
   }
 

--- a/companion/components/screens/EditAvailabilityOverrideScreen.ios.tsx
+++ b/companion/components/screens/EditAvailabilityOverrideScreen.ios.tsx
@@ -3,8 +3,8 @@ import { Ionicons } from "@expo/vector-icons";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from "react";
 import { Alert, Pressable, ScrollView, Switch, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useUpdateSchedule } from "@/hooks/useSchedules";
 import type { Schedule } from "@/services/calcom";
-import { CalComAPIService } from "@/services/calcom";
 import { showErrorAlert, showSuccessAlert } from "@/utils/alerts";
 
 // Convert 24-hour time to 12-hour format with AM/PM
@@ -89,13 +89,15 @@ export const EditAvailabilityOverrideScreen = forwardRef<
   const insets = useSafeAreaInsets();
   const backgroundStyle = transparentBackground ? "bg-transparent" : "bg-[#F2F2F7]";
 
+  // Use mutation hook for cache-synchronized updates
+  const { mutate: updateSchedule, isPending: isMutating } = useUpdateSchedule();
+
   const isEditing = overrideIndex !== undefined;
 
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [isUnavailable, setIsUnavailable] = useState(false);
   const [startTime, setStartTime] = useState<Date>(timeStringToDate("09:00"));
   const [endTime, setEndTime] = useState<Date>(timeStringToDate("17:00"));
-  const [isSaving, setIsSaving] = useState(false);
 
   // Initialize from existing override if editing
   useEffect(() => {
@@ -114,8 +116,8 @@ export const EditAvailabilityOverrideScreen = forwardRef<
 
   // Notify parent of saving state
   useEffect(() => {
-    onSavingChange?.(isSaving);
-  }, [isSaving, onSavingChange]);
+    onSavingChange?.(isMutating);
+  }, [isMutating, onSavingChange]);
 
   const handleDateChange = useCallback((date: Date) => {
     setSelectedDate(date);
@@ -130,26 +132,26 @@ export const EditAvailabilityOverrideScreen = forwardRef<
   }, []);
 
   const saveOverrides = useCallback(
-    async (
+    (
       newOverrides: { date: string; startTime: string; endTime: string }[],
       successMessage: string
     ) => {
       if (!schedule) return;
 
-      setIsSaving(true);
-      try {
-        await CalComAPIService.updateSchedule(schedule.id, {
-          overrides: newOverrides,
-        });
-        showSuccessAlert("Success", successMessage);
-        onSuccess();
-        setIsSaving(false);
-      } catch {
-        showErrorAlert("Error", "Failed to save override. Please try again.");
-        setIsSaving(false);
-      }
+      updateSchedule(
+        { id: schedule.id, updates: { overrides: newOverrides } },
+        {
+          onSuccess: () => {
+            showSuccessAlert("Success", successMessage);
+            onSuccess();
+          },
+          onError: () => {
+            showErrorAlert("Error", "Failed to save override. Please try again.");
+          },
+        }
+      );
     },
-    [schedule, onSuccess]
+    [schedule, onSuccess, updateSchedule]
   );
 
   const handleDeleteOverride = useCallback(
@@ -186,8 +188,8 @@ export const EditAvailabilityOverrideScreen = forwardRef<
     [schedule, saveOverrides]
   );
 
-  const handleSubmit = useCallback(async () => {
-    if (!schedule || isSaving) return;
+  const handleSubmit = useCallback(() => {
+    if (!schedule || isMutating) return;
 
     const dateStr = dateToDateString(selectedDate);
 
@@ -236,9 +238,9 @@ export const EditAvailabilityOverrideScreen = forwardRef<
             { text: "Cancel", style: "cancel" },
             {
               text: "Replace",
-              onPress: async () => {
+              onPress: () => {
                 newOverrides[existingIndex] = newOverride;
-                await saveOverrides(newOverrides, "Override replaced successfully");
+                saveOverrides(newOverrides, "Override replaced successfully");
               },
             },
           ]
@@ -249,7 +251,7 @@ export const EditAvailabilityOverrideScreen = forwardRef<
       newOverrides.push(newOverride);
     }
 
-    await saveOverrides(newOverrides, successMessage);
+    saveOverrides(newOverrides, successMessage);
   }, [
     schedule,
     selectedDate,
@@ -259,7 +261,7 @@ export const EditAvailabilityOverrideScreen = forwardRef<
     isEditing,
     overrideIndex,
     saveOverrides,
-    isSaving,
+    isMutating,
   ]);
 
   // Expose submit to parent via ref


### PR DESCRIPTION





https://github.com/user-attachments/assets/82dae8cd-4a65-498b-ad13-a2dde0eb086e





Fixes #26908
Fixes CAL-7077



## What does this PR do?

Implements optimistic updates for availability edit screens in the companion app (iOS, Android, browser extension). This is part of a larger refactoring effort to add auto-refresh/reload after save actions.

**Phase 1 - EditAvailabilityNameScreen:**
- Enhanced `useUpdateSchedule` hook with full optimistic update support (onMutate, onSuccess, onError)
- Refactored `EditAvailabilityNameScreen.tsx` and `EditAvailabilityNameScreen.ios.tsx` to use the mutation hook instead of direct API calls
- Cache is now updated immediately on save, providing instant UI feedback
- On error, cache automatically rolls back to previous state

**Phase 2 - EditAvailabilityOverrideScreen:**
- Refactored `EditAvailabilityOverrideScreen.tsx` and `EditAvailabilityOverrideScreen.ios.tsx` to use `useUpdateSchedule` mutation hook
- Replaced direct `CalComAPIService.updateSchedule` calls with the mutation hook
- Removed local `isSaving` state in favor of `isPending` from the mutation hook
- Override changes now update the cache automatically via optimistic updates

**Phase 3 - EditAvailabilityDayScreen:**
- Refactored `EditAvailabilityDayScreen.tsx` and `EditAvailabilityDayScreen.ios.tsx` to use `useUpdateSchedule` mutation hook
- Replaced direct `CalComAPIService.updateSchedule` calls with the mutation hook
- Removed local `isSaving` state in favor of `isPending` from the mutation hook
- Day availability changes now update the cache automatically via optimistic updates

**Supporting Changes (by @dhairyashiil):**
- Refactored `AvailabilityDetailScreen.tsx` and `AvailabilityDetailScreen.ios.tsx` to use `useScheduleById` hook instead of direct API calls
- This ensures the detail screen reads from React Query cache, enabling cache updates to propagate correctly
- Added `RefreshControl` for pull-to-refresh support
- Replaced direct API mutations with `useSetScheduleAsDefault` and `useDeleteSchedule` hooks

## Updates since last revision

**Fixed stale data issue on the Working Hours page (page 2 in the edit flow):**
- Refactored `edit-availability-hours.tsx` and `edit-availability-hours.ios.tsx` route files to use `useScheduleById` hook
- Previously, these routes used direct `CalComAPIService.getScheduleById()` calls with local `useState`, bypassing the React Query cache
- Now all 3 pages in the availability edit flow (detail → working hours → day edit) read from the same cache, ensuring updates propagate correctly

**Fixed Date Overrides section not clickable when empty:**
- Previously, when there were no date overrides, the section was a plain View without any press handler
- Users couldn't navigate to the edit override page to add new overrides
- Now the "No Overrides" section is wrapped in `AppPressable` with navigation handler and chevron icon
- Follows the same pattern as other sections (Weekly Schedule, Timezone) which are always clickable

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal companion app changes only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Phase 1 - Edit Name/Timezone:**
1. Open the companion app (iOS/Android/browser extension)
2. Navigate to Availability settings
3. Edit a schedule's name or timezone
4. Save the changes
5. Navigate back to the availability list
6. **Expected:** List should show updated name/timezone immediately without manual refresh

**Phase 2 - Edit Overrides:**
1. Navigate to a schedule's detail page
2. Add, edit, or delete a date override
3. Save the changes
4. Navigate back to the detail/list page
5. **Expected:** Changes should reflect immediately without manual refresh

**Phase 3 - Edit Day Availability:**
1. Navigate to a schedule's detail page
2. Tap "Edit Hours" to open the Working Hours page
3. Tap a specific day (e.g., Monday)
4. Toggle availability on/off or modify time slots
5. Save and navigate back
6. **Expected:** Working Hours page AND detail page should reflect changes immediately without manual refresh

**Date Overrides Empty State:**
1. Navigate to a schedule that has NO date overrides
2. Tap on the "Date Overrides" section (should show "No date overrides set")
3. **Expected:** Should navigate to the edit override page where you can add new overrides

**Error case:** If network fails, UI should roll back to previous state and show error alert

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify `AvailabilityDetailScreen` properly reads from React Query cache via `useScheduleById` (critical for cache updates to propagate)
- [ ] Verify `edit-availability-hours` route files properly read from React Query cache via `useScheduleById`
- [ ] Verify the optimistic update logic in `useUpdateSchedule` handles `availability` field correctly via spread operator
- [ ] Confirm the rollback in `onError` restores both detail and list caches correctly
- [ ] Verify Date Overrides section is clickable when empty (shows chevron, navigates to edit page)
- [ ] Test on iOS, Android, and browser extension
- [ ] Note: EventTypeDetail screen will be refactored in a subsequent phase

---


Link to Devin run: https://app.devin.ai/sessions/0e35f5cdab8943dabb66fc182e4241fe
Requested by: Dhairyashil Shinde (@dhairyashiil)