### PR TITLE
fix: calendar column misalignment at desktop resolutions (#27078)

### DIFF
--- a/packages/features/calendars/weeklyview/components/grid/index.tsx
+++ b/packages/features/calendars/weeklyview/components/grid/index.tsx
@@ -14,7 +14,7 @@ export const SchedulerColumns = React.forwardRef<HTMLOListElement, Props>(functi
   return (
     <ol
       ref={ref}
-      className="scheduler-grid-row-template col-start-1 col-end-2 row-start-1 grid auto-cols-auto text-[0px]"
+      className="scheduler-grid-row-template col-start-1 col-end-2 row-start-1 grid grid-flow-col auto-cols-fr text-[0px]"
       style={{ marginTop: offsetHeight || "var(--gridDefaultSize)", zIndex }}
       data-gridstopsperday={gridStopsPerDay}>
       {children}

--- a/packages/features/calendars/weeklyview/components/verticalLines/index.tsx
+++ b/packages/features/calendars/weeklyview/components/verticalLines/index.tsx
@@ -19,7 +19,7 @@ export const VerticalLines = ({ days, borderColor }: { days: dayjs.Dayjs[]; bord
   return (
     <div
       className={classNames(
-        "pointer-events-none relative z-60 col-start-1 col-end-2 row-start-1 grid auto-cols-auto grid-rows-1 divide-x",
+        "pointer-events-none relative z-60 col-start-1 col-end-2 row-start-1 grid grid-flow-col auto-cols-fr grid-rows-1 divide-x",
         borderColor === "subtle" ? "divide-subtle" : "divide-default"
       )}
       dir={direction}


### PR DESCRIPTION
## Description
This PR fixes a layout misalignment issue in the weekly calendar view (used on the bookings page) where column lines and scheduler grid columns were not expanding to fill the available width at desktop resolutions (>=1200px), causing them to be out of sync with the calendar headers.

The fix involves:
- Updating `VerticalLines` to use `grid-flow-col` and `auto-cols-fr` instead of `auto-cols-auto`.
- Updating `SchedulerColumns` to use `grid-flow-col` and `auto-cols-fr` instead of `auto-cols-auto`.

This ensures that the grid columns always distribute evenly and align perfectly with the date headers.

Fixes #27078

cc @anikdhabal
