### PR TITLE
fix: handle invalid timezones gracefully in calendar events

### DIFF
--- a/packages/features/bookings/lib/getLuckyUser.ts
+++ b/packages/features/bookings/lib/getLuckyUser.ts
@@ -842,25 +842,14 @@ export class LuckyUserService implements ILuckyUserService {
       const fullDayBusyTimes = userBusyTime.busyTimes
         .filter((busyTime) => {
           if (!busyTime.timeZone) return false;
-          try {
-            const timezoneOffset = dayjs(busyTime.start).tz(busyTime.timeZone).utcOffset() * 60000;
-            let start = new Date(new Date(busyTime.start).getTime() + timezoneOffset);
-            const end = new Date(new Date(busyTime.end).getTime() + timezoneOffset);
+          const timezoneOffset = dayjs(busyTime.start).tz(busyTime.timeZone).utcOffset() * 60000;
+          let start = new Date(new Date(busyTime.start).getTime() + timezoneOffset);
+          const end = new Date(new Date(busyTime.end).getTime() + timezoneOffset);
 
-            const earliestStartTime = new Date(Date.UTC(new Date().getFullYear(), new Date().getMonth(), 1));
-            if (start < earliestStartTime) start = earliestStartTime;
+          const earliestStartTime = new Date(Date.UTC(new Date().getFullYear(), new Date().getMonth(), 1));
+          if (start < earliestStartTime) start = earliestStartTime;
 
-            return end.getTime() < new Date().getTime() && isFullDayEvent(start, end);
-          } catch (error) {
-            // Skip busy times with invalid timezones (e.g., "GMT-05:00" instead of IANA format like "America/New_York")
-            // This can happen when calendar data comes from external sources with non-standard timezone formats
-            log.warn(`Skipping busy time with invalid timezone: ${busyTime.timeZone}`, {
-              userId: userBusyTime.userId,
-              busyTimeStart: busyTime.start,
-              busyTimeEnd: busyTime.end,
-            });
-            return false;
-          }
+          return end.getTime() < new Date().getTime() && isFullDayEvent(start, end);
         })
         .map((busyTime) => ({ start: new Date(busyTime.start), end: new Date(busyTime.end) }));
 

--- a/packages/features/calendars/lib/getCalendarsEvents.test.ts
+++ b/packages/features/calendars/lib/getCalendarsEvents.test.ts
@@ -530,6 +530,162 @@ describe("getCalendarsEventsWithTimezones", () => {
       expect(result).toEqual([[]]);
     });
   });
