### PR TITLE
added max attendee configuration option

### DIFF
--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -588,6 +588,7 @@ function FieldEditDialog({
     //resolver: zodResolver(fieldSchema),
   });
   const formFieldType = fieldForm.getValues("type");
+  const fieldName = fieldForm.watch("name");
 
   useEffect(() => {
     if (!formFieldType) {
@@ -712,6 +713,24 @@ function FieldEditDialog({
                     {fieldType?.supportsLengthCheck ? (
                       <FieldWithLengthCheckSupport containerClassName="mt-6" fieldForm={fieldForm} />
                     ) : null}
+
+                    {formFieldType === "multiemail" && fieldName === "guests" && (
+                      <InputField
+                        {...fieldForm.register("maxEntries", {
+                          setValueAs: (value) => {
+                            if (value === "") {
+                              return undefined;
+                            }
+                            const parsed = Number(value);
+                            return Number.isNaN(parsed) ? undefined : parsed;
+                          },
+                        })}
+                        containerClassName="mt-6"
+                        label={t("max_attendees")}
+                        type="number"
+                        min={1}
+                      />
+                    )}
 
                     {formFieldType === "email" && (
                       <InputField

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -12,6 +12,8 @@
   "min_characters": "Min. Characters",
   "min_characters_required": "Min. {{count}} characters required",
   "max_characters_allowed": "Max. {{count}} characters allowed",
+  "max_attendees": "Maximum attendees",
+  "max_attendees_allowed": "Maximum {{count}} attendees allowed",
   "calcom_explained": "{{appName}} provides scheduling infrastructure for absolutely everyone.",
   "calcom_explained_new_user": "Finish setting up your {{appName}} account! You're just a few steps away from solving all your scheduling problems.",
   "have_any_questions": "Have questions? We're here to help.",

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/widgets.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/widgets.tsx
@@ -70,6 +70,7 @@ export type SelectLikeComponentPropsRAQB<TVal extends string | string[] = string
 
 export type TextLikeComponentProps<TVal extends string | string[] | boolean = string> = CommonProps<TVal> & {
   name?: string;
+  maxEntries?: number;
 };
 
 export type TextLikeComponentPropsRAQB<TVal extends string | boolean = string> =

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -268,6 +268,13 @@ function preprocess<T extends z.ZodType>({
           }
 
           const emails = emailsParsed.data;
+          if (typeof bookingField.maxEntries === "number" && emails.length > bookingField.maxEntries) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: m("max_attendees_allowed", { count: bookingField.maxEntries }),
+            });
+            continue;
+          }
           emails.sort().some((item, i) => {
             if (item === emails[i + 1]) {
               ctx.addIssue({ code: z.ZodIssueCode.custom, message: m("duplicate_email") });

--- a/packages/features/form-builder/Components.tsx
+++ b/packages/features/form-builder/Components.tsx
@@ -247,7 +247,11 @@ export const Components: Record<FieldType, Component> = {
     factory: function MultiEmail({ value, readOnly, label, setValue, ...props }) {
       const placeholder = props.placeholder;
       const { t } = useLocale();
-      value = value || [];
+      const maxEntries = props.maxEntries;
+      const listValue = value || [];
+      const hasReachedLimit =
+        typeof maxEntries === "number" && maxEntries > 0 && listValue.length >= maxEntries;
+      value = listValue;
       return (
         <>
           {value.length ? (
@@ -293,12 +297,19 @@ export const Components: Record<FieldType, Component> = {
                   color="minimal"
                   StartIcon="user-plus"
                   className="my-2.5"
+                  disabled={hasReachedLimit}
                   onClick={() => {
+                    if (hasReachedLimit) {
+                      return;
+                    }
                     value.push("");
                     setValue(value);
                   }}>
                   {t("add_another")}
                 </Button>
+              )}
+              {!readOnly && typeof maxEntries === "number" && maxEntries > 0 && (
+                <p className="text-subtle text-xs">{t("max_attendees_allowed", { count: maxEntries })}</p>
               )}
             </div>
           ) : (
@@ -311,7 +322,11 @@ export const Components: Record<FieldType, Component> = {
               color="minimal"
               variant="button"
               StartIcon="user-plus"
+              disabled={hasReachedLimit}
               onClick={() => {
+                if (hasReachedLimit) {
+                  return;
+                }
                 value.push("");
                 setValue(value);
               }}

--- a/packages/features/form-builder/FormBuilderField.tsx
+++ b/packages/features/form-builder/FormBuilderField.tsx
@@ -312,6 +312,7 @@ export const ComponentForField = ({
           placeholder={field.placeholder}
           name={field.name}
           label={field.label}
+          maxEntries={field.maxEntries}
           readOnly={readOnly}
           value={value as string[]}
           setValue={setValue as (arg: typeof value) => void}

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -1091,6 +1091,12 @@ export const baseFieldSchema = z.object({
    */
   maxLength: z.number().optional(),
 
+  /**
+   * It is the maximum number of entries that can be provided for list fields.
+   * It is used for types like `multiemail`.
+   */
+  maxEntries: z.number().int().min(1).optional(),
+
   // Emails that needs to be excluded
   excludeEmails: excludeOrRequireEmailSchema.optional(),
   // Emails that need to be required


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a max attendees setting for the Guests (multiemail) field in event type forms. Hosts can set a limit, and the UI and validation enforce it with clear messages.

- **New Features**
  - Added maxEntries field property for list inputs.
  - Edit dialog shows “Maximum attendees” input for the Guests field.
  - Validation rejects submissions exceeding the limit with a localized error.
  - “Add another” is disabled at the limit and shows the allowed maximum.
  - Added locale strings for labels and errors.

<sup>Written for commit a50ab58e7d5e7d886e83d1dc3864d2e6410a4adf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

