### PR TITLE
fix: check team slug availability within organization scope

### DIFF
--- a/apps/web/modules/onboarding/teams/details/action/check-team-slug-availability.ts
+++ b/apps/web/modules/onboarding/teams/details/action/check-team-slug-availability.ts
@@ -1,12 +1,11 @@
 "use server";
 
-import { cookies, headers } from "next/headers";
-
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { RESERVED_SUBDOMAINS } from "@calcom/lib/constants";
 import { prisma } from "@calcom/prisma";
-
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
+import { cookies, headers } from "next/headers";
 
 export async function checkTeamSlugAvailability(slug: string): Promise<{
   available: boolean;
@@ -26,11 +25,14 @@ export async function checkTeamSlugAvailability(slug: string): Promise<{
     return { available: false, message: "Unauthorized" };
   }
 
-  // Check if slug already exists (teams have parentId, organizations don't)
+  // Get the user's organization ID from their profile
+  const organizationId = session.user.profile?.organizationId ?? null;
+
+  // Check if slug already exists within the organization scope (or globally if not in an org)
   const existingTeam = await prisma.team.findFirst({
     where: {
       slug,
-      parentId: null,
+      parentId: organizationId,
     },
     select: {
       id: true,
@@ -39,6 +41,18 @@ export async function checkTeamSlugAvailability(slug: string): Promise<{
 
   if (existingTeam) {
     return { available: false, message: "This slug is already taken" };
+  }
+
+  // If user is in an organization, also check if the slug is taken by a user in the organization
+  if (organizationId) {
+    const existingUserWithSlug = await ProfileRepository.findByOrgIdAndUsername({
+      organizationId,
+      username: slug,
+    });
+
+    if (existingUserWithSlug) {
+      return { available: false, message: "This slug is already taken by a user" };
+    }
   }
 
   return { available: true };


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where creating a new team in an organization was incorrectly checking team slug availability globally instead of within the organization scope.

**The problem**: The `checkTeamSlugAvailability` function was querying for teams with `parentId: null`, which only checks for top-level teams/organizations. This meant that if a team slug existed in *any* organization, it would be marked as unavailable even when creating a team in a different organization.

**The fix**: 
- Gets the user's organization ID from their session profile
- Checks for slug collision within the organization scope (`parentId: organizationId`) or globally if the user is not in an org
- Also checks if the slug is taken by a user in the organization (matching the behavior in `create.handler.ts`)

This aligns the availability check with the actual team creation logic in `packages/trpc/server/routers/viewer/teams/create.handler.ts`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Log in as a user who is part of an organization
2. Navigate to create a new team within the organization
3. Enter a team slug that exists in a *different* organization
4. **Expected**: The slug should be marked as available (since it's scoped to the current org)
5. Enter a team slug that exists in the *same* organization
6. **Expected**: The slug should be marked as unavailable

## Human Review Checklist

- [ ] Verify the logic matches the expected behavior in `create.handler.ts` (lines 70-86)
- [ ] Confirm `session.user.profile?.organizationId` provides the correct organization context
- [ ] Test in an organization context to ensure teams can have the same slug as teams in other organizations

---

**Link to Devin run**: https://app.devin.ai/sessions/71fd188d522247c89487ad0d3b347efa
**Requested by**: @sean-brydon