+
+  describe("Invalid timezone handling", () => {
+    it("should convert GMT-05:00 offset format to Etc/GMT+5", async () => {
+      const availability = [
+        {
+          start: new Date(2010, 11, 2),
+          end: new Date(2010, 11, 3),
+          timeZone: "GMT-05:00",
+        },
+        {
+          start: new Date(2010, 11, 2, 4),
+          end: new Date(2010, 11, 2, 16),
+          timeZone: "America/New_York",
+        },
+      ];
+
+      mockGoogleGetAvailabilityWithTimeZones.mockResolvedValueOnce(availability);
+
+      const selectedCalendar: SelectedCalendar = buildSelectedCalendar({
+        credentialId: 100,
+        externalId: "externalId",
+        integration: "google_calendar",
+        userId: 200,
+        id: "id",
+      });
+      const result = await getCalendarsEventsWithTimezones(
+        [buildRegularCredential(credential)],
+        "2010-12-01",
+        "2010-12-04",
+        [selectedCalendar]
+      );
+
+      expect(result).toEqual([
+        [
+          {
+            start: new Date(2010, 11, 2),
+            end: new Date(2010, 11, 3),
+            timeZone: "Etc/GMT+5",
+          },
+          {
+            start: new Date(2010, 11, 2, 4),
+            end: new Date(2010, 11, 2, 16),
+            timeZone: "America/New_York",
+          },
+        ],
+      ]);
+    });
+
+    it("should convert UTC+08:00 offset format to Etc/GMT-8", async () => {
+      const availability = [
+        {
+          start: new Date(2010, 11, 2),
+          end: new Date(2010, 11, 3),
+          timeZone: "UTC+08:00",
+        },
+      ];
+
+      mockGoogleGetAvailabilityWithTimeZones.mockResolvedValueOnce(availability);
+
+      const selectedCalendar: SelectedCalendar = buildSelectedCalendar({
+        credentialId: 100,
+        externalId: "externalId",
+        integration: "google_calendar",
+        userId: 200,
+        id: "id",
+      });
+      const result = await getCalendarsEventsWithTimezones(
+        [buildRegularCredential(credential)],
+        "2010-12-01",
+        "2010-12-04",
+        [selectedCalendar]
+      );
+
+      expect(result).toEqual([
+        [
+          {
+            start: new Date(2010, 11, 2),
+            end: new Date(2010, 11, 3),
+            timeZone: "Etc/GMT-8",
+          },
+        ],
+      ]);
+    });
+
+    it("should fallback to UTC when timezone is undefined", async () => {
+      const availability = [
+        {
+          start: new Date(2010, 11, 2),
+          end: new Date(2010, 11, 3),
+          timeZone: undefined,
+        },
+      ];
+
+      mockGoogleGetAvailabilityWithTimeZones.mockResolvedValueOnce(availability);
+
+      const selectedCalendar: SelectedCalendar = buildSelectedCalendar({
+        credentialId: 100,
+        externalId: "externalId",
+        integration: "google_calendar",
+        userId: 200,
+        id: "id",
+      });
+      const result = await getCalendarsEventsWithTimezones(
+        [buildRegularCredential(credential)],
+        "2010-12-01",
+        "2010-12-04",
+        [selectedCalendar]
+      );
+
+      expect(result).toEqual([
+        [
+          {
+            start: new Date(2010, 11, 2),
+            end: new Date(2010, 11, 3),
+            timeZone: "UTC",
+          },
+        ],
+      ]);
+    });
+
+    it("should fallback to UTC for completely invalid timezone formats", async () => {
+      const availability = [
+        {
+          start: new Date(2010, 11, 2),
+          end: new Date(2010, 11, 3),
+          timeZone: "InvalidTimezone",
+        },
+      ];
+
+      mockGoogleGetAvailabilityWithTimeZones.mockResolvedValueOnce(availability);
+
+      const selectedCalendar: SelectedCalendar = buildSelectedCalendar({
+        credentialId: 100,
+        externalId: "externalId",
+        integration: "google_calendar",
+        userId: 200,
+        id: "id",
+      });
+      const result = await getCalendarsEventsWithTimezones(
+        [buildRegularCredential(credential)],
+        "2010-12-01",
+        "2010-12-04",
+        [selectedCalendar]
+      );
+
+      expect(result).toEqual([
+        [
+          {
+            start: new Date(2010, 11, 2),
+            end: new Date(2010, 11, 3),
+            timeZone: "UTC",
+          },
+        ],
+      ]);
+    });
+  });
 });
 
 // CalDAV Credential Leak Prevention Tests

--- a/packages/features/calendars/lib/getCalendarsEvents.ts
+++ b/packages/features/calendars/lib/getCalendarsEvents.ts
@@ -8,70 +8,11 @@ import { performance } from "@calcom/lib/server/perfObserver";
 import type { CalendarFetchMode, EventBusyDate, SelectedCalendar } from "@calcom/types/Calendar";
 import type { CredentialForCalendarService } from "@calcom/types/Credential";
 
+import { normalizeTimezone } from "./timezone-conversion";
+
 const log = logger.getSubLogger({ prefix: ["getCalendarsEvents"] });
 
 const CALENDSO_ENCRYPTION_KEY = process.env.CALENDSO_ENCRYPTION_KEY || "";
