### PR TITLE
refactor: companion event type query parameters

### DIFF
--- a/companion/extension/entrypoints/background/index.ts
+++ b/companion/extension/entrypoints/background/index.ts
@@ -933,34 +933,9 @@ async function getAuthHeader(): Promise<string> {
 async function fetchEventTypes(): Promise<unknown[]> {
   const authHeader = await getAuthHeader();
 
-  const userResponse = await fetchWithTimeout(`${API_BASE_URL}/me`, {
-    headers: {
-      Authorization: authHeader,
-      "Content-Type": "application/json",
-      "cal-api-version": "2024-06-11",
-    },
-  });
-
-  if (!userResponse.ok) {
-    throw new Error(`Failed to get user: ${userResponse.statusText}`);
-  }
-
-  const userData = await userResponse.json();
-  const username = userData?.data?.username as string | undefined;
-  // For org users, include org slug to avoid username collisions across orgs
-  const orgSlug = userData?.data?.organization?.slug as string | undefined;
-
-  const params = new URLSearchParams();
-  if (username) {
-    params.append("username", username);
-  }
-  if (orgSlug) {
-    params.append("orgSlug", orgSlug);
-  }
-  const queryString = params.toString();
-  const endpoint = `${API_BASE_URL}/event-types${queryString ? `?${queryString}` : ""}`;
-
-  const response = await fetchWithTimeout(endpoint, {
+  // For authenticated users, no username/orgSlug params needed - API uses auth token
+  // This also ensures hidden event types are returned (they're filtered out when username is provided)
+  const response = await fetchWithTimeout(`${API_BASE_URL}/event-types`, {
     headers: {
       Authorization: authHeader,
       "Content-Type": "application/json",

--- a/companion/services/calcom.ts
+++ b/companion/services/calcom.ts
@@ -862,36 +862,10 @@ async function getTranscripts(bookingUid: string): Promise<BookingTranscript[]> 
 }
 
 async function getEventTypes(): Promise<EventType[]> {
-  // Get cached user profile to extract username and org slug (uses in-flight deduplication)
-  let username: string | undefined;
-  let orgSlug: string | undefined;
-  try {
-    const userProfile = await getUserProfile();
-    // Extract username from response
-    if (userProfile?.username) {
-      username = userProfile.username;
-    }
-    // For org users, include org slug to avoid username collisions across orgs
-    if (userProfile?.organization?.slug) {
-      orgSlug = userProfile.organization.slug;
-    }
-  } catch (_error) {}
-
-  // Build query string with username, orgSlug, and sorting
-  const params = new URLSearchParams();
-  if (username) {
-    params.append("username", username);
-  }
-  if (orgSlug) {
-    params.append("orgSlug", orgSlug);
-  }
+  // For authenticated users, no username/orgSlug params needed - API uses auth token
+  // This also ensures hidden event types are returned (they're filtered out when username is provided)
   // Sort by creation date descending (newer first) to match main codebase behavior
-  // Main codebase uses position: "desc", id: "desc" - since API doesn't expose position,
-  // we use sortCreatedAt: "desc" for similar behavior (newer event types first)
-  params.append("sortCreatedAt", "desc");
-
-  const queryString = params.toString();
-  const endpoint = `/event-types${queryString ? `?${queryString}` : ""}`;
+  const endpoint = `/event-types?sortCreatedAt=desc`;
 
   const response = await makeRequest<unknown>(endpoint, {}, "2024-06-14");
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored Companion to fetch event types without username/orgSlug query params, relying on the auth token. This removes an extra /me call, returns the full set of event types (including hidden), and keeps newest-first ordering.

- **Refactors**
  - Call /event-types directly with auth; no username/orgSlug params.
  - Preserve sortCreatedAt=desc to match main app ordering.
  - Removed user profile fetch used to build query.

<sup>Written for commit 1704cfcc7d2cfe258b380d67670e87719336e3b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

