### PR TITLE
fix: correct bookingUrl for EU instance in API responses

### DIFF
--- a/packages/features/ee/organizations/lib/orgDomains.test.ts
+++ b/packages/features/ee/organizations/lib/orgDomains.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@calcom/features/ee/organizations/lib/orgDomains";
 import * as constants from "@calcom/lib/constants";
 
-function setupEnvs({ WEBAPP_URL = "https://app.cal.com", WEBSITE_URL } = {}) {
+function setupEnvs({ WEBAPP_URL = "https://app.cal.com", WEBSITE_URL = "https://cal.com" } = {}) {
   Object.defineProperty(constants, "WEBAPP_URL", { value: WEBAPP_URL });
   Object.defineProperty(constants, "WEBSITE_URL", { value: WEBSITE_URL });
   Object.defineProperty(constants, "ALLOWED_HOSTNAMES", {
@@ -89,12 +89,19 @@ describe("Org Domains Utils", () => {
   });
 
   describe("getOrgFullOrigin", () => {
-    it("should return the regular(non-org) origin if slug is null", () => {
+    it("should return WEBSITE_URL when slug is null and domains match", () => {
       setupEnvs({
         WEBAPP_URL: "https://app.cal.com",
-        WEBSITE_URL: "https://abc.com",
+        WEBSITE_URL: "https://cal.com",
       });
-      expect(getOrgFullOrigin(null)).toEqual("https://abc.com");
+      expect(getOrgFullOrigin(null)).toEqual("https://cal.com");
+    });
+    it("should return WEBAPP_URL when slug is null and domains differ (EU case)", () => {
+      setupEnvs({
+        WEBAPP_URL: "https://app.cal.eu",
+        WEBSITE_URL: "https://cal.com",
+      });
+      expect(getOrgFullOrigin(null)).toEqual("https://app.cal.eu");
     });
     it("should return the org origin if slug is set", () => {
       setupEnvs({

--- a/packages/features/ee/organizations/lib/orgDomains.ts
+++ b/packages/features/ee/organizations/lib/orgDomains.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage } from "node:http";
 
 import { IS_PRODUCTION, WEBSITE_URL, SINGLE_ORG_SLUG } from "@calcom/lib/constants";
 import { ALLOWED_HOSTNAMES, RESERVED_SUBDOMAINS, WEBAPP_URL } from "@calcom/lib/constants";
+import { getTldPlus1 } from "@calcom/lib/getTldPlus1";
 import logger from "@calcom/lib/logger";
 import slugify from "@calcom/lib/slugify";
 import type { Prisma } from "@calcom/prisma/client";
@@ -147,9 +148,8 @@ export function subdomainSuffix() {
 export function getOrgFullOrigin(slug: string | null, options: { protocol: boolean } = { protocol: true }) {
   if (!slug) {
     // Use WEBAPP_URL if domains differ (e.g., EU: app.cal.eu vs cal.com)
-    const getBaseDomain = (hostname: string) => hostname.split(".").slice(-2).join(".");
     const useWebappUrl =
-      getBaseDomain(new URL(WEBSITE_URL).hostname) !== getBaseDomain(new URL(WEBAPP_URL).hostname);
+      getTldPlus1(new URL(WEBSITE_URL).hostname) !== getTldPlus1(new URL(WEBAPP_URL).hostname);
     const baseUrl = useWebappUrl ? WEBAPP_URL : WEBSITE_URL;
     return options.protocol ? baseUrl : baseUrl.replace("https://", "").replace("http://", "");
   }

--- a/packages/features/ee/organizations/lib/orgDomains.ts
+++ b/packages/features/ee/organizations/lib/orgDomains.ts
@@ -145,8 +145,14 @@ export function subdomainSuffix() {
 }
 
 export function getOrgFullOrigin(slug: string | null, options: { protocol: boolean } = { protocol: true }) {
-  if (!slug)
-    return options.protocol ? WEBSITE_URL : WEBSITE_URL.replace("https://", "").replace("http://", "");
+  if (!slug) {
+    // Use WEBAPP_URL if domains differ (e.g., EU: app.cal.eu vs cal.com)
+    const getBaseDomain = (hostname: string) => hostname.split(".").slice(-2).join(".");
+    const useWebappUrl =
+      getBaseDomain(new URL(WEBSITE_URL).hostname) !== getBaseDomain(new URL(WEBAPP_URL).hostname);
+    const baseUrl = useWebappUrl ? WEBAPP_URL : WEBSITE_URL;
+    return options.protocol ? baseUrl : baseUrl.replace("https://", "").replace("http://", "");
+  }
 
   const orgFullOrigin = `${
     options.protocol ? `${new URL(WEBSITE_URL).protocol}//` : ""

--- a/packages/lib/getSafeRedirectUrl.ts
+++ b/packages/lib/getSafeRedirectUrl.ts
@@ -1,4 +1,5 @@
 import { CONSOLE_URL, WEBAPP_URL, WEBSITE_URL, EMBED_LIB_URL } from "@calcom/lib/constants";
+import { getTldPlus1 } from "@calcom/lib/getTldPlus1";
 
 // It ensures that redirection URL safe where it is accepted through a query params or other means where user can change it.
 export const getSafeRedirectUrl = (url = "") => {
@@ -46,10 +47,5 @@ export function isSafeUrlToLoadResourceFrom(urlString: string) {
   } catch {
     return false;
   }
-
-  function getTldPlus1(hostname: string) {
-    // Note: It doesn't support multipart tlds like .co.uk and thus makes only one part tld's safe like .com(and thus cal.com)
-    // If we want to use it elsewhere as well(apart from embed/preview.ts) we must consider Public Suffix List
-    return hostname.split(".").slice(-2).join(".");
-  }
 }
+

--- a/packages/lib/getTldPlus1.ts
+++ b/packages/lib/getTldPlus1.ts
@@ -1,0 +1,7 @@
+/**
+ * Extracts TLD+1 from hostname (e.g., "cal.com" from "app.cal.com")
+ * Note: Doesn't support multi-part TLDs like .co.uk
+ */
+export function getTldPlus1(hostname: string): string {
+  return hostname.split(".").slice(-2).join(".");
+}

--- a/packages/lib/getTldPlus1.ts
+++ b/packages/lib/getTldPlus1.ts
@@ -1,6 +1,6 @@
 /**
- * Extracts TLD+1 from hostname (e.g., "cal.com" from "app.cal.com")
- * Note: Doesn't support multi-part TLDs like .co.uk
+ * Note: It doesn't support multipart tlds like .co.uk and thus makes only one part tld's safe like .com(and thus cal.com)
+ * If we want to use it elsewhere as well(apart from embed/preview.ts) we must consider Public Suffix List
  */
 export function getTldPlus1(hostname: string): string {
   return hostname.split(".").slice(-2).join(".");


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect `bookingUrl` field returned by `api.cal.eu/v2/event-types` for non-organization users.

### Problem
- EU API returns `https://cal.com/user/event` instead of `https://app.cal.eu/user/event`
- `cal.eu` redirects to marketing page, not booking pages
- Bookings are served from `app.cal.eu`

### Solution
Updated [getOrgFullOrigin()](cci:1://file:///Users/dhairyashilshinde/work/cal.com/packages/features/ee/organizations/lib/orgDomains.ts:146:0-160:1) to detect when `WEBSITE_URL` and `WEBAPP_URL` are on different root domains. When they differ (EU case), use `WEBAPP_URL` instead.

| Deployment | WEBAPP_URL | WEBSITE_URL | Result |
|------------|------------|-------------|--------|
| US | `app.cal.com` | [cal.com](cci:7://file:///Users/dhairyashilshinde/work/cal.com:0:0-0:0) | `cal.com/user/event` ✅ |
| EU | `app.cal.eu` | [cal.com](cci:7://file:///Users/dhairyashilshinde/work/cal.com:0:0-0:0) | `app.cal.eu/user/event` ✅ |

### Changes
- [packages/features/ee/organizations/lib/orgDomains.ts](cci:7://file:///Users/dhairyashilshinde/work/cal.com/packages/features/ee/organizations/lib/orgDomains.ts:0:0-0:0) - Updated [getOrgFullOrigin()](cci:1://file:///Users/dhairyashilshinde/work/cal.com/packages/features/ee/organizations/lib/orgDomains.ts:146:0-160:1) logic
- [packages/features/ee/organizations/lib/orgDomains.test.ts](cci:7://file:///Users/dhairyashilshinde/work/cal.com/packages/features/ee/organizations/lib/orgDomains.test.ts:0:0-0:0) - Added EU test case

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
1. Run `yarn test packages/features/ee/organizations/lib/orgDomains.test.ts` - all 10 tests pass
2. After deployment to EU, verify `GET api.cal.eu/v2/event-types` returns correct `bookingUrl`