### PR TITLE
fix: BookerEmbed mobile view detection (#26543)

### DIFF
--- a/packages/features/bookings/Booker/components/hooks/useBookerLayout.ts
+++ b/packages/features/bookings/Booker/components/hooks/useBookerLayout.ts
@@ -21,16 +21,12 @@ import { getQueryParam } from "../../utils/query-param";
 export type UseBookerLayoutType = ReturnType<typeof useBookerLayout>;
 
 export const useBookerLayout = (
-  profileBookerLayouts:
-    | BookerEvent["profile"]["bookerLayouts"]
-    | undefined
-    | null
+  profileBookerLayouts: BookerEvent["profile"]["bookerLayouts"] | undefined | null,
+  isEmbedOverride?: boolean
 ) => {
-  const [_layout, setLayout] = useBookerStoreContext(
-    (state) => [state.layout, state.setLayout],
-    shallow
-  );
-  const isEmbed = useIsEmbed();
+  const [_layout, setLayout] = useBookerStoreContext((state) => [state.layout, state.setLayout], shallow);
+  const _isEmbed = useIsEmbed();
+  const isEmbed = isEmbedOverride ?? _isEmbed;
   const isMobile = useMediaQuery("(max-width: 768px)");
   const isTablet = useMediaQuery("(max-width: 1024px)");
   const embedUiConfig = useEmbedUiConfig();
@@ -99,8 +95,8 @@ export const useBookerLayout = (
   const hideEventTypeDetails = isEmbed
     ? embedUiConfig.hideEventTypeDetails
     : typeof hideEventTypeDetailsParam === "string"
-    ? hideEventTypeDetailsParam === "true"
-    : false;
+      ? hideEventTypeDetailsParam === "true"
+      : false;
 
   const slotsViewOnSmallScreen = useSlotsViewOnSmallScreen();
 

--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -205,7 +205,7 @@ const BookerPlatformWrapperComponent = (
     selectedDuration,
   });
 
-  const bookerLayout = useBookerLayout(event.data?.profile?.bookerLayouts);
+  const bookerLayout = useBookerLayout(event.data?.profile?.bookerLayouts, true);
   useInitializeBookerStore({
     ...props,
     teamMemberEmail,
@@ -290,7 +290,7 @@ const BookerPlatformWrapperComponent = (
 
   const startTime =
     customStartTime &&
-    dayjs(customStartTime).isAfter(dayjs(calculatedStartTime))
+      dayjs(customStartTime).isAfter(dayjs(calculatedStartTime))
       ? dayjs(customStartTime).toISOString()
       : calculatedStartTime;
   const endTime = calculatedEndTime;
@@ -331,10 +331,10 @@ const BookerPlatformWrapperComponent = (
     teamMemberEmail: teamMemberEmail ?? undefined,
     ...(props.isTeamEvent
       ? {
-          isTeamEvent: props.isTeamEvent,
-          teamId: teamId,
-          rrHostSubsetIds: rrHostSubsetIds,
-        }
+        isTeamEvent: props.isTeamEvent,
+        teamId: teamId,
+        rrHostSubsetIds: rrHostSubsetIds,
+      }
       : {}),
     enabled:
       Boolean(teamId || username) &&
@@ -479,8 +479,8 @@ const BookerPlatformWrapperComponent = (
     },
     enabled: Boolean(
       hasSession &&
-        isOverlayCalendarEnabled &&
-        latestCalendarsToLoad?.length > 0
+      isOverlayCalendarEnabled &&
+      latestCalendarsToLoad?.length > 0
     ),
   });
 
@@ -497,8 +497,8 @@ const BookerPlatformWrapperComponent = (
     isBookingDryRun: isBookingDryRun ?? routingParams?.isBookingDryRun,
     ...(props.isTeamEvent
       ? {
-          rrHostSubsetIds: rrHostSubsetIds,
-        }
+        rrHostSubsetIds: rrHostSubsetIds,
+      }
       : {}),
   });
 


### PR DESCRIPTION
## Description
This PR fixes an issue where the `BookerEmbed` (Atom component) incorrectly displays the desktop view instead of the mobile view on mobile devices.

The root cause was identified in `useBookerLayout` which relies on `isEmbed` detection. In the context of the Atom component, the standard `isEmbed` detection (checking global window properties) can fail, causing it to fall back to desktop layout incorrectly.

The fix involves:
- Updating the `useBookerLayout` hook to accept an optional `isEmbedOverride` parameter.
- Updating `BookerPlatformWrapper` to explicitly pass `true` as the `isEmbedOverride`, ensuring the Atom component always correctly identifies itself as an embed for layout purposes.

Fixes #26543

cc @anikdhabal
