### PR TITLE
chore: Add initial webhook wiring (TRPC handlers) to the new architecture

### DIFF
--- a/packages/features/di/webhooks/Webhooks.tokens.ts
+++ b/packages/features/di/webhooks/Webhooks.tokens.ts
@@ -13,6 +13,8 @@ export const WEBHOOK_TOKENS = {
 
   // Repositories
   WEBHOOK_REPOSITORY: Symbol("IWebhookRepository"),
+  WEBHOOK_EVENT_TYPE_REPOSITORY: Symbol("IEventTypeRepository"),
+  WEBHOOK_USER_REPOSITORY: Symbol("IUserRepository"),
 
   // Producer/Consumer
   WEBHOOK_PRODUCER_SERVICE: Symbol("IWebhookProducerService"),

--- a/packages/features/di/webhooks/containers/webhook.ts
+++ b/packages/features/di/webhooks/containers/webhook.ts
@@ -32,7 +32,9 @@ loggerModuleLoader.loadModule(webhookContainer);
 prismaModuleLoader.loadModule(webhookContainer);
 webhookContainer.load(SHARED_TOKENS.TASKER, taskerServiceModule);
 
-// Load webhook module
+// Load webhook module (includes cross-table repositories + all webhook services)
+webhookContainer.load(WEBHOOK_TOKENS.WEBHOOK_EVENT_TYPE_REPOSITORY, webhookModule);
+webhookContainer.load(WEBHOOK_TOKENS.WEBHOOK_USER_REPOSITORY, webhookModule);
 webhookContainer.load(WEBHOOK_TOKENS.WEBHOOK_REPOSITORY, webhookModule);
 webhookContainer.load(WEBHOOK_TOKENS.WEBHOOK_SERVICE, webhookModule);
 webhookContainer.load(WEBHOOK_TOKENS.BOOKING_WEBHOOK_SERVICE, webhookModule);

--- a/packages/features/di/webhooks/modules/Webhook.module.ts
+++ b/packages/features/di/webhooks/modules/Webhook.module.ts
@@ -1,5 +1,3 @@
-import { createModule } from "@evyweb/ioctopus";
-
 import { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import { UsersRepository } from "@calcom/features/users/users.repository";
 import { createPayloadBuilderFactory } from "@calcom/features/webhooks/lib/factory/versioned/registry";
@@ -11,9 +9,9 @@ import { RecordingWebhookService } from "@calcom/features/webhooks/lib/service/R
 import { WebhookNotificationHandler } from "@calcom/features/webhooks/lib/service/WebhookNotificationHandler";
 import { WebhookNotifier } from "@calcom/features/webhooks/lib/service/WebhookNotifier";
 import { WebhookService } from "@calcom/features/webhooks/lib/service/WebhookService";
-
-import { DI_TOKENS } from "../../tokens";
+import { createModule } from "@evyweb/ioctopus";
 import { SHARED_TOKENS } from "../../shared/shared.tokens";
+import { DI_TOKENS } from "../../tokens";
 import { WEBHOOK_TOKENS } from "../Webhooks.tokens";
 
 const webhookModule = createModule();

--- a/packages/features/di/webhooks/modules/WebhookTaskConsumer.module.ts
+++ b/packages/features/di/webhooks/modules/WebhookTaskConsumer.module.ts
@@ -2,7 +2,7 @@ import type { IWebhookDataFetcher } from "@calcom/features/webhooks/lib/interfac
 import type { IWebhookRepository } from "@calcom/features/webhooks/lib/interface/IWebhookRepository";
 import type { ILogger } from "@calcom/features/webhooks/lib/interface/infrastructure";
 import { WebhookTaskConsumer } from "@calcom/features/webhooks/lib/service/WebhookTaskConsumer";
-import type { Container } from "@evyweb/ioctopus";
+import type { ResolveFunction } from "@evyweb/ioctopus";
 import { createModule } from "@evyweb/ioctopus";
 import { SHARED_TOKENS } from "../../shared/shared.tokens";
 import { WEBHOOK_TOKENS } from "../Webhooks.tokens";
@@ -18,16 +18,16 @@ import { WEBHOOK_TOKENS } from "../Webhooks.tokens";
  */
 export const webhookTaskConsumerModule = createModule();
 
-webhookTaskConsumerModule.bind(WEBHOOK_TOKENS.WEBHOOK_TASK_CONSUMER).toFactory((container: Container) => {
-  const webhookRepository = container.get<IWebhookRepository>(WEBHOOK_TOKENS.WEBHOOK_REPOSITORY);
+webhookTaskConsumerModule.bind(WEBHOOK_TOKENS.WEBHOOK_TASK_CONSUMER).toFactory((resolve: ResolveFunction) => {
+  const webhookRepository = resolve(WEBHOOK_TOKENS.WEBHOOK_REPOSITORY) as IWebhookRepository;
   const dataFetchers: IWebhookDataFetcher[] = [
-    container.get<IWebhookDataFetcher>(WEBHOOK_TOKENS.BOOKING_DATA_FETCHER),
-    container.get<IWebhookDataFetcher>(WEBHOOK_TOKENS.PAYMENT_DATA_FETCHER),
-    container.get<IWebhookDataFetcher>(WEBHOOK_TOKENS.FORM_DATA_FETCHER),
-    container.get<IWebhookDataFetcher>(WEBHOOK_TOKENS.RECORDING_DATA_FETCHER),
-    container.get<IWebhookDataFetcher>(WEBHOOK_TOKENS.OOO_DATA_FETCHER),
+    resolve(WEBHOOK_TOKENS.BOOKING_DATA_FETCHER) as IWebhookDataFetcher,
+    resolve(WEBHOOK_TOKENS.PAYMENT_DATA_FETCHER) as IWebhookDataFetcher,
+    resolve(WEBHOOK_TOKENS.FORM_DATA_FETCHER) as IWebhookDataFetcher,
+    resolve(WEBHOOK_TOKENS.RECORDING_DATA_FETCHER) as IWebhookDataFetcher,
+    resolve(WEBHOOK_TOKENS.OOO_DATA_FETCHER) as IWebhookDataFetcher,
   ];
-  const logger = container.get<ILogger>(SHARED_TOKENS.LOGGER);
+  const logger = resolve(SHARED_TOKENS.LOGGER) as ILogger;
 
   return new WebhookTaskConsumer(webhookRepository, dataFetchers, logger);
 });

--- a/packages/features/eventtypes/eventtypes.repository.interface.ts
+++ b/packages/features/eventtypes/eventtypes.repository.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * EventTypes Repository Interface
+ *
+ * Central interface for EventType repository methods.
+ * Add new methods here as needed by different features.
+ */
+
+export interface IEventTypesRepository {
+  /**
+   * Find parent event type ID for managed event types.
+   *
+   * Managed event types have a parentId - this is used to include parent webhooks
+   * when a child event type is triggered.
+   *
+   * @param eventTypeId - The event type to check
+   * @returns Parent ID if this is a managed child event type, null otherwise
+   */
+  findParentEventTypeId(eventTypeId: number): Promise<number | null>;
+}

--- a/packages/features/eventtypes/eventtypes.repository.interface.ts
+++ b/packages/features/eventtypes/eventtypes.repository.interface.ts
@@ -2,16 +2,10 @@
  * EventTypes Repository Interface
  *
  * Central interface for EventType repository methods.
- * Add new methods here as needed by different features.
  */
 
 export interface IEventTypesRepository {
   /**
-   * Find parent event type ID for managed event types.
-   *
-   * Managed event types have a parentId - this is used to include parent webhooks
-   * when a child event type is triggered.
-   *
    * @param eventTypeId - The event type to check
    * @returns Parent ID if this is a managed child event type, null otherwise
    */

--- a/packages/features/eventtypes/repositories/eventTypeRepository.ts
+++ b/packages/features/eventtypes/repositories/eventTypeRepository.ts
@@ -81,7 +81,6 @@ function usersWithSelectedCalendars<
 export class EventTypeRepository implements IEventTypesRepository {
   constructor(private prismaClient: PrismaClient) {}
 
-  // TODO: Confirm if we can improve performance of this query by indexing/compound indexing
   async findParentEventTypeId(eventTypeId: number): Promise<number | null> {
     const managedChildEventType = await this.prismaClient.eventType.findFirst({
       where: {

--- a/packages/features/eventtypes/repositories/eventTypeRepository.ts
+++ b/packages/features/eventtypes/repositories/eventTypeRepository.ts
@@ -1,3 +1,4 @@
+import type { IEventTypesRepository } from "@calcom/features/eventtypes/eventtypes.repository.interface";
 import { MembershipRepository } from "@calcom/features/membership/repositories/MembershipRepository";
 import { LookupTarget, ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import type { UserWithLegacySelectedCalendars } from "@calcom/features/users/repositories/UserRepository";
@@ -9,8 +10,7 @@ import { safeStringify } from "@calcom/lib/safeStringify";
 import { eventTypeSelect } from "@calcom/lib/server/eventTypeSelect";
 import type { PrismaClient } from "@calcom/prisma";
 import { availabilityUserSelect, userSelect as userSelectWithSelectedCalendars } from "@calcom/prisma";
-import type { EventType as PrismaEventType } from "@calcom/prisma/client";
-import type { Prisma } from "@calcom/prisma/client";
+import type { Prisma, EventType as PrismaEventType } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 import { EventTypeMetaDataSchema, rrSegmentQueryValueSchema } from "@calcom/prisma/zod-utils";
@@ -78,8 +78,25 @@ function usersWithSelectedCalendars<
   return users.map((user) => withSelectedCalendars(user));
 }
 
-export class EventTypeRepository {
+export class EventTypeRepository implements IEventTypesRepository {
   constructor(private prismaClient: PrismaClient) {}
+
+  // TODO: Confirm if we can improve performance of this query by indexing/compound indexing
+  async findParentEventTypeId(eventTypeId: number): Promise<number | null> {
+    const managedChildEventType = await this.prismaClient.eventType.findFirst({
+      where: {
+        id: eventTypeId,
+        parentId: {
+          not: null,
+        },
+      },
+      select: {
+        parentId: true,
+      },
+    });
+
+    return managedChildEventType?.parentId ?? null;
+  }
 
   private generateCreateEventTypeData = (eventTypeCreateData: IEventType) => {
     const {

--- a/packages/features/users/users.repository.interface.ts
+++ b/packages/features/users/users.repository.interface.ts
@@ -2,4 +2,10 @@ import type { User } from "@calcom/prisma/client";
 
 export interface IUsersRepository {
   updateLastActiveAt(userId: number): Promise<User>;
+
+  /**
+   * @param userId - The user ID to query
+   * @returns User with team memberships, or null if user not found
+   */
+  findUserTeams(userId: number): Promise<{ teams: { teamId: number }[] } | null>;
 }

--- a/packages/features/users/users.repository.ts
+++ b/packages/features/users/users.repository.ts
@@ -1,7 +1,5 @@
-import { captureException } from "@sentry/nextjs";
-
 import db from "@calcom/prisma";
-
+import { captureException } from "@sentry/nextjs";
 import type { IUsersRepository } from "./users.repository.interface";
 
 export class UsersRepository implements IUsersRepository {
@@ -10,6 +8,25 @@ export class UsersRepository implements IUsersRepository {
       const user = await db.user.update({
         where: { id: userId },
         data: { lastActiveAt: new Date() },
+      });
+      return user;
+    } catch (err) {
+      captureException(err);
+      throw err;
+    }
+  }
+
+  async findUserTeams(userId: number): Promise<{ teams: { teamId: number }[] } | null> {
+    try {
+      const user = await db.user.findUnique({
+        where: { id: userId },
+        select: {
+          teams: {
+            select: {
+              teamId: true,
+            },
+          },
+        },
       });
       return user;
     } catch (err) {

--- a/packages/features/users/users.repository.ts
+++ b/packages/features/users/users.repository.ts
@@ -1,4 +1,4 @@
-import db from "@calcom/prisma";
+import db, { prisma } from "@calcom/prisma";
 import { captureException } from "@sentry/nextjs";
 import type { IUsersRepository } from "./users.repository.interface";
 
@@ -18,7 +18,7 @@ export class UsersRepository implements IUsersRepository {
 
   async findUserTeams(userId: number): Promise<{ teams: { teamId: number }[] } | null> {
     try {
-      const user = await db.user.findUnique({
+      const user = await prisma.user.findUnique({
         where: { id: userId },
         select: {
           teams: {

--- a/packages/features/webhooks/lib/interface/IWebhookRepository.ts
+++ b/packages/features/webhooks/lib/interface/IWebhookRepository.ts
@@ -71,6 +71,10 @@ export interface IWebhookRepository {
     timeUnit: string | null;
     version: WebhookVersion;
   }>;
+  findByOrgIdAndTrigger(options: {
+    orgId: number;
+    triggerEvent: WebhookTriggerEvents;
+  }): Promise<WebhookSubscriber[]>;
   getFilteredWebhooksForUser(options: { userId: number; userRole?: UserPermissionRole }): Promise<{
     webhookGroups: WebhookGroup[];
     profiles: {

--- a/packages/features/webhooks/lib/interface/IWebhookRepository.ts
+++ b/packages/features/webhooks/lib/interface/IWebhookRepository.ts
@@ -1,6 +1,5 @@
-import type { WebhookTriggerEvents, UserPermissionRole } from "@calcom/prisma/enums";
-
-import type { Webhook, WebhookSubscriber, WebhookGroup } from "../dto/types";
+import type { UserPermissionRole, WebhookTriggerEvents } from "@calcom/prisma/enums";
+import type { Webhook, WebhookGroup, WebhookSubscriber } from "../dto/types";
 
 /**
  * Webhook Version enum - defines the payload format versions.
@@ -8,20 +7,20 @@ import type { Webhook, WebhookSubscriber, WebhookGroup } from "../dto/types";
  * This is a TypeScript-only enum (not Prisma).
  * DB operations go through the repository which enforces these values.
  */
-export const WebhookVersion = {
+const WebhookVersion = {
   V_2021_10_20: "2021-10-20",
 } as const;
 
-export type WebhookVersion = (typeof WebhookVersion)[keyof typeof WebhookVersion];
+type WebhookVersion = (typeof WebhookVersion)[keyof typeof WebhookVersion];
 
 /**
  * Default webhook version - used for new webhooks and as fallback
  */
-export const DEFAULT_WEBHOOK_VERSION = WebhookVersion.V_2021_10_20;
+const DEFAULT_WEBHOOK_VERSION: WebhookVersion = WebhookVersion.V_2021_10_20;
 
-const VALID_WEBHOOK_VERSIONS = new Set<string>(Object.values(WebhookVersion));
+const VALID_WEBHOOK_VERSIONS: Set<string> = new Set<string>(Object.values(WebhookVersion));
 
-
+export { WebhookVersion, DEFAULT_WEBHOOK_VERSION, VALID_WEBHOOK_VERSIONS };
 export function isValidWebhookVersion(value: string): value is WebhookVersion {
   return VALID_WEBHOOK_VERSIONS.has(value);
 }
@@ -88,4 +87,3 @@ export interface IWebhookRepository {
   }>;
   listWebhooks(options: ListWebhooksOptions): Promise<Webhook[]>;
 }
-

--- a/packages/features/webhooks/lib/repository/WebhookRepository.ts
+++ b/packages/features/webhooks/lib/repository/WebhookRepository.ts
@@ -284,6 +284,7 @@ export class WebhookRepository implements IWebhookRepository {
         teamId: orgId,
         platform: false,
         eventTriggers: { has: triggerEvent },
+        active: true,
       },
       select: {
         id: true,

--- a/packages/features/webhooks/lib/repository/WebhookRepository.ts
+++ b/packages/features/webhooks/lib/repository/WebhookRepository.ts
@@ -44,15 +44,6 @@ const filterWebhooks = (webhook: { appId: string | null }): boolean => {
   return !appIds.some((appId: string) => webhook.appId == appId);
 };
 
-/**
- * Repository for webhook operations.
- *
- * Now follows strict Repository Pattern (CODE_STANDARDS.md Rule #7):
- * - Only accesses webhook table directly
- * - Cross-table queries delegated to EventTypeRepository and UserRepository
- * - All dependencies injected via constructor (DI-compliant)
- * - Singleton pattern kept temporarily for backward compatibility during migration
- */
 export class WebhookRepository implements IWebhookRepository {
   private static _instance: WebhookRepository | undefined;
 

--- a/packages/features/webhooks/lib/triggerDelegationCredentialErrorWebhook.ts
+++ b/packages/features/webhooks/lib/triggerDelegationCredentialErrorWebhook.ts
@@ -1,10 +1,9 @@
 import { DelegationCredentialRepository } from "@calcom/features/delegation-credentials/repositories/DelegationCredentialRepository";
-import { DelegationCredentialErrorPayloadType } from "@calcom/features/webhooks/lib/dto/types";
+import { getWebhookFeature } from "@calcom/features/di/webhooks/containers/webhook";
+import type { DelegationCredentialErrorPayloadType } from "@calcom/features/webhooks/lib/dto/types";
 import type { CalendarAppDelegationCredentialError } from "@calcom/lib/CalendarAppError";
 import logger from "@calcom/lib/logger";
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
-
-import { WebhookRepository } from "./repository/WebhookRepository";
 import sendPayload from "./sendPayload";
 
 const log = logger.getSubLogger({ prefix: ["triggerDelegationCredentialErrorWebhook"] });
@@ -30,7 +29,7 @@ export async function triggerDelegationCredentialErrorWebhook(params: {
       return;
     }
 
-    const webhookRepository = WebhookRepository.getInstance();
+    const { repository: webhookRepository } = getWebhookFeature();
     const webhooks = await webhookRepository.findByOrgIdAndTrigger({
       orgId: delegationCredential.organizationId,
       triggerEvent: WebhookTriggerEvents.DELEGATION_CREDENTIAL_ERROR,

--- a/packages/trpc/server/routers/viewer/webhook/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/webhook/get.handler.ts
@@ -1,6 +1,5 @@
-import { WebhookRepository } from "@calcom/features/webhooks/lib/repository/WebhookRepository";
+import { getWebhookFeature } from "@calcom/features/di/webhooks/containers/webhook";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
-
 import type { TGetInputSchema } from "./get.schema";
 
 type GetOptions = {
@@ -11,6 +10,6 @@ type GetOptions = {
 };
 
 export const getHandler = async ({ ctx: _ctx, input }: GetOptions) => {
-  const webhookRepository = WebhookRepository.getInstance();
+  const { repository: webhookRepository } = getWebhookFeature();
   return await webhookRepository.findByWebhookId(input.webhookId);
 };

--- a/packages/trpc/server/routers/viewer/webhook/getByViewer.handler.ts
+++ b/packages/trpc/server/routers/viewer/webhook/getByViewer.handler.ts
@@ -1,5 +1,5 @@
+import { getWebhookFeature } from "@calcom/features/di/webhooks/containers/webhook";
 import type { WebhookGroup } from "@calcom/features/webhooks/lib/dto/types";
-import { WebhookRepository } from "@calcom/features/webhooks/lib/repository/WebhookRepository";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
 type GetByViewerOptions = {
@@ -21,7 +21,7 @@ export type WebhooksByViewer = {
 
 export const getByViewerHandler = async ({ ctx }: GetByViewerOptions): Promise<WebhooksByViewer> => {
   // Use the singleton instance to avoid creating new instances repeatedly
-  const webhookRepository = WebhookRepository.getInstance();
+  const { repository: webhookRepository } = getWebhookFeature();
   return await webhookRepository.getFilteredWebhooksForUser({
     userId: ctx.user.id,
     userRole: ctx.user.role,

--- a/packages/trpc/server/routers/viewer/webhook/list.handler.ts
+++ b/packages/trpc/server/routers/viewer/webhook/list.handler.ts
@@ -1,7 +1,6 @@
+import { getWebhookFeature } from "@calcom/features/di/webhooks/containers/webhook";
 import type { Webhook } from "@calcom/features/webhooks/lib/dto/types";
-import { WebhookRepository } from "@calcom/features/webhooks/lib/repository/WebhookRepository";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
-
 import type { TListInputSchema } from "./list.schema";
 
 type ListOptions = {
@@ -12,7 +11,7 @@ type ListOptions = {
 };
 
 export const listHandler = async ({ ctx, input }: ListOptions): Promise<Webhook[]> => {
-  const repository = WebhookRepository.getInstance();
+  const { repository } = getWebhookFeature();
 
   return repository.listWebhooks({
     userId: ctx.user.id,


### PR DESCRIPTION
## What does this PR do?

This PR refines webhook wiring as part of the ongoing migration toward the new Webhook DI-based architecture.  

Specifically, it:
- Cleans up webhook handling logic to better align with the new dependency-injected WebhookFeature facade.
- Prepares the codebase for upcoming booking webhook trigger migration while keeping current behavior stable.
- Repository Pattern fixes.

The result is clearer separation between system/app webhooks and user-configurable webhooks, improving maintainability and preventing accidental processing of third-party integration hooks in user webhook flows.

- Fixes #XXXX  
- Fixes CAL-XXXX  

## Visual Demo (For contributors especially)

No UI changes were introduced in this PR.

#### Video Demo (if applicable):

N/A

#### Image Demo (if applicable):

N/A

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** - I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. 
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- No new environment variables are required.
- Existing webhook configuration can be used as test data.

### Happy path
1. Create a user webhook subscription through the UI or API.
2. Verify webhook deliveries continue to function as before.
3. Run existing webhook-related test suites to ensure no regressions.

### Additional notes
- This change is internal refactoring only.
- No database migrations are introduced.
- No API contract changes are exposed to clients.

## Checklist

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired webhook module to the new DI architecture and refactored WebhookRepository to inject event type and user repositories. Migrated TRPC handlers and delegation credential error trigger to use DI, prepping booking webhook triggers for the new setup.

- **Refactors**
  - Added DI tokens and module bindings for EventTypeRepository and UsersRepository.
  - Refactored WebhookRepository to follow the Repository Pattern; injects Prisma, event type, and user repos; keeps singleton temporarily for legacy paths.
  - Implemented IEventTypesRepository.findParentEventTypeId and IUsersRepository.findUserTeams; added IWebhookRepository.findByOrgIdAndTrigger; updated repositories accordingly.
  - Switched TRPC handlers (list, get, getByViewer) and delegation credential error trigger to use getWebhookFeature() from the DI container.
  - Updated WebhookTaskConsumer factory to use the DI resolver function.
  - Ensured managed child event types include parent webhooks and team-based filters are resolved via injected repositories.
  - Added active=true filter to org-level webhook queries.

<sup>Written for commit 36d5becc4514f0a8164d653ef8c4b7a74c0608ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->




<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27170">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
