### PR TITLE
fix: routing form card text truncation at 325px viewport (#26579)

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/forms/[[...pages]]/Forms.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/forms/[[...pages]]/Forms.tsx
@@ -234,9 +234,9 @@ export default function RoutingForms({ appUrl }: { appUrl: string }) {
                             heading={form.name}
                             readOnly={readOnly}
                             subHeading={description}
-                            className="space-x-2 rtl:space-x-reverse"
+                            className="flex-col items-stretch space-y-4 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-2 rtl:space-x-reverse"
                             actions={
-                              <>
+                              <div className="flex flex-wrap items-center gap-2">
                                 {form.team?.name && (
                                   <div className="border-subtle border-r-2">
                                     <Badge className="ltr:mr-2 rtl:ml-2" variant="gray">
@@ -311,7 +311,7 @@ export default function RoutingForms({ appUrl }: { appUrl: string }) {
                                     </FormAction>
                                   </FormActionsDropdown>
                                 </ButtonGroup>
-                              </>
+                              </div>
                             }>
                             <div className="flex flex-wrap gap-1">
                               <Badge variant="gray" startIcon="menu">


### PR DESCRIPTION
## Description
This PR fixes an issue where text on routing form cards was getting truncated or hidden at very narrow viewports (e.g., 325px) because the actions were forcing a single-row layout that didn't leave enough space for the heading and subheading.

The fix involves:
- Updating `ListLinkItem` in `Forms.tsx` to use a responsive flex layout (`flex-col` on mobile, `sm:flex-row` on larger screens).
- Wrapping the actions in a `flex-wrap` container to ensure they stack correctly when space is limited.

This ensures that the form name and description remain visible and readable even on the smallest supported screens.

Fixes #26579

cc @anikdhabal
