### PR TITLE
fix: return 409 instead of 500 for NoAvailableUsersFound error

### DIFF
--- a/packages/app-store/hitpay/lib/PaymentService.ts
+++ b/packages/app-store/hitpay/lib/PaymentService.ts
@@ -5,6 +5,7 @@ import type z from "zod";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import prisma from "@calcom/prisma";
@@ -89,7 +90,7 @@ class HitPayPaymentService implements IAbstractPaymentService {
         }
       } else {
         if (bookingsWithSameTimeSlot.length > 1) {
-          throw new Error(ErrorCode.NoAvailableUsersFound);
+          throw new ErrorWithCode(ErrorCode.NoAvailableUsersFound, ErrorCode.NoAvailableUsersFound);
         }
       }
 

--- a/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
+++ b/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
@@ -7,6 +7,7 @@ import { getBusyTimesService } from "@calcom/features/di/containers/BusyTimes";
 import { getUserAvailabilityService } from "@calcom/features/di/containers/GetUserAvailability";
 import { buildDateRanges } from "@calcom/features/schedules/lib/date-ranges";
 import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import { parseBookingLimit } from "@calcom/lib/intervalLimits/isBookingLimits";
 import { parseDurationLimit } from "@calcom/lib/intervalLimits/isDurationLimits";
 import { getPiiFreeUser } from "@calcom/lib/piiFreeData";
@@ -255,7 +256,7 @@ const _ensureAvailableUsers = async (
 
   if (availableUsers.length === 0) {
     loggerWithEventDetails.error(`No available users found.`, piiFreeInputDataForLogging);
-    throw new Error(ErrorCode.NoAvailableUsersFound);
+    throw new ErrorWithCode(ErrorCode.NoAvailableUsersFound, ErrorCode.NoAvailableUsersFound);
   }
 
   // make sure TypeScript understands availableUsers is at least one.

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -1099,7 +1099,7 @@ async function handler(
               qualifiedRRUsers: qualifiedRRUsers.map((user) => user.id),
             })
           );
-          throw new Error(ErrorCode.NoAvailableUsersFound);
+          throw new ErrorWithCode(ErrorCode.NoAvailableUsersFound, ErrorCode.NoAvailableUsersFound);
         }
       }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a 500 Internal Server Error that should be a 409 Conflict when booking a round-robin event type where none of the hosts have availability.

## Why does `ErrorWithCode` fix this?

The error handling in `getServerErrorFromUnknown.ts` has **two different code paths**:

### Path 1: `ErrorWithCode` (lines 85-93) - Explicit handling
```typescript
if (cause instanceof ErrorWithCode) {
  const statusCode = getHttpStatusCode(cause);  // Uses cause.code
  return new HttpError({ statusCode, message: cause.message ?? "", ... });
}
```
- Uses `cause.code` property to determine HTTP status
- **No error redaction** - message is preserved as-is

### Path 2: Plain `Error` (lines 105-108) - Generic handling
```typescript
if (cause instanceof Error) {
  const statusCode = getHttpStatusCode(cause);  // Uses cause.message
  return getHttpError({ statusCode, cause, ... });  // Calls redactError()
}
```
- Uses `cause.message` to determine HTTP status
- Calls `redactError(cause)` which **can modify the error message**

`ErrorWithCode` stores the error code in a dedicated `code` property, making it explicit, reliable, and unaffected by error redaction.

### Why pass error code as both `code` AND `message`?

```typescript
throw new ErrorWithCode(ErrorCode.NoAvailableUsersFound, ErrorCode.NoAvailableUsersFound);
```

API v2 has its own error handler that checks `error.message` for backward compatibility:
```typescript
if (error.message === "no_available_users_found_error") { ... }
```

By passing the error code as both, we ensure:
- Main web app uses `cause.code` → returns **409**
- API v2 uses `error.message` → returns **400** with proper error message

## Changes

| File | Change |
|------|--------|
| `ensureAvailableUsers.ts` | `throw new Error(...)` → `throw new ErrorWithCode(...)` |
| `RegularBookingService.ts` | `throw new Error(...)` → `throw new ErrorWithCode(...)` |
| `PaymentService.ts` (HitPay) | `throw new Error(...)` → `throw new ErrorWithCode(...)` |

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a round-robin event type with multiple hosts
2. Attempt to book a time slot where none of the hosts have availability
3. Verify the API returns 409 Conflict instead of 500 Internal Server Error

Existing tests already verify this behavior:
- `defaultResponderForAppDir.test.ts` - verifies `NoAvailableUsersFound` → 409
- `defaultResponder.test.ts` - verifies `NoAvailableUsersFound` → 409
- `bookings.controller.e2e-spec.ts` - verifies API v2 returns 400 with correct message

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify `getHttpStatusCode()` in `getServerErrorFromUnknown.ts` (line 125) uses `cause.code` for `ErrorWithCode` instances
- [ ] Confirm `ErrorCode.NoAvailableUsersFound` maps to 409 in the switch statement (line 156)
- [ ] Verify the catch block in `PaymentService.ts:190` still works (it checks `error.message`)

---

Link to Devin run: https://app.devin.ai/sessions/0f3edb4331094385b610c862782ad440
Requested by: @hbjORbj