### PR TITLE
feat(companion): add optimistic updates to EventTypeDetail screen

### DIFF
--- a/companion/hooks/useEventTypes.ts
+++ b/companion/hooks/useEventTypes.ts
@@ -107,7 +107,7 @@ export function useCreateEventType() {
 }
 
 /**
- * Hook to update an event type
+ * Hook to update an event type with optimistic updates
  *
  * @returns Mutation function and state
  *
@@ -125,16 +125,73 @@ export function useUpdateEventType() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, updates }: { id: number; updates: Partial<CreateEventTypeInput> }) =>
+    mutationFn: ({ id, updates }: { id: number; updates: Record<string, unknown> }) =>
       CalComAPIService.updateEventType(id, updates),
-    onSuccess: (updatedEventType, variables) => {
-      // Invalidate the list
-      queryClient.invalidateQueries({ queryKey: queryKeys.eventTypes.lists() });
+    onMutate: async ({ id, updates }) => {
+      // Cancel any outgoing refetches to prevent overwriting optimistic update
+      await queryClient.cancelQueries({ queryKey: queryKeys.eventTypes.detail(id) });
+      await queryClient.cancelQueries({ queryKey: queryKeys.eventTypes.lists() });
 
-      // Update the specific event type in cache
-      queryClient.setQueryData(queryKeys.eventTypes.detail(variables.id), updatedEventType);
+      // Snapshot the previous values for rollback
+      const previousEventType = queryClient.getQueryData<EventType | null>(
+        queryKeys.eventTypes.detail(id)
+      );
+      const previousEventTypes = queryClient.getQueryData<EventType[]>(
+        queryKeys.eventTypes.lists()
+      );
+
+      // Optimistically update the detail cache if it exists
+      if (previousEventType) {
+        const optimisticEventType: EventType = {
+          ...previousEventType,
+          ...updates,
+        };
+        queryClient.setQueryData(queryKeys.eventTypes.detail(id), optimisticEventType);
+      }
+
+      // Update the list cache optimistically (even if detail cache doesn't exist)
+      if (previousEventTypes) {
+        const updatedList = previousEventTypes.map((et) => {
+          if (et.id === id) {
+            return {
+              ...et,
+              ...updates,
+            };
+          }
+          return et;
+        });
+        queryClient.setQueryData(queryKeys.eventTypes.lists(), updatedList);
+      }
+
+      return { previousEventType, previousEventTypes };
     },
-    onError: (error) => {
+    onSuccess: (updatedEventType, variables) => {
+      // Update the specific event type in cache with server response
+      queryClient.setQueryData(queryKeys.eventTypes.detail(variables.id), updatedEventType);
+
+      // Update the list cache with the server response
+      const currentEventTypes = queryClient.getQueryData<EventType[]>(queryKeys.eventTypes.lists());
+      if (currentEventTypes) {
+        const updatedList = currentEventTypes.map((et) =>
+          et.id === variables.id ? updatedEventType : et
+        );
+        queryClient.setQueryData(queryKeys.eventTypes.lists(), updatedList);
+      } else {
+        // If list cache doesn't exist, invalidate to trigger refetch when user navigates to list
+        queryClient.invalidateQueries({ queryKey: queryKeys.eventTypes.lists() });
+      }
+    },
+    onError: (error, variables, context) => {
+      // Rollback to previous values on error
+      if (context?.previousEventType) {
+        queryClient.setQueryData(
+          queryKeys.eventTypes.detail(variables.id),
+          context.previousEventType
+        );
+      }
+      if (context?.previousEventTypes) {
+        queryClient.setQueryData(queryKeys.eventTypes.lists(), context.previousEventTypes);
+      }
       console.error("Failed to update event type");
       if (__DEV__) {
         const message = error instanceof Error ? error.message : String(error);

--- a/companion/hooks/useEventTypes.ts
+++ b/companion/hooks/useEventTypes.ts
@@ -125,7 +125,7 @@ export function useUpdateEventType() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, updates }: { id: number; updates: Record<string, unknown> }) =>
+    mutationFn: ({ id, updates }: { id: number; updates: Partial<CreateEventTypeInput> }) =>
       CalComAPIService.updateEventType(id, updates),
     onMutate: async ({ id, updates }) => {
       // Cancel any outgoing refetches to prevent overwriting optimistic update


### PR DESCRIPTION
## What does this PR do?

This PR adds optimistic updates to the EventTypeDetail screen in the companion app, ensuring the event types list updates immediately after save/delete operations without requiring manual refresh.

**Note:** This is a stacked PR that depends on #26931 (`feat/companion-auto-reload-on-save`).

### Changes:

1. **Enhanced `useUpdateEventType` hook** with full optimistic update support:
   - Added `onMutate` callback to update cache immediately before server response
   - Added `onSuccess` callback to sync cache with server response
   - Added `onError` callback to rollback cache on failure
   - Updates both `eventTypes.detail(id)` and `eventTypes.lists()` caches

2. **Refactored `handleSave` in event-type-detail.tsx**:
   - Replaced direct `CalComAPIService.updateEventType()` with `useUpdateEventType` hook
   - Replaced direct `CalComAPIService.createEventType()` with `useCreateEventType` hook
   - Removed manual `fetchEventTypeData()` call after save (cache updates automatically)

3. **Refactored `handleDelete` in event-type-detail.tsx**:
   - Replaced direct `CalComAPIService.deleteEventType()` with `useDeleteEventType` hook

4. **Replaced local `saving` state** with mutation hooks' `isPending` states (`isUpdating || isCreating`)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal companion app changes only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Test on iOS and Android devices/simulators**
2. **Test update flow:**
   - Go to Event Types list
   - Tap an event type to open detail screen
   - Make changes (e.g., change title, duration, etc.)
   - Save changes
   - Navigate back to list
   - **Expected:** List should show updated values immediately without manual refresh

3. **Test delete flow:**
   - Go to Event Types list
   - Tap an event type to open detail screen
   - Delete the event type
   - **Expected:** Should navigate back and list should update immediately

4. **Test error rollback:**
   - Simulate a network error during save
   - **Expected:** UI should rollback to previous state

## Human Review Checklist

- [ ] Test optimistic updates work correctly on both iOS and Android
- [ ] Verify error rollback restores previous cache state
- [ ] Note: `eventTypeData` local state is not synced after update - dirty-checking may compare against stale baseline after first save. This is a known limitation that may need follow-up work if it causes issues.

---

Link to Devin run: https://app.devin.ai/sessions/0e35f5cdab8943dabb66fc182e4241fe
Requested by: Dhairyashil Shinde (@dhairyashiil)