### PR TITLE
fix: remove sticky header from ShellMain component

### DIFF
--- a/apps/web/modules/shell/Shell.tsx
+++ b/apps/web/modules/shell/Shell.tsx
@@ -130,7 +130,7 @@ export function ShellMain(props: LayoutProps) {
       {(props.heading || !!props.backPath) && (
         <div
           className={classNames(
-            "bg-default sticky top-0 z-10 mb-0 flex items-center md:mb-6 md:mt-0",
+            "flex items-center md:mb-6 md:mt-0",
             props.smallHeading ? "lg:mb-7" : "lg:mb-8"
           )}>
           {!!props.backPath && (


### PR DESCRIPTION
## What does this PR do?

Removes the sticky header behavior from the `ShellMain` component to make it consistent with `ShellMainAppDir`, which doesn't have sticky headers.

**Background**: Several pages had inconsistent sticky header behavior:
- `/routing` - had sticky header (uses ShellMain)
- `/workflows` - had sticky header (uses ShellMain)
- `/settings/organizations/[id]/members` - had sticky header (uses Shell with ShellMain)

Most other pages (bookings, event-types, availability, teams, insights) use `ShellMainAppDir` which doesn't have sticky headers. This PR removes the sticky behavior to make the UI consistent.

**Changes:**
- Removed `bg-default sticky top-0 z-10 mb-0` classes from the header div in `ShellMain`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to `/routing` page and scroll down - the title "Routing" and subtitle should no longer stay fixed at the top
2. Navigate to `/workflows` page and scroll down - the title "Workflows" and subtitle should no longer stay fixed at the top
3. Navigate to `/settings/organizations/[orgSlug]/members` page and scroll down - the header should no longer stay fixed at the top
4. Verify other pages using ShellMain still render correctly

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is not too large

---

> **Link to Devin run**: https://app.devin.ai/sessions/2a2dd4ccf33d422c98abff93cc346ab0
> **Requested by**: @eunjae-lee