### PR TITLE
chore: turn off explicit type rule in biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -120,7 +120,7 @@
         "rules": {
           "nursery": {
             "useQwikValidLexicalScope": "off",
-            "useExplicitType": "info",
+            "useExplicitType": "off",
             "noReactForwardRef": "warn",
             "noTernary": "info",
             "noUnresolvedImports": "warn",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`useExplicitType` rule is very strict even for 

`const translator = short();`

it requires you to add an expicit type even though it can be easily inferred


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled Biome’s useExplicitType rule so we don’t have to add explicit types when TypeScript can infer them. This reduces linter noise and keeps code simple.

<sup>Written for commit c20639a6a5846935a18a4758d4ebbf762ec8d444. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

