### PR TITLE
fix: nav tab stick position

### DIFF
--- a/apps/web/modules/event-types/components/EventTypeLayout.tsx
+++ b/apps/web/modules/event-types/components/EventTypeLayout.tsx
@@ -296,6 +296,7 @@ function EventTypeSingleLayout({
               className="primary-navigation w-64"
               tabs={EventTypeTabs}
               sticky
+              stickyOffset="var(--navbar-height, 64px)"
               linkShallow
               itemClassname="items-start"
             />

--- a/packages/ui/components/navigation/tabs/VerticalTabs.tsx
+++ b/packages/ui/components/navigation/tabs/VerticalTabs.tsx
@@ -10,6 +10,7 @@ export interface NavTabProps {
   children?: React.ReactNode;
   className?: string;
   sticky?: boolean;
+  stickyOffset?: number | string;
   linkShallow?: boolean;
   linkScroll?: boolean;
   itemClassname?: string;
@@ -20,6 +21,7 @@ const NavTabs = function ({
   tabs,
   className = "",
   sticky,
+  stickyOffset = 24,
   linkShallow,
   linkScroll,
   itemClassname,
@@ -28,17 +30,13 @@ const NavTabs = function ({
 }: NavTabProps) {
   return (
     <nav
-      className={classNames(
-        `no-scrollbar flex flex-col stack-y-1 overflow-scroll ${className}`,
-        sticky && "sticky top-0 -mt-7"
-      )}
+      className={classNames(`no-scrollbar flex flex-col stack-y-1 overflow-scroll ${className}`, sticky && "sticky")}
       style={{
         maxWidth: "256px",
+        ...(sticky ? { top: stickyOffset } : {}),
       }}
       aria-label="Tabs"
       {...props}>
-      {/* padding top for sticky */}
-      {sticky && <div className="pt-6" />}
       {props.children}
       {tabs.map((tab, idx) => (
         <VerticalTabItem

--- a/packages/ui/components/navigation/tabs/navigation.test.tsx
+++ b/packages/ui/components/navigation/tabs/navigation.test.tsx
@@ -158,8 +158,9 @@ describe("Navigation Components", () => {
         }
       });
 
-      // Check sticky behavior
+      // Check sticky behavior with default offset
       await expect(container.firstChild).toHaveClass("sticky");
+      await expect(container.firstChild).toHaveStyle("top: 24px");
     });
 
     test("applies custom icon correctly", async () => {


### PR DESCRIPTION
## What does this PR do?

Before:
https://www.loom.com/share/783ea155acc54997befb83b556914566



After:
https://www.loom.com/share/43213790ff394b7f8693c5018f212cc9


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sticky position of the event navigation tabs so they sit correctly below the navbar and no longer overlap or jump.

- **Bug Fixes**
  - Added stickyOffset prop (default 24px) to VerticalTabs and applied it to the top style when sticky.
  - Removed extra padding and negative margin from the sticky state to prevent layout shift.
  - EventType sidebar now uses stickyOffset="var(--navbar-height, 64px)" to match navbar height.
  - Updated tests to assert the default offset behavior.

<sup>Written for commit 83f8aac19ed87f2e301ad4af0f46a5650947e001. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

