### PR TITLE
refactor: store timestamp instead of boolean for feature opt-in

### DIFF
--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
@@ -2,17 +2,15 @@
 
 import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
 import { getOptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
-import { localStorage } from "@calcom/lib/webstorage";
 import { trpc } from "@calcom/trpc/react";
 import { useCallback, useMemo, useState } from "react";
-import { z } from "zod";
 
-const DISMISSED_STORAGE_KEY = "feature-opt-in-dismissed";
-const OPTED_IN_STORAGE_KEY = "feature-opt-in-enabled";
-
-const featuresMapSchema = z.record(z.string(), z.boolean());
-
-type FeaturesMap = z.infer<typeof featuresMapSchema>;
+import {
+  getFeatureOptInTimestamp,
+  isFeatureDismissed,
+  setFeatureDismissed,
+  setFeatureOptedIn,
+} from "../lib/feature-opt-in-storage";
 
 type UserRoleContext = {
   isOrgAdmin: boolean;
@@ -21,7 +19,7 @@ type UserRoleContext = {
   adminTeamNames: { id: number; name: string }[];
 };
 
-export type FeatureOptInMutations = {
+type FeatureOptInMutations = {
   setUserState: (params: { slug: string; state: "enabled" }) => Promise<unknown>;
   setTeamState: (params: { teamId: number; slug: string; state: "enabled" }) => Promise<unknown>;
   setOrganizationState: (params: { slug: string; state: "enabled" }) => Promise<unknown>;
@@ -31,7 +29,7 @@ export type FeatureOptInMutations = {
   invalidateQueries: () => void;
 };
 
-export type UseFeatureOptInBannerResult = {
+type UseFeatureOptInBannerResult = {
   shouldShow: boolean;
   isLoading: boolean;
   featureConfig: OptInFeatureConfig | null;
@@ -46,36 +44,14 @@ export type UseFeatureOptInBannerResult = {
   mutations: FeatureOptInMutations;
 };
 
-function getFeaturesMap(storageKey: string): FeaturesMap {
-  const stored = localStorage.getItem(storageKey);
-  if (!stored) return {};
-  try {
-    const parsed = JSON.parse(stored);
-    const result = featuresMapSchema.safeParse(parsed);
-    if (result.success) {
-      return result.data;
-    }
-    return {};
-  } catch {
-    return {};
-  }
+function isFeatureOptedIn(featureId: string): boolean {
+  return getFeatureOptInTimestamp(featureId) !== null;
 }
 
-function setFeatureInMap(storageKey: string, featureId: string): void {
-  const current = getFeaturesMap(storageKey);
-  current[featureId] = true;
-  localStorage.setItem(storageKey, JSON.stringify(current));
-}
-
-function isFeatureInMap(storageKey: string, featureId: string): boolean {
-  const features = getFeaturesMap(storageKey);
-  return features[featureId] === true;
-}
-
-export function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
+function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [isDismissed, setIsDismissed] = useState(() => isFeatureInMap(DISMISSED_STORAGE_KEY, featureId));
-  const [isOptedIn, setIsOptedIn] = useState(() => isFeatureInMap(OPTED_IN_STORAGE_KEY, featureId));
+  const [isDismissed, setIsDismissed] = useState(() => isFeatureDismissed(featureId));
+  const [isOptedIn, setIsOptedIn] = useState(() => isFeatureOptedIn(featureId));
 
   const featureConfig = useMemo(() => getOptInFeatureConfig(featureId) ?? null, [featureId]);
   const utils = trpc.useUtils();
@@ -98,13 +74,17 @@ export function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerR
 
   const mutations: FeatureOptInMutations = useMemo(
     () => ({
-      setUserState: (params) => setUserStateMutation.mutateAsync(params),
-      setTeamState: (params) => setTeamStateMutation.mutateAsync(params),
-      setOrganizationState: (params) => setOrganizationStateMutation.mutateAsync(params),
-      setUserAutoOptIn: (params) => setUserAutoOptInMutation.mutateAsync(params),
-      setTeamAutoOptIn: (params) => setTeamAutoOptInMutation.mutateAsync(params),
-      setOrganizationAutoOptIn: (params) => setOrganizationAutoOptInMutation.mutateAsync(params),
-      invalidateQueries: () => {
+      setUserState: (params: { slug: string; state: "enabled" }) => setUserStateMutation.mutateAsync(params),
+      setTeamState: (params: { teamId: number; slug: string; state: "enabled" }) =>
+        setTeamStateMutation.mutateAsync(params),
+      setOrganizationState: (params: { slug: string; state: "enabled" }) =>
+        setOrganizationStateMutation.mutateAsync(params),
+      setUserAutoOptIn: (params: { autoOptIn: boolean }) => setUserAutoOptInMutation.mutateAsync(params),
+      setTeamAutoOptIn: (params: { teamId: number; autoOptIn: boolean }) =>
+        setTeamAutoOptInMutation.mutateAsync(params),
+      setOrganizationAutoOptIn: (params: { autoOptIn: boolean }) =>
+        setOrganizationAutoOptInMutation.mutateAsync(params),
+      invalidateQueries: (): void => {
         utils.viewer.featureOptIn.checkFeatureOptInEligibility.invalidate();
         utils.viewer.featureOptIn.listForUser.invalidate();
       },
@@ -121,12 +101,12 @@ export function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerR
   );
 
   const dismiss = useCallback(() => {
-    setFeatureInMap(DISMISSED_STORAGE_KEY, featureId);
+    setFeatureDismissed(featureId);
     setIsDismissed(true);
   }, [featureId]);
 
   const markOptedIn = useCallback(() => {
-    setFeatureInMap(OPTED_IN_STORAGE_KEY, featureId);
+    setFeatureOptedIn(featureId);
     setIsOptedIn(true);
   }, [featureId]);
 
@@ -162,3 +142,6 @@ export function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerR
     mutations,
   };
 }
+
+export { useFeatureOptInBanner };
+export type { FeatureOptInMutations, UseFeatureOptInBannerResult };

--- a/apps/web/modules/feature-opt-in/lib/feature-opt-in-storage.ts
+++ b/apps/web/modules/feature-opt-in/lib/feature-opt-in-storage.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { localStorage } from "@calcom/lib/webstorage";
+import { z } from "zod";
+
+const DISMISSED_STORAGE_KEY = "feature-opt-in-dismissed";
+const OPTED_IN_STORAGE_KEY = "feature-opt-in-enabled";
+
+const booleanFeaturesMapSchema: z.ZodSchema<Record<string, boolean>> = z.record(z.string(), z.boolean());
+const timestampFeaturesMapSchema: z.ZodSchema<Record<string, number>> = z.record(z.string(), z.number());
+
+type BooleanFeaturesMap = z.infer<typeof booleanFeaturesMapSchema>;
+type TimestampFeaturesMap = z.infer<typeof timestampFeaturesMapSchema>;
+
+function getBooleanFeaturesMap(storageKey: string): BooleanFeaturesMap {
+  const stored = localStorage.getItem(storageKey);
+  if (!stored) return {};
+  try {
+    const parsed = JSON.parse(stored);
+    const result = booleanFeaturesMapSchema.safeParse(parsed);
+    if (result.success) {
+      return result.data;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function getTimestampFeaturesMap(storageKey: string): TimestampFeaturesMap {
+  const stored = localStorage.getItem(storageKey);
+  if (!stored) return {};
+  try {
+    const parsed = JSON.parse(stored);
+    const result = timestampFeaturesMapSchema.safeParse(parsed);
+    if (result.success) {
+      return result.data;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function setBooleanFeatureInMap(storageKey: string, featureId: string, value: boolean): void {
+  const current = getBooleanFeaturesMap(storageKey);
+  current[featureId] = value;
+  localStorage.setItem(storageKey, JSON.stringify(current));
+}
+
+function setTimestampFeatureInMap(storageKey: string, featureId: string, timestamp: number): void {
+  const current = getTimestampFeaturesMap(storageKey);
+  current[featureId] = timestamp;
+  localStorage.setItem(storageKey, JSON.stringify(current));
+}
+
+function isBooleanFeatureInMap(storageKey: string, featureId: string): boolean {
+  const features = getBooleanFeaturesMap(storageKey);
+  return features[featureId] === true;
+}
+
+function getFeatureOptInTimestamp(featureId: string): number | null {
+  const features = getTimestampFeaturesMap(OPTED_IN_STORAGE_KEY);
+  const timestamp = features[featureId];
+  if (typeof timestamp === "number") {
+    return timestamp;
+  }
+  return null;
+}
+
+function isFeatureDismissed(featureId: string): boolean {
+  return isBooleanFeatureInMap(DISMISSED_STORAGE_KEY, featureId);
+}
+
+function setFeatureDismissed(featureId: string): void {
+  setBooleanFeatureInMap(DISMISSED_STORAGE_KEY, featureId, true);
+}
+
+function setFeatureOptedIn(featureId: string): void {
+  setTimestampFeatureInMap(OPTED_IN_STORAGE_KEY, featureId, Date.now());
+}
+
+export {
+  getFeatureOptInTimestamp,
+  isFeatureDismissed,
+  setFeatureDismissed,
+  setFeatureOptedIn,
+};


### PR DESCRIPTION
## What does this PR do?

Changes the localStorage storage format for feature opt-in from storing a boolean (`true`) to storing a timestamp (Unix timestamp in milliseconds). This is the first PR in a stacked series - the follow-up PR will add delayed Formbricks tracking that uses this timestamp to determine when to trigger surveys.

**Key changes:**
- Extracted localStorage logic into a new `feature-opt-in-storage.ts` file
- Changed `feature-opt-in-enabled` storage from `{ "feature-id": true }` to `{ "feature-id": 1234567890123 }`
- `feature-opt-in-dismissed` continues to use boolean storage
- Added explicit type annotations to mutation params (lint compliance)

**localStorage structure change:**
```typescript
// Before
{ "bookings-v3": true }

// After  
{ "bookings-v3": 1234567890123 }  // Unix timestamp in ms
```

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal refactor.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Human Review Checklist

- [ ] **Breaking change consideration**: Existing users who opted in before this change have `true` stored, not a timestamp. The new code will not recognize this as opted-in (they may see the opt-in banner again). Please verify if this is acceptable or if migration logic is needed.
- [ ] Verify the storage helper functions handle edge cases correctly (invalid JSON, wrong types)

## How should this be tested?

1. Clear localStorage for `feature-opt-in-enabled` and `feature-opt-in-dismissed`
2. Configure a feature in `OPT_IN_FEATURES` 
3. Opt into the feature
4. Verify localStorage `feature-opt-in-enabled` stores a timestamp (number) instead of `true`
5. Refresh the page - verify the opt-in state is preserved

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/9d35d1c8ece34cf39c880c0abe25ea9b
Requested by: @eunjae-lee