### PR TITLE
fix: allow page scrolling when profile dropdown is open

### DIFF
--- a/apps/web/modules/shell/user-dropdown/ProfileDropdown.tsx
+++ b/apps/web/modules/shell/user-dropdown/ProfileDropdown.tsx
@@ -42,7 +42,7 @@ export function ProfileDropdown() {
   const currentOption = options.find((option) => option.value === sessionData.upId) || options[0];
 
   return (
-    <Dropdown open={menuOpen}>
+    <Dropdown open={menuOpen} modal={false}>
       <DropdownMenuTrigger asChild onClick={() => setMenuOpen((menuOpen) => !menuOpen)}>
         <button
           data-testid="user-dropdown-trigger-button"

--- a/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
+++ b/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
@@ -105,7 +105,7 @@ export function UserDropdown({ small }: UserDropdownProps) {
   }
 
   return (
-    <Dropdown open={menuOpen}>
+    <Dropdown open={menuOpen} modal={false}>
       <DropdownMenuTrigger asChild onClick={() => setMenuOpen((menuOpen) => !menuOpen)} disabled={isPending}>
         <button
           data-testid="user-dropdown-trigger-button"


### PR DESCRIPTION
## Summary
- Disabled modal behavior on user dropdown menus to prevent scroll-locking when the dropdown is open
- Users can now scroll the Event Types page (and other pages) while the profile dropdown menu is open

## Root Cause
The `Dropdown` component uses Radix UI's DropdownMenu which has `modal={true}` by default. When modal mode is enabled, Radix applies scroll-locking via `react-remove-scroll` library, which prevents background scrolling while the dropdown is open.

## Changes
1. **apps/web/modules/shell/user-dropdown/UserDropdown.tsx**: Added `modal={false}` prop to `Dropdown` component
2. **apps/web/modules/shell/user-dropdown/ProfileDropdown.tsx**: Added `modal={false}` prop to `Dropdown` component

## Test plan
- [x] Navigate to Event Types page
- [x] Open the profile dropdown (top-left)
- [x] Verify that the page can be scrolled while the dropdown is open
- [x] Verify that clicking outside the dropdown still closes it
- [x] Verify that dropdown functionality works correctly

Fixes #26997