### PR TITLE
fix: use Cal.com video URL instead of daily.co in email reminders workflow

### DIFF
--- a/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
+++ b/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
@@ -397,7 +397,12 @@ export class EmailWorkflowService {
 
     if (matchedTemplate === WorkflowTemplates.REMINDER) {
       const t = await getTranslation(locale, "common");
-
+      const meetingUrl =  
+        getVideoCallUrlFromCalEvent({
+          videoCallData: evt.videoCallData,
+          uid: evt.uid,
+          location: evt.location,
+        }) || bookingMetadataSchema.parse(evt.metadata || {})?.videoCallUrl;
       emailContent = emailReminderTemplate({
         isEditingMode: false,
         locale,
@@ -409,8 +414,7 @@ export class EmailWorkflowService {
         eventName: evt.title,
         timeZone,
         location: evt.location || "",
-        meetingUrl:
-          evt.videoCallData?.url || bookingMetadataSchema.parse(evt.metadata || {})?.videoCallUrl || "",
+        meetingUrl,
         otherPerson: attendeeName,
         name,
       });
@@ -438,7 +442,12 @@ export class EmailWorkflowService {
         sendToEmail: sendTo[0],
       });
       const meetingUrl =
-        getVideoCallUrlFromCalEvent({ videoCallData: evt.videoCallData }) || bookingMetadataSchema.parse(evt.metadata || {})?.videoCallUrl;
+        getVideoCallUrlFromCalEvent({
+          videoCallData: evt.videoCallData,
+          uid: evt.uid,
+          location: evt.location,
+        }) || bookingMetadataSchema.parse(evt.metadata || {})?.videoCallUrl;
+
       const variables: VariablesType = {
         eventName: evt.title || "",
         organizerName: evt.organizer.name,

--- a/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
+++ b/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
@@ -402,7 +402,7 @@ export class EmailWorkflowService {
           videoCallData: evt.videoCallData,
           uid: evt.uid,
           location: evt.location,
-        }) || bookingMetadataSchema.parse(evt.metadata || {})?.videoCallUrl;
+        }) || bookingMetadataSchema.safeParse(evt.metadata || {}).data?.videoCallUrl;
       emailContent = emailReminderTemplate({
         isEditingMode: false,
         locale,
@@ -446,7 +446,7 @@ export class EmailWorkflowService {
           videoCallData: evt.videoCallData,
           uid: evt.uid,
           location: evt.location,
-        }) || bookingMetadataSchema.parse(evt.metadata || {})?.videoCallUrl;
+        }) || bookingMetadataSchema.safeParse(evt.metadata || {}).data?.videoCallUrl;
 
       const variables: VariablesType = {
         eventName: evt.title || "",
@@ -524,7 +524,7 @@ export class EmailWorkflowService {
         language: { ...evt.organizer.language, translate: organizerT },
       },
       attendees: processedAttendees,
-      location: bookingMetadataSchema.parse(evt.metadata || {})?.videoCallUrl || evt.location,
+      location: bookingMetadataSchema.safeParse(evt.metadata || {}).data?.videoCallUrl || evt.location,
     };
 
     const shouldIncludeCalendarEvent =


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch email reminders and custom template meeting links to the Cal.com video URL, replacing daily.co links. Ensures consistent, branded links for Cal Video meetings.

- **Bug Fixes**
  - Build meetingUrl with getVideoCallUrlFromCalEvent using uid and location; fallback to metadata via safeParse.
  - Apply to REMINDER and CUSTOM email paths in EmailWorkflowService.
  - Add tests to ensure daily.co never appears and Cal.com /video/{uid} is used.

<sup>Written for commit 607fc5a219aca2219eb8bda55c279cf9fa2f6edd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

