### PR TITLE
perf: add composite index on EventType(parentId, teamId)

### DIFF
--- a/packages/prisma/migrations/20260121191700_add_eventtype_parentid_teamid_index/migration.sql
+++ b/packages/prisma/migrations/20260121191700_add_eventtype_parentid_teamid_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "EventType_parentId_teamId_idx" ON "public"."EventType"("parentId", "teamId");

--- a/packages/prisma/migrations/20260121191700_add_eventtype_parentid_teamid_index/migration.sql
+++ b/packages/prisma/migrations/20260121191700_add_eventtype_parentid_teamid_index/migration.sql
@@ -1,2 +1,2 @@
 -- CreateIndex
-CREATE INDEX CONCURRENTLY "EventType_parentId_teamId_idx" ON "public"."EventType"("parentId", "teamId");
+CREATE INDEX "EventType_parentId_teamId_idx" ON "public"."EventType"("parentId", "teamId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -274,6 +274,7 @@ model EventType {
   @@index([scheduleId])
   @@index([secondaryEmailId])
   @@index([parentId])
+  @@index([parentId, teamId])
   @@index([restrictionScheduleId])
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a composite index on `EventType(parentId, teamId)` to improve performance of the query in the bookings handler that joins EventType to itself on parentId and filters by teamId.

The query being optimized (from [get.handler.ts#L124-L136](https://github.com/calcom/cal.com/blob/5ddb4dce/packages/trpc/server/routers/viewer/bookings/get.handler.ts#L124-L136)):
```sql
SELECT "public"."EventType"."id" FROM "public"."EventType" 
LEFT JOIN "public"."EventType" AS "j0" ON ("j0"."id") = ("public"."EventType"."parentId") 
WHERE ("j0"."teamId" IN ($1,$2,...) AND ("j0"."id" IS NOT NULL)) OFFSET $11
```

The composite index allows the database to efficiently perform the join on `parentId` and then filter by `teamId` without a full table scan.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - this is a database index addition.

## How should this be tested?

This is a database index addition. Testing involves:
1. Verify the migration applies successfully
2. Verify the index exists after migration: `\d "EventType"` in psql should show the new index
3. Optionally, run EXPLAIN ANALYZE on the query to confirm the index is being used

## Human Review Checklist

- [ ] Verify the `CONCURRENTLY` keyword in the migration SQL is appropriate (note: CONCURRENTLY cannot run inside a transaction, which may conflict with Prisma's migration runner - may need to remove this keyword)
- [ ] Verify the index column order `(parentId, teamId)` matches the query access pattern

<!-- Link to Devin run: https://app.devin.ai/sessions/4a7e00a896a2460e8184614dd1263de2 -->
<!-- Requested by: @keithwillcode -->