### PR TITLE
fix: flaky E2E tests

### DIFF
--- a/apps/web/playwright/booking-seats.e2e.ts
+++ b/apps/web/playwright/booking-seats.e2e.ts
@@ -572,12 +572,13 @@ test.describe("Reschedule for booking with seats", () => {
       await expect(rescheduleLink).toHaveAttribute("href", /.+/);
     }
     await rescheduleLink.click();
-    await expect(page.getByText("Seats available").first()).toBeVisible();
 
     await page.waitForURL((url) => {
       const rescheduleUid = url.searchParams.get("rescheduleUid");
       return !!rescheduleUid && rescheduleUid === references[1].referenceUid;
     });
+
+    await expect(page.getByText("Seats available").first()).toBeVisible();
 
     await selectFirstAvailableTimeSlotNextMonth(page);
 

--- a/apps/web/playwright/filter-segment.e2e.ts
+++ b/apps/web/playwright/filter-segment.e2e.ts
@@ -116,12 +116,10 @@ test.describe("Filter Segment Functionality", () => {
 
     await applySelectFilter(page, "role", "admin");
     const segmentName = "Admin Users Persistent";
+    await createFilterSegment(page, segmentName);
 
     await page.reload();
     await expect(dataTable).toBeVisible();
-
-    await selectSegment(page, segmentName);
-
     await expect(getByTableColumnText(page, "member", adminUser.email)).toBeVisible();
     await expect(getByTableColumnText(page, "member", memberUser.email)).toBeHidden();
 

--- a/apps/web/playwright/filter-segment.e2e.ts
+++ b/apps/web/playwright/filter-segment.e2e.ts
@@ -118,7 +118,6 @@ test.describe("Filter Segment Functionality", () => {
     const segmentName = "Admin Users Persistent";
     await createFilterSegment(page, segmentName);
 
-    await page.reload();
     await expect(dataTable).toBeVisible();
 
     await selectSegment(page, segmentName);

--- a/apps/web/playwright/filter-segment.e2e.ts
+++ b/apps/web/playwright/filter-segment.e2e.ts
@@ -116,8 +116,8 @@ test.describe("Filter Segment Functionality", () => {
 
     await applySelectFilter(page, "role", "admin");
     const segmentName = "Admin Users Persistent";
-    await createFilterSegment(page, segmentName);
 
+    await page.reload();
     await expect(dataTable).toBeVisible();
 
     await selectSegment(page, segmentName);

--- a/apps/web/playwright/profile.e2e.ts
+++ b/apps/web/playwright/profile.e2e.ts
@@ -55,7 +55,7 @@ test.describe("Update Profile", () => {
     await page.goto("/settings/my-account/profile");
     await page.waitForLoadState("networkidle");
 
-    const emailInput = page.getByTestId("profile-form-email-0");
+    const emailInput = page.getByTestId("profile-form-email-0").first();
 
     await emailInput.fill(email);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilized Playwright E2E tests by removing unnecessary segment selection after reload in the filter segment spec, targeting the first email input in the profile spec, and asserting “Seats available” after reschedule navigation to avoid race conditions.

- **Bug Fixes**
  - filter-segment.e2e: removed selectSegment(...) after reload to keep the table state stable.
  - profile.e2e: use getByTestId("profile-form-email-0").first() to target the intended input when multiple inputs exist.
  - booking-seats.e2e: check "Seats available" after waitForURL so the assertion runs post-navigation.

<sup>Written for commit 7092bdca07cfa6a3c43ee868f2d4bc739f524ca2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

