### PR TITLE
docs: add guidance for creating smaller, self-contained PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,3 +42,4 @@ A visual demonstration is strongly recommended, for both the original and new ch
 - My code doesn't follow the style guidelines of this project
 - I haven't commented my code, particularly in hard-to-understand areas
 - I haven't checked if my changes generate no new warnings
+- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs

--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -120,8 +120,7 @@ jobs:
           2. Follow the existing code style and conventions in the repository.
           3. Test your changes if possible before pushing.
           4. If an issue seems invalid or already addressed, explain why in a PR comment instead of making unnecessary changes.
-          5. Never ask for user confirmation. Never wait for user messages.
-          6. PR Size Check: If the PR has more than 500 lines changed or more than 10 files modified, add a comment warning the author that the PR is too large and should be split into smaller, self-contained PRs. Suggest how the changes could be split (e.g., by layer, by feature component, or by separating refactoring from new features)."
+          5. Never ask for user confirmation. Never wait for user messages."
 
           HTTP_CODE=$(curl -s -o /tmp/devin-response.json -w "%{http_code}" -X POST "https://api.devin.ai/v1/sessions" \
             -H "Authorization: Bearer ${DEVIN_API_KEY}" \

--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -120,7 +120,8 @@ jobs:
           2. Follow the existing code style and conventions in the repository.
           3. Test your changes if possible before pushing.
           4. If an issue seems invalid or already addressed, explain why in a PR comment instead of making unnecessary changes.
-          5. Never ask for user confirmation. Never wait for user messages."
+          5. Never ask for user confirmation. Never wait for user messages.
+          6. PR Size Check: If the PR has more than 500 lines changed or more than 10 files modified, add a comment warning the author that the PR is too large and should be split into smaller, self-contained PRs. Suggest how the changes could be split (e.g., by layer, by feature component, or by separating refactoring from new features)."
 
           HTTP_CODE=$(curl -s -o /tmp/devin-response.json -w "%{http_code}" -X POST "https://api.devin.ai/v1/sessions" \
             -H "Authorization: Bearer ${DEVIN_API_KEY}" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,11 @@ Large PRs are difficult to review, prone to errors, and slow down the developmen
 
 ### Size Limits
 
-- **Lines changed**: Keep PRs under 500 lines (additions + deletions)
-- **Files changed**: Keep PRs under 10 files
+- **Lines changed**: Keep PRs under 500 lines of code (additions + deletions)
+- **Files changed**: Keep PRs under 10 code files
 - **Single responsibility**: Each PR should do one thing well
+
+**Note**: These limits apply to code files only. Non-code files like documentation (README.md, CHANGELOG.md), lock files (yarn.lock, package-lock.json), and auto-generated files are excluded from the count.
 
 ### How to Split Large Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,47 @@ You are a senior Cal.com engineer working in a Yarn/Turbo monorepo. You prioriti
 - Never skip running type checks before pushing
 - Never create large PRs (>500 lines or >10 files) - split them instead
 
+## PR Size Guidelines
+
+Large PRs are difficult to review, prone to errors, and slow down the development process. Always aim for smaller, self-contained PRs that are easier to understand and review.
+
+### Size Limits
+
+- **Lines changed**: Keep PRs under 500 lines (additions + deletions)
+- **Files changed**: Keep PRs under 10 files
+- **Single responsibility**: Each PR should do one thing well
+
+### How to Split Large Changes
+
+When a task requires extensive changes, break it into multiple PRs:
+
+1. **By layer**: Separate database/schema changes, backend logic, and frontend UI into different PRs
+2. **By feature component**: Split a feature into its constituent parts (e.g., API endpoint PR, then UI PR, then integration PR)
+3. **By refactor vs feature**: Do preparatory refactoring in a separate PR before adding new functionality
+4. **By dependency order**: Create PRs in the order they can be merged (base infrastructure first, then features that depend on it)
+
+### Examples of Good PR Splits
+
+**Instead of one large "Add booking notifications" PR:**
+- PR 1: Add notification preferences schema and migration
+- PR 2: Add notification service and API endpoints
+- PR 3: Add notification UI components
+- PR 4: Integrate notifications into booking flow
+
+**Instead of one large "Refactor calendar sync" PR:**
+- PR 1: Extract calendar sync logic into dedicated service
+- PR 2: Add new calendar provider abstraction
+- PR 3: Migrate existing providers to new abstraction
+- PR 4: Add new calendar provider support
+
+### Benefits of Smaller PRs
+
+- Faster review cycles and quicker feedback
+- Easier to identify and fix issues
+- Lower risk of merge conflicts
+- Simpler to revert if problems arise
+- Better git history and easier debugging
+
 ## Commands
 
 ### File-scoped (preferred for speed)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,7 @@ If you get errors, be sure to fix them before committing.
 
 Large PRs are difficult to review and more prone to errors. We strongly encourage smaller, self-contained PRs:
 
-- **Size limits**: Keep PRs under 500 lines changed and under 10 files modified
+- **Size limits**: Keep PRs under 500 lines of code changed and under 10 code files modified (excludes documentation, lock files, and auto-generated files)
 - **Single responsibility**: Each PR should address one concern (one feature, one bug fix, or one refactor)
 - **Split large changes**: If your task requires extensive changes, break it into multiple PRs that can be reviewed and merged independently
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,6 +190,22 @@ If you get errors, be sure to fix them before committing.
 
 ## Making a Pull Request
 
+### Keep PRs Small and Focused
+
+Large PRs are difficult to review and more prone to errors. We strongly encourage smaller, self-contained PRs:
+
+- **Size limits**: Keep PRs under 500 lines changed and under 10 files modified
+- **Single responsibility**: Each PR should address one concern (one feature, one bug fix, or one refactor)
+- **Split large changes**: If your task requires extensive changes, break it into multiple PRs that can be reviewed and merged independently
+
+**How to split large changes:**
+- Separate database/schema changes from application logic
+- Split frontend and backend changes when possible
+- Do preparatory refactoring in a separate PR before adding new features
+- Create PRs in dependency order (infrastructure first, then features)
+
+### PR Checklist
+
 - Be sure to [check the "Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) when creating your PR. (This option isn't available if you're [contributing from a fork belonging to an organization](https://github.com/orgs/community/discussions/5634))
 - If your PR refers to or fixes an issue, add `refs #XXX` or `fixes #XXX` to the PR description. Replace `XXX` with the respective issue number. See more about [linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
 - Fill out the PR template accordingly.


### PR DESCRIPTION
## What does this PR do?

Adds comprehensive documentation to encourage smaller, self-contained PRs across the codebase. This addresses the need for better PR hygiene and easier code reviews.

**Changes made:**
- **AGENTS.md**: Added a new "PR Size Guidelines" section with size limits, strategies for splitting large changes, concrete examples, and benefits
- **CONTRIBUTING.md**: Added "Keep PRs Small and Focused" guidance for contributors
- **PR Template**: Added checklist item to flag oversized PRs

## Updates since last revision

- Removed the PR size check instruction from `cubic-devin-review.yml` per review feedback (that workflow is specifically for Devin addressing Cubic.dev comments, not general PR review)
- Clarified that size limits apply to **code files only** - documentation (README.md, CHANGELOG.md), lock files (yarn.lock, package-lock.json), and auto-generated files are excluded from the count

## Visual Demo (For contributors especially)

N/A - Documentation changes only.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - this PR updates contributor-facing docs, not user docs.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - documentation only.

## How should this be tested?

This is a documentation-only PR. Verification:
- Review AGENTS.md for the new "PR Size Guidelines" section
- Review CONTRIBUTING.md for the new "Keep PRs Small and Focused" subsection
- Review the PR template for the new checklist item

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My changes follow the style guidelines of this project

---

> **Human Review Checklist:**
> - [ ] Verify the PR size limits (500 lines, 10 files) align with team expectations
> - [ ] Review the examples of good PR splits for accuracy and helpfulness
> - [ ] Confirm the exclusion of non-code files (docs, lock files, generated files) is appropriate

Link to Devin run: https://app.devin.ai/sessions/421990feeabb4ac58c2182153ec7949c
Requested by: Volnei Munhoz (@volnei)