### PR TITLE
test: [Stacked] add source field assertions for busy times

### DIFF
--- a/packages/features/busyTimes/lib/getBusyTimesFromLimits.test.ts
+++ b/packages/features/busyTimes/lib/getBusyTimesFromLimits.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import dayjs from "@calcom/dayjs";
+import { LimitSources } from "@calcom/lib/intervalLimits/limitManager";
+
+import { getBusyTimesFromBookingLimits, getBusyTimesFromLimits } from "./getBusyTimesFromLimits";
+
+vi.mock("@calcom/features/di/containers/BookingLimits", () => ({
+  getCheckBookingLimitsService: vi.fn(() => ({
+    checkBookingLimit: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock("@calcom/features/di/containers/BusyTimes", () => ({
+  getBusyTimesService: vi.fn(() => ({
+    getStartEndDateforLimitCheck: vi.fn((start, end) => ({
+      limitDateFrom: dayjs(start),
+      limitDateTo: dayjs(end),
+    })),
+  })),
+}));
+
+vi.mock("@calcom/features/bookings/repositories/BookingRepository", () => ({
+  BookingRepository: vi.fn().mockImplementation(() => ({
+    getTotalBookingDuration: vi.fn().mockResolvedValue(0),
+    getAllAcceptedTeamBookingsOfUser: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock("@calcom/prisma", () => ({
+  default: {},
+}));
+
+const startOfTomorrow = dayjs().add(1, "day").startOf("day");
+
+describe("LimitSources", () => {
+  it("should return correct title and source for eventBookingLimit", () => {
+    const result = LimitSources.eventBookingLimit({ limit: 5, unit: "day" });
+    expect(result.title).toBe("busy_time.event_booking_limit");
+    expect(result.source).toBe("Event Booking Limit for User: 5 per day");
+  });
+
+  it("should return correct title and source for eventDurationLimit", () => {
+    const result = LimitSources.eventDurationLimit({ limit: 120, unit: "week" });
+    expect(result.title).toBe("busy_time.event_duration_limit");
+    expect(result.source).toBe("Event Duration Limit for User: 120 minutes per week");
+  });
+
+  it("should return correct title and source for teamBookingLimit", () => {
+    const result = LimitSources.teamBookingLimit({ limit: 10, unit: "month" });
+    expect(result.title).toBe("busy_time.team_booking_limit");
+    expect(result.source).toBe("Team Booking Limit: 10 per month");
+  });
+});
+
+describe("getBusyTimesFromBookingLimits", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return busy times with correct source when booking limit is reached", async () => {
+    const dateFrom = startOfTomorrow;
+    const dateTo = startOfTomorrow.endOf("day");
+
+    const mockBookings = [
+      {
+        start: startOfTomorrow.set("hour", 9).toDate(),
+        end: startOfTomorrow.set("hour", 10).toDate(),
+        title: "Booking 1",
+        source: "eventType-1-booking-1",
+      },
+      {
+        start: startOfTomorrow.set("hour", 11).toDate(),
+        end: startOfTomorrow.set("hour", 12).toDate(),
+        title: "Booking 2",
+        source: "eventType-1-booking-2",
+      },
+    ];
+
+    const LimitManager = (await import("@calcom/lib/intervalLimits/limitManager")).default;
+    const limitManager = new LimitManager();
+
+    await getBusyTimesFromBookingLimits({
+      bookings: mockBookings,
+      bookingLimits: { PER_DAY: 2 },
+      dateFrom,
+      dateTo,
+      limitManager,
+      eventTypeId: 1,
+      timeZone: "UTC",
+    });
+
+    const busyTimes = limitManager.getBusyTimes();
+    expect(busyTimes.length).toBe(1);
+    expect(busyTimes[0]).toMatchObject({
+      title: "busy_time.event_booking_limit",
+      source: "Event Booking Limit for User: 2 per day",
+    });
+  });
+
+  it("should return busy times with team booking limit source when teamId is provided", async () => {
+    const dateFrom = startOfTomorrow;
+    const dateTo = startOfTomorrow.endOf("day");
+
+    const mockBookings = [
+      {
+        start: startOfTomorrow.set("hour", 9).toDate(),
+        end: startOfTomorrow.set("hour", 10).toDate(),
+        title: "Booking 1",
+        source: "eventType-1-booking-1",
+      },
+    ];
+
+    const LimitManager = (await import("@calcom/lib/intervalLimits/limitManager")).default;
+    const limitManager = new LimitManager();
+
+    await getBusyTimesFromBookingLimits({
+      bookings: mockBookings,
+      bookingLimits: { PER_DAY: 1 },
+      dateFrom,
+      dateTo,
+      limitManager,
+      teamId: 1,
+      user: { id: 1, email: "test@example.com" },
+      timeZone: "UTC",
+    });
+
+    const busyTimes = limitManager.getBusyTimes();
+    expect(busyTimes.length).toBe(1);
+    expect(busyTimes[0]).toMatchObject({
+      title: "busy_time.team_booking_limit",
+      source: "Team Booking Limit: 1 per day",
+    });
+  });
+});
+
+describe("getBusyTimesFromLimits", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return busy times with duration limit source when duration limit is exceeded", async () => {
+    const dateFrom = startOfTomorrow;
+    const dateTo = startOfTomorrow.endOf("day");
+
+    const mockBookings = [
+      {
+        start: startOfTomorrow.set("hour", 9).toDate(),
+        end: startOfTomorrow.set("hour", 10).toDate(),
+        title: "Booking 1",
+        source: "eventType-1-booking-1",
+      },
+    ];
+
+    const mockEventType = {
+      id: 1,
+      length: 30,
+      seatsPerTimeSlot: null,
+      hosts: [],
+      users: [],
+    };
+
+    const busyTimes = await getBusyTimesFromLimits(
+      null,
+      { PER_DAY: 60 },
+      dateFrom,
+      dateTo,
+      30,
+      mockEventType,
+      mockBookings,
+      "UTC"
+    );
+
+    expect(busyTimes.length).toBe(1);
+    expect(busyTimes[0]).toMatchObject({
+      title: "busy_time.event_duration_limit",
+      source: "Event Duration Limit for User: 60 minutes per day",
+    });
+  });
+
+  it("should return empty array when no limits are exceeded", async () => {
+    const dateFrom = startOfTomorrow;
+    const dateTo = startOfTomorrow.endOf("day");
+
+    const mockEventType = {
+      id: 1,
+      length: 30,
+      seatsPerTimeSlot: null,
+      hosts: [],
+      users: [],
+    };
+
+    const busyTimes = await getBusyTimesFromLimits(
+      { PER_DAY: 10 },
+      null,
+      dateFrom,
+      dateTo,
+      30,
+      mockEventType,
+      [],
+      "UTC"
+    );
+
+    expect(busyTimes.length).toBe(0);
+  });
+
+  it("should return busy times with booking limit source when booking limit is reached", async () => {
+    const dateFrom = startOfTomorrow;
+    const dateTo = startOfTomorrow.endOf("day");
+
+    const mockBookings = [
+      {
+        start: startOfTomorrow.set("hour", 9).toDate(),
+        end: startOfTomorrow.set("hour", 10).toDate(),
+        title: "Booking 1",
+        source: "eventType-1-booking-1",
+      },
+      {
+        start: startOfTomorrow.set("hour", 11).toDate(),
+        end: startOfTomorrow.set("hour", 12).toDate(),
+        title: "Booking 2",
+        source: "eventType-1-booking-2",
+      },
+      {
+        start: startOfTomorrow.set("hour", 14).toDate(),
+        end: startOfTomorrow.set("hour", 15).toDate(),
+        title: "Booking 3",
+        source: "eventType-1-booking-3",
+      },
+    ];
+
+    const mockEventType = {
+      id: 1,
+      length: 60,
+      seatsPerTimeSlot: null,
+      hosts: [],
+      users: [],
+    };
+
+    const busyTimes = await getBusyTimesFromLimits(
+      { PER_DAY: 3 },
+      null,
+      dateFrom,
+      dateTo,
+      60,
+      mockEventType,
+      mockBookings,
+      "UTC"
+    );
+
+    expect(busyTimes.length).toBe(1);
+    expect(busyTimes[0]).toMatchObject({
+      title: "busy_time.event_booking_limit",
+      source: "Event Booking Limit for User: 3 per day",
+    });
+  });
+});

--- a/packages/features/busyTimes/services/getBusyTimes.test.ts
+++ b/packages/features/busyTimes/services/getBusyTimes.test.ts
@@ -130,6 +130,35 @@ describe("getBusyTimes", () => {
       expect.objectContaining({
         start: dayjs(`${tomorrowDate}`).startOf("day").set("hour", 9).set("minute", 50).toDate(),
         end: dayjs(`${tomorrowDate}`).startOf("day").set("hour", 10).toDate(),
+        source: "busy_time.buffer_time",
+      }),
+    ]);
+  });
+
+  it("should have buffer time source for before and after buffers on seated events with remaining seats", async () => {
+    const busyTimesService = getBusyTimesService();
+    const busyTimes = await busyTimesService.getBusyTimes({
+      credentials: [],
+      userId: 1,
+      eventTypeId: 1,
+      userEmail: "exampleuser1@example.com",
+      username: "exampleuser1",
+      bypassBusyCalendarTimes: false,
+      selectedCalendars: [],
+      startTime: startOfTomorrow.format(),
+      endTime: startOfTomorrow.endOf("day").format(),
+      currentBookings: [mockBookings({ beforeEventBuffer: 10, afterEventBuffer: 15, seatsPerTimeSlot: 10 })[0]],
+    });
+    expect(busyTimes).toEqual([
+      expect.objectContaining({
+        start: dayjs(`${tomorrowDate}`).startOf("day").set("hour", 9).set("minute", 50).toDate(),
+        end: dayjs(`${tomorrowDate}`).startOf("day").set("hour", 10).toDate(),
+        source: "busy_time.buffer_time",
+      }),
+      expect.objectContaining({
+        start: dayjs(`${tomorrowDate}`).startOf("day").set("hour", 11).toDate(),
+        end: dayjs(`${tomorrowDate}`).startOf("day").set("hour", 11).set("minute", 15).toDate(),
+        source: "busy_time.buffer_time",
       }),
     ]);
   });


### PR DESCRIPTION
## What does this PR do?

Adds test coverage to verify that the `source` field is correctly returned on busy times. This PR is stacked on #27088 which made `source` required on `EventBusyDetails`.

**Changes:**
- Updated `getBusyTimes.test.ts` to assert `source: "busy_time.buffer_time"` for buffer times on seated events
- Added new test case for both before and after buffers on seated events with remaining seats
- Created `getBusyTimesFromLimits.test.ts` with tests for:
  - `LimitSources` helper functions (verifies correct title/source for each limit type)
  - `getBusyTimesFromBookingLimits` (verifies booking and team booking limit sources)
  - `getBusyTimesFromLimits` (verifies duration limit and booking limit sources)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - test-only changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the tests:
```bash
TZ=UTC yarn test packages/features/busyTimes/services/getBusyTimes.test.ts
TZ=UTC yarn test packages/features/busyTimes/lib/getBusyTimesFromLimits.test.ts
```

All 12 tests should pass (4 in getBusyTimes.test.ts, 8 in getBusyTimesFromLimits.test.ts).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the mock implementations in `getBusyTimesFromLimits.test.ts` reasonably reflect the real dependencies
- [ ] Confirm the expected source values (`busy_time.event_booking_limit`, `busy_time.event_duration_limit`, `busy_time.team_booking_limit`, `busy_time.buffer_time`) match what the parent PR produces

**Link to Devin run:** https://app.devin.ai/sessions/f661f978e64b4c7bb1c2a9da8b80a048
**Requested by:** @hariombalhara