### PR TITLE
feat: add organizeImports and useSortedClasses to biome config

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -4,7 +4,19 @@
   "assist": {
     "actions": {
       "source": {
-        "organizeImports": "on"
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [
+              ["**/__mocks__/**", "**/bookingScenario*"],
+              [":PACKAGE_WITH_PROTOCOL:", ":PACKAGE:"],
+              ["@calcom/**", "@ee/**"],
+              ["@lib/**", "@components/**", "@server/**", "@trpc/**"],
+              "~/**",
+              ":PATH:"
+            ]
+          }
+        }
       }
     },
     "enabled": true

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
   "root": true,
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    },
+    "enabled": true
+  },
   "css": {
     "parser": {
       "tailwindDirectives": true
@@ -103,7 +111,14 @@
             "useExplicitType": "info",
             "noReactForwardRef": "warn",
             "noTernary": "info",
-            "noUnresolvedImports": "warn"
+            "noUnresolvedImports": "warn",
+            "useSortedClasses": {
+              "level": "warn",
+              "options": {
+                "attributes": ["className", "classList"],
+                "functions": ["clsx", "cva", "cn", "tw"]
+              }
+            }
           },
           "correctness": {
             "useImportExtensions": "warn",


### PR DESCRIPTION
## What does this PR do?

Adds two formatting/linting features to the Biome configuration that were previously provided by Prettier plugins but were missing after the migration to Biome:

1. **`organizeImports`** - Enables automatic import organization via the `assist` section with **custom groups matching the trivago plugin order**:
   - `__mocks__` and `bookingScenario` imports first (for vi.mock and prismock)
   - Third-party packages (with and without protocols)
   - `@calcom/**` and `@ee/**` packages
   - `@lib/**`, `@components/**`, `@server/**`, `@trpc/**` aliases
   - `~/**` imports
   - Relative paths

2. **`useSortedClasses`** - Enables Tailwind CSS class sorting (nursery rule, set to warn level)

These additions help reduce unnecessary formatting changes in PRs caused by inconsistent import ordering and Tailwind class ordering.

The `useSortedClasses` rule is configured to handle:
- Attributes: `className`, `classList`
- Functions: `clsx`, `cva`, `cn`, `tw`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - config change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - config change validated by `yarn biome check`.

## How should this be tested?

1. Verify the biome config is valid: `yarn biome check biome.json`
2. Run the formatter on a file with unsorted Tailwind classes or unorganized imports to verify the new rules are active
3. Test import sorting on a file with mixed imports to verify the custom groups order matches expectations
4. Check that existing CI passes

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify import groups order matches the expected trivago plugin behavior (mocks first, then packages, then @calcom/*, etc.)
- [ ] Test on a few files to ensure imports are sorted correctly with the custom groups
- [ ] Verify `useSortedClasses` options cover all utility function patterns used in the codebase
- [ ] Note: `useSortedClasses` is a nursery (experimental) rule - may have edge cases
- [ ] Consider the impact of one-time reformatting when this is applied across the codebase

---

**Link to Devin run:** https://app.devin.ai/sessions/a427fb650beb4eba8778f257d3f06510
**Requested by:** Volnei Munhoz (@volnei)