### PR TITLE
fix: return 400 instead of 500 for invalid timezone errors

### DIFF
--- a/packages/lib/server/getServerErrorFromUnknown.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.ts
@@ -73,6 +73,16 @@ export function getServerErrorFromUnknown(cause: unknown): HttpError {
       data: traceId ? { ...tracedData, traceId } : undefined,
     });
   }
+  // Handle invalid timezone errors (e.g., "GMT-05:00" instead of IANA format like "America/New_York")
+  // These can occur when calendar data contains non-standard timezone formats
+  if (cause instanceof RangeError && cause.message.includes("Invalid time zone")) {
+    return new HttpError({
+      statusCode: 400,
+      message: "Invalid timezone format in calendar data. Please ensure all calendars use valid IANA timezone identifiers.",
+      cause,
+      data: traceId ? { ...tracedData, traceId } : undefined,
+    });
+  }
   if (isPrismaError(cause)) {
     return getServerErrorFromPrismaError(cause, traceId, tracedData);
   }

--- a/packages/lib/server/getServerErrorFromUnknown.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.ts
@@ -73,8 +73,6 @@ export function getServerErrorFromUnknown(cause: unknown): HttpError {
       data: traceId ? { ...tracedData, traceId } : undefined,
     });
   }
-  // Handle invalid timezone errors (e.g., "GMT-05:00" instead of IANA format like "America/New_York")
-  // These can occur when calendar data contains non-standard timezone formats
   if (cause instanceof RangeError && cause.message.includes("Invalid time zone")) {
     return new HttpError({
       statusCode: 400,


### PR DESCRIPTION
## What does this PR do?

Catches `RangeError: Invalid time zone specified` (e.g., `GMT-05:00` instead of `America/New_York`) in `getServerErrorFromUnknown()` and returns HTTP 400 instead of 500.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Trigger a booking where a host's calendar has an invalid timezone format → verify API returns 400 instead of 500.

---

**Link to Devin run**: https://app.devin.ai/sessions/0f3edb4331094385b610c862782ad440
**Requested by**: @hbjORbj