### PR TITLE
fix: filter out Google system calendars from calendar list

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -30,6 +30,22 @@ type FreeBusyArgs = { timeMin: string; timeMax: string; items: { id: string }[] 
 const log = logger.getSubLogger({ prefix: ["app-store/googlecalendar/lib/CalendarService"] });
 
 /**
+ * Google system calendars that don't return proper free/busy information,
+ * making them useless for availability checking. These include:
+ * - Holiday calendars (e.g., "en.usa#holiday@group.v.calendar.google.com")
+ * - Birthdays/contacts calendar ("addressbook#contacts@group.v.calendar.google.com")
+ */
+const GOOGLE_SYSTEM_CALENDAR_SUFFIXES = [
+  "#holiday@group.v.calendar.google.com",
+  "#contacts@group.v.calendar.google.com",
+];
+
+function isGoogleSystemCalendar(calendarId: string | null | undefined): boolean {
+  if (!calendarId) return false;
+  return GOOGLE_SYSTEM_CALENDAR_SUFFIXES.some((suffix) => calendarId.endsWith(suffix));
+}
+
+/**
  * Extended interface for Google Calendar service that includes Google-specific methods.
  * This interface is used by internal Google Calendar modules (callback, tests, etc.)
  * that need access to Google-specific functionality beyond the generic Calendar interface.
@@ -710,7 +726,11 @@ class GoogleCalendarService implements Calendar {
       );
 
       if (!cals.items) return [];
-      return cals.items.map(
+
+      // Filter out Google system calendars (holidays, birthdays) as they don't return proper free/busy information
+      const filteredCalendars = cals.items.filter((cal) => !isGoogleSystemCalendar(cal.id));
+
+      return filteredCalendars.map(
         (cal) =>
           ({
             externalId: cal.id ?? "No id",

--- a/packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts
@@ -803,3 +803,240 @@ describe("createEvent", () => {
     log.info("createEvent with just in time reminders test passed");
   });
 });
+
+describe("listCalendars", () => {
+  test("should filter out Google holiday calendars", async () => {
+    const calendarService = BuildCalendarService(mockCredential);
+    setFullMockOAuthManagerRequest();
+
+    calendarListMock.mockImplementation(() => {
+      return {
+        data: {
+          items: [
+            {
+              id: "user@example.com",
+              summary: "Primary Calendar",
+              primary: true,
+              accessRole: "owner",
+            },
+            {
+              id: "en.usa#holiday@group.v.calendar.google.com",
+              summary: "Holidays in United States",
+              primary: false,
+              accessRole: "reader",
+            },
+            {
+              id: "en.christian#holiday@group.v.calendar.google.com",
+              summary: "Christian Holidays",
+              primary: false,
+              accessRole: "reader",
+            },
+          ],
+        },
+      };
+    });
+
+    const calendars = await calendarService.listCalendars();
+
+    expect(calendars).toHaveLength(1);
+    expect(calendars[0].externalId).toBe("user@example.com");
+    expect(calendars[0].name).toBe("Primary Calendar");
+  });
+
+  test("should filter out Google birthdays/contacts calendar", async () => {
+    const calendarService = BuildCalendarService(mockCredential);
+    setFullMockOAuthManagerRequest();
+
+    calendarListMock.mockImplementation(() => {
+      return {
+        data: {
+          items: [
+            {
+              id: "user@example.com",
+              summary: "Primary Calendar",
+              primary: true,
+              accessRole: "owner",
+            },
+            {
+              id: "addressbook#contacts@group.v.calendar.google.com",
+              summary: "Birthdays",
+              primary: false,
+              accessRole: "reader",
+            },
+          ],
+        },
+      };
+    });
+
+    const calendars = await calendarService.listCalendars();
+
+    expect(calendars).toHaveLength(1);
+    expect(calendars[0].externalId).toBe("user@example.com");
+  });
+
+  test("should filter out all Google system calendars while keeping regular calendars", async () => {
+    const calendarService = BuildCalendarService(mockCredential);
+    setFullMockOAuthManagerRequest();
+
+    calendarListMock.mockImplementation(() => {
+      return {
+        data: {
+          items: [
+            {
+              id: "user@example.com",
+              summary: "Primary Calendar",
+              primary: true,
+              accessRole: "owner",
+            },
+            {
+              id: "work@example.com",
+              summary: "Work Calendar",
+              primary: false,
+              accessRole: "owner",
+            },
+            {
+              id: "en.usa#holiday@group.v.calendar.google.com",
+              summary: "Holidays in United States",
+              primary: false,
+              accessRole: "reader",
+            },
+            {
+              id: "addressbook#contacts@group.v.calendar.google.com",
+              summary: "Birthdays",
+              primary: false,
+              accessRole: "reader",
+            },
+            {
+              id: "shared@example.com",
+              summary: "Shared Calendar",
+              primary: false,
+              accessRole: "writer",
+            },
+          ],
+        },
+      };
+    });
+
+    const calendars = await calendarService.listCalendars();
+
+    expect(calendars).toHaveLength(3);
+    const calendarIds = calendars.map((cal) => cal.externalId);
+    expect(calendarIds).toContain("user@example.com");
+    expect(calendarIds).toContain("work@example.com");
+    expect(calendarIds).toContain("shared@example.com");
+    expect(calendarIds).not.toContain("en.usa#holiday@group.v.calendar.google.com");
+    expect(calendarIds).not.toContain("addressbook#contacts@group.v.calendar.google.com");
+  });
+
+  test("should return empty array when all calendars are system calendars", async () => {
+    const calendarService = BuildCalendarService(mockCredential);
+    setFullMockOAuthManagerRequest();
+
+    calendarListMock.mockImplementation(() => {
+      return {
+        data: {
+          items: [
+            {
+              id: "en.usa#holiday@group.v.calendar.google.com",
+              summary: "Holidays in United States",
+              primary: false,
+              accessRole: "reader",
+            },
+            {
+              id: "addressbook#contacts@group.v.calendar.google.com",
+              summary: "Birthdays",
+              primary: false,
+              accessRole: "reader",
+            },
+          ],
+        },
+      };
+    });
+
+    const calendars = await calendarService.listCalendars();
+
+    expect(calendars).toHaveLength(0);
+  });
+
+  test("should handle calendars with null or undefined ids", async () => {
+    const calendarService = BuildCalendarService(mockCredential);
+    setFullMockOAuthManagerRequest();
+
+    calendarListMock.mockImplementation(() => {
+      return {
+        data: {
+          items: [
+            {
+              id: "user@example.com",
+              summary: "Primary Calendar",
+              primary: true,
+              accessRole: "owner",
+            },
+            {
+              id: null,
+              summary: "Calendar with null id",
+              primary: false,
+              accessRole: "reader",
+            },
+            {
+              id: undefined,
+              summary: "Calendar with undefined id",
+              primary: false,
+              accessRole: "reader",
+            },
+          ],
+        },
+      };
+    });
+
+    const calendars = await calendarService.listCalendars();
+
+    expect(calendars).toHaveLength(3);
+    expect(calendars[0].externalId).toBe("user@example.com");
+    expect(calendars[1].externalId).toBe("No id");
+    expect(calendars[2].externalId).toBe("No id");
+  });
+
+  test("should correctly identify various holiday calendar formats", async () => {
+    const calendarService = BuildCalendarService(mockCredential);
+    setFullMockOAuthManagerRequest();
+
+    calendarListMock.mockImplementation(() => {
+      return {
+        data: {
+          items: [
+            {
+              id: "user@example.com",
+              summary: "Primary Calendar",
+              primary: true,
+              accessRole: "owner",
+            },
+            {
+              id: "en.uk#holiday@group.v.calendar.google.com",
+              summary: "Holidays in United Kingdom",
+              primary: false,
+              accessRole: "reader",
+            },
+            {
+              id: "de.german#holiday@group.v.calendar.google.com",
+              summary: "Holidays in Germany",
+              primary: false,
+              accessRole: "reader",
+            },
+            {
+              id: "ja.japanese#holiday@group.v.calendar.google.com",
+              summary: "Holidays in Japan",
+              primary: false,
+              accessRole: "reader",
+            },
+          ],
+        },
+      };
+    });
+
+    const calendars = await calendarService.listCalendars();
+
+    expect(calendars).toHaveLength(1);
+    expect(calendars[0].externalId).toBe("user@example.com");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Filters out Google system calendars (holidays and birthdays) from the calendar list in the Google Calendar integration. These calendars don't return proper free/busy information from Google's API, making them useless for availability checking.

**Filtered calendar types:**
- Holiday calendars (`#holiday@group.v.calendar.google.com`)
- Birthdays/contacts calendar (`#contacts@group.v.calendar.google.com`)

## Visual Demo (For contributors especially)

N/A - This is a backend filtering change. The effect is that holiday and birthday calendars will no longer appear in the calendar selection dropdown when users connect their Google Calendar.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Connect a Google Calendar account that has holiday calendars enabled (most accounts have these by default)
2. Go to calendar settings and view the list of available calendars
3. Verify that holiday calendars (e.g., "Holidays in United States") and the "Birthdays" calendar no longer appear in the list
4. Verify that regular user calendars still appear and function correctly

**Automated tests added:**
- Run `TZ=UTC yarn test packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts -t "listCalendars"` to verify the filtering logic

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

> **Human Review Checklist:**
> - [ ] Verify the calendar ID suffix patterns are correct for Google system calendars
> - [ ] Consider if there are other Google system calendar types that should be filtered
> - [ ] Note: Previously selected holiday/birthday calendars will remain selected - this only affects new selections
> - [ ] Verify test coverage is adequate for edge cases (null IDs, international holiday formats)

Link to Devin run: https://app.devin.ai/sessions/01f2a6f90fb64a9d996cfbdeaf5076a3
Requested by: Volnei Munhoz (@volnei)