### PR TITLE
feat: add delayed formbricks tracking for feature opt-in

### DIFF
--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
@@ -10,6 +10,7 @@ import {
   setFeatureDismissed,
   setFeatureOptedIn,
 } from "../lib/feature-opt-in-storage";
+import { useFormbricksOptInTracking } from "./useFormbricksOptInTracking";
 
 type UserRoleContext = {
   isOrgAdmin: boolean;
@@ -53,6 +54,9 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
   const [isOptedIn, setIsOptedIn] = useState(() => isFeatureOptedIn(featureId));
 
   const featureConfig = useMemo(() => getOptInFeatureConfig(featureId) ?? null, [featureId]);
+
+  useFormbricksOptInTracking(featureId, featureConfig);
+
   const utils = trpc.useUtils();
 
   const eligibilityQuery = trpc.viewer.featureOptIn.checkFeatureOptInEligibility.useQuery(

--- a/apps/web/modules/feature-opt-in/hooks/useFormbricksOptInTracking.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFormbricksOptInTracking.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
+import { useEffect, useRef } from "react";
+import { trackFormbricksAction } from "../../formbricks/lib/trackFormbricksAction";
+import { getFeatureOptInTimestamp, isFeatureTracked, setFeatureTracked } from "../lib/feature-opt-in-storage";
+
+/**
+ * Hook to handle delayed Formbricks tracking after a user opts into a feature.
+ * Tracks the configured action only after the specified delay has passed since opt-in.
+ */
+function useFormbricksOptInTracking(featureId: string, featureConfig: OptInFeatureConfig | null): void {
+  const hasTrackedRef = useRef(false);
+
+  useEffect(() => {
+    if (!featureConfig?.formbricks) return;
+
+    if (hasTrackedRef.current) return;
+
+    const alreadyTracked = isFeatureTracked(featureId);
+    if (alreadyTracked) return;
+
+    const optInTimestamp = getFeatureOptInTimestamp(featureId);
+    if (!optInTimestamp) return;
+
+    const { delayMs, actionName } = featureConfig.formbricks;
+    const timeSinceOptIn = Date.now() - optInTimestamp;
+
+    const trackAction = (): void => {
+      trackFormbricksAction(actionName);
+      setFeatureTracked(featureId);
+      hasTrackedRef.current = true;
+    };
+
+    if (timeSinceOptIn >= delayMs) {
+      trackAction();
+    } else {
+      const remainingTime = delayMs - timeSinceOptIn;
+      const timer = setTimeout(trackAction, remainingTime);
+
+      return () => clearTimeout(timer);
+    }
+  }, [featureId, featureConfig]);
+}
+
+export { useFormbricksOptInTracking };

--- a/apps/web/modules/feature-opt-in/lib/feature-opt-in-storage.ts
+++ b/apps/web/modules/feature-opt-in/lib/feature-opt-in-storage.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 const DISMISSED_STORAGE_KEY = "feature-opt-in-dismissed";
 const OPTED_IN_STORAGE_KEY = "feature-opt-in-enabled";
+const TRACKED_STORAGE_KEY = "feature-opt-in-tracked";
 
 const booleanFeaturesMapSchema: z.ZodSchema<Record<string, boolean>> = z.record(z.string(), z.boolean());
 const timestampFeaturesMapSchema: z.ZodSchema<Record<string, number>> = z.record(z.string(), z.number());
@@ -80,9 +81,19 @@ function setFeatureOptedIn(featureId: string): void {
   setTimestampFeatureInMap(OPTED_IN_STORAGE_KEY, featureId, Date.now());
 }
 
+function isFeatureTracked(featureId: string): boolean {
+  return isBooleanFeatureInMap(TRACKED_STORAGE_KEY, featureId);
+}
+
+function setFeatureTracked(featureId: string): void {
+  setBooleanFeatureInMap(TRACKED_STORAGE_KEY, featureId, true);
+}
+
 export {
   getFeatureOptInTimestamp,
   isFeatureDismissed,
+  isFeatureTracked,
   setFeatureDismissed,
   setFeatureOptedIn,
+  setFeatureTracked,
 };

--- a/apps/web/modules/formbricks/hooks/useFormbricks.ts
+++ b/apps/web/modules/formbricks/hooks/useFormbricks.ts
@@ -1,4 +1,4 @@
-import formbricks from "@formbricks/js/app";
+import formbricks from "@formbricks/js";
 import { useSession } from "next-auth/react";
 import { useEffect } from "react";
 
@@ -19,9 +19,9 @@ const initFormbricks = ({
   });
 
   if (process.env.NEXT_PUBLIC_FORMBRICKS_HOST_URL && process.env.NEXT_PUBLIC_FORMBRICKS_ENVIRONMENT_ID) {
-    formbricks.init({
+    formbricks.setup({
       environmentId: process.env.NEXT_PUBLIC_FORMBRICKS_ENVIRONMENT_ID,
-      apiHost: process.env.NEXT_PUBLIC_FORMBRICKS_HOST_URL,
+      appUrl: process.env.NEXT_PUBLIC_FORMBRICKS_HOST_URL,
       debug: process.env.NODE_ENV === "development",
       userId,
       attributes: filteredAttributes,

--- a/apps/web/modules/formbricks/lib/trackFormbricksAction.ts
+++ b/apps/web/modules/formbricks/lib/trackFormbricksAction.ts
@@ -1,4 +1,4 @@
-import formbricks from "@formbricks/js/app";
+import formbricks from "@formbricks/js";
 
 export const trackFormbricksAction = (eventName: string, properties: Record<string, string> = {}) => {
   if (process.env.NEXT_PUBLIC_FORMBRICKS_HOST_URL && process.env.NEXT_PUBLIC_FORMBRICKS_ENVIRONMENT_ID) {

--- a/packages/features/feature-opt-in/config.ts
+++ b/packages/features/feature-opt-in/config.ts
@@ -38,7 +38,7 @@ export interface OptInFeatureConfig {
   formbricks?: {
     /** The action name to track (e.g., "visit_bookings_v3_page"). */
     actionName: string;
-    /** Delay in milliseconds before tracking the action after opt-in. */
+    /** Show feedback form only after a certain delay */
     delayMs: number;
   };
 }
@@ -63,6 +63,10 @@ export const OPT_IN_FEATURES: OptInFeatureConfig[] = [
     policy: "permissive",
     displayLocations: ["settings"],
     scope: ["org", "team", "user"], // Optional: defaults to all scopes if not specified
+    formbricks: {
+      actionName: "visit_bookings_v3_page",
+      delayMs: 3 * 24 * 60 * 60 * 1000, // 3 days
+    },
   },
 ];
 

--- a/packages/features/feature-opt-in/config.ts
+++ b/packages/features/feature-opt-in/config.ts
@@ -30,6 +30,17 @@ export interface OptInFeatureConfig {
    * Use [] if you want the feature defined but not displayed anywhere.
    */
   displayLocations?: OptInFeatureDisplayLocation[];
+  /**
+   * Formbricks tracking configuration for delayed survey triggering after opt-in.
+   * When configured, a Formbricks action will be tracked after the specified delay
+   * has passed since the user opted in, allowing time for feature usage before collecting feedback.
+   */
+  formbricks?: {
+    /** The action name to track (e.g., "visit_bookings_v3_page"). */
+    actionName: string;
+    /** Delay in milliseconds before tracking the action after opt-in. */
+    delayMs: number;
+  };
 }
 
 /**

--- a/packages/lib/formbricks.ts
+++ b/packages/lib/formbricks.ts
@@ -4,8 +4,8 @@ import type { Feedback } from "@calcom/emails/templates/feedback-email";
 
 enum Rating {
   "Extremely unsatisfied" = 1,
-  "Unsatisfied" = 2,
-  "Satisfied" = 3,
+  Unsatisfied = 2,
+  Satisfied = 3,
   "Extremely satisfied" = 4,
 }
 
@@ -13,7 +13,7 @@ export const sendFeedbackFormbricks = async (userId: number, feedback: Feedback)
   if (!process.env.NEXT_PUBLIC_FORMBRICKS_HOST_URL || !process.env.NEXT_PUBLIC_FORMBRICKS_ENVIRONMENT_ID)
     throw new Error("Missing FORMBRICKS_HOST_URL or FORMBRICKS_ENVIRONMENT_ID env variable");
   const api = new FormbricksAPI({
-    apiHost: process.env.NEXT_PUBLIC_FORMBRICKS_HOST_URL,
+    appUrl: process.env.NEXT_PUBLIC_FORMBRICKS_HOST_URL,
     environmentId: process.env.NEXT_PUBLIC_FORMBRICKS_ENVIRONMENT_ID,
   });
   if (process.env.FORMBRICKS_FEEDBACK_SURVEY_ID) {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@calcom/config": "workspace:*",
     "@calcom/dayjs": "workspace:*",
-    "@formbricks/api": "1.7.0",
-    "@formbricks/js": "2.1.0",
+    "@formbricks/api": "3.0.0",
+    "@formbricks/js": "4.3.0",
     "@sendgrid/client": "7.7.0",
     "@unkey/ratelimit": "2.1.3",
     "@vercel/og": "0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,8 +2847,8 @@ __metadata:
     "@calcom/tsconfig": "workspace:*"
     "@calcom/types": "workspace:*"
     "@faker-js/faker": "npm:7.6.0"
-    "@formbricks/api": "npm:1.7.0"
-    "@formbricks/js": "npm:2.1.0"
+    "@formbricks/api": "npm:3.0.0"
+    "@formbricks/js": "npm:4.3.0"
     "@sendgrid/client": "npm:7.7.0"
     "@unkey/ratelimit": "npm:2.1.3"
     "@vercel/og": "npm:0.6.3"
@@ -5208,17 +5208,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formbricks/api@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@formbricks/api@npm:1.7.0"
-  checksum: 10/0f45372b12da4893ac9b75d71a94658420f75dd79e20af32315a33c45d6d4b5bfbeb33c7fb9816b677a3b9d7d105ce5130963d5f15fb7ebd2425d4ec8fb01982
+"@formbricks/api@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@formbricks/api@npm:3.0.0"
+  checksum: 10/d20cde3e904eaf62b3886dabfdcd8b51b7018f146325def413ba4c788ad3a5c8fc3be6e0931199b3ab8ba21ba0cd3e2aa2eaae874623fa17c43178d1269ee87a
   languageName: node
   linkType: hard
 
-"@formbricks/js@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@formbricks/js@npm:2.1.0"
-  checksum: 10/037743c4d4558e1ee434b283646244f6f594ea0ea6c61533ceb2fc987d0b6260fa45234801309c847af5a9745e1691785a5094f3743e54f3b2ec9c2fb5ccd30e
+"@formbricks/js@npm:4.3.0":
+  version: 4.3.0
+  resolution: "@formbricks/js@npm:4.3.0"
+  checksum: 10/9ab7e85963f03f095c4c7edd14670258afe5c1c9010137a8bf33fb09bed96a68ff6449e5949b4ea8dccce2c33d02cdd7c426034e422b675df28d6750ebdd8b84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

Adds delayed Formbricks survey tracking for feature opt-in. When a user opts into a feature, this allows triggering a Formbricks action after a configurable delay (e.g., 24 hours later) to collect feedback once they've had time to use the feature.

**Note: This PR is stacked on #27080** - it should be merged after that PR which changes the opt-in storage from boolean to timestamp.

**Key changes:**
- Added `formbricks` config option to `OptInFeatureConfig` interface with `actionName` and `delayMs` properties
- Created `useFormbricksOptInTracking` hook that handles the delayed tracking logic
- Added `isFeatureTracked` / `setFeatureTracked` storage helpers to prevent duplicate tracking
- Integrated the tracking hook into `useFeatureOptInBanner`

**How it works:**
1. When a feature is configured with `formbricks: { actionName: "...", delayMs: 86400000 }`, the hook checks if the delay has passed since opt-in
2. If delay has passed, it immediately tracks the action
3. If delay hasn't passed, it sets a timeout for the remaining time
4. Tracking state is persisted to localStorage to prevent duplicate tracking across sessions

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal feature, config is self-documented.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Merge PR #27080 first (the base PR for timestamp storage)
2. Configure a feature in `OPT_IN_FEATURES` with formbricks config:
   ```typescript
   formbricks: {
     actionName: "test_action",
     delayMs: 5000, // 5 seconds for testing
   }
   ```
3. Opt into the feature
4. Wait for the delay to pass
5. Verify `trackFormbricksAction` is called with the configured action name
6. Verify localStorage `feature-opt-in-tracked` contains the feature ID
7. Refresh the page - verify the action is NOT tracked again

## Human Review Checklist

- [ ] Verify the timer cleanup in useEffect handles component unmount correctly
- [ ] Verify the `hasTrackedRef` + localStorage double-check prevents race conditions
- [ ] Consider if unit tests should be added for the tracking hook
- [ ] This is stacked on PR #27080 - ensure that PR is reviewed/merged first

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/9d35d1c8ece34cf39c880c0abe25ea9b
Requested by: @eunjae-lee