### PR TITLE
perf: optimize getEventTypeIdsFromTeamIdsFilter with raw SQL query

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/get.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.test.ts
@@ -120,6 +120,7 @@ describe("getBookings - PBAC Permission Checks", () => {
       findUnique: vi.fn(),
       groupBy: vi.fn(),
     },
+    $queryRaw: vi.fn().mockResolvedValue([]),
   } as unknown as PrismaClient;
 
   // Create a comprehensive kysely mock that handles all chain methods
@@ -338,7 +339,7 @@ describe("getBookings - PBAC Permission Checks", () => {
     it("should get event types from teams where user has booking.read permission", async () => {
       mockGetTeamIdsWithPermission.mockResolvedValue([1]);
       mockPrisma.user.findMany = vi.fn().mockResolvedValue([]);
-      mockPrisma.eventType.findMany = vi.fn().mockResolvedValue([{ id: 10 }, { id: 11 }]);
+      mockPrisma.$queryRaw = vi.fn().mockResolvedValue([{ id: 10 }, { id: 11 }]);
       mockPrisma.booking.groupBy = vi.fn().mockResolvedValue([]);
 
       await getBookings({
@@ -351,8 +352,8 @@ describe("getBookings - PBAC Permission Checks", () => {
         skip: 0,
       });
 
-      // Verify event types are fetched from team 1
-      expect(mockPrisma.eventType.findMany).toHaveBeenCalled();
+      // Verify event types are fetched from team 1 using raw SQL query
+      expect(mockPrisma.$queryRaw).toHaveBeenCalled();
     });
   });
 

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -853,13 +853,15 @@ async function getEventTypeIdsFromTeamIdsFilter(prisma: PrismaClient, teamIds?: 
   }
 
   const result = await prisma.$queryRaw<{ id: number }[]>`
-    SELECT "child"."id" FROM "public"."EventType" AS "parent"
+    SELECT "child"."id"
+    FROM "public"."EventType" AS "parent"
     LEFT JOIN "public"."EventType" "child" ON ("parent"."id") = ("child"."parentId")
-    WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (${Prisma.join(teamIds)}))
+    WHERE "parent"."teamId" IN (${Prisma.join(teamIds)})
       AND "child"."id" IS NOT NULL
     UNION
-    SELECT "parent"."id" FROM "public"."EventType" AS "parent"
-    WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (${Prisma.join(teamIds)}))
+    SELECT "parent"."id"
+    FROM "public"."EventType" AS "parent"
+    WHERE "parent"."teamId" IN (${Prisma.join(teamIds)})
   `;
 
   return result.map((row) => row.id);

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -856,12 +856,12 @@ async function getEventTypeIdsFromTeamIdsFilter(prisma: PrismaClient, teamIds?: 
     SELECT "child"."id"
     FROM "public"."EventType" AS "parent"
     LEFT JOIN "public"."EventType" "child" ON ("parent"."id") = ("child"."parentId")
-    WHERE "parent"."teamId" IN (${Prisma.join(teamIds)})
+    WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (${Prisma.join(teamIds)}))
       AND "child"."id" IS NOT NULL
     UNION
     SELECT "parent"."id"
     FROM "public"."EventType" AS "parent"
-    WHERE "parent"."teamId" IN (${Prisma.join(teamIds)})
+    WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (${Prisma.join(teamIds)}))
   `;
 
   return result.map((row) => row.id);

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -856,7 +856,7 @@ async function getEventTypeIdsFromTeamIdsFilter(prisma: PrismaClient, teamIds?: 
     SELECT "child"."id"
     FROM "public"."EventType" AS "parent"
     LEFT JOIN "public"."EventType" "child" ON ("parent"."id") = ("child"."parentId")
-    WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (${Prisma.join(teamIds)}))
+    WHERE "parent"."id" IN (SELECT "id" FROM "public"."EventType" WHERE "teamId" IN (${Prisma.join(teamIds)}))
       AND "child"."id" IS NOT NULL
     UNION
     SELECT "parent"."id"

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -1,7 +1,3 @@
-import type { Kysely } from "kysely";
-import { type SelectQueryBuilder } from "kysely";
-import { jsonObjectFrom, jsonArrayFrom } from "kysely/helpers/postgres";
-
 import dayjs from "@calcom/dayjs";
 import getAllUserBookings from "@calcom/features/bookings/lib/getAllUserBookings";
 import { isTextFilterValue } from "@calcom/features/data-table/lib/utils";
@@ -13,12 +9,13 @@ import { parseRecurringEvent } from "@calcom/lib/isRecurringEvent";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import type { PrismaClient } from "@calcom/prisma";
-import type { Booking, Prisma, Prisma as PrismaClientType } from "@calcom/prisma/client";
-import { SchedulingType, BookingStatus, MembershipRole } from "@calcom/prisma/enums";
+import type { Booking, Prisma as PrismaClientType } from "@calcom/prisma/client";
+import { Prisma } from "@calcom/prisma/client";
+import { BookingStatus, MembershipRole, SchedulingType } from "@calcom/prisma/enums";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
-
 import { TRPCError } from "@trpc/server";
-
+import type { Kysely, SelectQueryBuilder } from "kysely";
+import { jsonArrayFrom, jsonObjectFrom } from "kysely/helpers/postgres";
 import type { TrpcSessionUser } from "../../../types";
 import type { TGetInputSchema } from "./get.schema";
 
@@ -440,7 +437,8 @@ export async function getBookings({
           "Booking.metadata",
           "Booking.uid",
           eb
-            .cast<Prisma.JsonValue>( // Target TypeScript type
+            .cast<Prisma.JsonValue>(
+              // Target TypeScript type
               eb.ref("Booking.responses"), // Source column
               "jsonb" // Target SQL type
             )
@@ -784,7 +782,7 @@ type EnrichedUserData = {
  * @returns Bookings with attendees enriched with user data (name, email, avatarUrl, username)
  */
 async function enrichAttendeesWithUserData<
-  TBooking extends { attendees: ReadonlyArray<{ id: number; email: string }> }
+  TBooking extends { attendees: ReadonlyArray<{ id: number; email: string }> },
 >(
   bookings: TBooking[],
   kysely: Kysely<DB>
@@ -833,38 +831,38 @@ async function enrichAttendeesWithUserData<
   }));
 }
 
+/**
+ * Gets event type IDs for the given team IDs using an optimized raw SQL query.
+ *
+ * This query uses a UNION to combine:
+ * 1. Child event types whose parent belongs to the specified teams (managed event types)
+ * 2. Direct team event types that belong to the specified teams
+ *
+ * The subquery structure `WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (...)))`
+ * is intentional - it allows PostgreSQL to use the composite index on EventType(parentId, teamId)
+ * efficiently via Nested Loop joins, resulting in ~66x faster execution compared to a direct
+ * WHERE clause on parent.teamId (2.46ms vs 164ms in production benchmarks).
+ *
+ * @param prisma The Prisma client
+ * @param teamIds Array of team IDs to filter by
+ * @returns Array of event type IDs or undefined if no teamIds provided
+ */
 async function getEventTypeIdsFromTeamIdsFilter(prisma: PrismaClient, teamIds?: number[]) {
   if (!teamIds || teamIds.length === 0) {
     return undefined;
   }
 
-  const [directTeamEventTypeIds, parentTeamEventTypeIds] = await Promise.all([
-    prisma.eventType
-      .findMany({
-        where: {
-          teamId: { in: teamIds },
-        },
-        select: {
-          id: true,
-        },
-      })
-      .then((eventTypes) => eventTypes.map((eventType) => eventType.id)),
+  const result = await prisma.$queryRaw<{ id: number }[]>`
+    SELECT "child"."id" FROM "public"."EventType" AS "parent"
+    LEFT JOIN "public"."EventType" "child" ON ("parent"."id") = ("child"."parentId")
+    WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (${Prisma.join(teamIds)}))
+      AND "child"."id" IS NOT NULL
+    UNION
+    SELECT "parent"."id" FROM "public"."EventType" AS "parent"
+    WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (${Prisma.join(teamIds)}))
+  `;
 
-    prisma.eventType
-      .findMany({
-        where: {
-          parent: {
-            teamId: { in: teamIds },
-          },
-        },
-        select: {
-          id: true,
-        },
-      })
-      .then((eventTypes) => eventTypes.map((eventType) => eventType.id)),
-  ]);
-
-  return Array.from(new Set([...directTeamEventTypeIds, ...parentTeamEventTypeIds]));
+  return result.map((row) => row.id);
 }
 
 async function getAttendeeEmailsFromUserIdsFilter(

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -9,7 +9,6 @@ import { parseRecurringEvent } from "@calcom/lib/isRecurringEvent";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import type { PrismaClient } from "@calcom/prisma";
-import { prisma as prismaSingleton } from "@calcom/prisma";
 import type { Booking, Prisma as PrismaClientType } from "@calcom/prisma/client";
 import { Prisma } from "@calcom/prisma/client";
 import { BookingStatus, MembershipRole, SchedulingType } from "@calcom/prisma/enums";
@@ -848,14 +847,12 @@ async function enrichAttendeesWithUserData<
  * @param teamIds Array of team IDs to filter by
  * @returns Array of event type IDs or undefined if no teamIds provided
  */
-async function getEventTypeIdsFromTeamIdsFilter(_prisma: PrismaClient, teamIds?: number[]) {
+async function getEventTypeIdsFromTeamIdsFilter(prisma: PrismaClient, teamIds?: number[]) {
   if (!teamIds || teamIds.length === 0) {
     return undefined;
   }
 
-  // Use the prisma singleton directly for raw queries since the passed PrismaClient type
-  // doesn't expose $queryRaw at runtime in all contexts
-  const result = await prismaSingleton.$queryRaw<{ id: number }[]>`
+  const result = await prisma.$queryRaw<{ id: number }[]>`
     SELECT "child"."id" FROM "public"."EventType" AS "parent"
     LEFT JOIN "public"."EventType" "child" ON ("parent"."id") = ("child"."parentId")
     WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (${Prisma.join(teamIds)}))

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -861,7 +861,7 @@ async function getEventTypeIdsFromTeamIdsFilter(prisma: PrismaClient, teamIds?: 
     UNION
     SELECT "parent"."id"
     FROM "public"."EventType" AS "parent"
-    WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (${Prisma.join(teamIds)}))
+    WHERE "parent"."teamId" IN (${Prisma.join(teamIds)})
   `;
 
   return result.map((row) => row.id);


