### PR TITLE
fix: only record organizerUuid in audit when organizer actually changes

### DIFF
--- a/packages/features/booking-audit/lib/actions/ReassignmentAuditActionService.ts
+++ b/packages/features/booking-audit/lib/actions/ReassignmentAuditActionService.ts
@@ -17,7 +17,7 @@ import type {
 
 // Module-level because it is passed to IAuditActionService type outside the class scope
 const fieldsSchemaV1 = z.object({
-  organizerUuid: StringChangeSchema,
+  organizerUuid: StringChangeSchema.optional(),
   hostAttendeeUpdated: z
     .object({
       id: z.number().optional(),
@@ -85,8 +85,8 @@ export class ReassignmentAuditActionService implements IAuditActionService {
   getDisplayJson({ storedData }: GetDisplayJsonParams): ReassignmentAuditDisplayData {
     const { fields } = this.parseStored(storedData);
     return {
-      previousOrganizerUuid: fields.organizerUuid.old ?? null,
-      newOrganizerUuid: fields.organizerUuid.new ?? null,
+      previousOrganizerUuid: fields.organizerUuid?.old ?? null,
+      newOrganizerUuid: fields.organizerUuid?.new ?? null,
       hostAttendeeIdUpdated: fields.hostAttendeeUpdated?.id ?? null,
       hostAttendeeUserUuidNew: fields.hostAttendeeUpdated?.withUserUuid?.new ?? null,
       hostAttendeeUserUuidOld: fields.hostAttendeeUpdated?.withUserUuid?.old ?? null,
@@ -98,10 +98,10 @@ export class ReassignmentAuditActionService implements IAuditActionService {
     const hasAttendeeUpdated = fields.hostAttendeeUpdated != null;
     const newHostUuid = hasAttendeeUpdated
       ? fields.hostAttendeeUpdated?.withUserUuid?.new
-      : fields.organizerUuid.new;
+      : fields.organizerUuid?.new;
     const previousHostUuid = hasAttendeeUpdated
       ? fields.hostAttendeeUpdated?.withUserUuid?.old
-      : fields.organizerUuid.old;
+      : fields.organizerUuid?.old;
 
     const newUser = newHostUuid ? await this.userRepository.findByUuid({ uuid: newHostUuid }) : null;
     const previousUser = previousHostUuid

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.test.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.test.ts
@@ -1227,7 +1227,8 @@ describe("roundRobinManualReassignment - Audit Data Verification", () => {
     expect(callArgs.actor).toEqual({ identifiedBy: "user", userUuid: reassigningUser.uuid });
     expect(callArgs.organizationId).toBe(null);
     expect(callArgs.source).toBe("WEBAPP");
-    expect(callArgs.auditData.organizerUuid).toEqual({ old: fixedHost.uuid, new: fixedHost.uuid });
+    // organizerUuid should NOT be included when organizer hasn't changed (fixed host scenario)
+    expect(callArgs.auditData.organizerUuid).toBeUndefined();
     expect(callArgs.auditData.reassignmentType).toBe("manual");
     expect(callArgs.auditData.reassignmentReason).toBe("Test reason");
     expect(callArgs.auditData.hostAttendeeUpdated).toBeDefined();

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -263,7 +263,7 @@ export const roundRobinManualReassignment = async ({
     source: actionSource,
     auditData: {
       ...(hasOrganizerChanged
-        ? { organizerUuid: { old: originalOrganizer.uuid ?? null, new: newUser.uuid ?? null } }
+        ? { organizerUuid: { old: originalOrganizer.uuid, new: newUser.uuid } }
         : null),
       ...(attendeeUpdatedId
         ? {

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -255,7 +255,6 @@ export const roundRobinManualReassignment = async ({
   }
 
   const bookingEventHandlerService = getBookingEventHandlerService();
-  const newOrganizerUuid = hasOrganizerChanged ? newUser.uuid : originalOrganizer.uuid;
 
   await bookingEventHandlerService.onReassignment({
     bookingUid: booking.uid,
@@ -263,7 +262,9 @@ export const roundRobinManualReassignment = async ({
     organizationId: orgId,
     source: actionSource,
     auditData: {
-      organizerUuid: { old: originalOrganizer.uuid ?? null, new: newOrganizerUuid ?? null },
+      ...(hasOrganizerChanged
+        ? { organizerUuid: { old: originalOrganizer.uuid ?? null, new: newUser.uuid ?? null } }
+        : null),
       ...(attendeeUpdatedId
         ? {
             hostAttendeeUpdated: {

--- a/packages/features/ee/round-robin/roundRobinReassignment.test.ts
+++ b/packages/features/ee/round-robin/roundRobinReassignment.test.ts
@@ -690,7 +690,8 @@ describe("roundRobinReassignment - Audit Data Verification", () => {
     expect(callArgs.actor).toEqual({ identifiedBy: "user", userUuid: reassigningUser.uuid });
     expect(callArgs.organizationId).toBe(null);
     expect(callArgs.source).toBe("WEBAPP");
-    expect(callArgs.auditData.organizerUuid).toEqual({ old: fixedHost.uuid, new: fixedHost.uuid });
+    // organizerUuid should NOT be included when organizer hasn't changed (fixed host scenario)
+    expect(callArgs.auditData.organizerUuid).toBeUndefined();
     expect(callArgs.auditData.reassignmentType).toBe("roundRobin");
     expect(callArgs.auditData.reassignmentReason).toBe(null);
     expect(callArgs.auditData.hostAttendeeUpdated).toBeDefined();

--- a/packages/features/ee/round-robin/roundRobinReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinReassignment.ts
@@ -293,14 +293,15 @@ export const roundRobinReassignment = async ({
   }
 
   const bookingEventHandlerService = getBookingEventHandlerService();
-  const newOrganizerUuid = hasOrganizerChanged ? reassignedRRHost.uuid : originalOrganizer.uuid;
   await bookingEventHandlerService.onReassignment({
     bookingUid: booking.uid,
     actor: makeUserActor(reassignedByUuid),
     organizationId: orgId,
     source: actionSource,
     auditData: {
-      organizerUuid: { old: originalOrganizer.uuid ?? null, new: newOrganizerUuid ?? null },
+      ...(hasOrganizerChanged
+        ? { organizerUuid: { old: originalOrganizer.uuid ?? null, new: reassignedRRHost.uuid ?? null } }
+        : null),
       ...(attendeeUpdatedId
         ? {
             hostAttendeeUpdated: {

--- a/packages/features/ee/round-robin/roundRobinReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinReassignment.ts
@@ -300,7 +300,7 @@ export const roundRobinReassignment = async ({
     source: actionSource,
     auditData: {
       ...(hasOrganizerChanged
-        ? { organizerUuid: { old: originalOrganizer.uuid ?? null, new: reassignedRRHost.uuid ?? null } }
+        ? { organizerUuid: { old: originalOrganizer.uuid, new: reassignedRRHost.uuid } }
         : null),
       ...(attendeeUpdatedId
         ? {


### PR DESCRIPTION
## What does this PR do?

This PR fixes the reassignment audit logging to only record `organizerUuid` when the organizer actually changes. Previously, `organizerUuid` was always recorded with `{ old: ..., new: ... }` even when the organizer didn't change (e.g., in fixed host scenarios where only the round-robin attendee changes but the organizer remains the same).

The principle is: **we shouldn't record a field in audit if it hasn't changed**.

### Changes:
- Made `organizerUuid` optional in the `ReassignmentAuditActionService` schema
- Updated `roundRobinManualReassignment.ts` to only include `organizerUuid` when `hasOrganizerChanged` is true
- Updated `roundRobinReassignment.ts` with the same conditional logic
- Updated accessor methods (`getDisplayJson`, `getPreviousAndNewAssigneeUser`) to handle optional `organizerUuid` with optional chaining
- Updated tests to expect `organizerUuid` to be undefined in fixed host scenarios

### Updates since last revision:
- Removed unnecessary nullish coalescing (`?? null`) for organizer uuids since `uuid` is a required string field on User in the Prisma schema

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the unit tests: `TZ=UTC yarn test packages/features/ee/round-robin/roundRobinManualReassignment.test.ts packages/features/ee/round-robin/roundRobinReassignment.test.ts packages/features/booking-audit/lib/actions/__tests__/ReassignmentAuditActionService.test.ts`
2. All 33 tests should pass

### Manual verification:
1. Trigger a manual round-robin reassignment where the organizer changes → verify `organizerUuid` is recorded in audit
2. Trigger a reassignment with a fixed host (organizer stays the same, only attendee changes) → verify `organizerUuid` is NOT recorded, only `hostAttendeeUpdated` is recorded

## Human Review Checklist

- [ ] Verify downstream consumers of `ReassignmentAuditDisplayData` can handle null values for `previousOrganizerUuid` and `newOrganizerUuid` (they were already nullable in the type)
- [ ] Verify the `getPreviousAndNewAssigneeUser` logic correctly handles the case when `organizerUuid` is undefined (falls back to null for host UUIDs)
- [ ] Confirm the conditional spread pattern `...(hasOrganizerChanged ? { organizerUuid: ... } : null)` correctly omits the field when false

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/4ccb270fee5143dba8a31ae76fa0756c
Requested by: @hariombalhara