### PR TITLE
fix: prevent HTML encoding of forward slash in booking confirmation

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -313,6 +313,7 @@ export default function Success(props: PageProps) {
       if (props.profile.name !== null) {
         return t(`user_needs_to_confirm_or_reject_booking${titleSuffix}`, {
           user: props.profile.name,
+          interpolation: { escapeValue: false },
         });
       }
       return t(`needs_to_be_confirmed_or_rejected${titleSuffix}`);

--- a/packages/emails/src/templates/AttendeeRequestEmail.tsx
+++ b/packages/emails/src/templates/AttendeeRequestEmail.tsx
@@ -15,7 +15,7 @@ export const AttendeeRequestEmail = (props: React.ComponentProps<typeof Attendee
             props.calEvent.recurringEvent?.count
               ? "user_needs_to_confirm_or_reject_booking_recurring"
               : "user_needs_to_confirm_or_reject_booking",
-            { user: props.calEvent.organizer.name }
+            { user: props.calEvent.organizer.name, interpolation: { escapeValue: false } }
           )}
         </>
       }

--- a/packages/emails/templates/attendee-request-email.ts
+++ b/packages/emails/templates/attendee-request-email.ts
@@ -26,6 +26,7 @@ export default class AttendeeRequestEmail extends AttendeeScheduledEmail {
         }),
         this.calEvent.attendees[0].language.translate("user_needs_to_confirm_or_reject_booking", {
           user: this.calEvent.organizer.name,
+          interpolation: { escapeValue: false },
         })
       ),
     };


### PR DESCRIPTION
## What does this PR do?

Fixes special characters (like `/`) being HTML-encoded to `&#x2F;` in booking confirmation emails and success dialog.

Add `interpolation: { escapeValue: false }` to translation calls in:
1. Email templates - AttendeeRequestEmail.tsx and attendee-request-email.ts
2. Booking success UI - bookings-single-view.tsx

- Fixes #26938
- Fixes [CAL-7083](https://linear.app/calcom/issue/CAL-7083/shown-as-andx2f-in-email)

## Visual Demo (For contributors especially)
- before :
<img width="1918" height="961" alt="Screenshot 2026-01-17 010426" src="https://github.com/user-attachments/assets/6ff1b7b6-a9b2-4113-be60-830c7b6a1849" />

- after: 

https://github.com/user-attachments/assets/7881f774-5009-4762-8999-0128328fc5f8

<img width="1914" height="960" alt="Screenshot 2026-01-17 011147" src="https://github.com/user-attachments/assets/92c4ffe5-257e-4396-a1b2-6c3adf3f93f5" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs).N/A 
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Create a booking with an organizer name containing a forward slash (e.g., "Carina / ") and verify the email subtitle displays correctly without HTML encoding.
