### PR TITLE
fix: app card action button alignment

### DIFF
--- a/apps/web/modules/apps/components/AppCard.tsx
+++ b/apps/web/modules/apps/components/AppCard.tsx
@@ -139,7 +139,7 @@ export function AppCard({ app, credentials, searchText, userAdminTeams }: AppCar
         }}
       />
 
-      <div className="mt-5 flex max-w-full flex-row justify-between gap-2">
+      <div className="mt-auto flex max-w-full flex-row justify-between gap-2">
         <Button
           color="secondary"
           className="flex w-32 grow justify-center"


### PR DESCRIPTION
## What does this PR do?

Fixes the misaligned action buttons in AppCard by changing the bottom margin from mt-5 to mt-auto.
Ensures that buttons always stick to the bottom of the card, regardless of the content height.
Purely a UI alignment fix; no functional logic was changed.

Fixes N/A (no GitHub or Linear issue; minor UI adjustment)

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

Before 
<img width="1610" height="722" alt="Screenshot 2026-01-17 052225" src="https://github.com/user-attachments/assets/b953490b-e9db-4c95-b65e-737d7544696f" />

After
<img width="1648" height="763" alt="Screenshot 2026-01-17 054751" src="https://github.com/user-attachments/assets/317b5d53-f6b0-47fa-af7a-1bec08c64f54" />


## Mandatory Tasks (DO NOT REMOVE)

I have self-reviewed the code.
I have updated developer docs if applicable: N/A
I confirm automated tests are in place if relevant: N/A

## How should this be tested?

Navigate to the  apps/web/modules/apps/components/AppCard.tsx
Verify that the action buttons in each card are aligned at the bottom, even when descriptions vary in length.
Check across different screen sizes (desktop and mobile) to ensure consistent alignment.




