### PR TITLE
fix(umami): add default SCRIPT_URL in zod.ts

### DIFF
--- a/packages/app-store/umami/components/EventTypeAppCardInterface.tsx
+++ b/packages/app-store/umami/components/EventTypeAppCardInterface.tsx
@@ -30,7 +30,7 @@ const EventTypeAppCard: EventTypeAppCardComponent = function EventTypeAppCard({
           disabled={disabled}
           name="Script URL"
           value={scriptURL}
-          defaultValue="https://us.umami.is/script.js"
+          defaultValue="https://cloud.umami.is/script.js"
           placeholder="Enter the script source URL"
           onChange={(e) => {
             setAppData("SCRIPT_URL", e.target.value);

--- a/packages/app-store/umami/zod.ts
+++ b/packages/app-store/umami/zod.ts
@@ -5,7 +5,7 @@ import { eventTypeAppCardZod } from "@calcom/app-store/eventTypeAppCardZod";
 export const appDataSchema = eventTypeAppCardZod.merge(
   z.object({
     SITE_ID: z.string().optional(),
-    SCRIPT_URL: z.string().optional(),
+    SCRIPT_URL: z.string().optional().default("https://us.umami.is/script.js").or(z.undefined()),
   })
 );
 

--- a/packages/app-store/umami/zod.ts
+++ b/packages/app-store/umami/zod.ts
@@ -5,7 +5,7 @@ import { eventTypeAppCardZod } from "@calcom/app-store/eventTypeAppCardZod";
 export const appDataSchema = eventTypeAppCardZod.merge(
   z.object({
     SITE_ID: z.string().optional(),
-    SCRIPT_URL: z.string().optional().default("https://us.umami.is/script.js").or(z.undefined()),
+    SCRIPT_URL: z.string().optional().default("https://cloud.umami.is/script.js").or(z.undefined()),
   })
 );
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #27112
- Fixes CAL-7115

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

N/A

#### Image Demo (if applicable):

N/A

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A *I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.*
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

As described in the original issue (#27112), you should:
1. Create a new booking with the Umami integration enabled
2. Create an Umami account & create a site
3. Copy the API key and paste inside the Cal Umami config. **Do not change the script URL**
4. Visit your booking page and inspect the HTML

## Checklist

<!-- Remove bullet points below that don't apply to you -->

*All bullet points accounted for*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a default Umami SCRIPT_URL ("https://cloud.umami.is/script.js") in the app data schema, allow it to be undefined, and update the EventType card default to match. Connects to CAL-7115 and fixes #27112.

<sup>Written for commit 0f12adff82e7b5640be718090d9bc84ef6924bf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

