### PR TITLE
fix(ci): add build step for platform packages in API v2 breaking changes check

### DIFF
--- a/.github/workflows/check-api-v2-breaking-changes.yml
+++ b/.github/workflows/check-api-v2-breaking-changes.yml
@@ -39,6 +39,16 @@ jobs:
       - uses: ./.github/actions/cache-checkout
       - uses: ./.github/actions/yarn-install
 
+      - name: Build platform packages
+        run: |
+          yarn turbo run build \
+            --filter=@calcom/platform-constants \
+            --filter=@calcom/platform-enums \
+            --filter=@calcom/platform-utils \
+            --filter=@calcom/platform-types \
+            --filter=@calcom/platform-libraries \
+            --filter=@calcom/trpc
+
       - name: Generate Swagger
         working-directory: apps/api/v2
         run: |


### PR DESCRIPTION
## What does this PR do?

Fixes the "Check API v2 breaking changes" CI workflow which was failing with TypeScript errors like `Cannot find module '@calcom/platform-libraries/pbac'`.

The workflow was missing a build step for platform packages before running `yarn generate-swagger`. The swagger generation needs to compile TypeScript, but the platform packages' `dist/` folders didn't exist yet, causing module resolution failures.

This adds the same build step used in `e2e-api-v2.yml` and `api-v2-unit-tests.yml` workflows.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - this fixes the CI workflow itself.

## How should this be tested?

This will be verified when CI runs on any PR that touches API v2 files (which triggers the "Check API v2 breaking changes" workflow). The workflow should now pass instead of failing with TypeScript module resolution errors.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the build step matches what other API v2 workflows use (`e2e-api-v2.yml`, `api-v2-unit-tests.yml`)
- [ ] Confirm the set of packages being built is correct and complete

---

Link to Devin run: https://app.devin.ai/sessions/f7c710a65b90495a89c321afb8dc2f65
Requested by: Rajiv (@Ryukemeister)