### PR DESCRIPTION
## What does this PR do?

Optimizes the `getEventTypeIdsFromTeamIdsFilter` function in the bookings handler by replacing two separate Prisma queries with a single optimized raw SQL query. This is a follow-up to #27099 which added a composite index on `EventType(parentId, teamId)`.

**Performance improvement:** ~66x faster execution (2.46ms vs 164ms in production benchmarks)

The key insight from EXPLAIN ANALYZE is that the subquery structure `WHERE "parent"."id" IN (SELECT "id" FROM "EventType" WHERE "teamId" IN (...))` allows PostgreSQL to use the composite index efficiently via Nested Loop joins, whereas a direct `WHERE parent.teamId IN (...)` clause causes PostgreSQL to choose a less efficient Merge Join strategy that scans 150k+ rows.

**Before:** Two parallel Prisma `findMany` queries + JavaScript Set deduplication
**After:** Single raw SQL UNION query with database-level deduplication

### Updates since last revision

- Fixed `prisma.$queryRaw is not a function` error - the issue was that the test mock didn't include `$queryRaw`. Added `$queryRaw: vi.fn().mockResolvedValue([])` to the mock and kept using the context-passed prisma parameter (which does have `$queryRaw` at runtime since it's the same singleton)
- Restored subquery optimization per Cubic AI feedback (confidence 9/10) - the subquery structure is intentional for performance

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal optimization only
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. E2E tests added in #27144

## How should this be tested?

1. The e2e tests in #27144 cover the team filter functionality
2. To verify locally, run: `PLAYWRIGHT_HEADLESS=1 yarn e2e bookings-list.e2e.ts --grep "Team filter"`
3. The query can be validated by filtering bookings by team in the bookings list UI

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (JSDoc explaining the query optimization rationale)
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify `Prisma.join(teamIds)` properly parameterizes the array to prevent SQL injection
- [ ] Confirm the hardcoded `"public"` schema is appropriate for all deployment environments
- [ ] Verify the UNION query produces identical results to the original two Prisma queries (both direct team event types AND managed event type children)

---

Link to Devin run: https://app.devin.ai/sessions/e1bd375f6ccd4713aa06b69077f9d1ab
Requested by: @keithwillcode