### PR TITLE
docs:  add deprecation warnings to API v2 platform endpoints

### DIFF
--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.ts
@@ -61,7 +61,10 @@ export class OAuthClientUsersController {
   ) {}
 
   @Get("/")
-  @ApiOperation({ summary: "Get all managed users" })
+  @ApiOperation({
+    summary: "Get all managed users",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
   async getManagedUsers(
     @Param("clientId") oAuthClientId: string,
@@ -77,7 +80,10 @@ export class OAuthClientUsersController {
   }
 
   @Post("/")
-  @ApiOperation({ summary: "Create a managed user" })
+  @ApiOperation({
+    summary: "Create a managed user",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
   async createUser(
     @Param("clientId") oAuthClientId: string,
@@ -105,7 +111,10 @@ export class OAuthClientUsersController {
 
   @Get("/:userId")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "Get a managed user" })
+  @ApiOperation({
+    summary: "Get a managed user",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
   async getUserById(
     @Param("clientId") clientId: string,
@@ -121,7 +130,10 @@ export class OAuthClientUsersController {
 
   @Patch("/:userId")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "Update a managed user" })
+  @ApiOperation({
+    summary: "Update a managed user",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
   async updateUser(
     @Param("clientId") clientId: string,
@@ -147,7 +159,10 @@ export class OAuthClientUsersController {
 
   @Delete("/:userId")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "Delete a managed user" })
+  @ApiOperation({
+    summary: "Delete a managed user",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
   async deleteUser(
     @Param("clientId") clientId: string,
@@ -168,7 +183,7 @@ export class OAuthClientUsersController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: "Force refresh tokens",
-    description: `If you have lost managed user access or refresh token, then you can get new ones by using OAuth credentials. ${TOKENS_DOCS}`,
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning> If you have lost managed user access or refresh token, then you can get new ones by using OAuth credentials. ${TOKENS_DOCS}`,
   })
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
   async forceRefresh(

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-webhooks/oauth-client-webhooks.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-webhooks/oauth-client-webhooks.controller.ts
@@ -44,7 +44,10 @@ export class OAuthClientWebhooksController {
 
   @Post("/")
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
-  @ApiOperation({ summary: "Create a webhook" })
+  @ApiOperation({
+    summary: "Create a webhook",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   async createOAuthClientWebhook(
     @Body() body: CreateWebhookInputDto,
     @Param("clientId") oAuthClientId: string
@@ -64,7 +67,10 @@ export class OAuthClientWebhooksController {
 
   @Patch("/:webhookId")
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
-  @ApiOperation({ summary: "Update a webhook" })
+  @ApiOperation({
+    summary: "Update a webhook",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   @UseGuards(IsOAuthClientWebhookGuard)
   async updateOAuthClientWebhook(
     @Body() body: UpdateWebhookInputDto,
@@ -84,7 +90,10 @@ export class OAuthClientWebhooksController {
 
   @Get("/:webhookId")
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER, MembershipRole.MEMBER])
-  @ApiOperation({ summary: "Get a webhook" })
+  @ApiOperation({
+    summary: "Get a webhook",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   @UseGuards(IsOAuthClientWebhookGuard)
   async getOAuthClientWebhook(@GetWebhook() webhook: Webhook): Promise<OAuthClientWebhookOutputResponseDto> {
     return {
@@ -97,7 +106,10 @@ export class OAuthClientWebhooksController {
 
   @Get("/")
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER, MembershipRole.MEMBER])
-  @ApiOperation({ summary: "Get all webhooks" })
+  @ApiOperation({
+    summary: "Get all webhooks",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   async getOAuthClientWebhooks(
     @Param("clientId") oAuthClientId: string,
     @Query() pagination: SkipTakePagination
@@ -119,7 +131,10 @@ export class OAuthClientWebhooksController {
 
   @Delete("/:webhookId")
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
-  @ApiOperation({ summary: "Delete a webhook" })
+  @ApiOperation({
+    summary: "Delete a webhook",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   @UseGuards(IsOAuthClientWebhookGuard)
   async deleteOAuthClientWebhook(
     @GetWebhook() webhook: Webhook
@@ -135,7 +150,10 @@ export class OAuthClientWebhooksController {
 
   @Delete("/")
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
-  @ApiOperation({ summary: "Delete all webhooks" })
+  @ApiOperation({
+    summary: "Delete all webhooks",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   async deleteAllOAuthClientWebhooks(
     @Param("clientId") oAuthClientId: string
   ): Promise<DeleteManyWebhooksOutputResponseDto> {

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.ts
@@ -63,7 +63,10 @@ export class OAuthClientsController {
     description: "Create an OAuth client",
     type: CreateOAuthClientResponseDto,
   })
-  @ApiOperation({ summary: "Create an OAuth client" })
+  @ApiOperation({
+    summary: "Create an OAuth client",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   async createOAuthClient(
     @GetOrgId() organizationId: number,
     @Body() body: CreateOAuthClientInput
@@ -87,7 +90,10 @@ export class OAuthClientsController {
 
   @Get("/")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "Get all OAuth clients" })
+  @ApiOperation({
+    summary: "Get all OAuth clients",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER, MembershipRole.MEMBER])
   async getOAuthClients(@GetOrgId() organizationId: number): Promise<GetOAuthClientsResponseDto> {
     const clients = await this.oAuthClientsService.getOAuthClients(organizationId);
@@ -98,7 +104,10 @@ export class OAuthClientsController {
   @HttpCode(HttpStatus.OK)
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER, MembershipRole.MEMBER])
   @UseGuards(OAuthClientGuard)
-  @ApiOperation({ summary: "Get an OAuth client" })
+  @ApiOperation({
+    summary: "Get an OAuth client",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   async getOAuthClientById(@Param("clientId") clientId: string): Promise<GetOAuthClientResponseDto> {
     const client = await this.oAuthClientsService.getOAuthClientById(clientId);
     return { status: SUCCESS_STATUS, data: client };
@@ -132,7 +141,10 @@ export class OAuthClientsController {
   @HttpCode(HttpStatus.OK)
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
   @UseGuards(OAuthClientGuard)
-  @ApiOperation({ summary: "Update an OAuth client" })
+  @ApiOperation({
+    summary: "Update an OAuth client",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   async updateOAuthClient(
     @Param("clientId") clientId: string,
     @Body() body: UpdateOAuthClientInput
@@ -146,7 +158,10 @@ export class OAuthClientsController {
   @HttpCode(HttpStatus.OK)
   @MembershipRoles([MembershipRole.ADMIN, MembershipRole.OWNER])
   @UseGuards(OAuthClientGuard)
-  @ApiOperation({ summary: "Delete an OAuth client" })
+  @ApiOperation({
+    summary: "Delete an OAuth client",
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning>`,
+  })
   async deleteOAuthClient(@Param("clientId") clientId: string): Promise<GetOAuthClientResponseDto> {
     this.logger.log(`Deleting OAuth Client with ID: ${clientId}`);
     const client = await this.oAuthClientsService.deleteOAuthClient(clientId);

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
@@ -116,7 +116,7 @@ export class OAuthFlowController {
   })
   @ApiOperation({
     summary: "Refresh managed user tokens",
-    description: `If managed user access token is expired then get a new one using this endpoint - it will also refresh the refresh token, because we use
+    description: `<Warning>These endpoints are deprecated and will be removed in the future.</Warning> If managed user access token is expired then get a new one using this endpoint - it will also refresh the refresh token, because we use
     "refresh token rotation" mechanism. ${TOKENS_DOCS}`,
   })
   async refreshTokens(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added deprecation warnings to API v2 platform endpoints for OAuth clients, managed users, webhooks, and token refresh in Swagger docs. This clearly marks these endpoints as deprecated and helps developers plan migrations before removal.

<sup>Written for commit 50e0acf57883026b34185095be73b89a4013149e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

