### PR TITLE
fix: prevent HTML encoding of forward slash in booking confirmation email subtitle

### DIFF
--- a/packages/emails/src/templates/AttendeeRequestEmail.tsx
+++ b/packages/emails/src/templates/AttendeeRequestEmail.tsx
@@ -15,7 +15,10 @@ export const AttendeeRequestEmail = (props: React.ComponentProps<typeof Attendee
             props.calEvent.recurringEvent?.count
               ? "user_needs_to_confirm_or_reject_booking_recurring"
               : "user_needs_to_confirm_or_reject_booking",
-            { user: props.calEvent.organizer.name }
+            {
+              user: props.calEvent.organizer.name,
+              interpolation: { escapeValue: false },
+            }
           )}
         </>
       }


### PR DESCRIPTION
### What does this PR do?

- fixes forward slashes in organizer names being HTML-encoded as "&#x2F;" in the booking confirmation email subtitle. Adds `interpolation: { escapeValue: false }` to the translation options.

fix: #26938

### Visual Demo

**Before:** "Carina &#x2F; Test still needs to confirm or reject the booking."  
**After:** "Carina / Test still needs to confirm or reject the booking."

## How should this be tested?

- Create a booking with an organizer name containing a forward slash (e.g., "Carina / Test") and verify the email subtitle displays correctly without HTML encoding.