### PR TITLE
fix(companion): show splash screen during auth check to prevent login flash

### DIFF
--- a/companion/app/_layout.tsx
+++ b/companion/app/_layout.tsx
@@ -2,6 +2,7 @@ import { PortalHost } from "@rn-primitives/portal";
 import { isLiquidGlassAvailable } from "expo-glass-effect";
 import { Stack } from "expo-router";
 import { Platform, StatusBar, View } from "react-native";
+import { CalComLogo } from "@/components/CalComLogo";
 import LoginScreenComponent from "@/components/LoginScreen";
 import { NetworkStatusBanner } from "@/components/NetworkStatusBanner";
 import { GlobalToast } from "@/components/ui/GlobalToast";
@@ -11,7 +12,24 @@ import { ToastProvider } from "@/contexts/ToastContext";
 import "../global.css";
 
 function RootLayoutContent() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, loading } = useAuth();
+
+  // Show Cal.com logo while checking auth state to prevent login flash
+  if (loading) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: "#FFFFFF",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
+        <CalComLogo width={120} height={26} />
+      </View>
+    );
+  }
 
   const content = isAuthenticated ? (
     <Stack>


### PR DESCRIPTION

https://github.com/user-attachments/assets/20bcc529-6828-4091-be10-e91af26f4f54



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a simple splash screen with the Cal.com logo while the Companion app checks authentication, preventing the brief login screen flash on startup. Uses useAuth.loading in RootLayout to render a white screen with the logo and a dark status bar until auth resolves.

<sup>Written for commit e270521a65b6d6a05e5aed8c5af8c4d46a8bef38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

