### PR TITLE
fix: make user dropdown avatar more visible

### DIFF
--- a/apps/web/modules/apps/components/AppCard.tsx
+++ b/apps/web/modules/apps/components/AppCard.tsx
@@ -139,7 +139,7 @@ export function AppCard({ app, credentials, searchText, userAdminTeams }: AppCar
         }}
       />
 
-      <div className="mt-5 flex max-w-full flex-row justify-between gap-2">
+      <div className="mt-auto flex max-w-full flex-row justify-between gap-2">
         <Button
           color="secondary"
           className="flex w-32 grow justify-center"

--- a/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
+++ b/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
@@ -91,19 +91,19 @@ export function UserDropdown({ small }: UserDropdownProps) {
           )}>
           <span
             className={classNames(
-              small ? "h-4 w-4" : "h-5 w-5 ltr:mr-2 rtl:ml-2",
+              small ? "h-5 w-4" : "h-5 w-6.5 ltr:mr-2 rtl:ml-2",
               "relative shrink-0 rounded-full"
             )}>
             <Avatar
-              size={small ? "xs" : "xsm"}
+              size={small ? "sm" : "sm"}
               imageSrc={user?.avatarUrl ?? user?.avatar}
               alt={user?.username ? `${user.username} Avatar` : "Nameless User Avatar"}
               className="overflow-hidden"
             />
             <span
               className={classNames(
-                "border-muted absolute -bottom-1 -right-1 rounded-full border bg-green-500",
-                small ? "-bottom-0.5 -right-0.5 h-2.5 w-2.5" : "-bottom-0.5 right-0 h-2 w-2"
+                "border-muted absolute -bottom-0 -right-1 rounded-full border bg-green-500",
+                small ? "-bottom-1.5 -right-2 h-2.5 w-2.5" : "-bottom-0.5 right-0 h-2 w-2 "
               )}
             />
           </span>


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the user dropdown avatar appeared smaller than intended, reducing visibility and visual consistency.

- Fixes #27023
- Fixes CAL-7097

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Image Demo (if applicable):

Before 
<img width="458" height="902" alt="Screenshot 2026-01-19 113143" src="https://github.com/user-attachments/assets/4a6088e5-c763-44fd-ad5f-51c4e88636a9" />

After
<img width="517" height="824" alt="Screenshot 2026-01-19 155929" src="https://github.com/user-attachments/assets/8bf3b39f-8fe8-4911-918b-7af331481158" />

## Mandatory Tasks (DO NOT REMOVE)

Self-review: ✅
Docs: N/A (check it)
Tests: N/A – visual-only UI change, no logic affected.


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

1. Open the user dropdown from the top-right profile menu.
2. Verify avatar size is consistent and clearly visible.
3. Confirm no layout regression on desktop view.


