### PR TITLE
fix: use createPortal for FeatureOptInBanner to avoid Intercom widget conflict

### DIFF
--- a/packages/features/feature-opt-in/components/FeatureOptInBannerWrapper.tsx
+++ b/packages/features/feature-opt-in/components/FeatureOptInBannerWrapper.tsx
@@ -42,6 +42,7 @@ function FeatureOptInBannerWrapper({ state }: FeatureOptInBannerWrapperProps): R
   return (
     <>
       {state.shouldShow &&
+        typeof document !== "undefined" &&
         createPortal(
           <FeatureOptInBanner
             featureConfig={state.featureConfig}

--- a/packages/features/feature-opt-in/components/FeatureOptInBannerWrapper.tsx
+++ b/packages/features/feature-opt-in/components/FeatureOptInBannerWrapper.tsx
@@ -2,6 +2,7 @@
 
 import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
 import type { ReactElement } from "react";
+import { createPortal } from "react-dom";
 
 import { FeatureOptInBanner } from "./FeatureOptInBanner";
 import type { FeatureOptInMutations } from "./FeatureOptInConfirmDialog";
@@ -40,13 +41,15 @@ function FeatureOptInBannerWrapper({ state }: FeatureOptInBannerWrapperProps): R
 
   return (
     <>
-      {state.shouldShow && (
-        <FeatureOptInBanner
-          featureConfig={state.featureConfig}
-          onDismiss={state.dismiss}
-          onOpenDialog={state.openDialog}
-        />
-      )}
+      {state.shouldShow &&
+        createPortal(
+          <FeatureOptInBanner
+            featureConfig={state.featureConfig}
+            onDismiss={state.dismiss}
+            onOpenDialog={state.openDialog}
+          />,
+          document.body
+        )}
       {state.userRoleContext && (
         <FeatureOptInConfirmDialog
           isOpen={state.isDialogOpen}


### PR DESCRIPTION
## What does this PR do?

Renders the `FeatureOptInBanner` component using React's `createPortal` to `document.body` instead of inline rendering. This prevents z-index/stacking context conflicts with the Intercom widget, which is also positioned at the bottom of the viewport.

## Updates since last revision

Added SSR guard (`typeof document !== "undefined"`) before accessing `document.body` in `createPortal` to prevent crashes in SSR/test environments where `document` is undefined. This addresses the Cubic AI review feedback.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Enable a feature that shows the opt-in banner (e.g., a feature flag that triggers `FeatureOptInBannerWrapper`)
2. Ensure the Intercom widget is also visible on the page
3. Verify the banner appears correctly and doesn't overlap/conflict with the Intercom widget
4. Test banner interactions (dismiss button, opening the dialog)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [x] ~~Verify no SSR/hydration issues~~ - Added `typeof document !== "undefined"` guard to prevent SSR crashes
- [ ] Confirm banner positioning and functionality remain intact after portal change

---

> **Link to Devin run**: https://app.devin.ai/sessions/c98fd1129fcf4f73bccc4900e86ec685
> **Requested by**: @eunjae-lee