### PR TITLE
fix: validate hosts belong to team in managed event type create/update

### DIFF
--- a/apps/api/v2/src/modules/organizations/event-types/services/input.service.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/services/input.service.ts
@@ -316,6 +316,7 @@ export class InputOrganizationsEventTypesService {
     }
 
     if (inputEventType.hosts) {
+      await this.validateHosts(teamId, inputEventType.hosts);
       return inputEventType.hosts.map((host) => host.userId);
     }
 
@@ -354,6 +355,7 @@ export class InputOrganizationsEventTypesService {
     }
 
     if (inputEventType.hosts) {
+      await this.validateHosts(teamId, inputEventType.hosts);
       return inputEventType.hosts.map((host) => host.userId);
     }
 

--- a/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.e2e-spec.ts
@@ -205,6 +205,52 @@ describe("Organizations Event Types Endpoints", () => {
       return request(app.getHttpServer()).post(`/v2/teams/${team.id}/event-types`).send(body).expect(404);
     });
 
+    it("should not be able to create managed event-type for user outside team", async () => {
+      const userId = falseTestUser.id;
+
+      const body: CreateTeamEventTypeInput_2024_06_14 = {
+        title: `managed-outside-team-${randomString()}`,
+        slug: `managed-outside-team-${randomString()}`,
+        description: "Managed event type with non-team member.",
+        lengthInMinutes: 60,
+        locations: [
+          {
+            type: "integration",
+            integration: "cal-video",
+          },
+        ],
+        schedulingType: "MANAGED",
+        hosts: [
+          {
+            userId,
+            mandatory: true,
+            priority: "high",
+          },
+        ],
+      };
+
+      return request(app.getHttpServer()).post(`/v2/teams/${team.id}/event-types`).send(body).expect(404);
+    });
+
+    it("should not be able to update managed event-type with user outside team", async () => {
+      await ensureManagedEventType();
+
+      const body: UpdateTeamEventTypeInput_2024_06_14 = {
+        hosts: [
+          {
+            userId: falseTestUser.id,
+            mandatory: true,
+            priority: "high",
+          },
+        ],
+      };
+
+      return request(app.getHttpServer())
+        .patch(`/v2/teams/${team.id}/event-types/${managedEventType?.id}`)
+        .send(body)
+        .expect(404);
+    });
+
     it("should not be able to create phone-only event type", async () => {
       const body: CreateTeamEventTypeInput_2024_06_14 = {
         title: "Phone coding consultation",

--- a/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.e2e-spec.ts
@@ -232,25 +232,6 @@ describe("Organizations Event Types Endpoints", () => {
       return request(app.getHttpServer()).post(`/v2/teams/${team.id}/event-types`).send(body).expect(404);
     });
 
-    it("should not be able to update managed event-type with user outside team", async () => {
-      await ensureManagedEventType();
-
-      const body: UpdateTeamEventTypeInput_2024_06_14 = {
-        hosts: [
-          {
-            userId: falseTestUser.id,
-            mandatory: true,
-            priority: "high",
-          },
-        ],
-      };
-
-      return request(app.getHttpServer())
-        .patch(`/v2/teams/${team.id}/event-types/${managedEventType?.id}`)
-        .send(body)
-        .expect(404);
-    });
-
     it("should not be able to create phone-only event type", async () => {
       const body: CreateTeamEventTypeInput_2024_06_14 = {
         title: "Phone coding consultation",
@@ -608,6 +589,25 @@ describe("Organizations Event Types Endpoints", () => {
           evaluateHost(collectiveEventType.hosts[0], eventTypeCollective?.hosts[0]);
           evaluateHost(collectiveEventType.hosts[1], eventTypeCollective?.hosts[1]);
         });
+    });
+
+    it("should not be able to update managed event-type with user outside team", async () => {
+      await ensureManagedEventType();
+
+      const body: UpdateTeamEventTypeInput_2024_06_14 = {
+        hosts: [
+          {
+            userId: falseTestUser.id,
+            mandatory: true,
+            priority: "high",
+          },
+        ],
+      };
+
+      return request(app.getHttpServer())
+        .patch(`/v2/teams/${team.id}/event-types/${managedEventType?.id}`)
+        .send(body)
+        .expect(404);
     });
 
     it("should not be able to update non existing event-type", async () => {


### PR DESCRIPTION
## What does this PR do?

Adds defense-in-depth validation to ensure that when hosts are explicitly provided for managed event types, those hosts actually belong to the team. This addresses a potential issue where users could be assigned to managed event-types of organizations they have no connection to.

The fix adds `validateHosts()` calls in two methods:
- `getOwnersIdsForManagedEventTypeUpdate` - validates hosts when updating managed event types
- `getOwnersIdsForManagedEventTypeCreate` - validates hosts when creating managed event types

The `validateHosts` method uses `getTeamUsersIds()` which for platform teams returns only managed users, ensuring proper OAuth client compatibility.

## Updates since last revision

Added e2e tests to confirm the validation works:
- `should not be able to create managed event-type for user outside team` - verifies creating a managed event type with a non-team member is rejected (404)
- `should not be able to update managed event-type with user outside team` - verifies updating a managed event type with a non-team member is rejected (404)

Fixed test ordering by placing the update test after the "should get team event-types" test to avoid creating event types before count assertions.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a platform organization with an OAuth client
2. Create a managed user via the OAuth client
3. Attempt to create/update a managed event type with a `hosts` array containing a user ID that is NOT a member of the team
4. Verify the request is rejected with an error indicating the hosts are not members of the team

Alternatively, run the e2e tests:
```bash
yarn test:e2e --testPathPattern="teams-event-types.controller.e2e-spec" --testNamePattern="should not be able to create managed event-type for user outside team|should not be able to update managed event-type with user outside team"
```

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify this defense-in-depth approach is appropriate - note that `validateHosts` is already called at the top level in `transformAndValidateCreateTeamEventTypeInput` and `transformAndValidateUpdateTeamEventTypeInput`, so this adds redundant validation
- [ ] Consider if the duplicate validation calls could cause performance issues (additional DB queries)
- [ ] Consider if the root cause of how users were being assigned without validation should be investigated further

---

Link to Devin run: https://app.devin.ai/sessions/0092a7aade8e4c5a87a27383fd22d9ef
Requested by: @ThyMinimalDev