### PR TITLE
chore: convert console.log to debug log in raqbUtils

### DIFF
--- a/packages/app-store/_utils/raqb/raqbUtils.server.ts
+++ b/packages/app-store/_utils/raqb/raqbUtils.server.ts
@@ -14,9 +14,12 @@ import type {
   AttributeOptionValue,
 } from "@calcom/app-store/routing-forms/types/types";
 import type { dynamicFieldValueOperands } from "@calcom/lib/raqb/types";
+import logger from "@calcom/lib/logger";
 import { caseInsensitive } from "@calcom/lib/raqb/utils";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { AttributeType } from "@calcom/prisma/enums";
+
+const log = logger.getSubLogger({ prefix: ["raqbUtils"] });
 
 function ensureArray(value: string | string[]) {
   return typeof value === "string" ? [value] : value;
@@ -89,7 +92,7 @@ export function getValueOfAttributeOption(
   ) {
     if (attributeOption.isGroup) {
       const subOptions = attributeOption.contains.map((option) => option.value);
-      console.log("A group option found. Using all its sub-options instead", safeStringify(subOptions));
+      log.debug("A group option found. Using all its sub-options instead", safeStringify(subOptions));
       return subOptions;
     }
     return attributeOption.value;


### PR DESCRIPTION
## What does this PR do?

Converts a `console.log` statement to use the proper `@calcom/lib/logger` with debug level in the raqbUtils.server.ts file. This ensures the log message only appears when debug logging is enabled, reducing noise in production logs.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - logging change only.

## How should this be tested?

This is a simple logging change. No specific testing required beyond CI passing.

The log message "A group option found. Using all its sub-options instead" will now only appear when the logger level is set to debug (level 2 or lower via `NEXT_PUBLIC_LOGGER_LEVEL`).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

<!-- Link to Devin run: https://app.devin.ai/sessions/45d95cd7127541ffac96764f251ae1c9 -->
<!-- Requested by: @hariombalhara -->