### PR TITLE
refactor(teams): use TeamRepository for org validation in LegacyRemoveMemberService

### DIFF
--- a/packages/features/ee/teams/repositories/TeamRepository.ts
+++ b/packages/features/ee/teams/repositories/TeamRepository.ts
@@ -614,6 +614,16 @@ export class TeamRepository {
     });
   }
 
+  async findByIdsAndOrgId({ teamIds, orgId }: { teamIds: number[]; orgId: number }) {
+    return await this.prismaClient.team.findMany({
+      where: {
+        id: { in: teamIds },
+        OR: [{ id: orgId }, { parentId: orgId }],
+      },
+      select: { id: true },
+    });
+  }
+
   async findTeamBySlugWithAdminRole(teamSlug: string, userId: number) {
     return this.prismaClient.team.findFirst({
       select: { id: true },

--- a/packages/trpc/server/routers/viewer/teams/removeMember.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/removeMember.handler.ts
@@ -9,8 +9,10 @@ type RemoveMemberOptions = {
   ctx: {
     user: {
       id: number;
+      organizationId: number | null;
       organization?: {
         isOrgAdmin: boolean;
+        id: number | null;
       };
     };
   };
@@ -19,7 +21,7 @@ type RemoveMemberOptions = {
 
 export const removeMemberHandler = async ({
   ctx: {
-    user: { id: userId, organization },
+    user: { id: userId, organizationId, organization },
   },
   input,
 }: RemoveMemberOptions) => {
@@ -45,6 +47,7 @@ export const removeMemberHandler = async ({
   const { hasPermission } = await service.checkRemovePermissions({
     userId,
     isOrgAdmin,
+    organizationId: organizationId ?? undefined,
     memberIds,
     teamIds,
     isOrg,
@@ -58,6 +61,7 @@ export const removeMemberHandler = async ({
     {
       userId,
       isOrgAdmin,
+      organizationId: organizationId ?? undefined,
       memberIds,
       teamIds,
       isOrg,

--- a/packages/trpc/server/routers/viewer/teams/removeMember/IRemoveMemberService.ts
+++ b/packages/trpc/server/routers/viewer/teams/removeMember/IRemoveMemberService.ts
@@ -3,6 +3,7 @@ import type { MembershipRole } from "@calcom/prisma/enums";
 export interface RemoveMemberContext {
   userId: number;
   isOrgAdmin: boolean;
+  organizationId?: number;
   memberIds: number[];
   teamIds: number[];
   isOrg: boolean;

--- a/packages/trpc/server/routers/viewer/teams/removeMember/RemoveMemberServiceFactory.ts
+++ b/packages/trpc/server/routers/viewer/teams/removeMember/RemoveMemberServiceFactory.ts
@@ -1,4 +1,5 @@
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
+import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { prisma } from "@calcom/prisma";
 
 import type { IRemoveMemberService } from "./IRemoveMemberService";
@@ -14,7 +15,8 @@ export class RemoveMemberServiceFactory {
     const featuresRepository = new FeaturesRepository(prisma);
     const isPBACEnabled = await featuresRepository.checkIfTeamHasFeature(teamId, "pbac");
 
-    const service = isPBACEnabled ? new PBACRemoveMemberService() : new LegacyRemoveMemberService();
+    const teamRepository = new TeamRepository(prisma);
+    const service = isPBACEnabled ? new PBACRemoveMemberService() : new LegacyRemoveMemberService(teamRepository);
 
     return service;
   }


### PR DESCRIPTION
## What does this PR do?

Refactors the organization validation logic in `LegacyRemoveMemberService` to use the `TeamRepository` instead of direct Prisma queries, following the repository pattern established in the codebase.

This PR adds:
- A new `findByIdsAndOrgId` method to `TeamRepository` that finds teams belonging to an organization (either the org itself or teams with that org as parent)
- Organization scope validation when org admins remove members - verifying target teams belong to the admin's organization
- Proper dependency injection of `TeamRepository` into `LegacyRemoveMemberService`

Related to: https://github.com/calcom/cal.com/pull/26964

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. As org admin, remove member from own team → should work
2. As org admin, remove member from own org → should work  
3. As org admin, attempt to remove member from unrelated team → should return UNAUTHORIZED
4. As non-admin with OWNER/ADMIN role, remove member → should work (existing flow)

## Checklist for Human Review

- [ ] Verify the `findByIdsAndOrgId` query logic correctly identifies teams belonging to an org (teams where `id === orgId` OR `parentId === orgId`)
- [ ] Confirm `organizationId` is properly passed through the handler to the service
- [ ] Review that the new test cases cover edge cases (missing organizationId, teams not belonging to org)

---

Link to Devin run: https://app.devin.ai/sessions/572e1e4604ed4c63b552456c9ce6e3a1
Requested by: @keithwillcode