### PR TITLE
feat: add composite index on Booking(createdAt, userId)

### DIFF
--- a/packages/prisma/migrations/20260122170317_add_booking_createdat_userid_index/migration.sql
+++ b/packages/prisma/migrations/20260122170317_add_booking_createdat_userid_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Booking_createdAt_userId_idx" ON "public"."Booking"("createdAt", "userId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -907,6 +907,7 @@ model Booking {
   @@index([status])
   @@index([startTime, endTime, status])
   @@index([fromReschedule])
+  @@index([createdAt, userId])
 }
 
 model Tracking {


### PR DESCRIPTION
## What does this PR do?

Adds a composite index on Booking `(createdAt, userId)` to improve query performance for spam detection and user activity analysis.

**Context:** Our Grafana "Suspicious Bookings" alert queries recent bookings by `createdAt`, but without an index it causes full table scans on 13M rows, leading to intermittent "conflict with recovery" errors on the replica.

### Changes

| Layer | File(s) | Change |
|-------|---------|--------|
| Schema | `packages/prisma/schema.prisma` | Add `@@index([createdAt, userId])` to Booking model |
| Migration | `migrations/..._add_booking_createdat_userid_index` | CREATE INDEX statement |

### Benchmark Results

Tested with 1M pre-populated rows and 5k write operations:
- Write overhead: within measurement noise (±4%)
- No significant impact on INSERT/UPDATE latency

## How should this be tested?

1. Run migration on staging
2. Verify index exists: `\d "Booking"` shows `Booking_createdAt_userId_idx`
3. Query performance: `EXPLAIN ANALYZE SELECT * FROM "Booking" WHERE "createdAt" > NOW() - INTERVAL '30 minutes' AND
"userId" = X`

## Mandatory Tasks

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs)
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works