### PR TITLE
fix: use seatsShowAttendees from CalendarEvent for attendee email privacy

### DIFF
--- a/packages/emails/templates/attendee-scheduled-email.ts
+++ b/packages/emails/templates/attendee-scheduled-email.ts
@@ -18,7 +18,11 @@ export default class AttendeeScheduledEmail extends BaseEmail {
 
   constructor(calEvent: CalendarEvent, attendee: Person, showAttendees?: boolean | undefined) {
     super();
-    if (!showAttendees && calEvent.seatsPerTimeSlot) {
+    // Use calEvent.seatsShowAttendees as default when showAttendees is not explicitly provided
+    // This ensures attendee privacy is respected in all email types (reschedule, cancel, etc.)
+    // that extend this base class, even if they don't explicitly pass showAttendees
+    const shouldShowAttendees = showAttendees ?? calEvent.seatsShowAttendees ?? true;
+    if (!shouldShowAttendees && calEvent.seatsPerTimeSlot) {
       this.calEvent = cloneDeep(calEvent);
       this.calEvent.attendees = [attendee];
     } else {


### PR DESCRIPTION
## What does this PR do?

Fixes a privacy gap in seated event emails where attendees could see other attendees even when `hideAttendees` was enabled on the event type.

### Changes:

1. **`AttendeeScheduledEmail` base class** - Now uses `calEvent.seatsShowAttendees` as the default when the `showAttendees` parameter is not explicitly provided. This ensures attendee privacy is respected in all email types (reschedule, cancel, location change, etc.) that extend this base class.

2. **`AttendeeWasRequestedToRescheduleEmail`** - This class extends `OrganizerScheduledEmail` instead of `AttendeeScheduledEmail`, so it needed separate handling. Added the same filtering logic to protect attendee privacy in reschedule request emails.

**Before:** When `showAttendees` was `undefined`, the code treated it as falsy and would filter attendees, but only if explicitly passed. Many email functions (like `sendRescheduledEmailsAndSMS`, `sendCancelledEmailsAndSMS`) don't pass this parameter, causing all attendees to be exposed.

**After:** Uses nullish coalescing to check `showAttendees ?? calEvent.seatsShowAttendees ?? true`, properly respecting the event type's privacy setting.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a seated event type with `seatsShowAttendees` set to `false` (hide attendees)
2. Have multiple attendees book seats on the same time slot
3. Trigger various email types (reschedule, cancel, location change, request to reschedule)
4. Verify that each attendee only sees themselves in the email, not other attendees
5. Verify organizer emails still show all attendees (they use separate email classes)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Human Review Checklist

- [ ] Verify the nullish coalescing chain (`showAttendees ?? calEvent.seatsShowAttendees ?? true`) handles all edge cases correctly in `AttendeeScheduledEmail`
- [ ] Verify the filtering logic in `AttendeeWasRequestedToRescheduleEmail` correctly filters to only the first attendee
- [ ] Confirm existing email flows that explicitly pass `showAttendees` still work as expected
- [ ] Consider if unit tests should be added for this privacy-sensitive feature

---

Link to Devin run: https://app.devin.ai/sessions/d385df5460644ff7b0fe53e1234be3ed
Requested by: @joeauyeung