### PR TITLE
fix(workflows): enable email subject/body editing for all plans

### DIFF
--- a/apps/web/modules/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/apps/web/modules/ee/workflows/components/WorkflowStepContainer.tsx
@@ -1,7 +1,7 @@
-import { type TFunction } from "i18next";
+import type { TFunction } from "i18next";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import type { Dispatch, SetStateAction } from "react";
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { Controller, useWatch } from "react-hook-form";
 import "react-phone-number-input/style.css";
@@ -10,14 +10,15 @@ import type { RetellAgentWithDetails } from "@calcom/features/calAIPhone/provide
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import PhoneInput from "@calcom/features/components/phone-input";
 import {
-  isSMSAction,
-  isWhatsappAction,
   getTemplateBodyForAction,
-  shouldScheduleEmailReminder,
-  isSMSOrWhatsappAction,
-  isCalAIAction,
-  isFormTrigger,
   hasCalAIAction,
+  isCalAIAction,
+  isEmailAction,
+  isFormTrigger,
+  isSMSAction,
+  isSMSOrWhatsappAction,
+  isWhatsappAction,
+  shouldScheduleEmailReminder,
 } from "@calcom/features/ee/workflows/lib/actionHelperFunctions";
 import { DYNAMIC_TEXT_VARIABLES } from "@calcom/features/ee/workflows/lib/constants";
 import {
@@ -48,11 +49,7 @@ import { trpc } from "@calcom/trpc/react";
 import classNames from "@calcom/ui/classNames";
 import { Badge, InfoBadge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
-import {
-  DialogContent,
-  DialogFooter,
-  DialogClose,
-} from "@calcom/ui/components/dialog";
+import { DialogClose, DialogContent, DialogFooter } from "@calcom/ui/components/dialog";
 import {
   Dropdown,
   DropdownItem,
@@ -60,29 +57,26 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@calcom/ui/components/dropdown";
-import { AddVariablesDropdown } from "@calcom/ui/components/editor";
-import { Editor } from "@calcom/ui/components/editor";
-import { CheckboxField } from "@calcom/ui/components/form";
-import { EmailField } from "@calcom/ui/components/form";
-import { TextArea } from "@calcom/ui/components/form";
-import { Input } from "@calcom/ui/components/form";
-import { Label } from "@calcom/ui/components/form";
-import { TextField } from "@calcom/ui/components/form";
-import { Select } from "@calcom/ui/components/form";
-import { MultiSelectCheckbox } from "@calcom/ui/components/form";
+import { AddVariablesDropdown, Editor } from "@calcom/ui/components/editor";
 import type { MultiSelectCheckboxesOptionType as Option } from "@calcom/ui/components/form";
+import {
+  CheckboxField,
+  EmailField,
+  Input,
+  Label,
+  MultiSelectCheckbox,
+  Select,
+  TextArea,
+  TextField,
+} from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { showToast } from "@calcom/ui/components/toast";
-import {
-  useHasPaidPlan,
-  useHasActiveTeamPlan,
-} from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
-
+import { useHasActiveTeamPlan, useHasPaidPlan } from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
+import { AgentConfigurationSheet } from "./agent-configuration/AgentConfigurationSheet";
 import { TestPhoneCallDialog } from "./TestPhoneCallDialog";
 import { TimeTimeUnitInput } from "./TimeTimeUnitInput";
 import { WebCallDialog } from "./WebCallDialog";
-import { AgentConfigurationSheet } from "./agent-configuration/AgentConfigurationSheet";
 
 type User = RouterOutputs["viewer"]["me"]["get"];
 
@@ -120,23 +114,21 @@ type WorkflowStepProps = {
   isInboundAgentLoading?: boolean;
 };
 
-const getTimeSectionText = (trigger: WorkflowTriggerEvents, t: TFunction) => {
+const getTimeSectionText = (trigger: WorkflowTriggerEvents, t: TFunction): string | null => {
   const triggerMap: Partial<Record<WorkflowTriggerEvents, string>> = {
     [WorkflowTriggerEvents.AFTER_EVENT]: "how_long_after",
     [WorkflowTriggerEvents.BEFORE_EVENT]: "how_long_before",
-    [WorkflowTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW]:
-      "how_long_after_hosts_no_show",
-    [WorkflowTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW]:
-      "how_long_after_guests_no_show",
-    [WorkflowTriggerEvents.FORM_SUBMITTED_NO_EVENT]:
-      "how_long_after_form_submitted_no_event",
+    [WorkflowTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW]: "how_long_after_hosts_no_show",
+    [WorkflowTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW]: "how_long_after_guests_no_show",
+    [WorkflowTriggerEvents.FORM_SUBMITTED_NO_EVENT]: "how_long_after_form_submitted_no_event",
   };
-  return triggerMap[trigger] ? t(triggerMap[trigger]) : null;
+  if (triggerMap[trigger]) return t(triggerMap[trigger]);
+  return null;
 };
 
-const CalAIAgentDataSkeleton = () => {
+const CalAIAgentDataSkeleton = (): JSX.Element => {
   return (
-    <div className="bg-cal-muted mt-4 rounded-lg p-4">
+    <div className="mt-4 rounded-lg bg-cal-muted p-4">
       <div className="flex items-center justify-between">
         <div>
           <SkeletonText className="h-5 w-28" />
@@ -157,17 +149,16 @@ const CalAIAgentDataSkeleton = () => {
 
 const getActivePhoneNumbers = (
   phoneNumbers?: Array<{ subscriptionStatus?: string; phoneNumber: string }>
-) => {
+): Array<{ subscriptionStatus?: string; phoneNumber: string }> => {
   return (
     phoneNumbers?.filter(
       (phone) =>
-        phone.subscriptionStatus === PhoneNumberSubscriptionStatus.ACTIVE ||
-        !phone.subscriptionStatus
+        phone.subscriptionStatus === PhoneNumberSubscriptionStatus.ACTIVE || !phone.subscriptionStatus
     ) || []
   );
 };
 
-export default function WorkflowStepContainer(props: WorkflowStepProps) {
+export default function WorkflowStepContainer(props: WorkflowStepProps): JSX.Element {
   const { t, i18n } = useLocale();
   const utils = trpc.useUtils();
   const params = useParams();
@@ -195,18 +186,14 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
     updateTemplate,
     setUpdateTemplate,
   } = props;
-  const { data: _verifiedNumbers } =
-    trpc.viewer.workflows.getVerifiedNumbers.useQuery(
-      { teamId },
-      { enabled: !!teamId }
-    );
+  const { data: _verifiedNumbers } = trpc.viewer.workflows.getVerifiedNumbers.useQuery(
+    { teamId },
+    { enabled: !!teamId }
+  );
 
   const isMobile = useMediaQuery("(max-width: 569px)");
 
-  const { data: userTeams } = trpc.viewer.teams.list.useQuery(
-    {},
-    { enabled: !teamId }
-  );
+  const { data: userTeams } = trpc.viewer.teams.list.useQuery({}, { enabled: !teamId });
   const [agentConfigurationSheet, setAgentConfigurationSheet] = useState<{
     open: boolean;
     activeTab?: "outgoingCalls" | "phoneNumber" | "incomingCalls";
@@ -216,24 +203,19 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
   });
 
   const creditsTeamId = userTeams?.find(
-    (team) =>
-      team.accepted &&
-      (team.role === MembershipRole.ADMIN || team.role === MembershipRole.OWNER)
+    (team) => team.accepted && (team.role === MembershipRole.ADMIN || team.role === MembershipRole.OWNER)
   )?.id;
 
   const { hasPaidPlan } = useHasPaidPlan();
   const { hasActiveTeamPlan, isTrial } = useHasActiveTeamPlan();
   const planState = { hasPaidPlan, hasActiveTeamPlan, isTrial };
 
-  const { data: _verifiedEmails } =
-    trpc.viewer.workflows.getVerifiedEmails.useQuery({ teamId });
+  const { data: _verifiedEmails } = trpc.viewer.workflows.getVerifiedEmails.useQuery({ teamId });
 
-  const timeFormat = getTimeFormatStringFromUserTimeFormat(
-    props.user.timeFormat
-  );
+  const timeFormat = getTimeFormatStringFromUserTimeFormat(props.user.timeFormat);
 
   const createAgentMutation = trpc.viewer.aiVoiceAgent.create.useMutation({
-    onSuccess: async (data) => {
+    onSuccess: async (data: RouterOutputs["viewer"]["aiVoiceAgent"]["create"]) => {
       showToast(t("agent_created_successfully"), "success");
 
       const url = new URL(window.location.href);
@@ -254,14 +236,12 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
     },
   });
 
-  const stepAgentId =
-    step?.agentId ||
-    form.watch(`steps.${step ? step.stepNumber - 1 : 0}.agentId`) ||
-    null;
-  const stepInboundAgentId =
-    step?.inboundAgentId ||
-    form.watch(`steps.${step ? step.stepNumber - 1 : 0}.inboundAgentId`) ||
-    null;
+  let stepIndex = 0;
+  if (step) {
+    stepIndex = step.stepNumber - 1;
+  }
+  const stepAgentId = step?.agentId || form.watch(`steps.${stepIndex}.agentId`) || null;
+  const stepInboundAgentId = step?.inboundAgentId || form.watch(`steps.${stepIndex}.inboundAgentId`) || null;
 
   const updateAgentMutation = trpc.viewer.aiVoiceAgent.update.useMutation({
     onSuccess: async () => {
@@ -276,26 +256,23 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
     },
   });
 
-  const unsubscribePhoneNumberMutation =
-    trpc.viewer.phoneNumber.update.useMutation({
-      onSuccess: async () => {
-        showToast(t("phone_number_unsubscribed_successfully"), "success");
-        setIsUnsubscribeDialogOpen(false);
-        const currentAgentId = stepAgentId || stepInboundAgentId;
-        if (currentAgentId) {
-          utils.viewer.aiVoiceAgent.get.invalidate({ id: currentAgentId });
-        }
-      },
-      onError: (error: { message: string }) => {
-        showToast(error.message, "error");
-      },
-    });
+  const unsubscribePhoneNumberMutation = trpc.viewer.phoneNumber.update.useMutation({
+    onSuccess: async () => {
+      showToast(t("phone_number_unsubscribed_successfully"), "success");
+      setIsUnsubscribeDialogOpen(false);
+      const currentAgentId = stepAgentId || stepInboundAgentId;
+      if (currentAgentId) {
+        utils.viewer.aiVoiceAgent.get.invalidate({ id: currentAgentId });
+      }
+    },
+    onError: (error: { message: string }) => {
+      showToast(error.message, "error");
+    },
+  });
 
-  const verifiedNumbers =
-    _verifiedNumbers?.map((number) => number.phoneNumber) || [];
+  const verifiedNumbers = _verifiedNumbers?.map((number) => number.phoneNumber) || [];
   const verifiedEmails = _verifiedEmails || [];
-  const [isAdditionalInputsDialogOpen, setIsAdditionalInputsDialogOpen] =
-    useState(false);
+  const [isAdditionalInputsDialogOpen, setIsAdditionalInputsDialogOpen] = useState(false);
   const [isTestAgentDialogOpen, setIsTestAgentDialogOpen] = useState(false);
   const [isWebCallDialogOpen, setIsWebCallDialogOpen] = useState(false);
   const [isUnsubscribeDialogOpen, setIsUnsubscribeDialogOpen] = useState(false);
@@ -304,29 +281,24 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
 
   const action = step?.action;
   const requirePhoneNumber =
-    WorkflowActions.SMS_NUMBER === action ||
-    WorkflowActions.WHATSAPP_NUMBER === action;
-  const [isPhoneNumberNeeded, setIsPhoneNumberNeeded] =
-    useState(requirePhoneNumber);
+    WorkflowActions.SMS_NUMBER === action || WorkflowActions.WHATSAPP_NUMBER === action;
+  const [isPhoneNumberNeeded, setIsPhoneNumberNeeded] = useState(requirePhoneNumber);
 
   const [firstRender, setFirstRender] = useState(true);
 
   const senderNeeded =
-    step?.action === WorkflowActions.SMS_NUMBER ||
-    step?.action === WorkflowActions.SMS_ATTENDEE;
+    step?.action === WorkflowActions.SMS_NUMBER || step?.action === WorkflowActions.SMS_ATTENDEE;
 
   const [_isSenderIsNeeded, setIsSenderIsNeeded] = useState(senderNeeded);
 
   const [isEmailAddressNeeded, setIsEmailAddressNeeded] = useState(
-    step?.action === WorkflowActions.EMAIL_ADDRESS ? true : false
+    step?.action === WorkflowActions.EMAIL_ADDRESS
   );
 
   const [isEmailSubjectNeeded, setIsEmailSubjectNeeded] = useState(
     step?.action === WorkflowActions.EMAIL_ATTENDEE ||
       step?.action === WorkflowActions.EMAIL_HOST ||
       step?.action === WorkflowActions.EMAIL_ADDRESS
-      ? true
-      : false
   );
 
   const trigger = useWatch({
@@ -334,9 +306,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
     name: "trigger",
   });
 
-  const [timeSectionText, setTimeSectionText] = useState(
-    getTimeSectionText(trigger, t)
-  );
+  const [timeSectionText, setTimeSectionText] = useState(getTimeSectionText(trigger, t));
   const isCreatingAgent = useRef(false);
   const hasAutoCreated = useRef(false);
 
@@ -355,14 +325,14 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
         }
 
         const updatedSteps = form.getValues("steps");
-        const currentStepIndex = step ? step.stepNumber - 1 : 0;
+        let currentStepIndex = 0;
+        if (step) {
+          currentStepIndex = step.stepNumber - 1;
+        }
         const updatedStep = updatedSteps[currentStepIndex];
 
         if (updatedStep?.action !== WorkflowActions.CAL_AI_PHONE_CALL) {
-          form.setValue(
-            `steps.${currentStepIndex}.action`,
-            WorkflowActions.CAL_AI_PHONE_CALL
-          );
+          form.setValue(`steps.${currentStepIndex}.action`, WorkflowActions.CAL_AI_PHONE_CALL);
         }
 
         if (updatedStep?.id) {
@@ -415,21 +385,14 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
   ]);
 
   const triggerOptions = getWorkflowTriggerOptions(t, planState);
-  const templateOptions = getWorkflowTemplateOptions(
-    t,
-    step?.action,
-    planState,
-    trigger
-  );
+  const templateOptions = getWorkflowTemplateOptions(t, step?.action, planState, trigger);
 
   const steps = useWatch({
     control: form.control,
     name: "steps",
   });
 
-  const hasEmailToHostAction = steps.some(
-    (s) => s.action === WorkflowActions.EMAIL_HOST
-  );
+  const hasEmailToHostAction = steps.some((s) => s.action === WorkflowActions.EMAIL_HOST);
   const hasWhatsappAction = steps.some((s) => isWhatsappAction(s.action));
 
   const disallowFormTriggers = hasEmailToHostAction || hasWhatsappAction;
@@ -438,135 +401,112 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
     (option) => !(isFormTrigger(option.value) && disallowFormTriggers)
   );
 
-  const { ref: emailSubjectFormRef, ...restEmailSubjectForm } = step
-    ? form.register(`steps.${step.stepNumber - 1}.emailSubject`)
-    : { ref: null, name: "" };
+  let emailSubjectFormRef;
+  let restEmailSubjectForm;
+
+  if (step) {
+    const { ref, ...rest } = form.register(`steps.${step.stepNumber - 1}.emailSubject`);
+    emailSubjectFormRef = ref;
+    restEmailSubjectForm = rest;
+  } else {
+    emailSubjectFormRef = null;
+    restEmailSubjectForm = { name: "" };
+  }
 
   const refEmailSubject = useRef<HTMLTextAreaElement | null>(null);
 
-  const getNumberVerificationStatus = () =>
+  const getNumberVerificationStatus = (): boolean =>
     !!step &&
     !!verifiedNumbers.find(
-      (number: string) =>
-        number === form.getValues(`steps.${step.stepNumber - 1}.sendTo`)
+      (number: string) => number === form.getValues(`steps.${step.stepNumber - 1}.sendTo`)
     );
 
-  const getEmailVerificationStatus = () =>
+  const getEmailVerificationStatus = (): boolean =>
     !!step &&
-    !!verifiedEmails.find(
-      (email: string) =>
-        email === form.getValues(`steps.${step.stepNumber - 1}.sendTo`)
-    );
+    !!verifiedEmails.find((email: string) => email === form.getValues(`steps.${step.stepNumber - 1}.sendTo`));
 
-  const [numberVerified, setNumberVerified] = useState(
-    getNumberVerificationStatus()
-  );
-  const [emailVerified, setEmailVerified] = useState(
-    getEmailVerificationStatus()
-  );
+  const [numberVerified, setNumberVerified] = useState(getNumberVerificationStatus());
+  const [emailVerified, setEmailVerified] = useState(getEmailVerificationStatus());
 
   // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only run when verifiedNumbers.length changes
-  useEffect(
-    () => setNumberVerified(getNumberVerificationStatus()),
-    [verifiedNumbers.length]
-  );
+  useEffect(() => setNumberVerified(getNumberVerificationStatus()), [getNumberVerificationStatus]);
   // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only run when verifiedEmails.length changes
-  useEffect(
-    () => setEmailVerified(getEmailVerificationStatus()),
-    [verifiedEmails.length]
-  );
+  useEffect(() => setEmailVerified(getEmailVerificationStatus()), [getEmailVerificationStatus]);
 
-  const addVariableEmailSubject = (variable: string) => {
+  const addVariableEmailSubject = (variable: string): void => {
     if (step) {
       const currentEmailSubject = refEmailSubject?.current?.value || "";
-      const cursorPosition =
-        refEmailSubject?.current?.selectionStart || currentEmailSubject.length;
-      const subjectWithAddedVariable = `${currentEmailSubject.substring(
-        0,
-        cursorPosition
-      )}{${variable
+      const cursorPosition = refEmailSubject?.current?.selectionStart || currentEmailSubject.length;
+      const subjectWithAddedVariable = `${currentEmailSubject.substring(0, cursorPosition)}{${variable
         .toUpperCase()
         .replace(/ /g, "_")}}${currentEmailSubject.substring(cursorPosition)}`;
-      form.setValue(
-        `steps.${step.stepNumber - 1}.emailSubject`,
-        subjectWithAddedVariable
-      );
+      form.setValue(`steps.${step.stepNumber - 1}.emailSubject`, subjectWithAddedVariable);
     }
   };
 
-  const sendVerificationCodeMutation =
-    trpc.viewer.workflows.sendVerificationCode.useMutation({
-      onSuccess: async () => {
-        showToast(t("verification_code_sent"), "success");
-      },
-      onError: async (error) => {
-        showToast(error.message, "error");
-      },
-    });
+  const sendVerificationCodeMutation = trpc.viewer.workflows.sendVerificationCode.useMutation({
+    onSuccess: async () => {
+      showToast(t("verification_code_sent"), "success");
+    },
+    onError: async (error: { message: string }) => {
+      showToast(error.message, "error");
+    },
+  });
 
-  const verifyPhoneNumberMutation =
-    trpc.viewer.workflows.verifyPhoneNumber.useMutation({
-      onSuccess: async (isVerified) => {
-        showToast(
-          isVerified ? t("verified_successfully") : t("wrong_code"),
-          "success"
-        );
-        setNumberVerified(isVerified);
-        if (
-          step &&
-          form?.formState?.errors?.steps &&
-          form.formState.errors.steps[step.stepNumber - 1]?.sendTo &&
-          isVerified
-        ) {
-          form.clearErrors(`steps.${step.stepNumber - 1}.sendTo`);
-        }
+  const verifyPhoneNumberMutation = trpc.viewer.workflows.verifyPhoneNumber.useMutation({
+    onSuccess: async (isVerified: boolean) => {
+      showToast(isVerified ? t("verified_successfully") : t("wrong_code"), "success");
+      setNumberVerified(isVerified);
+      if (
+        step &&
+        form?.formState?.errors?.steps &&
+        form.formState.errors.steps[step.stepNumber - 1]?.sendTo &&
+        isVerified
+      ) {
+        form.clearErrors(`steps.${step.stepNumber - 1}.sendTo`);
+      }
 
-        utils.viewer.workflows.getVerifiedNumbers.invalidate();
-      },
-      onError: (err) => {
-        if (err instanceof HttpError) {
-          const message = `${err.statusCode}: ${err.message}`;
-          showToast(message, "error");
-          setNumberVerified(false);
-        }
-      },
-    });
+      utils.viewer.workflows.getVerifiedNumbers.invalidate();
+    },
+    onError: (err) => {
+      if (err instanceof HttpError) {
+        const message = `${err.statusCode}: ${err.message}`;
+        showToast(message, "error");
+        setNumberVerified(false);
+      }
+    },
+  });
 
-  const sendEmailVerificationCodeMutation =
-    trpc.viewer.auth.sendVerifyEmailCode.useMutation({
-      onSuccess() {
-        showToast(t("email_sent"), "success");
-      },
-      onError: () => {
-        showToast(t("email_not_sent"), "error");
-      },
-    });
+  const sendEmailVerificationCodeMutation = trpc.viewer.auth.sendVerifyEmailCode.useMutation({
+    onSuccess() {
+      showToast(t("email_sent"), "success");
+    },
+    onError: () => {
+      showToast(t("email_not_sent"), "error");
+    },
+  });
 
-  const verifyEmailCodeMutation =
-    trpc.viewer.workflows.verifyEmailCode.useMutation({
-      onSuccess: (isVerified) => {
-        showToast(
-          isVerified ? t("verified_successfully") : t("wrong_code"),
-          "success"
-        );
-        setEmailVerified(true);
-        if (
-          step &&
-          form?.formState?.errors?.steps &&
-          form.formState.errors.steps[step.stepNumber - 1]?.sendTo &&
-          isVerified
-        ) {
-          form.clearErrors(`steps.${step.stepNumber - 1}.sendTo`);
-        }
-        utils.viewer.workflows.getVerifiedEmails.invalidate();
-      },
-      onError: (err) => {
-        if (err.message === "invalid_code") {
-          showToast(t("code_provided_invalid"), "error");
-          setEmailVerified(false);
-        }
-      },
-    });
+  const verifyEmailCodeMutation = trpc.viewer.workflows.verifyEmailCode.useMutation({
+    onSuccess: (isVerified) => {
+      showToast(isVerified ? t("verified_successfully") : t("wrong_code"), "success");
+      setEmailVerified(true);
+      if (
+        step &&
+        form?.formState?.errors?.steps &&
+        form.formState.errors.steps[step.stepNumber - 1]?.sendTo &&
+        isVerified
+      ) {
+        form.clearErrors(`steps.${step.stepNumber - 1}.sendTo`);
+      }
+      utils.viewer.workflows.getVerifiedEmails.invalidate();
+    },
+    onError: (err) => {
+      if (err.message === "invalid_code") {
+        showToast(t("code_provided_invalid"), "error");
+        setEmailVerified(false);
+      }
+    },
+  });
   /* const testActionMutation = trpc.viewer.workflows.testAction.useMutation({
     onSuccess: async () => {
       showToast(t("notification_sent"), "success");
@@ -599,9 +539,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
     return (
       <>
         <div className="mb-3">
-          <Label className="text-default text-sm leading-none">
-            {t("when")}
-          </Label>
+          <Label className="text-default text-sm leading-none">{t("when")}</Label>
           <Controller
             name="trigger"
             control={form.control}
@@ -610,17 +548,14 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 <Select
                   isSearchable={false}
                   innerClassNames={{ valueContainer: "font-medium" }}
-                  className="text-sm font-medium"
+                  className="font-medium text-sm"
                   id="trigger-select"
                   isDisabled={props.readOnly}
                   onChange={(val) => {
                     if (val) {
                       const triggerValue = val.value as WorkflowTriggerEvents;
-                      const currentTrigger = form.getValues(
-                        "trigger"
-                      ) as WorkflowTriggerEvents;
-                      const isCurrentFormTrigger =
-                        isFormTrigger(currentTrigger);
+                      const currentTrigger = form.getValues("trigger") as WorkflowTriggerEvents;
+                      const isCurrentFormTrigger = isFormTrigger(currentTrigger);
                       const isNewFormTrigger = isFormTrigger(triggerValue);
 
                       form.setValue("trigger", triggerValue);
@@ -634,17 +569,12 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                         form.setValue("selectAll", false);
                       }
 
-                      const newTimeSectionText = getTimeSectionText(
-                        triggerValue,
-                        t
-                      );
+                      const newTimeSectionText = getTimeSectionText(triggerValue, t);
                       if (newTimeSectionText) {
                         setTimeSectionText(newTimeSectionText);
                         if (
-                          triggerValue ===
-                            WorkflowTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW ||
-                          triggerValue ===
-                            WorkflowTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW
+                          triggerValue === WorkflowTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW ||
+                          triggerValue === WorkflowTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW
                         ) {
                           form.setValue("time", 5);
                           form.setValue("timeUnit", TimeUnit.MINUTE);
@@ -683,11 +613,9 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                     needsTeamsUpgrade: option.needsTeamsUpgrade,
                     upgradeTeamsBadgeProps: option.upgradeTeamsBadgeProps,
                   }))}
-                  isOptionDisabled={(option: {
-                    label: string;
-                    value: string;
-                    needsTeamsUpgrade?: boolean;
-                  }) => !!option.needsTeamsUpgrade}
+                  isOptionDisabled={(option: { label: string; value: string; needsTeamsUpgrade?: boolean }) =>
+                    !!option.needsTeamsUpgrade
+                  }
                 />
               );
             }}
@@ -695,8 +623,8 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
         </div>
         <div>
           {!!timeSectionText && (
-            <div className="mb-3 mt-3">
-              <Label className="text-default mb-0">{timeSectionText}</Label>
+            <div className="mt-3 mb-3">
+              <Label className="mb-0 text-default">{timeSectionText}</Label>
               <TimeTimeUnitInput disabled={props.readOnly} />
             </div>
           )}
@@ -704,7 +632,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
           {selectedOptions && setSelectedOptions && allOptions && (
             <div className={classNames(!!timeSectionText && "mb-3")}>
               {isOrganization ? (
-                <div className="text-default flex items-center gap-2">
+                <div className="flex items-center gap-2 text-default">
                   <Label>{t("which_team_apply")}</Label>
                   <div className="mb-2">
                     <InfoBadge content={t("team_select_info")} />
@@ -712,9 +640,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 </div>
               ) : (
                 <Label>
-                  {isFormTrigger(trigger)
-                    ? t("which_routing_form_apply")
-                    : t("which_event_type_apply")}
+                  {isFormTrigger(trigger) ? t("which_routing_form_apply") : t("which_event_type_apply")}
                 </Label>
               )}
               <Controller
@@ -727,11 +653,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                       isDisabled={props.readOnly || form.getValues("selectAll")}
                       className="w-full"
                       setSelected={setSelectedOptions}
-                      selected={
-                        form.getValues("selectAll")
-                          ? allOptions
-                          : selectedOptions
-                      }
+                      selected={form.getValues("selectAll") ? allOptions : selectedOptions}
                       setValue={(s: Option[]) => {
                         form.setValue("activeOn", s);
                       }}
@@ -739,8 +661,8 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                         isOrganization
                           ? "count_team"
                           : isFormTrigger(form.getValues("trigger"))
-                          ? "nr_routing_form"
-                          : "nr_event_type"
+                            ? "nr_routing_form"
+                            : "nr_event_type"
                       }
                     />
                   );
@@ -756,8 +678,8 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                           isOrganization
                             ? t("apply_to_all_teams")
                             : isFormTrigger(form.getValues("trigger"))
-                            ? t("apply_to_all_routing_forms")
-                            : t("apply_to_all_event_types")
+                              ? t("apply_to_all_routing_forms")
+                              : t("apply_to_all_event_types")
                         }
                         disabled={props.readOnly}
                         descriptionClassName="ml-0"
@@ -778,10 +700,8 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
           )}
           {!!timeSectionText && steps.some((s) => isSMSAction(s.action)) && (
             <div className="mt-1 flex text-gray-500">
-              <Icon name="info" className="mr-1 mt-0.5 h-4 w-4" />
-              <p className="text-sm">
-                {t("testing_sms_workflow_info_message")}
-              </p>
+              <Icon name="info" className="mt-0.5 mr-1 h-4 w-4" />
+              <p className="text-sm">{t("testing_sms_workflow_info_message")}</p>
             </div>
           )}
         </div>
@@ -789,7 +709,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
     );
   }
 
-  if (step && step.action) {
+  if (step?.action) {
     const actionString = t(`${step.action.toLowerCase()}_action`);
 
     const selectedAction = {
@@ -809,8 +729,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
 
     const canRequirePhoneNumber = (workflowStep: string) => {
       return (
-        WorkflowActions.SMS_ATTENDEE === workflowStep ||
-        WorkflowActions.WHATSAPP_ATTENDEE === workflowStep
+        WorkflowActions.SMS_ATTENDEE === workflowStep || WorkflowActions.WHATSAPP_ATTENDEE === workflowStep
       );
     };
 
@@ -837,9 +756,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                     isDisabled={props.readOnly}
                     onChange={(val) => {
                       if (val) {
-                        const oldValue = form.getValues(
-                          `steps.${step.stepNumber - 1}.action`
-                        );
+                        const oldValue = form.getValues(`steps.${step.stepNumber - 1}.action`);
 
                         const template = getTemplateBodyForAction({
                           action: val.value,
@@ -849,10 +766,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                           timeFormat,
                         });
 
-                        form.setValue(
-                          `steps.${step.stepNumber - 1}.reminderBody`,
-                          template
-                        );
+                        form.setValue(`steps.${step.stepNumber - 1}.reminderBody`, template);
 
                         const setNumberRequiredConfigs = (
                           phoneNumberIsNeeded: boolean,
@@ -865,79 +779,42 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                         };
 
                         if (isSMSAction(val.value)) {
-                          setNumberRequiredConfigs(
-                            val.value === WorkflowActions.SMS_NUMBER
-                          );
+                          setNumberRequiredConfigs(val.value === WorkflowActions.SMS_NUMBER);
                           // email action changes to sms action
                           if (!isSMSAction(oldValue)) {
-                            form.setValue(
-                              `steps.${step.stepNumber - 1}.sender`,
-                              SENDER_ID
-                            );
+                            form.setValue(`steps.${step.stepNumber - 1}.sender`, SENDER_ID);
                           }
 
                           setIsEmailSubjectNeeded(false);
-                          form.setValue(
-                            `steps.${step.stepNumber - 1}.agentId`,
-                            null
-                          );
+                          form.setValue(`steps.${step.stepNumber - 1}.agentId`, null);
                         } else if (isWhatsappAction(val.value)) {
-                          setNumberRequiredConfigs(
-                            val.value === WorkflowActions.WHATSAPP_NUMBER,
-                            false
-                          );
+                          setNumberRequiredConfigs(val.value === WorkflowActions.WHATSAPP_NUMBER, false);
 
                           if (!isWhatsappAction(oldValue)) {
-                            form.setValue(
-                              `steps.${step.stepNumber - 1}.sender`,
-                              ""
-                            );
+                            form.setValue(`steps.${step.stepNumber - 1}.sender`, "");
                           }
 
                           setIsEmailSubjectNeeded(false);
-                          form.setValue(
-                            `steps.${step.stepNumber - 1}.agentId`,
-                            null
-                          );
+                          form.setValue(`steps.${step.stepNumber - 1}.agentId`, null);
                         } else if (isCalAIAction(val.value)) {
                           setIsPhoneNumberNeeded(false);
                           setIsSenderIsNeeded(false);
                           setIsEmailAddressNeeded(false);
                           setIsEmailSubjectNeeded(false);
-                          form.setValue(
-                            `steps.${step.stepNumber - 1}.emailSubject`,
-                            null
-                          );
-                          form.setValue(
-                            `steps.${step.stepNumber - 1}.reminderBody`,
-                            null
-                          );
-                          form.setValue(
-                            `steps.${step.stepNumber - 1}.sender`,
-                            null
-                          );
+                          form.setValue(`steps.${step.stepNumber - 1}.emailSubject`, null);
+                          form.setValue(`steps.${step.stepNumber - 1}.reminderBody`, null);
+                          form.setValue(`steps.${step.stepNumber - 1}.sender`, null);
                         } else {
                           setIsPhoneNumberNeeded(false);
                           setIsSenderIsNeeded(false);
-                          setIsEmailAddressNeeded(
-                            val.value === WorkflowActions.EMAIL_ADDRESS
-                          );
+                          setIsEmailAddressNeeded(val.value === WorkflowActions.EMAIL_ADDRESS);
                           setIsEmailSubjectNeeded(true);
-                          form.setValue(
-                            `steps.${step.stepNumber - 1}.agentId`,
-                            null
-                          );
+                          form.setValue(`steps.${step.stepNumber - 1}.agentId`, null);
                         }
 
-                        form.setValue(
-                          `steps.${step.stepNumber - 1}.sendTo`,
-                          null
-                        );
+                        form.setValue(`steps.${step.stepNumber - 1}.sendTo`, null);
                         form.clearErrors(`steps.${step.stepNumber - 1}.sendTo`);
-                        form.setValue(
-                          `steps.${step.stepNumber - 1}.action`,
-                          val.value
-                        );
+                        form.setValue(`steps.${step.stepNumber - 1}.action`, val.value);
                         setUpdateTemplate(!updateTemplate);
                       }
                     }}
@@ -951,12 +828,8 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
               }}
             />
           </div>
-          {!isWhatsappAction(
-            form.getValues(`steps.${step.stepNumber - 1}.action`)
-          ) &&
-            !isCalAIAction(
-              form.getValues(`steps.${step.stepNumber - 1}.action`)
-            ) && (
+          {!isWhatsappAction(form.getValues(`steps.${step.stepNumber - 1}.action`)) &&
+            !isCalAIAction(form.getValues(`steps.${step.stepNumber - 1}.action`)) && (
               <div>
                 {_isSenderIsNeeded ? (
                   <>
@@ -969,85 +842,59 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                         placeholder={SENDER_ID}
                         disabled={props.readOnly}
                         maxLength={11}
-                        {...form.register(
-                          `steps.${step.stepNumber - 1}.sender`
-                        )}
+                        {...form.register(`steps.${step.stepNumber - 1}.sender`)}
                       />
                       <div className="mt-1.5 flex items-center gap-1">
                         <Icon name="info" size="10" className="text-gray-500" />
-                        <div className="text-subtle text-xs">
-                          {t("sender_id_info")}
-                        </div>
+                        <div className="text-subtle text-xs">{t("sender_id_info")}</div>
                       </div>
                     </div>
-                    {form.formState.errors.steps &&
-                      form.formState?.errors?.steps[step.stepNumber - 1]
-                        ?.sender && (
-                        <p className="text-error mt-1 text-xs">
-                          {t("sender_id_error_message")}
-                        </p>
-                      )}
+                    {form.formState?.errors?.steps?.[step.stepNumber - 1]?.sender && (
+                      <p className="mt-1 text-error text-xs">{t("sender_id_error_message")}</p>
+                    )}
                   </>
                 ) : (
-                  <>
-                    <div className="pt-4">
-                      <Label>{t("sender_name")}</Label>
-                      <Input
-                        type="text"
-                        disabled={props.readOnly}
-                        placeholder={SENDER_NAME}
-                        {...form.register(
-                          `steps.${step.stepNumber - 1}.senderName`
-                        )}
-                      />
-                    </div>
-                  </>
+                  <div className="pt-4">
+                    <Label>{t("sender_name")}</Label>
+                    <Input
+                      type="text"
+                      disabled={props.readOnly}
+                      placeholder={SENDER_NAME}
+                      {...form.register(`steps.${step.stepNumber - 1}.senderName`)}
+                    />
+                  </div>
                 )}
               </div>
             )}
-          {isCalAIAction(
-            form.getValues(`steps.${step.stepNumber - 1}.action`)
-          ) &&
-            !stepAgentId && (
-              <div className="bg-cal-muted border-muted mt-2 rounded-2xl border p-3">
-                <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center sm:gap-0">
-                  <div>
-                    <h2 className="text-emphasis text-sm font-medium leading-none">
-                      {t("cal_ai_agent")}
-                      <Badge
-                        startIcon="info"
-                        className="ms-2 rounded-md"
-                        variant="warning"
-                      >
-                        {t("set_up_required")}
-                      </Badge>
-                    </h2>
-                    <p className="text-muted mt-1 text-sm font-medium leading-none">
-                      {t("no_phone_number_connected")}.
-                    </p>
-                  </div>
-                  <Button
-                    color="primary"
-                    disabled={
-                      props.readOnly ||
-                      isCreatingAgent.current ||
-                      hasAutoCreated.current
-                    }
-                    className="flex items-center justify-center"
-                    onClick={() => handleCreateAgent()}
-                    loading={
-                      createAgentMutation.isPending || isCreatingAgent.current
-                    }
-                  >
-                    {t("set_up_agent")}
-                  </Button>
+          {isCalAIAction(form.getValues(`steps.${step.stepNumber - 1}.action`)) && !stepAgentId && (
+            <div className="mt-2 rounded-2xl border border-muted bg-cal-muted p-3">
+              <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center sm:gap-0">
+                <div>
+                  <h2 className="font-medium text-emphasis text-sm leading-none">
+                    {t("cal_ai_agent")}
+                    <Badge startIcon="info" className="ms-2 rounded-md" variant="warning">
+                      {t("set_up_required")}
+                    </Badge>
+                  </h2>
+                  <p className="mt-1 font-medium text-muted text-sm leading-none">
+                    {t("no_phone_number_connected")}.
+                  </p>
                 </div>
+                <Button
+                  color="primary"
+                  disabled={props.readOnly || isCreatingAgent.current || hasAutoCreated.current}
+                  className="flex items-center justify-center"
+                  onClick={() => handleCreateAgent()}
+                  loading={createAgentMutation.isPending || isCreatingAgent.current}>
+                  {t("set_up_agent")}
+                </Button>
               </div>
-            )}
+            </div>
+          )}
 
           {stepAgentId && isAgentLoading && <CalAIAgentDataSkeleton />}
           {stepAgentId && agentData && (
-            <div className="bg-cal-muted mt-4 rounded-lg p-4">
+            <div className="mt-4 rounded-lg bg-cal-muted p-4">
               <div
                 className="flex cursor-pointer items-center justify-between"
                 onClick={(e) => {
@@ -1065,19 +912,14 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                       activeTab: "outgoingCalls",
                     });
                   }
-                }}
-              >
+                }}>
                 <div>
-                  <h3 className="text-emphasis text-base font-medium">
-                    {t("cal_ai_agent")}
-                  </h3>
+                  <h3 className="font-medium text-base text-emphasis">{t("cal_ai_agent")}</h3>
                   {arePhoneNumbersActive.length > 0 ? (
                     <div className="flex items-center gap-2">
-                      <Icon name="phone" className="text-emphasis h-4 w-4" />
+                      <Icon name="phone" className="h-4 w-4 text-emphasis" />
                       <span className="text-emphasis text-sm">
-                        {formatPhoneNumber(
-                          arePhoneNumbersActive[0].phoneNumber
-                        )}
+                        {formatPhoneNumber(arePhoneNumbersActive[0].phoneNumber)}
                       </span>
                       <Badge variant="green" size="sm" withDot>
                         {t("active")}
@@ -1085,16 +927,11 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                     </div>
                   ) : (
                     <div className="flex items-center gap-1">
-                      <span className="text-subtle text-sm">
-                        {t("no_phone_number_connected")}
-                      </span>
+                      <span className="text-sm text-subtle">{t("no_phone_number_connected")}</span>
                     </div>
                   )}
                 </div>
-                <div
-                  className="flex items-center gap-1"
-                  onClick={(e) => e.stopPropagation()}
-                >
+                <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
                   {arePhoneNumbersActive.length > 0 ? (
                     <Dropdown>
                       <DropdownMenuTrigger asChild>
@@ -1102,8 +939,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                           color="secondary"
                           className="rounded-[10px]"
                           disabled={props.readOnly}
-                          EndIcon="chevron-down"
-                        >
+                          EndIcon="chevron-down">
                           {t("test_agent")}
                         </Button>
                       </DropdownMenuTrigger>
@@ -1112,8 +948,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                           <DropdownItem
                             type="button"
                             StartIcon="phone"
-                            onClick={() => setIsTestAgentDialogOpen(true)}
-                          >
+                            onClick={() => setIsTestAgentDialogOpen(true)}>
                             {t("phone_call")}
                           </DropdownItem>
                         </DropdownMenuItem>
@@ -1121,8 +956,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                           <DropdownItem
                             type="button"
                             StartIcon="monitor"
-                            onClick={() => setIsWebCallDialogOpen(true)}
-                          >
+                            onClick={() => setIsWebCallDialogOpen(true)}>
                             {t("web_call")}
                           </DropdownItem>
                         </DropdownMenuItem>
@@ -1139,16 +973,14 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                             activeTab: "phoneNumber",
                           }));
                         }}
-                        disabled={props.readOnly}
-                      >
+                        disabled={props.readOnly}>
                         {t("connect_phone_number")}
                       </Button>
                       <Button
                         color="secondary"
                         onClick={() => setIsWebCallDialogOpen(true)}
                         disabled={props.readOnly}
-                        StartIcon="monitor"
-                      >
+                        StartIcon="monitor">
                         {t("test_web_call")}
                       </Button>
                     </>
@@ -1177,8 +1009,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                                   open: true,
                                   activeTab: "phoneNumber",
                                 }));
-                              }}
-                            >
+                              }}>
                               {t("connect_phone_number")}
                             </DropdownItem>
                           </DropdownMenuItem>
@@ -1187,8 +1018,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                               type="button"
                               onClick={() => setIsWebCallDialogOpen(true)}
                               disabled={props.readOnly}
-                              StartIcon="monitor"
-                            >
+                              StartIcon="monitor">
                               {t("test_web_call")}
                             </DropdownItem>
                           </DropdownMenuItem>
@@ -1203,8 +1033,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                               open: true,
                               activeTab: "outgoingCalls",
                             })
-                          }
-                        >
+                          }>
                           {t("edit")}
                         </DropdownItem>
                       </DropdownMenuItem>
@@ -1215,7 +1044,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
             </div>
           )}
           {isPhoneNumberNeeded && (
-            <div className="bg-cal-muted mt-2 rounded-md p-4 pt-0">
+            <div className="mt-2 rounded-md bg-cal-muted p-4 pt-0">
               <Label className="pt-4">{t("custom_phone_number")}</Label>
               <div className="block sm:flex">
                 <Controller
@@ -1224,18 +1053,14 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                     <PhoneInput
                       placeholder={t("phone_number")}
                       id={`steps.${step.stepNumber - 1}.sendTo`}
-                      className="min-w-fit sm:rounded-r-none sm:rounded-bl-md sm:rounded-tl-md"
+                      className="min-w-fit sm:rounded-r-none sm:rounded-tl-md sm:rounded-bl-md"
                       required
                       disabled={props.readOnly}
                       value={value}
                       onChange={(val) => {
                         const isAlreadyVerified = !!verifiedNumbers
                           ?.concat([])
-                          .find(
-                            (number) =>
-                              number.replace(/\s/g, "") ===
-                              val?.replace(/\s/g, "")
-                          );
+                          .find((number) => number.replace(/\s/g, "") === val?.replace(/\s/g, ""));
                         setNumberVerified(isAlreadyVerified);
                         onChange(val);
                       }}
@@ -1246,28 +1071,23 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                   color="secondary"
                   disabled={numberVerified || props.readOnly || false}
                   className={classNames(
-                    "-ml-[3px] h-[40px] min-w-fit sm:block sm:rounded-bl-none sm:rounded-tl-none",
+                    "-ml-[3px] h-[40px] min-w-fit sm:block sm:rounded-tl-none sm:rounded-bl-none",
                     numberVerified ? "hidden" : "mt-3 sm:mt-0"
                   )}
                   onClick={() =>
                     sendVerificationCodeMutation.mutate({
-                      phoneNumber:
-                        form.getValues(`steps.${step.stepNumber - 1}.sendTo`) ||
-                        "",
+                      phoneNumber: form.getValues(`steps.${step.stepNumber - 1}.sendTo`) || "",
                     })
-                  }
-                >
+                  }>
                   {t("send_code")}
                 </Button>
               </div>
 
-              {form.formState.errors.steps &&
-                form.formState?.errors?.steps[step.stepNumber - 1]?.sendTo && (
-                  <p className="text-error mt-1 text-xs">
-                    {form.formState?.errors?.steps[step.stepNumber - 1]?.sendTo
-                      ?.message || ""}
-                  </p>
-                )}
+              {form.formState?.errors?.steps?.[step.stepNumber - 1]?.sendTo && (
+                <p className="mt-1 text-error text-xs">
+                  {form.formState?.errors?.steps[step.stepNumber - 1]?.sendTo?.message || ""}
+                </p>
+              )}
               {numberVerified ? (
                 <div className="mt-1">
                   <Badge variant="green">{t("number_verified")}</Badge>
@@ -1293,44 +1113,30 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                           color="secondary"
                           size="sm"
                           className="ml-2 min-w-fit rounded-[10px]"
-                          disabled={
-                            verifyPhoneNumberMutation.isPending ||
-                            props.readOnly
-                          }
+                          disabled={verifyPhoneNumberMutation.isPending || props.readOnly}
                           onClick={() => {
                             verifyPhoneNumberMutation.mutate({
-                              phoneNumber:
-                                form.getValues(
-                                  `steps.${step.stepNumber - 1}.sendTo`
-                                ) || "",
+                              phoneNumber: form.getValues(`steps.${step.stepNumber - 1}.sendTo`) || "",
                               code: verificationCode,
                               teamId,
                             });
-                          }}
-                        >
+                          }}>
                           {t("verify")}
                         </Button>
                       </div>
                     </div>
-                    {form.formState.errors.steps &&
-                      form.formState?.errors?.steps[step.stepNumber - 1]
-                        ?.sendTo && (
-                        <p className="text-error mt-1 text-xs">
-                          {form.formState?.errors?.steps[step.stepNumber - 1]
-                            ?.sendTo?.message || ""}
-                        </p>
-                      )}
+                    {form.formState?.errors?.steps?.[step.stepNumber - 1]?.sendTo && (
+                      <p className="mt-1 text-error text-xs">
+                        {form.formState?.errors?.steps[step.stepNumber - 1]?.sendTo?.message || ""}
+                      </p>
+                    )}
                   </>
                 )
               )}
             </div>
           )}
-          {canRequirePhoneNumber(
-            form.getValues(`steps.${step.stepNumber - 1}.action`)
-          ) &&
-            !isCalAIAction(
-              form.getValues(`steps.${step.stepNumber - 1}.action`)
-            ) && (
+          {canRequirePhoneNumber(form.getValues(`steps.${step.stepNumber - 1}.action`)) &&
+            !isCalAIAction(form.getValues(`steps.${step.stepNumber - 1}.action`)) && (
               <div className="mt-2">
                 <Controller
                   name={`steps.${step.stepNumber - 1}.numberRequired`}
@@ -1338,141 +1144,113 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                   render={() => (
                     <CheckboxField
                       disabled={props.readOnly}
-                      defaultChecked={
-                        form.getValues(
-                          `steps.${step.stepNumber - 1}.numberRequired`
-                        ) || false
-                      }
+                      defaultChecked={form.getValues(`steps.${step.stepNumber - 1}.numberRequired`) || false}
                       description={t("make_phone_number_required")}
                       descriptionClassName="ml-0"
                       onChange={(e) =>
-                        form.setValue(
-                          `steps.${step.stepNumber - 1}.numberRequired`,
-                          e.target.checked
-                        )
+                        form.setValue(`steps.${step.stepNumber - 1}.numberRequired`, e.target.checked)
                       }
                     />
                   )}
                 />
               </div>
             )}
-          {isEmailAddressNeeded &&
-            !isCalAIAction(
-              form.getValues(`steps.${step.stepNumber - 1}.action`)
-            ) && (
-              <div className="bg-cal-muted border-muted mt-5 rounded-2xl border p-4">
-                <Label>{t("email_address")}</Label>
-                <div className="block items-center gap-2 sm:flex">
-                  <Controller
-                    name={`steps.${step.stepNumber - 1}.sendTo`}
-                    render={({ field: { value, onChange } }) => (
-                      <EmailField
-                        required
-                        containerClassName="w-full"
-                        className="h-8 min-w-fit"
-                        placeholder={t("email_address")}
-                        value={value}
-                        disabled={props.readOnly}
-                        onChange={(val) => {
-                          const isAlreadyVerified = !!verifiedEmails
-                            ?.concat([])
-                            .find((email) => email === val.target.value);
-                          setEmailVerified(isAlreadyVerified);
-                          onChange(val);
-                        }}
-                      />
-                    )}
-                  />
-                  <Button
-                    color="secondary"
-                    size="sm"
-                    disabled={emailVerified || props.readOnly || false}
-                    className={classNames(
-                      "min-w-fit text-sm font-medium",
-                      emailVerified ? "hidden" : "mt-3 sm:mt-0"
-                    )}
-                    onClick={() => {
-                      const email =
-                        form.getValues(`steps.${step.stepNumber - 1}.sendTo`) ||
-                        "";
-                      sendEmailVerificationCodeMutation.mutate({
-                        email,
-                        isVerifyingEmail: true,
-                        language: i18n.language || "en",
-                      });
-                    }}
-                  >
-                    {t("send_code")}
-                  </Button>
-                </div>
-                {form.formState.errors.steps &&
-                  form.formState?.errors?.steps[step.stepNumber - 1]
-                    ?.sendTo && (
-                    <p className="text-error mt-1 text-xs">
-                      {form.formState?.errors?.steps[step.stepNumber - 1]
-                        ?.sendTo?.message || ""}
-                    </p>
+          {isEmailAddressNeeded && !isCalAIAction(form.getValues(`steps.${step.stepNumber - 1}.action`)) && (
+            <div className="mt-5 rounded-2xl border border-muted bg-cal-muted p-4">
+              <Label>{t("email_address")}</Label>
+              <div className="block items-center gap-2 sm:flex">
+                <Controller
+                  name={`steps.${step.stepNumber - 1}.sendTo`}
+                  render={({ field: { value, onChange } }) => (
+                    <EmailField
+                      required
+                      containerClassName="w-full"
+                      className="h-8 min-w-fit"
+                      placeholder={t("email_address")}
+                      value={value}
+                      disabled={props.readOnly}
+                      onChange={(val) => {
+                        const isAlreadyVerified = !!verifiedEmails
+                          ?.concat([])
+                          .find((email) => email === val.target.value);
+                        setEmailVerified(isAlreadyVerified);
+                        onChange(val);
+                      }}
+                    />
                   )}
-                {emailVerified ? (
-                  <div className="mt-1">
-                    <Badge variant="green">{t("email_verified")}</Badge>
-                  </div>
-                ) : (
-                  !props.readOnly && (
-                    <>
-                      <div className="mt-3 flex w-full flex-col">
-                        <Label className="">{t("verification_code")}</Label>
-                        <div className="flex w-full items-center">
-                          <TextField
-                            containerClassName="w-full"
-                            className="h-8 rounded-xl"
-                            placeholder={t("code")}
-                            disabled={props.readOnly}
-                            value={verificationCode}
-                            onChange={(e) => {
-                              setVerificationCode(e.target.value);
-                            }}
-                            required
-                          />
-                          <Button
-                            color="secondary"
-                            size="sm"
-                            className="ml-2 min-w-fit rounded-[10px]"
-                            disabled={
-                              verifyEmailCodeMutation.isPending ||
-                              props.readOnly
-                            }
-                            onClick={() => {
-                              verifyEmailCodeMutation.mutate({
-                                code: verificationCode,
-                                email:
-                                  form.getValues(
-                                    `steps.${step.stepNumber - 1}.sendTo`
-                                  ) || "",
-                                teamId,
-                              });
-                            }}
-                          >
-                            {t("verify")}
-                          </Button>
-                        </div>
-                      </div>
-                      {form.formState.errors.steps &&
-                        form.formState?.errors?.steps[step.stepNumber - 1]
-                          ?.sendTo && (
-                          <p className="text-error mt-1 text-xs">
-                            {form.formState?.errors?.steps[step.stepNumber - 1]
-                              ?.sendTo?.message || ""}
-                          </p>
-                        )}
-                    </>
-                  )
-                )}
+                />
+                <Button
+                  color="secondary"
+                  size="sm"
+                  disabled={emailVerified || props.readOnly || false}
+                  className={classNames(
+                    "min-w-fit font-medium text-sm",
+                    emailVerified ? "hidden" : "mt-3 sm:mt-0"
+                  )}
+                  onClick={() => {
+                    const email = form.getValues(`steps.${step.stepNumber - 1}.sendTo`) || "";
+                    sendEmailVerificationCodeMutation.mutate({
+                      email,
+                      isVerifyingEmail: true,
+                      language: i18n.language || "en",
+                    });
+                  }}>
+                  {t("send_code")}
+                </Button>
               </div>
-            )}
-          {!isCalAIAction(
-            form.getValues(`steps.${step.stepNumber - 1}.action`)
-          ) && (
+              {form.formState?.errors?.steps?.[step.stepNumber - 1]?.sendTo && (
+                <p className="mt-1 text-error text-xs">
+                  {form.formState?.errors?.steps[step.stepNumber - 1]?.sendTo?.message || ""}
+                </p>
+              )}
+              {emailVerified ? (
+                <div className="mt-1">
+                  <Badge variant="green">{t("email_verified")}</Badge>
+                </div>
+              ) : (
+                !props.readOnly && (
+                  <>
+                    <div className="mt-3 flex w-full flex-col">
+                      <Label className="">{t("verification_code")}</Label>
+                      <div className="flex w-full items-center">
+                        <TextField
+                          containerClassName="w-full"
+                          className="h-8 rounded-xl"
+                          placeholder={t("code")}
+                          disabled={props.readOnly}
+                          value={verificationCode}
+                          onChange={(e) => {
+                            setVerificationCode(e.target.value);
+                          }}
+                          required
+                        />
+                        <Button
+                          color="secondary"
+                          size="sm"
+                          className="ml-2 min-w-fit rounded-[10px]"
+                          disabled={verifyEmailCodeMutation.isPending || props.readOnly}
+                          onClick={() => {
+                            verifyEmailCodeMutation.mutate({
+                              code: verificationCode,
+                              email: form.getValues(`steps.${step.stepNumber - 1}.sendTo`) || "",
+                              teamId,
+                            });
+                          }}>
+                          {t("verify")}
+                        </Button>
+                      </div>
+                    </div>
+                    {form.formState?.errors?.steps?.[step.stepNumber - 1]?.sendTo && (
+                      <p className="mt-1 text-error text-xs">
+                        {form.formState?.errors?.steps[step.stepNumber - 1]?.sendTo?.message || ""}
+                      </p>
+                    )}
+                  </>
+                )
+              )}
+            </div>
+          )}
+          {!isCalAIAction(form.getValues(`steps.${step.stepNumber - 1}.action`)) && (
             <div className="mt-3">
               <Label>{t("message_template")}</Label>
               <Controller
@@ -1486,9 +1264,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                       isDisabled={props.readOnly}
                       onChange={(val) => {
                         if (val) {
-                          const action = form.getValues(
-                            `steps.${step.stepNumber - 1}.action`
-                          );
+                          const action = form.getValues(`steps.${step.stepNumber - 1}.action`);
                           const value = val.value as WorkflowTemplates;
 
                           const template = getTemplateBodyForAction({
@@ -1499,10 +1275,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                             timeFormat,
                           });
 
-                          form.setValue(
-                            `steps.${step.stepNumber - 1}.reminderBody`,
-                            template
-                          );
+                          form.setValue(`steps.${step.stepNumber - 1}.reminderBody`, template);
 
                           if (shouldScheduleEmailReminder(action)) {
                             if (value === WorkflowTemplates.REMINDER) {
@@ -1530,10 +1303,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                             }
                           }
                           field.onChange(value);
-                          form.setValue(
-                            `steps.${step.stepNumber - 1}.template`,
-                            value
-                          );
+                          form.setValue(`steps.${step.stepNumber - 1}.template`, value);
                           setUpdateTemplate(!updateTemplate);
                         }
                       }}
@@ -1542,11 +1312,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                       options={templateOptions.map((option) => {
                         const needsTeamsUpgrade =
                           option.needsTeamsUpgrade &&
-                          !isSMSAction(
-                            form.getValues(
-                              `steps.${step.stepNumber - 1}.action`
-                            )
-                          );
+                          !isSMSAction(form.getValues(`steps.${step.stepNumber - 1}.action`));
                         return {
                           label: option.label,
                           value: option.value,
@@ -1567,21 +1333,16 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
               />
             </div>
           )}
-          {!isCalAIAction(
-            form.getValues(`steps.${step.stepNumber - 1}.action`)
-          ) && (
-            <div className="bg-cal-muted border-muted mt-3 rounded-2xl border py-1 px-3">
+          {!isCalAIAction(form.getValues(`steps.${step.stepNumber - 1}.action`)) && (
+            <div className="mt-3 rounded-2xl border border-muted bg-cal-muted px-3 py-1">
               {isEmailSubjectNeeded && (
                 <div className="mb-6">
                   <div className="flex items-center">
                     <Label
                       className={classNames(
                         "flex-none",
-                        props.readOnly || isFormTrigger(trigger)
-                          ? "mb-2"
-                          : "mb-0"
-                      )}
-                    >
+                        props.readOnly || isFormTrigger(trigger) ? "mb-2" : "mb-0"
+                      )}>
                       {t("email_subject")}
                     </Label>
                     {!props.readOnly && !isFormTrigger(trigger) && (
@@ -1599,19 +1360,16 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                       refEmailSubject.current = e;
                     }}
                     rows={2}
-                    disabled={props.readOnly || !hasActiveTeamPlan}
+                    disabled={props.readOnly || (!hasActiveTeamPlan && !isEmailAction(step.action))}
                     className="my-0 focus:ring-transparent"
                     required
                     {...restEmailSubjectForm}
                   />
-                  {form.formState.errors.steps &&
-                    form.formState?.errors?.steps[step.stepNumber - 1]
-                      ?.emailSubject && (
-                      <p className="text-error mt-1 text-xs">
-                        {form.formState?.errors?.steps[step.stepNumber - 1]
-                          ?.emailSubject?.message || ""}
-                      </p>
-                    )}
+                  {form.formState?.errors?.steps?.[step.stepNumber - 1]?.emailSubject && (
+                    <p className="mt-1 text-error text-xs">
+                      {form.formState?.errors?.steps[step.stepNumber - 1]?.emailSubject?.message || ""}
+                    </p>
+                  )}
                 </div>
               )}
               <div className="mb-2 flex items-center pb-1">
@@ -1620,21 +1378,12 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 </Label>
               </div>
               <Editor
-                getText={() =>
-                  props.form.getValues(
-                    `steps.${step.stepNumber - 1}.reminderBody`
-                  ) || ""
-                }
+                getText={() => props.form.getValues(`steps.${step.stepNumber - 1}.reminderBody`) || ""}
                 setText={(text: string) => {
-                  props.form.setValue(
-                    `steps.${step.stepNumber - 1}.reminderBody`,
-                    text
-                  );
+                  props.form.setValue(`steps.${step.stepNumber - 1}.reminderBody`, text);
                   props.form.clearErrors();
                 }}
-                variables={
-                  !isFormTrigger(trigger) ? DYNAMIC_TEXT_VARIABLES : undefined
-                }
+                variables={!isFormTrigger(trigger) ? DYNAMIC_TEXT_VARIABLES : undefined}
                 addVariableButtonTop={isSMSAction(step.action)}
                 height="200px"
                 updateTemplate={updateTemplate}
@@ -1643,28 +1392,24 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 editable={
                   !props.readOnly &&
                   !isWhatsappAction(step.action) &&
-                  (hasActiveTeamPlan || isSMSAction(step.action))
+                  (hasActiveTeamPlan || isSMSAction(step.action) || isEmailAction(step.action))
                 }
                 excludedToolbarItems={
                   isSMSAction(step.action)
                     ? ["blockType", "bold", "italic", "link"]
                     : isOrganization
-                    ? []
-                    : ["link"]
+                      ? []
+                      : ["link"]
                 }
                 plainText={isSMSAction(step.action)}
               />
 
-              {form.formState.errors.steps &&
-                form.formState?.errors?.steps[step.stepNumber - 1]
-                  ?.reminderBody && (
-                  <p className="text-error mt-1 text-sm">
-                    {form.formState?.errors?.steps[step.stepNumber - 1]
-                      ?.reminderBody?.message || ""}
-                  </p>
-                )}
-              {isEmailSubjectNeeded &&
-                trigger !== WorkflowTriggerEvents.BOOKING_REQUESTED && (
+              {form.formState?.errors?.steps?.[step.stepNumber - 1]?.reminderBody && (
+                <p className="mt-1 text-error text-sm">
+                  {form.formState?.errors?.steps[step.stepNumber - 1]?.reminderBody?.message || ""}
+                </p>
+              )}
+              {isEmailSubjectNeeded && trigger !== WorkflowTriggerEvents.BOOKING_REQUESTED && (
                 <div className="mt-2">
                   <Controller
                     name={`steps.${step.stepNumber - 1}.includeCalendarEvent`}
@@ -1673,17 +1418,12 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                       <CheckboxField
                         disabled={props.readOnly}
                         defaultChecked={
-                          form.getValues(
-                            `steps.${step.stepNumber - 1}.includeCalendarEvent`
-                          ) || false
+                          form.getValues(`steps.${step.stepNumber - 1}.includeCalendarEvent`) || false
                         }
                         description={t("include_calendar_event")}
                         descriptionClassName="ml-0"
                         onChange={(e) =>
-                          form.setValue(
-                            `steps.${step.stepNumber - 1}.includeCalendarEvent`,
-                            e.target.checked
-                          )
+                          form.setValue(`steps.${step.stepNumber - 1}.includeCalendarEvent`, e.target.checked)
                         }
                       />
                     )}
@@ -1691,12 +1431,9 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 </div>
               )}
               {!props.readOnly && (
-                <div className="ml-1 mt-2">
-                  <button
-                    type="button"
-                    onClick={() => setIsAdditionalInputsDialogOpen(true)}
-                  >
-                    <div className="text-subtle ml-1 flex items-center gap-2">
+                <div className="mt-2 ml-1">
+                  <button type="button" onClick={() => setIsAdditionalInputsDialogOpen(true)}>
+                    <div className="ml-1 flex items-center gap-2 text-subtle">
                       <Icon name="circle-help" className="h-3 w-3" />
                       <p className="text-left text-xs">
                         {isFormTrigger(trigger)
@@ -1807,24 +1544,17 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
             {t("send_sms_to_number", { number: form.getValues(`steps.${step.stepNumber - 1}.sendTo`) })}
           </ConfirmationDialogContent>
         </Dialog> */}
-        <Dialog
-          open={isAdditionalInputsDialogOpen}
-          onOpenChange={setIsAdditionalInputsDialogOpen}
-        >
-          <DialogContent
-            enableOverflow
-            type="creation"
-            className="sm:max-w-[610px]"
-          >
+        <Dialog open={isAdditionalInputsDialogOpen} onOpenChange={setIsAdditionalInputsDialogOpen}>
+          <DialogContent enableOverflow type="creation" className="sm:max-w-[610px]">
             <div>
-              <h1 className="w-full text-xl font-semibold">
+              <h1 className="w-full font-semibold text-xl">
                 {isFormTrigger(trigger)
                   ? t("how_form_responses_as_variables")
                   : t("how_booking_questions_as_variables")}
               </h1>
               <div className="mb-6 rounded-md sm:p-4">
                 <p className="test-sm font-medium">{t("format")}</p>
-                <ul className="text-emphasis ml-5 mt-2 list-disc">
+                <ul className="mt-2 ml-5 list-disc text-emphasis">
                   <li>{t("uppercase_for_letters")}</li>
                   <li>{t("replace_whitespaces_underscores")}</li>
                   <li>
@@ -1836,19 +1566,13 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 <div className="mt-4">
                   <p className="test-sm w-full font-medium">{t("example_1")}</p>
                   <div className="mt-2 grid grid-cols-12">
-                    <div className="test-sm text-default col-span-5 ltr:mr-2 rtl:ml-2">
-                      {isFormTrigger(trigger)
-                        ? t("form_field_identifier")
-                        : t("booking_question_identifier")}
+                    <div className="test-sm col-span-5 text-default ltr:mr-2 rtl:ml-2">
+                      {isFormTrigger(trigger) ? t("form_field_identifier") : t("booking_question_identifier")}
                     </div>
-                    <div className="test-sm text-emphasis col-span-7">
-                      {t("company_size")}
-                    </div>
-                    <div className="test-sm text-default col-span-5 w-full">
-                      {t("variable")}
-                    </div>
+                    <div className="test-sm col-span-7 text-emphasis">{t("company_size")}</div>
+                    <div className="test-sm col-span-5 w-full text-default">{t("variable")}</div>
 
-                    <div className="test-sm text-emphasis wrap-break-word col-span-7">
+                    <div className="test-sm wrap-break-word col-span-7 text-emphasis">
                       {" "}
                       {`{${t("company_size")
                         .replace(/[^a-zA-Z0-9 ]/g, "")
@@ -1861,18 +1585,12 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 <div className="mt-4">
                   <p className="test-sm w-full font-medium">{t("example_2")}</p>
                   <div className="mt-2 grid grid-cols-12">
-                    <div className="test-sm text-default col-span-5 ltr:mr-2 rtl:ml-2">
-                      {isFormTrigger(trigger)
-                        ? t("form_field_identifier")
-                        : t("booking_question_identifier")}
+                    <div className="test-sm col-span-5 text-default ltr:mr-2 rtl:ml-2">
+                      {isFormTrigger(trigger) ? t("form_field_identifier") : t("booking_question_identifier")}
                     </div>
-                    <div className="test-sm text-emphasis col-span-7">
-                      {t("what_help_needed")}
-                    </div>
-                    <div className="test-sm text-default col-span-5">
-                      {t("variable")}
-                    </div>
-                    <div className="test-sm text-emphasis wrap-break-word col-span-7">
+                    <div className="test-sm col-span-7 text-emphasis">{t("what_help_needed")}</div>
+                    <div className="test-sm col-span-5 text-default">{t("variable")}</div>
+                    <div className="test-sm wrap-break-word col-span-7 text-emphasis">
                       {" "}
                       {`{${t("what_help_needed")
                         .replace(/[^a-zA-Z0-9 ]/g, "")
@@ -1893,9 +1611,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
           <AgentConfigurationSheet
             open={agentConfigurationSheet.open}
             activeTab={agentConfigurationSheet.activeTab}
-            onOpenChange={(val) =>
-              setAgentConfigurationSheet((prev) => ({ ...prev, open: val }))
-            }
+            onOpenChange={(val) => setAgentConfigurationSheet((prev) => ({ ...prev, open: val }))}
             agentId={stepAgentId}
             inboundAgentId={stepInboundAgentId}
             agentData={agentData}
@@ -1926,9 +1642,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
             agentId={stepAgentId || ""}
             teamId={teamId}
             form={form}
-            eventTypeIds={props.eventTypeOptions?.map((opt) =>
-              parseInt(opt.value, 10)
-            )}
+            eventTypeIds={props.eventTypeOptions?.map((opt) => parseInt(opt.value, 10))}
             outboundEventTypeId={agentData?.outboundEventTypeId}
           />
         )}
@@ -1941,40 +1655,31 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
             teamId={teamId}
             isOrganization={props.isOrganization}
             form={form}
-            eventTypeIds={
-              props.eventTypeOptions?.map((opt) => parseInt(opt.value, 10)) ||
-              []
-            }
+            eventTypeIds={props.eventTypeOptions?.map((opt) => parseInt(opt.value, 10)) || []}
             outboundEventTypeId={agentData?.outboundEventTypeId}
           />
         )}
 
         {/* Unsubscribe Confirmation Dialog */}
-        <Dialog
-          open={isUnsubscribeDialogOpen}
-          onOpenChange={setIsUnsubscribeDialogOpen}
-        >
+        <Dialog open={isUnsubscribeDialogOpen} onOpenChange={setIsUnsubscribeDialogOpen}>
           <DialogContent type="creation" title={t("unsubscribe_phone_number")}>
             <div className="stack-y-4">
-              <p className="text-default text-sm">
-                {t("do_you_still_want_to_unsubscribe")}
-              </p>
+              <p className="text-default text-sm">{t("do_you_still_want_to_unsubscribe")}</p>
               {getActivePhoneNumbers(
                 agentData?.outboundPhoneNumbers?.map((phone) => ({
                   ...phone,
                   subscriptionStatus: phone.subscriptionStatus ?? undefined,
                 }))
               ).length > 0 && (
-                <div className="bg-cal-muted rounded-lg p-3">
+                <div className="rounded-lg bg-cal-muted p-3">
                   <div className="flex items-center gap-2">
-                    <Icon name="phone" className="text-emphasis h-4 w-4" />
-                    <span className="text-emphasis text-sm font-medium">
+                    <Icon name="phone" className="h-4 w-4 text-emphasis" />
+                    <span className="font-medium text-emphasis text-sm">
                       {formatPhoneNumber(
                         getActivePhoneNumbers(
                           agentData?.outboundPhoneNumbers?.map((phone) => ({
                             ...phone,
-                            subscriptionStatus:
-                              phone.subscriptionStatus ?? undefined,
+                            subscriptionStatus: phone.subscriptionStatus ?? undefined,
                           }))
                         )?.[0]?.phoneNumber
                       )}
@@ -1982,16 +1687,10 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                   </div>
                 </div>
               )}
-              <p className="text-subtle text-sm">
-                {t("the_action_will_disconnect_phone_number")}
-              </p>
+              <p className="text-sm text-subtle">{t("the_action_will_disconnect_phone_number")}</p>
             </div>
             <DialogFooter showDivider>
-              <Button
-                type="button"
-                color="secondary"
-                onClick={() => setIsUnsubscribeDialogOpen(false)}
-              >
+              <Button type="button" color="secondary" onClick={() => setIsUnsubscribeDialogOpen(false)}>
                 {t("cancel")}
               </Button>
               <Button
@@ -2012,8 +1711,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                     });
                   }
                 }}
-                loading={unsubscribePhoneNumberMutation.isPending}
-              >
+                loading={unsubscribePhoneNumberMutation.isPending}>
                 {t("unsubscribe")}
               </Button>
             </DialogFooter>
@@ -2021,66 +1719,41 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
         </Dialog>
 
         {/* Delete Step Confirmation Dialog */}
-        <Dialog
-          open={isDeleteStepDialogOpen}
-          onOpenChange={setIsDeleteStepDialogOpen}
-        >
+        <Dialog open={isDeleteStepDialogOpen} onOpenChange={setIsDeleteStepDialogOpen}>
           <DialogContent type="confirmation" title={t("delete_workflow_step")}>
             <div className="stack-y-4">
-              <p className="text-default text-sm">
-                {t("are_you_sure_you_want_to_delete_workflow_step")}
-              </p>
+              <p className="text-default text-sm">{t("are_you_sure_you_want_to_delete_workflow_step")}</p>
               {(() => {
                 const relevantPhoneNumbers =
                   agentData?.outboundPhoneNumbers?.filter(
-                    (phone) =>
-                      phone.subscriptionStatus !==
-                      PhoneNumberSubscriptionStatus.CANCELLED
+                    (phone) => phone.subscriptionStatus !== PhoneNumberSubscriptionStatus.CANCELLED
                   ) || [];
 
                 return (
                   relevantPhoneNumbers.length > 0 && (
                     <>
-                      <div className="bg-attention rounded-lg p-3">
+                      <div className="rounded-lg bg-attention p-3">
                         <div className="flex items-start gap-2">
-                          <Icon
-                            name="info"
-                            className="text-attention mt-0.5 h-4 w-4"
-                          />
+                          <Icon name="info" className="mt-0.5 h-4 w-4 text-attention" />
                           <div className="stack-y-2">
-                            <p className="text-attention text-sm font-medium">
-                              {t("this_action_will_also")}
-                            </p>
-                            <ul className="text-attention stack-y-1 list-inside list-disc text-sm">
+                            <p className="font-medium text-attention text-sm">{t("this_action_will_also")}</p>
+                            <ul className="stack-y-1 list-inside list-disc text-attention text-sm">
                               {relevantPhoneNumbers.some(
-                                (phone) =>
-                                  phone.subscriptionStatus ===
-                                  PhoneNumberSubscriptionStatus.ACTIVE
-                              ) && (
-                                <li>
-                                  {t("cancel_your_phone_number_subscription")}
-                                </li>
-                              )}
+                                (phone) => phone.subscriptionStatus === PhoneNumberSubscriptionStatus.ACTIVE
+                              ) && <li>{t("cancel_your_phone_number_subscription")}</li>}
                               <li>{t("delete_associated_phone_number")}</li>
                             </ul>
                           </div>
                         </div>
                       </div>
                       {relevantPhoneNumbers.map((phone) => (
-                        <div
-                          key={phone.phoneNumber}
-                          className="bg-cal-muted rounded-lg p-3"
-                        >
+                        <div key={phone.phoneNumber} className="rounded-lg bg-cal-muted p-3">
                           <div className="flex items-center gap-2">
-                            <Icon
-                              name="phone"
-                              className="text-emphasis h-4 w-4"
-                            />
-                            <span className="text-emphasis text-sm font-medium">
+                            <Icon name="phone" className="h-4 w-4 text-emphasis" />
+                            <span className="font-medium text-emphasis text-sm">
                               {formatPhoneNumber(phone.phoneNumber)}
                             </span>
-                            {phone.subscriptionStatus ===
-                              PhoneNumberSubscriptionStatus.ACTIVE && (
+                            {phone.subscriptionStatus === PhoneNumberSubscriptionStatus.ACTIVE && (
                               <Badge variant="green" size="sm" withDot>
                                 {t("active_subscription")}
                               </Badge>
@@ -2094,11 +1767,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
               })()}
             </div>
             <DialogFooter showDivider>
-              <Button
-                type="button"
-                color="secondary"
-                onClick={() => setIsDeleteStepDialogOpen?.(false)}
-              >
+              <Button type="button" color="secondary" onClick={() => setIsDeleteStepDialogOpen?.(false)}>
                 {t("cancel")}
               </Button>
               <Button
@@ -2122,8 +1791,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                     setReload(!reload);
                   }
                   setIsDeleteStepDialogOpen?.(false);
-                }}
-              >
+                }}>
                 {t("delete")}
               </Button>
             </DialogFooter>


### PR DESCRIPTION
Fixes #27059.

**Description:**
The email subject and body fields in the Workflows email editor were always disabled, even when the 'Custom' template was selected. This was caused by the hasActiveTeamPlan check, which blocked editing for users without an active team plan.

**Changes:**
- Imported isEmailAction helper function.
- Updated the disabled prop on the email subject TextArea to allow editing if the action is an email action (isEmailAction(step.action)).
- Updated the editable prop on the email body Editor to allow editing if the action is an email action.

This allows users to customize email subjects and bodies for email-type workflow actions regardless of their plan status.