### PR TITLE
fix: restrict dynamic variables and custom templates to paid plan users

### DIFF
--- a/apps/web/modules/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/apps/web/modules/ee/workflows/components/WorkflowStepContainer.tsx
@@ -1643,7 +1643,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 editable={
                   !props.readOnly &&
                   !isWhatsappAction(step.action) &&
-                  (hasPaidPlan || isSMSAction(step.action))
+                  hasPaidPlan
                 }
                 excludedToolbarItems={
                   isSMSAction(step.action)

--- a/apps/web/modules/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/apps/web/modules/ee/workflows/components/WorkflowStepContainer.tsx
@@ -1575,6 +1575,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 <div className="mb-6">
                   <div className="flex items-center">
                     <Label
+                      data-testid="email-subject-label"
                       className={classNames(
                         "flex-none",
                         props.readOnly || isFormTrigger(trigger) || !hasPaidPlan

--- a/apps/web/modules/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/apps/web/modules/ee/workflows/components/WorkflowStepContainer.tsx
@@ -1577,14 +1577,14 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                     <Label
                       className={classNames(
                         "flex-none",
-                        props.readOnly || isFormTrigger(trigger)
+                        props.readOnly || isFormTrigger(trigger) || !hasPaidPlan
                           ? "mb-2"
                           : "mb-0"
                       )}
                     >
                       {t("email_subject")}
                     </Label>
-                    {!props.readOnly && !isFormTrigger(trigger) && (
+                    {!props.readOnly && !isFormTrigger(trigger) && hasPaidPlan && (
                       <div className="grow text-right">
                         <AddVariablesDropdown
                           addVariable={addVariableEmailSubject}
@@ -1599,7 +1599,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                       refEmailSubject.current = e;
                     }}
                     rows={2}
-                    disabled={props.readOnly || !hasActiveTeamPlan}
+                    disabled={props.readOnly || !hasPaidPlan}
                     className="my-0 focus:ring-transparent"
                     required
                     {...restEmailSubjectForm}
@@ -1633,9 +1633,9 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                   props.form.clearErrors();
                 }}
                 variables={
-                  !isFormTrigger(trigger) ? DYNAMIC_TEXT_VARIABLES : undefined
+                  !isFormTrigger(trigger) && hasPaidPlan ? DYNAMIC_TEXT_VARIABLES : undefined
                 }
-                addVariableButtonTop={isSMSAction(step.action)}
+                addVariableButtonTop={isSMSAction(step.action) && hasPaidPlan}
                 height="200px"
                 updateTemplate={updateTemplate}
                 firstRender={firstRender}
@@ -1643,7 +1643,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 editable={
                   !props.readOnly &&
                   !isWhatsappAction(step.action) &&
-                  (hasActiveTeamPlan || isSMSAction(step.action))
+                  (hasPaidPlan || isSMSAction(step.action))
                 }
                 excludedToolbarItems={
                   isSMSAction(step.action)

--- a/apps/web/playwright/workflow-dynamic-vars.e2e.ts
+++ b/apps/web/playwright/workflow-dynamic-vars.e2e.ts
@@ -1,0 +1,162 @@
+import { expect } from "@playwright/test";
+import { MembershipRole } from "@calcom/prisma/enums";
+import { loginUserWithTeam } from "./fixtures/regularBookings";
+import { test } from "./lib/fixtures";
+
+test.describe.configure({ mode: "parallel" });
+
+test.afterEach(async ({ users }) => {
+  await users.deleteAll();
+});
+
+test.describe("Workflow Dynamic Variables - Paid Plan Features", () => {
+  test.beforeEach(async ({ page, users }) => {
+    await loginUserWithTeam(users, MembershipRole.ADMIN);
+    await page.goto("/workflows");
+  });
+
+  test("add variable dropdown is visible for email subject", async ({ page, workflowPage }) => {
+    const { createWorkflow, editSelectedWorkflow } = workflowPage;
+
+    await createWorkflow({ name: "Dynamic Vars Test Workflow", isTeam: true });
+    await editSelectedWorkflow("Dynamic Vars Test Workflow");
+    await page.waitForLoadState("networkidle");
+
+    // Paid users should see the Add Variable dropdown
+    const addVariableDropdowns = page.locator('[aria-label="Add variable"]');
+    await expect(addVariableDropdowns.first()).toBeVisible();
+  });
+
+  test("email subject textarea is enabled for editing", async ({ page, workflowPage }) => {
+    const { createWorkflow, editSelectedWorkflow } = workflowPage;
+
+    await createWorkflow({ name: "Email Subject Test Workflow", isTeam: true });
+    await editSelectedWorkflow("Email Subject Test Workflow");
+    await page.waitForLoadState("networkidle");
+
+    const emailSubjectLabel = page.getByText("Email subject");
+    await expect(emailSubjectLabel).toBeVisible();
+
+    const emailSubjectTextarea = page.locator("textarea").first();
+    await expect(emailSubjectTextarea).toBeEnabled();
+  });
+
+  test("editor toolbar has add variable button", async ({ page, workflowPage }) => {
+    const { createWorkflow, editSelectedWorkflow } = workflowPage;
+
+    await createWorkflow({ name: "Editor Toolbar Test Workflow", isTeam: true });
+    await editSelectedWorkflow("Editor Toolbar Test Workflow");
+    await page.waitForLoadState("networkidle");
+
+    const editorToolbarAddVariable = page.locator('[aria-label="Add variable"]');
+    await expect(editorToolbarAddVariable.first()).toBeVisible();
+  });
+
+  test("email body editor is editable", async ({ page, workflowPage }) => {
+    const { createWorkflow, editSelectedWorkflow } = workflowPage;
+
+    await createWorkflow({ name: "Editor Editable Test Workflow", isTeam: true });
+    await editSelectedWorkflow("Editor Editable Test Workflow");
+    await page.waitForLoadState("networkidle");
+
+    const editorContainer = page.locator("[data-lexical-editor]").first();
+    await expect(editorContainer).toBeVisible();
+
+    const contentEditable = await editorContainer.getAttribute("contenteditable");
+    expect(contentEditable).toBe("true");
+  });
+
+  test("can open add variable dropdown and see dynamic variables", async ({ page, workflowPage }) => {
+    const { createWorkflow, editSelectedWorkflow } = workflowPage;
+
+    await createWorkflow({ name: "Variable Dropdown Test Workflow", isTeam: true });
+    await editSelectedWorkflow("Variable Dropdown Test Workflow");
+    await page.waitForLoadState("networkidle");
+
+    const addVariableButton = page.locator('[aria-label="Add variable"]').first();
+    await addVariableButton.click();
+
+    await expect(page.getByText("{ORGANIZER_NAME}")).toBeVisible();
+    await expect(page.getByPlaceholder(/search variables/i)).toBeVisible();
+  });
+
+  test("can insert dynamic variable from dropdown", async ({ page, workflowPage }) => {
+    const { createWorkflow, editSelectedWorkflow } = workflowPage;
+
+    await createWorkflow({ name: "Variable Insert Test Workflow", isTeam: true });
+    await editSelectedWorkflow("Variable Insert Test Workflow");
+    await page.waitForLoadState("networkidle");
+
+    const addVariableButton = page.locator('[aria-label="Add variable"]').first();
+    await addVariableButton.click();
+
+    const variableOption = page.getByText("{ORGANIZER_NAME}");
+    await expect(variableOption).toBeVisible();
+
+    await variableOption.click();
+    await expect(variableOption).not.toBeVisible();
+  });
+});
+
+test.describe("Workflow Dynamic Variables - Free Plan Users", () => {
+  test.beforeEach(async ({ page, users, prisma }) => {
+    const freeUser = await users.create({ name: "freeuser" });
+    await prisma.user.update({
+      where: { id: freeUser.id },
+      data: { metadata: { forceFree: true } },
+    });
+    await freeUser.apiLogin();
+    await page.goto("/workflows");
+  });
+
+  test("add variable dropdown is NOT visible for email subject", async ({ page, workflowPage }) => {
+    const { createWorkflow, editSelectedWorkflow } = workflowPage;
+
+    await createWorkflow({ name: "Free User Workflow" });
+    await editSelectedWorkflow("Free User Workflow");
+    await page.waitForLoadState("networkidle");
+
+    // Free users should NOT see the Add Variable dropdown
+    const addVariableDropdowns = page.locator('[aria-label="Add variable"]');
+    await expect(addVariableDropdowns).toBeHidden();
+  });
+
+  test("email subject textarea is disabled", async ({ page, workflowPage }) => {
+    const { createWorkflow, editSelectedWorkflow } = workflowPage;
+
+    await createWorkflow({ name: "Free User Subject Workflow" });
+    await editSelectedWorkflow("Free User Subject Workflow");
+    await page.waitForLoadState("networkidle");
+
+    const emailSubjectLabel = page.getByText("Email subject");
+    await expect(emailSubjectLabel).toBeVisible();
+
+    const emailSubjectTextarea = page.locator("textarea").first();
+    await expect(emailSubjectTextarea).toBeDisabled();
+  });
+
+  test("editor toolbar does NOT have add variable button", async ({ page, workflowPage }) => {
+    const { createWorkflow, editSelectedWorkflow } = workflowPage;
+
+    await createWorkflow({ name: "Free User Toolbar Workflow" });
+    await editSelectedWorkflow("Free User Toolbar Workflow");
+    await page.waitForLoadState("networkidle");
+
+    const editorToolbarAddVariable = page.locator('[aria-label="Add variable"]');
+    await expect(editorToolbarAddVariable).toBeHidden();
+  });
+
+  test("email body editor is NOT editable", async ({ page, workflowPage }) => {
+    const { createWorkflow, editSelectedWorkflow } = workflowPage;
+
+    await createWorkflow({ name: "Free User Editor Workflow" });
+    await editSelectedWorkflow("Free User Editor Workflow");
+    await page.waitForLoadState("networkidle");
+
+    const editorContainer = page.locator("[data-lexical-editor]").first();
+    await expect(editorContainer).toBeVisible();
+
+    const contentEditable = await editorContainer.getAttribute("contenteditable");
+    expect(contentEditable).toBe("false");
+  });
+});

--- a/apps/web/playwright/workflow-dynamic-vars.e2e.ts
+++ b/apps/web/playwright/workflow-dynamic-vars.e2e.ts
@@ -34,7 +34,7 @@ test.describe("Workflow Dynamic Variables - Paid Plan Features", () => {
     await editSelectedWorkflow("Email Subject Test Workflow");
     await page.waitForLoadState("networkidle");
 
-    const emailSubjectLabel = page.getByText("Email subject");
+    const emailSubjectLabel = page.getByTestId("email-subject-label");
     await expect(emailSubjectLabel).toBeVisible();
 
     const emailSubjectTextarea = page.locator("textarea").first();
@@ -76,8 +76,8 @@ test.describe("Workflow Dynamic Variables - Paid Plan Features", () => {
     const addVariableButton = page.locator('[aria-label="Add variable"]').first();
     await addVariableButton.click();
 
-    await expect(page.getByText("{ORGANIZER_NAME}")).toBeVisible();
-    await expect(page.getByPlaceholder(/search variables/i)).toBeVisible();
+    await expect(page.getByTestId("variable-option-organizer_name")).toBeVisible();
+    await expect(page.getByTestId("search-variables-input")).toBeVisible();
   });
 
   test("can insert dynamic variable from dropdown", async ({ page, workflowPage }) => {
@@ -90,7 +90,7 @@ test.describe("Workflow Dynamic Variables - Paid Plan Features", () => {
     const addVariableButton = page.locator('[aria-label="Add variable"]').first();
     await addVariableButton.click();
 
-    const variableOption = page.getByText("{ORGANIZER_NAME}");
+    const variableOption = page.getByTestId("variable-option-organizer_name");
     await expect(variableOption).toBeVisible();
 
     await variableOption.click();
@@ -128,7 +128,7 @@ test.describe("Workflow Dynamic Variables - Free Plan Users", () => {
     await editSelectedWorkflow("Free User Subject Workflow");
     await page.waitForLoadState("networkidle");
 
-    const emailSubjectLabel = page.getByText("Email subject");
+    const emailSubjectLabel = page.getByTestId("email-subject-label");
     await expect(emailSubjectLabel).toBeVisible();
 
     const emailSubjectTextarea = page.locator("textarea").first();

--- a/packages/ui/components/editor/plugins/AddVariablesDropdown.tsx
+++ b/packages/ui/components/editor/plugins/AddVariablesDropdown.tsx
@@ -135,7 +135,8 @@ export const AddVariablesDropdown = (props: IAddVariablesDropdown) => {
             {t("add_dynamic_variables")}
           </div>
           <div>
-            <Input
+            <Input 
+              data-testid="search-variables-input"
               type="text"
               size="sm"
               value={query}
@@ -152,12 +153,13 @@ export const AddVariablesDropdown = (props: IAddVariablesDropdown) => {
               filteredVariables.map((variable, index) => (
                 <DropdownMenuItem key={variable} className="w-full rounded-md p-1 hover:ring-0 focus:outline-none">
                   <button
+                    data-testid={`variable-option-${variable}`}
                     ref={(el) => (itemRefs.current[index] = el)}
                     key={variable}
                     type="button"
                     className={`w-full rounded-md px-3 py-2 text-left transition-colors focus:outline-none ${
                       selectedIndex === index ? "bg-muted" : ""
-                    }`}
+                      }`}
                     onMouseEnter={() => setSelectedIndex(index)}
                     data-active={selectedIndex === index}
                     onClick={() => {


### PR DESCRIPTION
## What does this PR do?
Restrict dynamic variable insertion and editing to paid plan users only. free users can only use predefined templates and cannot add or edit dynamic variables in workflow.

- Fixes #27075
- Fixes [CAL-7109](https://linear.app/calcom/issue/CAL-7109/ui-improvements-for-custom-workflows-on-free-plan)

## Changes
- Plan : Changed from `hasActiveTeamPlan` (team-only) to `hasPaidPlan` (team + personal premium) for free user detection
- **Email Subject Variables**: Hidden "Add variable" dropdown and disabled TextArea editing for free users
- **Message Editor**: Disabled dynamic variables, variable button, and editing for free users

## Feature Status
- Custom templates already blocked for free users (via `needsTeamsUpgrade` flag)
- "Add variable" dropdown now hidden for free users
- Email subject editing disabled for free users  
- Dynamic variables hidden in editor for free users
- Message editor read-only for free users with variable features

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):
- before : 

https://github.com/user-attachments/assets/b96ef0ab-a448-4e02-bdef-0ad01cca7c30

- after : 

https://github.com/user-attachments/assets/24f4e7df-335c-4881-bce5-752d8826f45b

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
1. Log in as free plan user
2. Create/edit workflow with email action
3. Verify:
   - Custom template is disabled with "Upgrade" badge
   - Email subject "Add variable" dropdown is **not visible**