### PR TITLE
refactor: rename onboarding prop to autoSelectCalendarForConflictCheck

### DIFF
--- a/apps/api/v1/pages/api/connected-calendars/_get.ts
+++ b/apps/api/v1/pages/api/connected-calendars/_get.ts
@@ -116,7 +116,7 @@ async function getHandler(req: NextApiRequest) {
 
 async function getConnectedCalendars(users: UserWithCalendars[]) {
   const connectedDestinationCalendarsPromises = users.map((user) =>
-    getConnectedDestinationCalendarsAndEnsureDefaultsInDb({ user, onboarding: false, prisma }).then(
+    getConnectedDestinationCalendarsAndEnsureDefaultsInDb({ user, autoSelectCalendarForConflictCheck: false, prisma }).then(
       (connectedCalendarsResult) =>
         connectedCalendarsResult.connectedCalendars.map((calendar) => ({
           userId: user.id,

--- a/apps/api/v2/src/ee/calendars/services/calendars.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/calendars.service.ts
@@ -71,7 +71,7 @@ export class CalendarsService {
           (calendar) => !calendar.eventTypeId
         ),
       },
-      onboarding: false,
+      autoSelectCalendarForConflictCheck: false,
       eventTypeId: null,
       prisma: this.dbWrite.prisma as unknown as PrismaClient,
     });

--- a/apps/web/components/getting-started/steps-views/ConnectCalendars.tsx
+++ b/apps/web/components/getting-started/steps-views/ConnectCalendars.tsx
@@ -17,7 +17,7 @@ interface IConnectCalendarsProps {
 const ConnectedCalendars = (props: IConnectCalendarsProps) => {
   const { nextStep, isPageLoading } = props;
   const queryConnectedCalendars = trpc.viewer.calendars.connectedCalendars.useQuery({
-    onboarding: true,
+    autoSelectCalendarForConflictCheck: true,
     eventTypeId: null,
   });
   const { t } = useLocale();

--- a/packages/trpc/server/routers/viewer/calendars/connectedCalendars.handler.ts
+++ b/packages/trpc/server/routers/viewer/calendars/connectedCalendars.handler.ts
@@ -27,12 +27,12 @@ export const connectedCalendarsHandler = async ({
   input,
 }: ConnectedCalendarsOptions): Promise<ConnectedCalendarsHandlerResult> => {
   const { user } = ctx;
-  const onboarding = input?.onboarding || false;
+  const autoSelectCalendarForConflictCheck = input?.autoSelectCalendarForConflictCheck || false;
 
   const { connectedCalendars, destinationCalendar } =
     await getConnectedDestinationCalendarsAndEnsureDefaultsInDb({
       user,
-      onboarding,
+      autoSelectCalendarForConflictCheck,
       eventTypeId: input?.eventTypeId ?? null,
       prisma,
     });

--- a/packages/trpc/server/routers/viewer/calendars/connectedCalendars.schema.ts
+++ b/packages/trpc/server/routers/viewer/calendars/connectedCalendars.schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export type TConnectedCalendarsInputSchema =
   | {
-      onboarding?: boolean;
+      autoSelectCalendarForConflictCheck?: boolean;
       // Fetches the calendars for this event-type only if present
       // Otherwise, fetches the calendars for the authenticated user
       eventTypeId?: number | null;
@@ -11,7 +11,7 @@ export type TConnectedCalendarsInputSchema =
 
 export const ZConnectedCalendarsInputSchema: z.ZodType<TConnectedCalendarsInputSchema> = z
   .object({
-    onboarding: z.boolean().optional(),
+    autoSelectCalendarForConflictCheck: z.boolean().optional(),
     // Fetches the calendars for this event-type only if present
     // Otherwise, fetches the calendars for the authenticated user
     eventTypeId: z.number().nullish(),


### PR DESCRIPTION
## What does this PR do?

Renames the `onboarding` prop in `getConnectedDestinationCalendarsAndEnsureDefaultsInDb` to `autoSelectCalendarForConflictCheck` to better describe what the prop actually does.

The previous name `onboarding` was misleading because it didn't describe the actual behavior. The new name clearly indicates that when `true`, the function:
1. Automatically selects the destination calendar for conflict checking
2. Persists this selection to the `SelectedCalendar` table in the database

This is a pure rename refactor with no functional changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - existing tests cover this functionality.

## How should this be tested?

This is a pure rename refactor. To verify:
1. The onboarding flow should still work correctly - when connecting calendars during onboarding, the primary calendar should be auto-selected for conflict checking
2. The calendar settings page should still work correctly - calendars should not be auto-selected when viewing settings

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify all call sites of `getConnectedDestinationCalendarsAndEnsureDefaultsInDb` have been updated
- [ ] Confirm the new prop name accurately describes the behavior
- [ ] Check that the tRPC schema and handler are in sync

---

Link to Devin run: https://app.devin.ai/sessions/2be84d8a8189463a905240255a71aa5c
Requested by: @ThyMinimalDev