### PR TITLE
fix: return 504 status code for timeout errors instead of 500

### DIFF
--- a/packages/lib/server/getServerErrorFromUnknown.test.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.test.ts
@@ -40,6 +40,29 @@ const test409Codes = [
 ];
 
 describe("getServerErrorFromUnknown", () => {
+  describe("Timeout error handling", () => {
+    test("should return 504 for Vercel timeout error", () => {
+      const error = new Error("Vercel Runtime Timeout Error: Task timed out after 60 seconds");
+      const result = getServerErrorFromUnknown(error);
+      expect(result.statusCode).toBe(504);
+      expect(result.message).toBe("Request timed out. Please try again.");
+    });
+
+    test("should return 504 for generic timeout error", () => {
+      const error = new Error("Request timed out");
+      const result = getServerErrorFromUnknown(error);
+      expect(result.statusCode).toBe(504);
+      expect(result.message).toBe("Request timed out. Please try again.");
+    });
+
+    test("should return 504 for FUNCTION_INVOCATION_TIMEOUT error", () => {
+      const error = new Error("FUNCTION_INVOCATION_TIMEOUT");
+      const result = getServerErrorFromUnknown(error);
+      expect(result.statusCode).toBe(504);
+      expect(result.message).toBe("Request timed out. Please try again.");
+    });
+  });
+
   test("should handle a StripeInvalidRequestError", () => {
     const stripeError = {
       name: "StripeInvalidRequestError",


### PR DESCRIPTION
## What does this PR do?

When serverless functions timeout (e.g., Vercel's 60-second limit), the error handling was returning 500 Internal Server Error. This corrupts monitoring systems that have special handling for 500 errors vs timeout errors.

This PR adds timeout error detection to `getServerErrorFromUnknown()` to return **504 Gateway Timeout** instead of 500 when timeout-related errors are caught.

**Changes:**
- Added `isTimeoutError()` helper function that detects timeout errors by checking for "timed out", "timeout", or "function_invocation_timeout" in the error message
- Updated `getServerErrorFromUnknown()` to return 504 status code for timeout errors
- Added unit tests for the new timeout handling

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the unit tests: `yarn test packages/lib/server/getServerErrorFromUnknown.test.ts`
2. All 3 new timeout-related tests should pass:
   - "should return 504 for Vercel timeout error"
   - "should return 504 for generic timeout error"  
   - "should return 504 for FUNCTION_INVOCATION_TIMEOUT error"

## Human Review Checklist

- [ ] Verify the timeout detection patterns (`timed out`, `timeout`, `function_invocation_timeout`) are appropriate and won't cause false positives for non-timeout errors
- [ ] Confirm this change aligns with monitoring requirements

---

**Link to Devin run:** https://app.devin.ai/sessions/b15699f6613c47d38d92a2f097798a22
**Requested by:** @hbjORbj