### PR TITLE
fix(companion): extension copy link button

### DIFF
--- a/companion/extension/entrypoints/content.ts
+++ b/companion/extension/entrypoints/content.ts
@@ -69,6 +69,9 @@ export default defineContentScript({
     const COMPANION_URL =
       (import.meta.env.EXPO_PUBLIC_COMPANION_DEV_URL as string) || "https://companion.cal.com";
     iframe.src = COMPANION_URL;
+    // Enable clipboard access for the cross-origin iframe
+    // This allows the companion app to use navigator.clipboard.writeText()
+    iframe.allow = "clipboard-write; clipboard-read";
     // Use explicit dimensions - Brave has issues with percentage-based sizing
     iframe.style.cssText = `
       position: absolute !important;


### PR DESCRIPTION


https://github.com/user-attachments/assets/68641bd9-cbbe-42ab-a1ce-c784f3434735





Root Cause: The companion app runs inside a cross-origin iframe in the extension, and the iframe was missing the clipboard permissions. The navigator.clipboard.writeText() API requires explicit permission to work in cross-origin iframes.

Fix Applied: Added allow="clipboard-write; clipboard-read" attribute to the iframe in content.ts (line 74). This grants the cross-origin iframe permission to use the Clipboard API.