### PR TITLE
feat: Add download CSV button on bookings page

### DIFF
--- a/apps/web/modules/bookings/components/BookingListContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingListContainer.tsx
@@ -1,19 +1,7 @@
 "use client";
 
-import {
-  useReactTable,
-  getCoreRowModel,
-  getSortedRowModel,
-} from "@tanstack/react-table";
-import { useRouter } from "next/navigation";
-import React, { useState, useMemo, useEffect, useCallback } from "react";
-
 import dayjs from "@calcom/dayjs";
-import {
-  useDataTable,
-  useDisplayedFilterCount,
-} from "@calcom/features/data-table";
-import { DataTableSegment, DataTableFilters } from "~/data-table/components";
+import { useDataTable, useDisplayedFilterCount } from "@calcom/features/data-table";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
@@ -22,7 +10,9 @@ import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
 import { ToggleGroup } from "@calcom/ui/components/form";
 import { WipeMyCalActionButton } from "@calcom/web/components/apps/wipemycalother/wipeMyCalActionButton";
-
+import { getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
+import { useRouter } from "next/navigation";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useBookingFilters } from "~/bookings/hooks/useBookingFilters";
 import { useBookingListColumns } from "~/bookings/hooks/useBookingListColumns";
 import { useBookingListData } from "~/bookings/hooks/useBookingListData";
@@ -30,18 +20,15 @@ import { useBookingStatusTab } from "~/bookings/hooks/useBookingStatusTab";
 import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues";
 import { useListAutoSelector } from "~/bookings/hooks/useListAutoSelector";
 import { useListNavigationCapabilities } from "~/bookings/hooks/useListNavigationCapabilities";
-
+import { DataTableFilters, DataTableSegment } from "~/data-table/components";
 import {
   BookingDetailsSheetStoreProvider,
   useBookingDetailsSheetStore,
 } from "../store/bookingDetailsSheetStore";
-import type {
-  RowData,
-  BookingListingStatus,
-  BookingsGetOutput,
-} from "../types";
+import type { BookingListingStatus, BookingsGetOutput, RowData } from "../types";
 import { BookingDetailsSheet } from "./BookingDetailsSheet";
 import { BookingList } from "./BookingList";
