### PR TITLE
chore: drop deprecated user.startTime and user.endTime columns

### DIFF
--- a/packages/lib/test/builder.ts
+++ b/packages/lib/test/builder.ts
@@ -267,7 +267,6 @@ type UserPayload = Prisma.UserGetPayload<{
     defaultScheduleId: true;
     disableImpersonation: true;
     emailVerified: true;
-    endTime: true;
     hideBranding: true;
     identityProvider: true;
     identityProviderId: true;
@@ -275,7 +274,6 @@ type UserPayload = Prisma.UserGetPayload<{
     locale: true;
     metadata: true;
     role: true;
-    startTime: true;
     theme: true;
     appTheme: true;
     timeFormat: true;
@@ -318,7 +316,6 @@ export const buildUser = <T extends Partial<UserPayload>>(
     destinationCalendar: null,
     disableImpersonation: false,
     emailVerified: null,
-    endTime: 0,
     hideBranding: true,
     identityProvider: "CAL",
     identityProviderId: null,
@@ -328,7 +325,6 @@ export const buildUser = <T extends Partial<UserPayload>>(
     role: "USER",
     schedules: [],
     selectedCalendars: [],
-    startTime: 0,
     theme: null,
     appTheme: null,
     timeFormat: null,

--- a/packages/prisma/migrations/20260122145500_drop_user_starttime_endtime/migration.sql
+++ b/packages/prisma/migrations/20260122145500_drop_user_starttime_endtime/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "startTime",
+DROP COLUMN "endTime";

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -383,10 +383,6 @@ model User {
   timeZone            String               @default("Europe/London")
   travelSchedules     TravelSchedule[]
   weekStart           String               @default("Sunday")
-  // DEPRECATED - TO BE REMOVED
-  startTime           Int                  @default(0)
-  endTime             Int                  @default(1440)
-  // </DEPRECATED>
   bufferTime          Int                  @default(0)
   hideBranding        Boolean              @default(false)
   // TODO: should be renamed since it only affects the booking page


### PR DESCRIPTION
## What does this PR do?

Follow-up to #27085 and #27092 - creates the database migration to drop the deprecated `startTime` and `endTime` columns from the `users` table.

These columns were marked as `// DEPRECATED - TO BE REMOVED` in the Prisma schema. The prerequisite PRs removed all code references to these columns, making it safe to now drop them from the database.

**Changes:**
- Remove `startTime` and `endTime` fields from the `User` model in `schema.prisma`
- Add migration to drop both columns from the `users` table
- Remove `startTime` and `endTime` from test builder (`packages/lib/test/builder.ts`)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal schema cleanup
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - schema migration only, existing tests should continue to pass

## How should this be tested?

1. Verify PRs #27085 and #27092 have been merged (prerequisite)
2. Run `yarn prisma generate` - should complete without errors
3. Run `yarn type-check:ci --force` - should pass (no code references these columns anymore)
4. Apply migration to a test database and verify columns are dropped

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Confirm PRs #27085 and #27092 are merged before merging this PR
- [ ] Verify no remaining code references to `user.startTime` or `user.endTime` in the codebase
- [ ] ⚠️ **Breaking change**: This permanently drops data from the `users` table. Ensure no external systems depend on these columns.

---

Link to Devin run: https://app.devin.ai/sessions/c5a10684d905496fbce66a0b464a73a5
Requested by: @emrysal