### PR TITLE
refactor: Deduplicate organization members page logic

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/members/page.tsx
@@ -1,18 +1,13 @@
-import { PrismaAttributeRepository } from "@calcom/features/attributes/repositories/PrismaAttributeRepository";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { CrudAction, CustomAction, Resource } from "@calcom/features/pbac/domain/types/permission-registry";
-import { getSpecificPermissions } from "@calcom/features/pbac/lib/resource-permissions";
-import { RoleManagementFactory } from "@calcom/features/pbac/services/role-management.factory";
-import { prisma } from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/enums";
-import { viewerOrganizationsRouter } from "@calcom/trpc/server/routers/viewer/organizations/_router";
+
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
-import { createRouterCaller } from "app/_trpc/context";
+
 import { _generateMetadata, getTranslate } from "app/_utils";
 import { ShellMainAppDir } from "app/(use-page-wrapper)/(main-nav)/ShellMainAppDir";
-import { unstable_cache } from "next/cache";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
+
+import { getOrgMembersPageData } from "~/members/getOrgMembersPageData";
 import { MembersView } from "~/members/members-view";
 
 export const generateMetadata = async () =>
@@ -24,25 +19,6 @@ export const generateMetadata = async () =>
     "/members"
   );
 
-const getCachedAttributes = unstable_cache(
-  async (orgId: number) => {
-    const attributeRepo = new PrismaAttributeRepository(prisma);
-
-    return await attributeRepo.findAllByOrgIdWithOptions({ orgId });
-  },
-  undefined,
-  { revalidate: 3600, tags: ["viewer.attributes.list"] }
-);
-
-const getCachedRoles = unstable_cache(
-  async (orgId: number) => {
-    const roleManager = await RoleManagementFactory.getInstance().createRoleManager(orgId);
-    return await roleManager.getAllRoles(orgId);
-  },
-  undefined,
-  { revalidate: 3600, tags: ["pbac.roles.list"] }
-);
-
 const Page = async () => {
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
 
@@ -50,92 +26,7 @@ const Page = async () => {
     return redirect("/settings/my-account/profile");
   }
 
-  const orgCaller = await createRouterCaller(viewerOrganizationsRouter);
-  const [org, teams] = await Promise.all([orgCaller.listCurrent(), orgCaller.getTeams()]);
-  const [attributes, roles] = await Promise.all([getCachedAttributes(org.id), getCachedRoles(org.id)]);
-
-  const fallbackRolesThatCanSeeMembers: MembershipRole[] = [MembershipRole.ADMIN, MembershipRole.OWNER];
-
-  if (!org?.isPrivate) {
-    fallbackRolesThatCanSeeMembers.push(MembershipRole.MEMBER);
-  }
-
-  const [orgPermissions, attributesPermissions] = await Promise.all([
-    getSpecificPermissions({
-      userId: session.user.id,
-      teamId: session.user.profile.organizationId,
-      resource: Resource.Organization,
-      userRole: session.user.org.role,
-      actions: [
-        CustomAction.ListMembers,
-        CustomAction.ListMembersPrivate,
-        CustomAction.Invite,
-        CustomAction.ChangeMemberRole,
-        CustomAction.Remove,
-        CustomAction.Impersonate,
-      ],
-      fallbackRoles: {
-        [CustomAction.ListMembers]: {
-          roles: fallbackRolesThatCanSeeMembers,
-        },
-        [CustomAction.ListMembersPrivate]: {
-          roles: fallbackRolesThatCanSeeMembers,
-        },
-        [CustomAction.Invite]: {
-          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-        [CustomAction.ChangeMemberRole]: {
-          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-        [CustomAction.Remove]: {
-          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-        [CustomAction.Impersonate]: {
-          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-      },
-    }),
-    getSpecificPermissions({
-      userId: session.user.id,
-      teamId: session.user.profile.organizationId,
-      resource: Resource.Attributes,
-      userRole: session.user.org.role,
-      actions: [CrudAction.Read, CustomAction.EditUsers],
-      fallbackRoles: {
-        [CrudAction.Read]: {
-          roles: [MembershipRole.MEMBER, MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-        [CustomAction.EditUsers]: {
-          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-      },
-    }),
-  ]);
-
-  const memberPermissions = {
-    canListMembers: org.isPrivate
-      ? orgPermissions[CustomAction.ListMembersPrivate]
-      : orgPermissions[CustomAction.ListMembers],
-    canInvite: orgPermissions[CustomAction.Invite],
-    canChangeMemberRole: orgPermissions[CustomAction.ChangeMemberRole],
-    canRemove: orgPermissions[CustomAction.Remove],
-    canImpersonate: orgPermissions[CustomAction.Impersonate],
-    canViewAttributes: attributesPermissions[CrudAction.Read],
-    canEditAttributesForUser: attributesPermissions[CustomAction.EditUsers],
-  };
-
-  const facetedTeamValues = {
-    roles,
-    teams,
-    attributes: attributes.map((attribute) => ({
-      id: attribute.id,
-      name: attribute.name,
-      options: Array.from(new Set(attribute.options.map((option) => option.value))).map((value) => ({
-        value,
-      })),
-    })),
-  };
-
+  const { org, teams, facetedTeamValues, attributes, permissions } = await getOrgMembersPageData(session);
   const t = await getTranslate();
 
   return (
@@ -145,7 +36,7 @@ const Page = async () => {
         teams={teams}
         facetedTeamValues={facetedTeamValues}
         attributes={attributes}
-        permissions={memberPermissions}
+        permissions={permissions}
       />
     </ShellMainAppDir>
   );

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/page.tsx
@@ -1,20 +1,12 @@
-import { createRouterCaller } from "app/_trpc/context";
-import { _generateMetadata } from "app/_utils";
-import { unstable_cache } from "next/cache";
-import { headers, cookies } from "next/headers";
-import { redirect } from "next/navigation";
-
-import { PrismaAttributeRepository } from "@calcom/features/attributes/repositories/PrismaAttributeRepository";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { Resource, CustomAction, CrudAction } from "@calcom/features/pbac/domain/types/permission-registry";
-import { getSpecificPermissions } from "@calcom/features/pbac/lib/resource-permissions";
-import { RoleManagementFactory } from "@calcom/features/pbac/services/role-management.factory";
-import { prisma } from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/enums";
-import { viewerOrganizationsRouter } from "@calcom/trpc/server/routers/viewer/organizations/_router";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
+import { _generateMetadata } from "app/_utils";
+import { cookies, headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { getOrgMembersPageData } from "~/members/getOrgMembersPageData";
 import { MembersView } from "~/members/members-view";
 
 export const generateMetadata = async () =>
@@ -26,25 +18,6 @@ export const generateMetadata = async () =>
     "/settings/organizations/members"
   );
 
-const getCachedAttributes = unstable_cache(
-  async (orgId: number) => {
-    const attributeRepo = new PrismaAttributeRepository(prisma);
-
-    return await attributeRepo.findAllByOrgIdWithOptions({ orgId });
-  },
-  undefined,
-  { revalidate: 3600, tags: ["viewer.attributes.list"] } // Cache for 1 hour
-);
-
-const getCachedRoles = unstable_cache(
-  async (orgId: number) => {
-    const roleManager = await RoleManagementFactory.getInstance().createRoleManager(orgId);
-    return await roleManager.getAllRoles(orgId);
-  },
-  undefined,
-  { revalidate: 3600, tags: ["pbac.roles.list"] } // Cache for 1 hour
-);
-
 const Page = async () => {
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
 
@@ -52,93 +25,7 @@ const Page = async () => {
     return redirect("/settings/profile");
   }
 
-  const orgCaller = await createRouterCaller(viewerOrganizationsRouter);
-  const [org, teams] = await Promise.all([orgCaller.listCurrent(), orgCaller.getTeams()]);
-  const [attributes, roles] = await Promise.all([getCachedAttributes(org.id), getCachedRoles(org.id)]);
-
-  const fallbackRolesThatCanSeeMembers: MembershipRole[] = [MembershipRole.ADMIN, MembershipRole.OWNER];
-
-  if (!org?.isPrivate) {
-    fallbackRolesThatCanSeeMembers.push(MembershipRole.MEMBER);
-  }
-
-  // Get specific PBAC permissions for organization member actions
-  const [orgPermissions, attributesPermissions] = await Promise.all([
-    getSpecificPermissions({
-      userId: session.user.id,
-      teamId: session.user.profile.organizationId,
-      resource: Resource.Organization,
-      userRole: session.user.org.role,
-      actions: [
-        CustomAction.ListMembers,
-        CustomAction.ListMembersPrivate,
-        CustomAction.Invite,
-        CustomAction.ChangeMemberRole,
-        CustomAction.Remove,
-        CustomAction.Impersonate,
-      ],
-      fallbackRoles: {
-        [CustomAction.ListMembers]: {
-          roles: fallbackRolesThatCanSeeMembers,
-        },
-        [CustomAction.ListMembersPrivate]: {
-          roles: fallbackRolesThatCanSeeMembers,
-        },
-        [CustomAction.Invite]: {
-          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-        [CustomAction.ChangeMemberRole]: {
-          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-        [CustomAction.Remove]: {
-          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-        [CustomAction.Impersonate]: {
-          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-      },
-    }),
-    getSpecificPermissions({
-      userId: session.user.id,
-      teamId: session.user.profile.organizationId,
-      resource: Resource.Attributes,
-      userRole: session.user.org.role,
-      actions: [CrudAction.Read, CustomAction.EditUsers],
-      fallbackRoles: {
-        [CrudAction.Read]: {
-          roles: [MembershipRole.MEMBER, MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-        [CustomAction.EditUsers]: {
-          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        },
-      },
-    }),
-  ]);
-
-  // Map specific permissions to member actions
-  const memberPermissions = {
-    canListMembers: org.isPrivate
-      ? orgPermissions[CustomAction.ListMembersPrivate]
-      : orgPermissions[CustomAction.ListMembers],
-    canInvite: orgPermissions[CustomAction.Invite],
-    canChangeMemberRole: orgPermissions[CustomAction.ChangeMemberRole],
-    canRemove: orgPermissions[CustomAction.Remove],
-    canImpersonate: orgPermissions[CustomAction.Impersonate],
-    canViewAttributes: attributesPermissions[CrudAction.Read],
-    canEditAttributesForUser: attributesPermissions[CustomAction.EditUsers],
-  };
-
-  const facetedTeamValues = {
-    roles,
-    teams,
-    attributes: attributes.map((attribute) => ({
-      id: attribute.id,
-      name: attribute.name,
-      options: Array.from(new Set(attribute.options.map((option) => option.value))).map((value) => ({
-        value,
-      })),
-    })),
-  };
+  const { org, teams, facetedTeamValues, attributes, permissions } = await getOrgMembersPageData(session);
 
   return (
     <MembersView
@@ -146,7 +33,7 @@ const Page = async () => {
       teams={teams}
       facetedTeamValues={facetedTeamValues}
       attributes={attributes}
-      permissions={memberPermissions}
+      permissions={permissions}
     />
   );
 };

--- a/apps/web/modules/members/getOrgMembersPageData.ts
+++ b/apps/web/modules/members/getOrgMembersPageData.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from "next/cache";
+import { redirect } from "next/navigation";
 
 import { PrismaAttributeRepository } from "@calcom/features/attributes/repositories/PrismaAttributeRepository";
 import type { Session } from "next-auth";
@@ -33,6 +34,11 @@ const getCachedRoles = unstable_cache(
 export async function getOrgMembersPageData(session: Session) {
   const orgCaller = await createRouterCaller(viewerOrganizationsRouter);
   const [org, teams] = await Promise.all([orgCaller.listCurrent(), orgCaller.getTeams()]);
+
+  if (!org) {
+    redirect("/settings/my-account/profile");
+  }
+
   const [attributes, roles] = await Promise.all([getCachedAttributes(org.id), getCachedRoles(org.id)]);
 
   const fallbackRolesThatCanSeeMembers: MembershipRole[] = [MembershipRole.ADMIN, MembershipRole.OWNER];

--- a/apps/web/modules/members/getOrgMembersPageData.ts
+++ b/apps/web/modules/members/getOrgMembersPageData.ts
@@ -1,0 +1,127 @@
+import { unstable_cache } from "next/cache";
+
+import { PrismaAttributeRepository } from "@calcom/features/attributes/repositories/PrismaAttributeRepository";
+import type { Session } from "next-auth";
+import { CrudAction, CustomAction, Resource } from "@calcom/features/pbac/domain/types/permission-registry";
+import type { MemberPermissions } from "@calcom/features/pbac/lib/team-member-permissions";
+import { getSpecificPermissions } from "@calcom/features/pbac/lib/resource-permissions";
+import { RoleManagementFactory } from "@calcom/features/pbac/services/role-management.factory";
+import { prisma } from "@calcom/prisma";
+import { MembershipRole } from "@calcom/prisma/enums";
+import { viewerOrganizationsRouter } from "@calcom/trpc/server/routers/viewer/organizations/_router";
+
+import { createRouterCaller } from "app/_trpc/context";
+
+const getCachedAttributes = unstable_cache(
+  async (orgId: number) => {
+    const attributeRepo = new PrismaAttributeRepository(prisma);
+    return await attributeRepo.findAllByOrgIdWithOptions({ orgId });
+  },
+  undefined,
+  { revalidate: 3600, tags: ["viewer.attributes.list"] }
+);
+
+const getCachedRoles = unstable_cache(
+  async (orgId: number) => {
+    const roleManager = await RoleManagementFactory.getInstance().createRoleManager(orgId);
+    return await roleManager.getAllRoles(orgId);
+  },
+  undefined,
+  { revalidate: 3600, tags: ["pbac.roles.list"] }
+);
+
+export async function getOrgMembersPageData(session: Session) {
+  const orgCaller = await createRouterCaller(viewerOrganizationsRouter);
+  const [org, teams] = await Promise.all([orgCaller.listCurrent(), orgCaller.getTeams()]);
+  const [attributes, roles] = await Promise.all([getCachedAttributes(org.id), getCachedRoles(org.id)]);
+
+  const fallbackRolesThatCanSeeMembers: MembershipRole[] = [MembershipRole.ADMIN, MembershipRole.OWNER];
+
+  if (!org?.isPrivate) {
+    fallbackRolesThatCanSeeMembers.push(MembershipRole.MEMBER);
+  }
+
+  const [orgPermissions, attributesPermissions] = await Promise.all([
+    getSpecificPermissions({
+      userId: session.user.id,
+      teamId: session.user.profile!.organizationId!,
+      resource: Resource.Organization,
+      userRole: session.user.org!.role,
+      actions: [
+        CustomAction.ListMembers,
+        CustomAction.ListMembersPrivate,
+        CustomAction.Invite,
+        CustomAction.ChangeMemberRole,
+        CustomAction.Remove,
+        CustomAction.Impersonate,
+      ],
+      fallbackRoles: {
+        [CustomAction.ListMembers]: {
+          roles: fallbackRolesThatCanSeeMembers,
+        },
+        [CustomAction.ListMembersPrivate]: {
+          roles: fallbackRolesThatCanSeeMembers,
+        },
+        [CustomAction.Invite]: {
+          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+        },
+        [CustomAction.ChangeMemberRole]: {
+          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+        },
+        [CustomAction.Remove]: {
+          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+        },
+        [CustomAction.Impersonate]: {
+          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+        },
+      },
+    }),
+    getSpecificPermissions({
+      userId: session.user.id,
+      teamId: session.user.profile!.organizationId!,
+      resource: Resource.Attributes,
+      userRole: session.user.org!.role,
+      actions: [CrudAction.Read, CustomAction.EditUsers],
+      fallbackRoles: {
+        [CrudAction.Read]: {
+          roles: [MembershipRole.MEMBER, MembershipRole.ADMIN, MembershipRole.OWNER],
+        },
+        [CustomAction.EditUsers]: {
+          roles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+        },
+      },
+    }),
+  ]);
+
+  const permissions: MemberPermissions = {
+    canListMembers: org.isPrivate
+      ? orgPermissions[CustomAction.ListMembersPrivate]
+      : orgPermissions[CustomAction.ListMembers],
+    canInvite: orgPermissions[CustomAction.Invite],
+    canChangeMemberRole: orgPermissions[CustomAction.ChangeMemberRole],
+    canRemove: orgPermissions[CustomAction.Remove],
+    canImpersonate: orgPermissions[CustomAction.Impersonate],
+    canViewAttributes: attributesPermissions[CrudAction.Read],
+    canEditAttributesForUser: attributesPermissions[CustomAction.EditUsers],
+  };
+
+  const facetedTeamValues = {
+    roles,
+    teams,
+    attributes: attributes.map((attribute) => ({
+      id: attribute.id,
+      name: attribute.name,
+      options: Array.from(new Set(attribute.options.map((option) => option.value))).map((value) => ({
+        value,
+      })),
+    })),
+  };
+
+  return {
+    org,
+    teams,
+    facetedTeamValues,
+    attributes,
+    permissions,
+  };
+}


### PR DESCRIPTION
### Overview
This PR refactors the organization members page implementation to eliminate significant code duplication between the new main navigation route (/members) and the existing settings route (/settings/organizations/members).

### Changes

- Extracted Shared Logic: Created apps/web/modules/members/getOrgMembersPageData.ts to house server-side data fetching, caching strategies, and permission checks.
- Refactored Pages: Updated both (main-nav)/members/page.tsx and settings/.../members/page.tsx to consume the new shared module.

### Technical Details

- Moved getCachedAttributes, getCachedRoles, elaborate permission logic (~50 lines), and facetedTeamValues construction into the reusable function.
- Reduced the size of each page file from ~155 lines to ~45 lines.
- No functional changes: The behavior, permissions, and UI remain exactly the same; this is purely a code structure improvement.