### PR TITLE
refactor: Add compile-time and runtime validation for NoShowUpdatedAuditData

### DIFF
--- a/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
@@ -298,7 +298,28 @@ describe("No-Show Updated Action Integration", () => {
     });
   });
 
-  describe("schema validation with string keys", () => {
+  describe("schema validation", () => {
+    /**
+     * This test verifies that the Zod refine validation rejects empty data.
+     * The schema requires at least one of hostNoShow or attendeesNoShow to be provided.
+     */
+    it("should reject data with neither hostNoShow nor attendeesNoShow (validates refine)", async () => {
+      const actor = makeUserActor(testData.owner.uuid);
+
+      // Attempt to create audit with empty data - should fail validation
+      await expect(
+        bookingAuditTaskConsumer.onBookingAction({
+          bookingUid: testData.booking.uid,
+          actor,
+          action: "NO_SHOW_UPDATED",
+          source: "WEBAPP",
+          operationId: `op-${Date.now()}`,
+          data: {},
+          timestamp: Date.now(),
+        })
+      ).rejects.toThrow();
+    });
+
     /**
      * This test explicitly demonstrates that string keys work correctly
      * due to z.coerce.number() in the schema.


### PR DESCRIPTION
## What does this PR do?

This PR adds both compile-time (TypeScript) and runtime (Zod) validation to ensure that `NoShowUpdatedAuditData` always contains at least one of `hostNoShow` or `attendeesNoShow`. Previously, both fields were optional, which allowed an invalid state where neither was set.

**Changes:**
- Added Zod `.refine()` validation to reject empty data at runtime
- Created a TypeScript union type that enforces the same constraint at compile-time
- Updated call sites in `handleMarkNoShow.ts` and `triggerNoShow/common.ts` to satisfy the new union type
- Added integration test to verify the refine validation

This is a stacked PR on top of #26570.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal type changes only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the integration tests:
   ```bash
   VITEST_MODE=integration TZ=UTC yarn test packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
   ```

2. Verify type checking passes:
   ```bash
   yarn type-check:ci --force
   ```

3. The new test "should reject data with neither hostNoShow nor attendeesNoShow" validates the refine validation.

## Human Review Checklist

- [ ] Verify the union type correctly enforces the three valid cases (host only, attendees only, both)
- [ ] Verify the refactored if/else branches in `handleMarkNoShow.ts` and `common.ts` correctly handle all cases
- [ ] Consider if the code duplication in the if/else branches is acceptable (it's intentional to satisfy TypeScript's union type checking)

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---
Link to Devin run: https://app.devin.ai/sessions/d432f5fb2cac475ea42c660916835597
Requested by: @hariombalhara