+import { BookingsCsvDownload } from "./BookingsCsvDownload";
 import { ViewToggleButton } from "./ViewToggleButton";
 
 interface FilterButtonProps {
@@ -50,11 +37,7 @@ interface FilterButtonProps {
   setShowFilters: (value: boolean | ((prev: boolean) => boolean)) => void;
 }
 
-function FilterButton({
-  table,
-  displayedFilterCount,
-  setShowFilters,
-}: FilterButtonProps) {
+function FilterButton({ table, displayedFilterCount, setShowFilters }: FilterButtonProps) {
   const { t } = useLocale();
 
   if (displayedFilterCount === 0) {
@@ -67,8 +50,7 @@ function FilterButton({
       StartIcon="list-filter"
       className="h-full"
       size="sm"
-      onClick={() => setShowFilters((value) => !value)}
-    >
+      onClick={() => setShowFilters((value) => !value)}>
       {t("filter")}
       <Badge variant="gray" className="ml-1">
         {displayedFilterCount}
@@ -109,9 +91,7 @@ function BookingListInner({
 }: BookingListInnerProps) {
   const { t } = useLocale();
   const user = useMeQuery().data;
-  const setSelectedBookingUid = useBookingDetailsSheetStore(
-    (state) => state.setSelectedBookingUid
-  );
+  const setSelectedBookingUid = useBookingDetailsSheetStore((state) => state.setSelectedBookingUid);
   const router = useRouter();
   const [showFilters, setShowFilters] = useState(true);
 
@@ -119,11 +99,7 @@ function BookingListInner({
   useListAutoSelector(bookings);
 
   const ErrorView = errorMessage ? (
-    <Alert
-      severity="error"
-      title={t("something_went_wrong")}
-      message={errorMessage}
-    />
+    <Alert severity="error" title={t("something_went_wrong")} message={errorMessage} />
   ) : undefined;
 
   const handleBookingClick = useCallback(
@@ -190,9 +166,7 @@ function BookingListInner({
               value={currentTab}
               onValueChange={(value) => {
                 if (!value) return;
-                const selectedTab = tabOptions.find(
-                  (tab) => tab.value === value
-                );
+                const selectedTab = tabOptions.find((tab) => tab.value === value);
                 if (selectedTab?.href) {
                   router.push(selectedTab.href);
                 }
@@ -213,9 +187,8 @@ function BookingListInner({
         <div className="hidden grow md:block" />
 
         <DataTableSegment.Select />
-        {bookingsV3Enabled && (
-          <ViewToggleButton bookingsV3Enabled={bookingsV3Enabled} />
-        )}
+        <BookingsCsvDownload status={status} />
+        {bookingsV3Enabled && <ViewToggleButton bookingsV3Enabled={bookingsV3Enabled} />}
       </div>
       {displayedFilterCount > 0 && showFilters && (
         <div className="mt-3 flex flex-wrap items-center gap-2">
@@ -230,11 +203,7 @@ function BookingListInner({
         </div>
       )}
       {status === "upcoming" && !isEmpty && (
-        <WipeMyCalActionButton
-          className="mt-4"
-          bookingStatus={status}
-          bookingsEmpty={isEmpty}
-        />
+        <WipeMyCalActionButton className="mt-4" bookingStatus={status} bookingsEmpty={isEmpty} />
       )}
       <div className="mt-4">
         <BookingList
@@ -250,9 +219,7 @@ function BookingListInner({
       {bookingsV3Enabled && (
         <BookingDetailsSheet
           userTimeZone={user?.timeZone}
-          userTimeFormat={
-            user?.timeFormat === null ? undefined : user?.timeFormat
-          }
+          userTimeFormat={user?.timeFormat === null ? undefined : user?.timeFormat}
           userId={user?.id}
           userEmail={user?.email}
           bookingAuditEnabled={bookingAuditEnabled}
@@ -264,15 +231,8 @@ function BookingListInner({
 
 export function BookingListContainer(props: BookingListContainerProps) {
   const { limit, offset, setPageIndex } = useDataTable();
-  const {
-    eventTypeIds,
-    teamIds,
-    userIds,
-    dateRange,
-    attendeeName,
-    attendeeEmail,
-    bookingUid,
-  } = useBookingFilters();
+  const { eventTypeIds, teamIds, userIds, dateRange, attendeeName, attendeeEmail, bookingUid } =
+    useBookingFilters();
 
   // Build query input once - shared between query and prefetching
   const queryInput = useMemo(
@@ -290,9 +250,7 @@ export function BookingListContainer(props: BookingListContainerProps) {
         afterStartDate: dateRange?.startDate
           ? dayjs(dateRange?.startDate).startOf("day").toISOString()
           : undefined,
-        beforeEndDate: dateRange?.endDate
-          ? dayjs(dateRange?.endDate).endOf("day").toISOString()
-          : undefined,
+        beforeEndDate: dateRange?.endDate ? dayjs(dateRange?.endDate).endOf("day").toISOString() : undefined,
       },
     }),
     [
@@ -314,10 +272,7 @@ export function BookingListContainer(props: BookingListContainerProps) {
     gcTime: 30 * 60 * 1000, // 30 minutes - cache retention time
   });
 
-  const bookings = useMemo(
-    () => query.data?.bookings ?? [],
-    [query.data?.bookings]
-  );
+  const bookings = useMemo(() => query.data?.bookings ?? [], [query.data?.bookings]);
 
   // Always call the hook and provide navigation capabilities
   // The BookingDetailsSheet is only rendered when bookingsV3Enabled is true (see line 212)
@@ -330,10 +285,7 @@ export function BookingListContainer(props: BookingListContainerProps) {
   });
 
   return (
-    <BookingDetailsSheetStoreProvider
-      bookings={bookings}
-      capabilities={capabilities}
-    >
+    <BookingDetailsSheetStoreProvider bookings={bookings} capabilities={capabilities}>
       <BookingListInner
         {...props}
         data={query.data}

--- a/apps/web/modules/bookings/components/BookingsCsvDownload.tsx
+++ b/apps/web/modules/bookings/components/BookingsCsvDownload.tsx
@@ -13,6 +13,7 @@ import { useBookingFilters } from "~/bookings/hooks/useBookingFilters";
 import type { BookingListingStatus } from "../types";
 
 type BookingOutput = RouterOutputs["viewer"]["bookings"]["get"]["bookings"][number];
+type TranslationFunction = (key: string) => string;
 
 const BATCH_SIZE = 100;
 
@@ -20,17 +21,17 @@ interface BookingsCsvDownloadProps {
   status: BookingListingStatus;
 }
 
-function transformBookingToCsv(booking: BookingOutput) {
+function transformBookingToCsv(booking: BookingOutput, t: TranslationFunction) {
   return {
-    "Booking UID": booking.uid,
-    Title: booking.title,
-    Status: booking.status,
-    "Start Time": dayjs(booking.startTime).format("YYYY-MM-DD HH:mm:ss"),
-    "End Time": dayjs(booking.endTime).format("YYYY-MM-DD HH:mm:ss"),
-    "Attendee Name": booking.attendees.map((a) => a.name).join("; "),
-    "Attendee Email": booking.attendees.map((a) => a.email).join("; "),
-    "Event Type": booking.eventType?.title ?? "",
-    Location: booking.location ?? "",
+    [t("booking_uid")]: booking.uid,
+    [t("title")]: booking.title,
+    [t("status")]: booking.status,
+    [t("start_time")]: dayjs(booking.startTime).format("YYYY-MM-DD HH:mm:ss"),
+    [t("end_time")]: dayjs(booking.endTime).format("YYYY-MM-DD HH:mm:ss"),
+    [t("attendee_name")]: booking.attendees.map((a) => a.name).join("; "),
+    [t("email")]: booking.attendees.map((a) => a.email).join("; "),
+    [t("event_type")]: booking.eventType?.title ?? "",
+    [t("location")]: booking.location ?? "",
   };
 }
 
@@ -98,8 +99,8 @@ export function BookingsCsvDownload({ status }: BookingsCsvDownloadProps) {
       showProgressToast(100);
 
       // Transform and download
-      const csvData = allBookings.map(transformBookingToCsv);
-      const filename = `bookings-${status}-${dayjs().format("YYYY-MM-DD")}.csv`;
+      const csvData = allBookings.map((booking) => transformBookingToCsv(booking, t));
+      const filename = `${t("bookings").toLowerCase()}-${status}-${dayjs().format("YYYY-MM-DD")}.csv`;
       downloadAsCsv(csvData, filename);
     } catch {
       showToast(t("unexpected_error_try_again"), "error");

--- a/apps/web/modules/bookings/components/BookingsCsvDownload.tsx
+++ b/apps/web/modules/bookings/components/BookingsCsvDownload.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import dayjs from "@calcom/dayjs";
+import { downloadAsCsv } from "@calcom/lib/csvUtils";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import type { RouterOutputs } from "@calcom/trpc/react";
+import { trpc } from "@calcom/trpc/react";
+import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
+import { Button } from "@calcom/ui/components/button";
+import { hideProgressToast, showProgressToast, showToast } from "@calcom/ui/components/toast";
+import { useState } from "react";
+import { useBookingFilters } from "~/bookings/hooks/useBookingFilters";
+import type { BookingListingStatus } from "../types";
+
+type BookingOutput = RouterOutputs["viewer"]["bookings"]["get"]["bookings"][number];
+
+const BATCH_SIZE = 100;
+
+interface BookingsCsvDownloadProps {
+  status: BookingListingStatus;
+}
+
+function transformBookingToCsv(booking: BookingOutput) {
+  return {
+    "Booking UID": booking.uid,
+    Title: booking.title,
+    Status: booking.status,
+    "Start Time": dayjs(booking.startTime).format("YYYY-MM-DD HH:mm:ss"),
+    "End Time": dayjs(booking.endTime).format("YYYY-MM-DD HH:mm:ss"),
+    "Attendee Name": booking.attendees.map((a) => a.name).join("; "),
+    "Attendee Email": booking.attendees.map((a) => a.email).join("; "),
+    "Event Type": booking.eventType?.title ?? "",
+    Location: booking.location ?? "",
+  };
+}
+
+export function BookingsCsvDownload({ status }: BookingsCsvDownloadProps) {
+  const { t } = useLocale();
+  const { data: user, isPending: isUserPending } = useMeQuery();
+  const [isDownloading, setIsDownloading] = useState(false);
+  const utils = trpc.useUtils();
+
+  const { eventTypeIds, teamIds, userIds, dateRange, attendeeName, attendeeEmail, bookingUid } =
+    useBookingFilters();
+
+  // Only show for users who are part of an organization
+  const isOrgUser = Boolean(user?.organizationId);
+
+  if (isUserPending || !isOrgUser) {
+    return null;
+  }
+
+  const fetchBatch = async (offset: number) => {
+    const result = await utils.viewer.bookings.get.fetch({
+      limit: BATCH_SIZE,
+      offset,
+      filters: {
+        statuses: [status],
+        eventTypeIds,
+        teamIds,
+        userIds,
+        attendeeName,
+        attendeeEmail,
+        bookingUid,
+        afterStartDate: dateRange?.startDate
+          ? dayjs(dateRange?.startDate).startOf("day").toISOString()
+          : undefined,
+        beforeEndDate: dateRange?.endDate ? dayjs(dateRange?.endDate).endOf("day").toISOString() : undefined,
+      },
+    });
+
+    return {
+      bookings: result.bookings,
+      totalCount: result.totalCount,
+    };
+  };
+
+  const handleDownload = async () => {
+    try {
+      setIsDownloading(true);
+      showProgressToast(0);
+
+      // Fetch first batch to get total count
+      const firstBatch = await fetchBatch(0);
+      let allBookings = firstBatch.bookings;
+      const totalCount = firstBatch.totalCount;
+
+      // Continue fetching remaining batches
+      while (allBookings.length < totalCount) {
+        const offset = allBookings.length;
+        const batch = await fetchBatch(offset);
+        allBookings = [...allBookings, ...batch.bookings];
+
+        const currentProgress = Math.min(Math.round((allBookings.length / totalCount) * 100), 99);
+        showProgressToast(currentProgress);
+      }
+
+      showProgressToast(100);
+
+      // Transform and download
+      const csvData = allBookings.map(transformBookingToCsv);
+      const filename = `bookings-${status}-${dayjs().format("YYYY-MM-DD")}.csv`;
+      downloadAsCsv(csvData, filename);
+    } catch {
+      showToast(t("unexpected_error_try_again"), "error");
+    } finally {
+      setIsDownloading(false);
+      hideProgressToast();
+    }
+  };
+
+  return (
+    <Button
+      color="secondary"
+      StartIcon="download"
+      loading={isDownloading}
+      onClick={handleDownload}
+      size="sm"
+      className="h-full">
+      {t("download")}
+    </Button>
+  );
+}

--- a/apps/web/modules/bookings/components/BookingsCsvDownload.tsx
+++ b/apps/web/modules/bookings/components/BookingsCsvDownload.tsx
@@ -90,6 +90,7 @@ export function BookingsCsvDownload({ status }: BookingsCsvDownloadProps) {
       while (allBookings.length < totalCount) {
         const offset = allBookings.length;
         const batch = await fetchBatch(offset);
+        if (batch.bookings.length === 0) break; // Prevent infinite loop if batch returns empty
         allBookings = [...allBookings, ...batch.bookings];
 
         const currentProgress = Math.min(Math.round((allBookings.length / totalCount) * 100), 99);


### PR DESCRIPTION
## What does this PR do?

Adds a download bookings CSV button for organization users on the bookings page. The button fetches all bookings matching the current filters in batches and exports them as a CSV file.

## Visual Demo

#### Image Demo:

Download button visible for org users:
<img width="1509" height="239" alt="Screenshot 2026-01-21 at 6 53 05 PM" src="https://github.com/user-attachments/assets/f9a05b0f-4587-4e4e-b1cb-5fddd77c1cf1" />

Button hidden for non-org users:
<img width="1514" height="232" alt="Screenshot 2026-01-21 at 6 53 28 PM" src="https://github.com/user-attachments/assets/b8bdc8e5-c3fb-40aa-8c22-7ebd53df3be9" />

Downloaded CSV:
<img width="867" height="218" alt="Screenshot 2026-01-21 at 6 54 00 PM" src="https://github.com/user-attachments/assets/01a2e612-ef95-40ad-a29c-f0bd8695a002" />

## Updates since last revision

- Localized CSV headers and filename using i18n `t()` function instead of hardcoded English strings (addresses Cubic AI review feedback)
- CSV headers now use existing translation keys: `booking_uid`, `title`, `status`, `start_time`, `end_time`, `attendee_name`, `email`, `event_type`, `location`
- Filename uses localized "bookings" text
- Added safeguard to prevent infinite loop when batch returns empty bookings during CSV download (addresses DevinAI review feedback)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Log in as a user who is part of an organization
2. Navigate to the Bookings page
3. Verify the "Download" button appears next to the view toggle
4. Click the button and verify a CSV file is downloaded with localized headers
5. Log in as a non-org user and verify the button is not visible

## Human Review Checklist

- [ ] Verify all translation keys used exist in `apps/web/public/static/locales/en/common.json`
- [ ] Consider if localized CSV headers could cause issues for users who process CSVs programmatically (expecting English headers)
- [ ] Verify the infinite loop safeguard at line 93 correctly handles edge cases where bookings are deleted between batch fetches

---

Link to Devin run: https://app.devin.ai/sessions/29e729784b1f40518a404ed9c352ad78
Link to Devin run (infinite loop fix): https://app.devin.ai/sessions/68fa2f67f0db4b38bd0e01622caf635f
Requested by: alex@cal.com (@emrysal)