### PR TITLE
fix: add type property to @ApiQuery decorators in slots controller

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/slots.controller.ts
@@ -1,3 +1,33 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import {
+  ApiResponse,
+  GetReservedSlotOutput_2024_09_04 as GetReservedSlotOutputType_2024_09_04,
+  GetSlotsInput_2024_09_04,
+  GetSlotsInputPipe,
+  ReserveSlotInput_2024_09_04,
+  ReserveSlotOutput_2024_09_04 as ReserveSlotOutputType_2024_09_04,
+} from "@calcom/platform-types";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiHeader,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse as DocsResponse,
+  ApiTags as DocsTags,
+} from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { VERSION_2024_09_04 } from "@/lib/api-versions";
 import { OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER, OPTIONAL_X_CAL_CLIENT_ID_HEADER } from "@/lib/docs/headers";
 import {
@@ -9,37 +39,6 @@ import { GetReservedSlotOutput_2024_09_04 } from "@/modules/slots/slots-2024-09-
 import { GetSlotsOutput_2024_09_04 } from "@/modules/slots/slots-2024-09-04/outputs/get-slots.output";
 import { ReserveSlotOutputResponse_2024_09_04 } from "@/modules/slots/slots-2024-09-04/outputs/reserve-slot.output";
 import { SlotsService_2024_09_04 } from "@/modules/slots/slots-2024-09-04/services/slots.service";
-import {
-  Query,
-  Body,
-  Controller,
-  Get,
-  Delete,
-  Post,
-  Param,
-  HttpCode,
-  HttpStatus,
-  Patch,
-  UseGuards,
-} from "@nestjs/common";
-import {
-  ApiOperation,
-  ApiTags as DocsTags,
-  ApiHeader,
-  ApiResponse as DocsResponse,
-  ApiQuery,
-} from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import {
-  GetSlotsInput_2024_09_04,
-  GetSlotsInputPipe,
-  ReserveSlotInput_2024_09_04,
-  ReserveSlotOutput_2024_09_04 as ReserveSlotOutputType_2024_09_04,
-  GetReservedSlotOutput_2024_09_04 as GetReservedSlotOutputType_2024_09_04,
-} from "@calcom/platform-types";
-import { ApiResponse } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/slots",
@@ -95,12 +94,14 @@ export class SlotsController_2024_09_04 {
   })
   @ApiQuery({
     name: "timeZone",
+    type: String,
     required: false,
     description: "Time zone in which the available slots should be returned. Defaults to UTC.",
     example: "Europe/Rome",
   })
   @ApiQuery({
     name: "duration",
+    type: Number,
     required: false,
     description:
       "If event type has multiple possible durations then you can specify the desired duration here. Also, if you are fetching slots for a dynamic event then you can specify the duration her which defaults to 30, meaning that returned slots will be each 30 minutes long.",
@@ -108,6 +109,7 @@ export class SlotsController_2024_09_04 {
   })
   @ApiQuery({
     name: "format",
+    type: String,
     required: false,
     description:
       "Format of slot times in response. Use 'range' to get start and end times. Use 'time' or omit this query parameter to get only start time.",
@@ -115,6 +117,7 @@ export class SlotsController_2024_09_04 {
   })
   @ApiQuery({
     name: "usernames",
+    type: String,
     required: false,
     description: `The usernames for which available slots should be checked separated by a comma.
 
@@ -125,12 +128,14 @@ export class SlotsController_2024_09_04 {
   })
   @ApiQuery({
     name: "eventTypeId",
+    type: Number,
     required: false,
     description: "The ID of the event type for which available slots should be checked.",
     example: "100",
   })
   @ApiQuery({
     name: "eventTypeSlug",
+    type: String,
     required: false,
     description:
       "The slug of the event type for which available slots should be checked. If slug is provided then username or teamSlug must be provided too and if relevant organizationSlug too.",
@@ -138,6 +143,7 @@ export class SlotsController_2024_09_04 {
   })
   @ApiQuery({
     name: "username",
+    type: String,
     required: false,
     description:
       "The username of the user who owns event type with eventTypeSlug - used when slots are checked for individual user event type.",
@@ -145,6 +151,7 @@ export class SlotsController_2024_09_04 {
   })
   @ApiQuery({
     name: "teamSlug",
+    type: String,
     required: false,
     description:
       "The slug of the team who owns event type with eventTypeSlug - used when slots are checked for team event type.",
@@ -152,6 +159,7 @@ export class SlotsController_2024_09_04 {
   })
   @ApiQuery({
     name: "organizationSlug",
+    type: String,
     required: false,
     description:
       "The slug of the organization to which user with username belongs or team with teamSlug belongs.",
@@ -159,6 +167,7 @@ export class SlotsController_2024_09_04 {
   })
   @ApiQuery({
     name: "end",
+    type: String,
     required: true,
     description: `
     Time until which available slots should be checked.
@@ -171,6 +180,7 @@ export class SlotsController_2024_09_04 {
   })
   @ApiQuery({
     name: "start",
+    type: String,
     required: true,
     description: `
       Time starting from which available slots should be checked.
@@ -183,6 +193,7 @@ export class SlotsController_2024_09_04 {
   })
   @ApiQuery({
     name: "bookingUidToReschedule",
+    type: String,
     required: false,
     description:
       "The unique identifier of the booking being rescheduled. When provided will ensure that the original booking time appears within the returned available slots when rescheduling.",

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -13910,7 +13910,9 @@
             "in": "query",
             "description": "The unique identifier of the booking being rescheduled. When provided will ensure that the original booking time appears within the returned available slots when rescheduling.",
             "example": "abc123def456",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "start",
@@ -13918,7 +13920,9 @@
             "in": "query",
             "description": "\n      Time starting from which available slots should be checked.\n\n      Must be in UTC timezone as ISO 8601 datestring.\n\n      You can pass date without hours which defaults to start of day or specify hours:\n      2024-08-13 (will have hours 00:00:00 aka at very beginning of the date) or you can specify hours manually like 2024-08-13T09:00:00Z.",
             "example": "2050-09-05",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "end",
@@ -13926,7 +13930,9 @@
             "in": "query",
             "description": "\n    Time until which available slots should be checked.\n\n    Must be in UTC timezone as ISO 8601 datestring.\n\n    You can pass date without hours which defaults to end of day or specify hours:\n    2024-08-20 (will have hours 23:59:59 aka at the very end of the date) or you can specify hours manually like 2024-08-20T18:00:00Z.",
             "example": "2050-09-06",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "organizationSlug",
@@ -13934,7 +13940,9 @@
             "in": "query",
             "description": "The slug of the organization to which user with username belongs or team with teamSlug belongs.",
             "example": "org-slug",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "teamSlug",
@@ -13942,7 +13950,9 @@
             "in": "query",
             "description": "The slug of the team who owns event type with eventTypeSlug - used when slots are checked for team event type.",
             "example": "team-slug",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "username",
@@ -13950,7 +13960,9 @@
             "in": "query",
             "description": "The username of the user who owns event type with eventTypeSlug - used when slots are checked for individual user event type.",
             "example": "bob",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "eventTypeSlug",
@@ -13958,7 +13970,9 @@
             "in": "query",
             "description": "The slug of the event type for which available slots should be checked. If slug is provided then username or teamSlug must be provided too and if relevant organizationSlug too.",
             "example": "event-type-slug",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "eventTypeId",
@@ -13966,7 +13980,9 @@
             "in": "query",
             "description": "The ID of the event type for which available slots should be checked.",
             "example": "100",
-            "schema": {}
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "usernames",
@@ -13974,7 +13990,9 @@
             "in": "query",
             "description": "The usernames for which available slots should be checked separated by a comma.\n\n    Checking slots by usernames is used mainly for dynamic events where there is no specific event but we just want to know when 2 or more people are available.\n\n    Must contain at least 2 usernames.",
             "example": "alice,bob",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "format",
@@ -13982,7 +14000,9 @@
             "in": "query",
             "description": "Format of slot times in response. Use 'range' to get start and end times. Use 'time' or omit this query parameter to get only start time.",
             "example": "range",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "duration",
@@ -13990,7 +14010,9 @@
             "in": "query",
             "description": "If event type has multiple possible durations then you can specify the desired duration here. Also, if you are fetching slots for a dynamic event then you can specify the duration her which defaults to 30, meaning that returned slots will be each 30 minutes long.",
             "example": "60",
-            "schema": {}
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "timeZone",
@@ -13998,7 +14020,9 @@
             "in": "query",
             "description": "Time zone in which the available slots should be returned. Defaults to UTC.",
             "example": "Europe/Rome",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -23908,7 +23932,8 @@
               "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
               "AFTER_GUESTS_CAL_VIDEO_NO_SHOW",
               "FORM_SUBMITTED_NO_EVENT",
-              "DELEGATION_CREDENTIAL_ERROR"
+              "DELEGATION_CREDENTIAL_ERROR",
+              "WRONG_ASSIGNMENT_REPORT"
             ]
           },
           "secret": {
@@ -23982,7 +24007,8 @@
               "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
               "AFTER_GUESTS_CAL_VIDEO_NO_SHOW",
               "FORM_SUBMITTED_NO_EVENT",
-              "DELEGATION_CREDENTIAL_ERROR"
+              "DELEGATION_CREDENTIAL_ERROR",
+              "WRONG_ASSIGNMENT_REPORT"
             ]
           },
           "secret": {


### PR DESCRIPTION
## What does this PR do?

Fixes missing query parameter types in the Swagger documentation for the `getAvailableSlots` endpoint. The `@ApiQuery` decorators were missing the `type` property, which resulted in empty `schema: {}` objects in the generated OpenAPI spec, causing query parameters to not display properly in the Swagger UI.

Added `type: String` or `type: Number` to all 12 `@ApiQuery` decorators based on their expected data types:
- `type: Number` for `duration` and `eventTypeId`
- `type: String` for all other parameters (`timeZone`, `format`, `usernames`, `eventTypeSlug`, `username`, `teamSlug`, `organizationSlug`, `end`, `start`, `bookingUidToReschedule`)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - this fixes auto-generated API docs.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - documentation metadata change only.

## How should this be tested?

1. Regenerate the OpenAPI spec by running the API v2 app
2. Check `docs/api-reference/v2/openapi.json` for the `/v2/slots` GET endpoint
3. Verify that query parameters now have proper type schemas (e.g., `"schema": { "type": "string" }`) instead of empty `"schema": {}`
4. Optionally, view the Swagger UI at `/docs` endpoint and confirm query parameters are displayed correctly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small and focused

---

**Link to Devin run:** https://app.devin.ai/sessions/07fd94547d60441fbe6f749c24c0289f
**Requested by:** @ThyMinimalDev

### Human Review Checklist
- [ ] Verify the type assignments match the expected data types (Number for `duration`/`eventTypeId`, String for others)
- [ ] Note: Import reordering at top of file is from Biome formatter, not manual changes