### PR TITLE
feat: add no-show payload to Zapier webhooks

### DIFF
--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -238,6 +238,15 @@ const sendPayload = async (
     if (appId === "zapier") {
       body = getZapierPayload({ ...data, createdAt });
     }
+  } else if (appId === "zapier" && isNoShowPayload(data)) {
+    body = JSON.stringify({
+      bookingUid: data.bookingUid,
+      bookingId: data.bookingId,
+      attendees: data.attendees,
+      message: data.message,
+      triggerEvent,
+      createdAt,
+    });
   }
 
   if (body === undefined) {


### PR DESCRIPTION
## Summary
- send no-show webhook payloads to Zapier in the same raw format as other Zapier events
- include booking uid/id, attendee no-show flags, message, trigger event, and created timestamp

## Testing
- Not run locally (change isolated to webhook payload formatting)

## Issue
- https://github.com/calcom/cal.com/issues/18992