### PR TITLE
fix: textarea overlaps

### DIFF
--- a/apps/web/modules/onboarding/personal/settings/personal-settings-view.tsx
+++ b/apps/web/modules/onboarding/personal/settings/personal-settings-view.tsx
@@ -204,7 +204,7 @@ export const PersonalSettingsView = ({
               {/* Bio */}
               <div className="flex w-full flex-col gap-1.5">
                 <Label className="text-emphasis mb-0 text-sm font-medium leading-4">{t("bio")}</Label>
-                <TextArea {...form.register("bio")} className="min-h-[108px]" />
+                <TextArea {...form.register("bio")} className="min-h-[108px] max-h-[150px]" />
                 {form.formState.errors.bio && (
                   <p className="text-error text-sm">{form.formState.errors.bio.message}</p>
                 )}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #26903 
- Fixes [CAL-7075](https://linear.app/calcom/issue/CAL-7075/ui-bug-bio-textarea-overlaps-with-footer-buttons-when-textarea-is)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

<img width="1621" height="840" alt="image" src="https://github.com/user-attachments/assets/8c22ce4b-1b15-4804-968e-14cde9761c4b" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- I haven't checked if my changes generate no new warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bio textarea overlap in onboarding and adds a 256-character limit with a small tip. Addresses #26903 and Linear CAL-7075.

- **Bug Fixes**
  - Cap textarea height and make overflow scrollable to avoid footer overlap.

- **New Features**
  - Enforce a 256-character max for bio.
  - Show an info tip under the field.

<sup>Written for commit 0f1e26e56d9eb5dc27d2b5c3dfbd5ee670b08b6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