-
-/**
- * Converts offset-based timezone formats (e.g., "GMT-05:00", "UTC+08:00") to valid IANA Etc/GMT timezones.
- * Note: Etc/GMT uses inverted signs (Etc/GMT+5 = UTC-5, Etc/GMT-8 = UTC+8).
- * Returns null if the format doesn't match or conversion fails.
- */
-function convertOffsetToEtcGmt(timeZone: string): string | null {
-  const offsetMatch = timeZone.match(/^(?:GMT|UTC)([+-])(\d{1,2})(?::(\d{2}))?$/i);
-  if (!offsetMatch) return null;
-
-  const sign = offsetMatch[1];
-  const hours = parseInt(offsetMatch[2], 10);
-  const minutes = offsetMatch[3] ? parseInt(offsetMatch[3], 10) : 0;
-
-  if (hours > 14 || minutes > 59 || (hours === 14 && minutes > 0)) return null;
-  if (minutes !== 0) {
-    log.warn(`Cannot convert timezone with non-zero minutes to Etc/GMT, falling back to UTC`, {
-      originalTimezone: timeZone,
-    });
-    return "UTC";
-  }
-
-  const etcSign = sign === "+" ? "-" : "+";
-  const etcTimezone = hours === 0 ? "Etc/GMT" : `Etc/GMT${etcSign}${hours}`;
-
-  try {
-    Intl.DateTimeFormat(undefined, { timeZone: etcTimezone });
-    return etcTimezone;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Validates and normalizes a timezone string to a valid IANA timezone.
- * 1. Returns the timezone as-is if it's already valid
- * 2. Converts offset formats (GMT±HH:MM, UTC±HH:MM) to Etc/GMT timezones
- * 3. Falls back to UTC if conversion fails
- */
-function getValidTimezoneOrFallback(timeZone: string | undefined): string {
-  if (!timeZone) return "UTC";
-
-  try {
-    Intl.DateTimeFormat(undefined, { timeZone });
-    return timeZone;
-  } catch {
-    const converted = convertOffsetToEtcGmt(timeZone);
-    if (converted) {
-      log.info(`Converted offset timezone to IANA format`, {
-        original: timeZone,
-        converted,
-      });
-      return converted;
-    }
-
-    log.warn(`Invalid timezone format, falling back to UTC`, {
-      invalidTimezone: timeZone,
-    });
-    return "UTC";
-  }
-}
 
 // only for Google Calendar for now
 export const getCalendarsEventsWithTimezones = async (
@@ -139,7 +80,7 @@ export const getCalendarsEventsWithTimezones = async (
 
     return eventBusyDates.map((event) => ({
       ...event,
-      timeZone: getValidTimezoneOrFallback(event.timeZone),
+      timeZone: normalizeTimezone(event.timeZone),
     }));
   });
   const awaitedResults = await Promise.all(results);

--- a/packages/features/calendars/lib/timezone-conversion.test.ts
+++ b/packages/features/calendars/lib/timezone-conversion.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { convertOffsetToIanaTimezone, normalizeTimezone } from "./timezone-conversion";
+
+vi.mock("@calcom/lib/logger", () => ({
+  default: {
+    getSubLogger: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}));
+
+describe("timezone-conversion", () => {
+  describe("Intl.DateTimeFormat behavior with offset formats", () => {
+    it("throws RangeError for GMT-05:00 offset format", () => {
+      expect(() => Intl.DateTimeFormat(undefined, { timeZone: "GMT-05:00" })).toThrow(RangeError);
+    });
+
+    it("throws RangeError for UTC+08:00 offset format", () => {
+      expect(() => Intl.DateTimeFormat(undefined, { timeZone: "UTC+08:00" })).toThrow(RangeError);
+    });
+
+    it("throws RangeError for GMT+5 offset format without minutes", () => {
+      expect(() => Intl.DateTimeFormat(undefined, { timeZone: "GMT+5" })).toThrow(RangeError);
+    });
+
+    it("accepts valid IANA timezone America/New_York", () => {
+      expect(() => Intl.DateTimeFormat(undefined, { timeZone: "America/New_York" })).not.toThrow();
+    });
+
+    it("accepts Etc/GMT+5 as valid IANA timezone", () => {
+      expect(() => Intl.DateTimeFormat(undefined, { timeZone: "Etc/GMT+5" })).not.toThrow();
+    });
+
+    it("accepts UTC as valid timezone", () => {
+      expect(() => Intl.DateTimeFormat(undefined, { timeZone: "UTC" })).not.toThrow();
+    });
+  });
+
+  describe("convertOffsetToIanaTimezone", () => {
+    it("converts GMT-05:00 to Etc/GMT+5 (inverted sign)", () => {
+      expect(convertOffsetToIanaTimezone("GMT-05:00")).toBe("Etc/GMT+5");
+    });
+
+    it("converts UTC+08:00 to Etc/GMT-8 (inverted sign)", () => {
+      expect(convertOffsetToIanaTimezone("UTC+08:00")).toBe("Etc/GMT-8");
+    });
+
+    it("converts GMT+0 to Etc/GMT", () => {
+      expect(convertOffsetToIanaTimezone("GMT+0")).toBe("Etc/GMT");
+    });
+
+    it("converts GMT-00:00 to Etc/GMT", () => {
+      expect(convertOffsetToIanaTimezone("GMT-00:00")).toBe("Etc/GMT");
+    });
+
+    it("handles case insensitivity (gmt-05:00)", () => {
+      expect(convertOffsetToIanaTimezone("gmt-05:00")).toBe("Etc/GMT+5");
+    });
+
+    it("handles format without minutes (GMT+5)", () => {
+      expect(convertOffsetToIanaTimezone("GMT+5")).toBe("Etc/GMT-5");
+    });
+
+    it("returns null for non-zero minutes (cannot be represented in Etc/GMT)", () => {
+      expect(convertOffsetToIanaTimezone("GMT+05:30")).toBeNull();
+    });
+
+    it("returns null for hours > 14", () => {
+      expect(convertOffsetToIanaTimezone("GMT+15:00")).toBeNull();
+    });
+
+    it("returns null for invalid format", () => {
+      expect(convertOffsetToIanaTimezone("America/New_York")).toBeNull();
+    });
+
+    it("returns null for completely invalid string", () => {
+      expect(convertOffsetToIanaTimezone("InvalidTimezone")).toBeNull();
+    });
+  });
+
+  describe("normalizeTimezone", () => {
+    it("returns UTC for undefined timezone", () => {
+      expect(normalizeTimezone(undefined)).toBe("UTC");
+    });
+
+    it("returns valid IANA timezone as-is", () => {
+      expect(normalizeTimezone("America/New_York")).toBe("America/New_York");
+    });
+
+    it("converts GMT-05:00 to Etc/GMT+5", () => {
+      expect(normalizeTimezone("GMT-05:00")).toBe("Etc/GMT+5");
+    });
+
+    it("converts UTC+08:00 to Etc/GMT-8", () => {
+      expect(normalizeTimezone("UTC+08:00")).toBe("Etc/GMT-8");
+    });
+
+    it("falls back to UTC for completely invalid timezone", () => {
+      expect(normalizeTimezone("InvalidTimezone")).toBe("UTC");
+    });
+
+    it("falls back to UTC for non-zero minutes offset", () => {
+      expect(normalizeTimezone("GMT+05:30")).toBe("UTC");
+    });
+  });
+});

--- a/packages/features/calendars/lib/timezone-conversion.ts
+++ b/packages/features/calendars/lib/timezone-conversion.ts
@@ -1,0 +1,43 @@
+import logger from "@calcom/lib/logger";
+
+const log = logger.getSubLogger({ prefix: ["timezoneConversion"] });
+
+/**
+ * Converts offset-based timezone formats (GMT±HH:MM, UTC±HH:MM) to IANA Etc/GMT timezones.
+ * Etc/GMT uses inverted signs: Etc/GMT+5 = UTC-5, Etc/GMT-8 = UTC+8.
+ */
+export function convertOffsetToIanaTimezone(timezone: string): string | null {
+  const match = timezone.match(/^(?:GMT|UTC)([+-])(\d{1,2})(?::(\d{2}))?$/i);
+  if (!match) return null;
+
+  const [, sign, hoursStr, minutesStr] = match;
+  const hours = parseInt(hoursStr, 10);
+  const minutes = minutesStr ? parseInt(minutesStr, 10) : 0;
+
+  // Etc/GMT only supports whole hours up to 14
+  if (minutes !== 0 || hours > 14) return null;
+
+  if (hours === 0) return "Etc/GMT";
+  return `Etc/GMT${sign === "+" ? "-" : "+"}${hours}`;
+}
+
+/**
+ * Validates and normalizes a timezone string to a valid IANA timezone.
+ * Converts offset formats to Etc/GMT, falls back to UTC if invalid.
+ */
+export function normalizeTimezone(timezone: string | undefined): string {
+  if (!timezone) return "UTC";
+
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    return timezone;
+  } catch {
+    const converted = convertOffsetToIanaTimezone(timezone);
+    if (converted) {
+      log.info(`Converted offset timezone to IANA format`, { original: timezone, converted });
+      return converted;
+    }
+    log.warn(`Invalid timezone format, falling back to UTC`, { invalidTimezone: timezone });
+    return "UTC";
+  }
+}


### PR DESCRIPTION
## What does this PR do?

**Root cause**: External calendar sources (like Google Calendar) can return non-standard timezone formats. Previously, these invalid timezones caused a `RangeError` in downstream code (`dayjs().tz()`), resulting in 500 errors during booking.

**Fix**: 
- Created `timezone-conversion.ts` with `convertOffsetToIanaTimezone()` and `normalizeTimezone()` functions
- Converts offset formats (`GMT±HH:MM`, `UTC±HH:MM`) to valid `Etc/GMT` timezones
- Falls back to UTC only if conversion fails or timezone is completely invalid

**Why convert instead of skip?** Converting preserves timezone precision for round-robin fairness calculations. A busy time at 9 AM in GMT-05:00 is correctly interpreted as 9 AM UTC-5, rather than being skipped or incorrectly treated as 9 AM UTC.

**Note**: `Etc/GMT` uses inverted signs (`Etc/GMT+5` = UTC-5, `Etc/GMT-8` = UTC+8). This is per IANA spec.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.