### PR TITLE
fix: add mandatory field indicators on login page

### DIFF
--- a/apps/web/modules/auth/login-view.tsx
+++ b/apps/web/modules/auth/login-view.tsx
@@ -247,6 +247,7 @@ export default function Login({
                   defaultValue={totpEmail || (searchParams?.get("email") as string)}
                   placeholder="john.doe@example.com"
                   required
+                  showAsteriskIndicator
                   autoComplete="email"
                   {...register("email")}
                 />
@@ -255,6 +256,7 @@ export default function Login({
                     id="password"
                     autoComplete="current-password"
                     required={!totpEmail}
+                    showAsteriskIndicator
                     className="mb-0"
                     {...register("password")}
                   />

--- a/packages/ui/components/form/inputs/TextField.tsx
+++ b/packages/ui/components/form/inputs/TextField.tsx
@@ -163,7 +163,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
           >
             {label}
             {showAsteriskIndicator && !readOnly && passThrough.required ? (
-              <span className="text-default ml-1 font-medium">*</span>
+              <span className="text-error ml-1 font-medium">*</span>
             ) : null}
             {LockedIcon}
           </Label>


### PR DESCRIPTION
## Summary
- Added red asterisks (*) to indicate required fields on the login page
- Changed the asterisk indicator color from `text-default` to `text-error` for better visibility and consistency with validation error styling

## Changes
1. **apps/web/modules/auth/login-view.tsx**: Added `showAsteriskIndicator` prop to `EmailField` and `PasswordField` components
2. **packages/ui/components/form/inputs/TextField.tsx**: Changed the asterisk color class from `text-default` to `text-error` so required field indicators are visually prominent in red

## Before
The login page had no visual indication of which fields were mandatory.

## After
Required fields now display a red asterisk (*) next to their labels, making it clear which fields must be filled in.

## Test plan
- [x] Navigate to `/auth/login`
- [x] Verify red asterisks appear next to "Email address" and "Password" labels
- [x] Verify validation errors still display correctly when form is submitted empty

Fixes #27011