### PR TITLE
perf: Add teamId index on Credential

### DIFF
--- a/packages/prisma/migrations/20260122140703_add_credential_teamid_index/migration.sql
+++ b/packages/prisma/migrations/20260122140703_add_credential_teamid_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Credential_teamId_idx" ON "public"."Credential"("teamId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -309,6 +309,7 @@ model Credential {
   @@index([subscriptionId])
   @@index([invalid])
   @@index([userId, delegationCredentialId])
+  @@index([teamId])
 }
 
 enum IdentityProvider {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add an index on Credential.teamId to speed up team-scoped queries and reduce DB latency. Updates Prisma schema with @@index([teamId]) and adds a migration to create Credential_teamId_idx.

<sup>Written for commit 45062f4eb00b154865ed724829b7b71507a82309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

