### PR TITLE
fix: managed event type bug

### DIFF
--- a/apps/web/test/lib/handleChildrenEventTypes.test.ts
+++ b/apps/web/test/lib/handleChildrenEventTypes.test.ts
@@ -240,6 +240,9 @@ describe("handleChildrenEventTypes", () => {
       // @ts-expect-error - partial mock for test purposes
       prismaMock.eventType.findMany.mockResolvedValue([{ userId: 4, metadata: {} }]);
 
+      // @ts-expect-error - partial mock for test purposes
+      prismaMock.eventType.update.mockResolvedValue({ id: 100 });
+
       const result = await updateChildrenEventTypes({
         eventTypeId: 1,
         oldEventType: { children: [{ userId: 4 }], team: { name: "" } },
@@ -312,6 +315,9 @@ describe("handleChildrenEventTypes", () => {
       // Mock findMany for existing records lookup (new batch update optimization)
       // @ts-expect-error - partial mock for test purposes
       prismaMock.eventType.findMany.mockResolvedValue([{ userId: 4, metadata: {} }]);
+
+      // @ts-expect-error - partial mock for test purposes
+      prismaMock.eventType.update.mockResolvedValue({ id: 101 });
 
       const result = await updateChildrenEventTypes({
         eventTypeId: 1,
@@ -449,6 +455,9 @@ describe("handleChildrenEventTypes", () => {
       // Mock findMany for existing records lookup (new batch update optimization)
       // @ts-expect-error - partial mock for test purposes
       prismaMock.eventType.findMany.mockResolvedValue([{ userId: 4, metadata: {} }]);
+
+      // @ts-expect-error - partial mock for test purposes
+      prismaMock.eventType.update.mockResolvedValue({ id: 102 });
 
       prismaMock.eventType.deleteMany.mockResolvedValue([123] as unknown as Prisma.BatchPayload);
       const result = await updateChildrenEventTypes({

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
@@ -716,6 +716,17 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
     return acc;
   }, {});
 
+  // Determine calVideoSettings to pass to children:
+  // - If calVideoSettings provided in input, sync to children
+  // - If Cal Video location removed, delete from children (pass null)
+  // - Otherwise, leave children's settings untouched (pass undefined)
+  let calVideoSettingsForChildren: typeof calVideoSettings | null | undefined = undefined;
+  if (calVideoSettings !== undefined) {
+    calVideoSettingsForChildren = calVideoSettings;
+  } else if (eventType.calVideoSettings && !isCalVideoLocationActive) {
+    calVideoSettingsForChildren = null;
+  }
+
   // Handling updates to children event types (managed events types)
   await updateChildrenEventTypes({
     eventTypeId: id,
@@ -726,6 +737,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
     profileId: ctx.user.profile.id,
     prisma: ctx.prisma,
     updatedValues,
+    calVideoSettings: calVideoSettingsForChildren,
   });
 
   // Clean up empty host groups


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes the issue when you update the cal video settings on the team managed event type but the children event types were not updated.



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1) Create a manageed event type and assign some team members
2) Update teh cal video setting on event type setup page
3) Check if the cal video settings were updated on all the children event types.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cal Video settings propagation for managed event types so children stay in sync. New children inherit settings; existing children are updated or cleared based on parent changes.

- **Bug Fixes**
  - Create CalVideoSettings for new child event types when the parent has settings.
  - Upsert settings for existing children; delete when the parent removes Cal Video; no-op when unchanged.
  - Update handler passes the correct calVideoSettings to children based on input and Cal Video location state, with tests covering create/sync/delete/no-op.

<sup>Written for commit 78e760347ccbd208e66b5ee4acf617a33b69f1f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

