### PR TITLE
feat: add new issue template for companion

### DIFF
--- a/.github/ISSUE_TEMPLATE/companion.md
+++ b/.github/ISSUE_TEMPLATE/companion.md
@@ -1,0 +1,120 @@
+---
+name: Companion (iOS/Android/Extension)
+about: Report bugs or request features for mobile apps and browser extension
+title: ""
+labels: ["companion", "🚨 needs approval"]
+assignees: ""
+---
+
+### Issue Type
+
+<!--
+  Select one:
+  - Bug Report
+  - Feature Request
+-->
+
+- [ ] 🐛 Bug Report
+- [ ] ✨ Feature Request
+
+### Platform
+
+<!--
+  Select all that apply:
+-->
+
+- [ ] 📱 iOS App
+- [ ] 🤖 Android App
+- [ ] 🧩 Browser Extension
+
+### Platform Details
+
+<!--
+  Fill in the details for your selected platform(s).
+  Delete sections that don't apply.
+-->
+
+#### iOS
+- **iOS Version**: (e.g., 17.2)
+- **Device Model**: (e.g., iPhone 15 Pro)
+- **App Version**: (e.g., 1.0.0)
+
+#### Android
+- **Android Version**: (e.g., 14)
+- **Device Model**: (e.g., Pixel 8)
+- **App Version**: (e.g., 1.0.0)
+
+#### Browser Extension
+- **Browser & Version**: (e.g., Chrome 120, Firefox 121)
+- **Extension Version**: (e.g., 1.0.0)
+
+---
+
+### Description
+
+<!--
+  Provide a clear and concise description of the issue or feature.
+-->
+
+(Write your description here.)
+
+### Steps to Reproduce (Bug Reports Only)
+
+<!--
+  If this is a bug report, provide steps to reproduce the issue.
+  Delete this section for feature requests.
+-->
+
+1. Go to...
+2. Click on...
+3. See error...
+
+### Expected Behavior
+
+<!--
+  What did you expect to happen?
+-->
+
+(Describe what you expected.)
+
+### Actual Behavior (Bug Reports Only)
+
+<!--
+  What actually happened? Delete this section for feature requests.
+-->
+
+(Describe what actually happened.)
+
+### Proposed Solution (Feature Requests Only)
+
+<!--
+  If this is a feature request, describe your proposed solution.
+  Delete this section for bug reports.
+-->
+
+(Describe your proposed solution.)
+
+### Screenshots / Evidence
+
+<!--
+  Add screenshots, screen recordings, or console logs if applicable.
+  You can use tools like Bird Eats Bug for recordings.
+-->
+
+(Attach evidence here.)
+
+### Additional Context
+
+<!--
+  Any other information that might be helpful.
+-->
+
+(Add any additional context here.)
+
+---
+
+##### House rules
+
+- If this issue has a `🚨 needs approval` label, don't start coding yet. Wait until a core member approves the request by removing this label.
+- Your ideas are invaluable! However, they undergo review to ensure alignment with the product's direction.
+- Follow best practices in our [Contributor Docs](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GitHub issue template for Companion (iOS, Android, and browser extension) to standardize bug reports and feature requests and improve triage. It prompts for platform details, reproduction steps, and evidence to reduce back-and-forth.

- **New Features**
  - New template: .github/ISSUE_TEMPLATE/companion.md
  - Covers bug reports and feature requests with clear prompts
  - Platform selectors and fields for OS, device, and app/extension version
  - Sections for steps to reproduce, expected vs. actual behavior, proposed solution, and evidence
  - Auto-labels with "companion" and "🚨 needs approval"; includes house rules and a link to Contributor Docs

<sup>Written for commit bb8f72e20605b89e0327d794f749c403cd172e19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

