### PR TITLE
fix: use orgAwareUsername in troubleshooter getSchedule request

### DIFF
--- a/apps/web/modules/troubleshooter/components/LargeCalendar.tsx
+++ b/apps/web/modules/troubleshooter/components/LargeCalendar.tsx
@@ -1,15 +1,13 @@
-import { useSession } from "next-auth/react";
-import { useMemo } from "react";
-
 import dayjs from "@calcom/dayjs";
 import { useAvailableTimeSlots } from "@calcom/features/bookings/Booker/components/hooks/useAvailableTimeSlots";
-import { Calendar } from "@calcom/web/modules/calendars/weeklyview/components/Calendar";
-import { BookingStatus } from "@calcom/prisma/enums";
-import { trpc } from "@calcom/trpc/react";
-
 import { useTimePreferences } from "@calcom/features/bookings/lib/timePreferences";
 import { useSchedule } from "@calcom/features/schedules/lib/use-schedule/useSchedule";
 import { useTroubleshooterStore } from "@calcom/features/troubleshooter/store";
+import { BookingStatus } from "@calcom/prisma/enums";
+import { trpc } from "@calcom/trpc/react";
+import { Calendar } from "@calcom/web/modules/calendars/weeklyview/components/Calendar";
+import { useSession } from "next-auth/react";
+import { useMemo } from "react";
 
 export const LargeCalendar = ({ extraDays }: { extraDays: number }) => {
   const { timezone } = useTimePreferences();
@@ -38,7 +36,7 @@ export const LargeCalendar = ({ extraDays }: { extraDays: number }) => {
 
   const isTeamEvent = !!event?.teamId;
   const { data: schedule } = useSchedule({
-    username: session?.user.username || "",
+    username: session?.user.orgAwareUsername || "",
     // For team events, don't pass eventSlug to avoid slug lookup issues - use eventId instead
     eventSlug: isTeamEvent ? null : event?.slug,
     eventId: event?.id,


### PR DESCRIPTION
## What does this PR do?

Fixes the troubleshooter's `getSchedule` request to use `orgAwareUsername` instead of `username` when fetching schedule data.

In organization contexts, users have different usernames per organization (via Profiles). The troubleshooter was using `session?.user.username` which returns the base username, but the `getSchedule` endpoint expects the org-aware username to properly resolve the user's schedule within the organization context. This aligns the troubleshooter behavior with how the booking page handles the same request.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Set up a user within an organization that has a different org username than their base username
2. Navigate to the troubleshooter page
3. Verify that the schedule loads correctly and shows the user's availability
4. Compare behavior with the booking page to ensure consistency

## Human Review Checklist

- [ ] Verify `orgAwareUsername` is available in all contexts where `username` was previously used (org and non-org users)
- [ ] Confirm this matches how the booking page handles username in `getSchedule` requests

---

> **Link to Devin run**: https://app.devin.ai/sessions/5661869d6af3401c9ba6a099575673a9
> Requested by: @hariombalhara