### PR TITLE
refactor: make getDisplayFields async in AuditAction services

### DIFF
--- a/packages/features/booking-audit/lib/actions/IAuditActionService.ts
+++ b/packages/features/booking-audit/lib/actions/IAuditActionService.ts
@@ -99,12 +99,12 @@ export interface IAuditActionService {
      * Returns additional display fields with translation keys for frontend rendering
      * Optional - implement only if custom display fields are needed
      * @param storedData - Parsed stored data { version, fields }
-     * @returns Array of field objects with label and value translation keys
+     * @returns Promise of array of field objects with label and value translation keys
      */
-    getDisplayFields?(storedData: BaseStoredAuditData): Array<{
+    getDisplayFields?(storedData: BaseStoredAuditData): Promise<Array<{
         labelKey: string;  // Translation key for field label
         valueKey: string;  // Translation key for field value
-    }>;
+    }>>;
 
     /**
      * Migrate old version data to latest version

--- a/packages/features/booking-audit/lib/actions/ReassignmentAuditActionService.ts
+++ b/packages/features/booking-audit/lib/actions/ReassignmentAuditActionService.ts
@@ -84,10 +84,10 @@ export class ReassignmentAuditActionService implements IAuditActionService {
         };
     }
 
-    getDisplayFields(storedData: BaseStoredAuditData): Array<{
+    async getDisplayFields(storedData: BaseStoredAuditData): Promise<Array<{
         labelKey: string;
         valueKey: string;
-    }> {
+    }>> {
         const { fields } = this.parseStored(storedData);
         const map = {
             manual: "manual",

--- a/packages/features/booking-audit/lib/service/BookingAuditViewerService.ts
+++ b/packages/features/booking-audit/lib/service/BookingAuditViewerService.ts
@@ -151,7 +151,7 @@ export class BookingAuditViewerService {
             : null;
 
         const displayFields = actionService.getDisplayFields
-            ? actionService.getDisplayFields(parsedData)
+            ? await actionService.getDisplayFields(parsedData)
             : null;
 
         const impersonatedBy = await this.enrichImpersonator(log.context);


### PR DESCRIPTION
## What does this PR do?

Makes the `getDisplayFields` method async in the `IAuditActionService` interface to enable async operations within the method implementation.

Changes:
- Updated `IAuditActionService` interface to return `Promise<Array<...>>` instead of `Array<...>`
- Updated `ReassignmentAuditActionService.getDisplayFields` to be async
- Updated `BookingAuditViewerService.enrichAuditLog` to await the `getDisplayFields` call

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal refactor only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run existing unit tests for booking-audit: `TZ=UTC yarn test packages/features/booking-audit`
2. Verify type checks pass: `yarn type-check:ci --force`

## Human Review Checklist

- [ ] Verify no other implementations of `getDisplayFields` exist that were missed (grep shows only `ReassignmentAuditActionService` implements it)
- [ ] Confirm the async/await pattern is correctly applied in `BookingAuditViewerService`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/bca867510e794ee2bd63f1e68818bfdf
Requested by: @hariombalhara