### PR TITLE
Fix: use portal for timezones dropdown to avoid overlaps

### DIFF
--- a/packages/features/bookings/Booker/components/EventMeta.tsx
+++ b/packages/features/bookings/Booker/components/EventMeta.tsx
@@ -234,7 +234,7 @@ export const EventMeta = ({
                     classNames={{
                       control: () =>
                         "!min-h-0 p-0 w-full border-0 bg-transparent focus-within:ring-0 shadow-none!",
-                      menu: () => "!w-64 max-w-[90vw] mb-1 ",
+                      menu: () => "!w-64 max-w-[90vw] mb-1 z-50",
                       singleValue: () => "text-text py-1",
                       indicatorsContainer: () => "ml-auto",
                       container: () => "max-w-full",

--- a/packages/features/components/timezone-select/TimezoneSelect.tsx
+++ b/packages/features/components/timezone-select/TimezoneSelect.tsx
@@ -67,6 +67,8 @@ export type TimezoneSelectComponentProps = SelectProps & {
   size?: "sm" | "md";
   grow?: boolean;
   isWebTimezoneSelect?: boolean;
+  menuPortal?: boolean;
+  menuPortalTarget?: HTMLElement;
 };
 
 // TODO: I wonder if we move this to ui package, and keep the TRPC version in features
@@ -81,6 +83,8 @@ export function TimezoneSelectComponent({
   size = "md",
   grow = false,
   isWebTimezoneSelect = true,
+  menuPortal = true,
+  menuPortalTarget,
   ...props
 }: TimezoneSelectComponentProps) {
   const data = [...(props.data || [])];
@@ -102,6 +106,9 @@ export function TimezoneSelectComponent({
     });
   }, [components]);
 
+  // Default to document.body for portal target if not specified and menuPortal is enabled
+  const portalTarget = menuPortalTarget || (typeof document !== "undefined" && menuPortal ? document.body : undefined);
+
   return (
     <BaseSelect
       value={value}
@@ -110,6 +117,8 @@ export function TimezoneSelectComponent({
       isLoading={isPending}
       data-testid="timezone-select"
       isDisabled={isPending}
+      menuPortal={menuPortal}
+      menuPortalTarget={portalTarget}
       {...reactSelectProps}
       timezones={{
         ...(props.data ? addTimezonesToDropdown(data) : {}),
@@ -198,7 +207,7 @@ export function TimezoneSelectComponent({
           ),
         menu: (state) =>
           classNames(
-            "rounded-md bg-default text-sm leading-4 text-default mt-1 border border-subtle",
+            "rounded-md bg-default text-sm leading-4 text-default mt-1 border border-subtle z-50",
             state.selectProps.menuIsOpen && "shadow-dropdown", // Add box-shadow when menu is open
             timezoneClassNames?.menu && timezoneClassNames.menu(state)
           ),


### PR DESCRIPTION
## What does this PR do?

- Fixes PD-1331

## Visual Demo (For contributors especially)

Don't have one cannot run server locally atm

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Needs to be checked on 3 product lines if works nicely to select the timezone. Didn't do any test myself.

## Checklist

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the timezone dropdown in a portal to prevent overlap/clipping with surrounding UI. Adds portal support and a higher z-index to ensure the menu displays correctly, addressing PD-1331.

- **Bug Fixes**
  - Added menuPortal and menuPortalTarget props to TimezoneSelect (default target: document.body).
  - Set z-50 on the timezone menu and EventMeta dropdown to ensure proper stacking.

<sup>Written for commit 908b0d927bb665f3208618131f711d71d0d4d1e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

