### PR TITLE
ci(companion): add lint and typecheck steps to companion CI

### DIFF
--- a/.github/workflows/companion-build.yml
+++ b/.github/workflows/companion-build.yml
@@ -1,4 +1,4 @@
-name: Companion Builds
+name: Companion Checks & Builds
 
 on:
   workflow_call:
@@ -31,6 +31,14 @@ jobs:
       - name: Install dependencies
         working-directory: companion
         run: bun install --frozen-lockfile
+
+      - name: Run lint checks
+        working-directory: companion
+        run: bun lint:all
+
+      - name: Run type checks
+        working-directory: companion
+        run: bun typecheck:all
 
       - name: Build Expo web app
         working-directory: companion


### PR DESCRIPTION
## What does this PR do?

Adds lint and typecheck validation steps to the companion app CI workflow to catch issues before they reach production.

**Background:** PR #26960 fixed a critical bug where missing `useEffect` imports caused iOS/Android app crashes. These issues would have been caught earlier if lint and typecheck checks were part of the companion CI pipeline.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a PR that modifies files in the `companion/` directory
2. Verify the "Companion Checks & Builds" workflow runs
3. Confirm the workflow executes in this order:
   - Install dependencies
   - **Run lint checks** (new)
   - **Run type checks** (new)
   - Build Expo web app
   - Build browser extension

To verify the checks work, you can intentionally introduce a type error in companion code and confirm the workflow fails at the typecheck step.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify `bun lint:all` and `bun typecheck:all` are the correct commands (they were tested locally and pass)
- [ ] Confirm steps are placed before build steps for fail-fast behavior
- [ ] Check that renaming the workflow doesn't break any workflow references in `pr.yml`

---

Link to Devin run: https://app.devin.ai/sessions/292e159b683c42649f7286a32539d188
Requested by: Dhairyashil Shinde (@dhairyashiil)