### PR TITLE
feat: tasker notifications for monthly proration 

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -4449,5 +4449,13 @@
   "error_enabling_feature": "Error enabling feature. Please try again.",
   "set_organizer_as_contact_owner": "Set booking organizer as contact owner",
   "overwrite_existing_contact_owner": "Overwrite existing contact owner",
+  "proration_invoice_email_subject": "Invoice for additional seats - {{teamName}}",
+  "proration_invoice_email_heading": "You have a new invoice",
+  "proration_invoice_email_body": "An invoice has been created for {{seatCount}} additional seat(s) on your {{teamName}} subscription.",
+  "proration_invoice_email_amount": "Amount due: {{amount}}",
+  "proration_invoice_email_view_invoice": "View and Pay Invoice",
+  "proration_invoice_reminder_subject": "Reminder: Invoice pending payment - {{teamName}}",
+  "proration_invoice_reminder_heading": "Invoice reminder",
+  "proration_invoice_reminder_body": "This is a reminder that you have an unpaid invoice for your {{teamName}} subscription.",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS":"↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/emails/src/templates/ProrationInvoiceEmail.tsx
+++ b/packages/emails/src/templates/ProrationInvoiceEmail.tsx
@@ -1,0 +1,86 @@
+import type { TFunction } from "i18next";
+
+import { APP_NAME } from "@calcom/lib/constants";
+
+import { CallToAction, V2BaseEmailHtml } from "../components";
+
+export type ProrationInvoiceEmailProps = {
+  language: TFunction;
+  to: string;
+  teamName: string;
+  seatCount: number;
+  amountFormatted: string;
+  invoiceUrl: string;
+  isReminder: boolean;
+};
+
+export const ProrationInvoiceEmail = (
+  props: ProrationInvoiceEmailProps & Partial<React.ComponentProps<typeof V2BaseEmailHtml>>
+) => {
+  const { language, teamName, seatCount, amountFormatted, invoiceUrl, isReminder } = props;
+
+  const subject = isReminder
+    ? language("proration_invoice_reminder_subject", { teamName })
+    : language("proration_invoice_email_subject", { teamName });
+
+  const heading = isReminder
+    ? language("proration_invoice_reminder_heading")
+    : language("proration_invoice_email_heading");
+
+  const body = isReminder
+    ? language("proration_invoice_reminder_body", { teamName })
+    : language("proration_invoice_email_body", { seatCount, teamName });
+
+  return (
+    <V2BaseEmailHtml subject={subject}>
+      <p style={{ fontSize: "24px", marginBottom: "16px", textAlign: "center" }}>{heading}</p>
+
+      <p
+        style={{
+          fontWeight: 400,
+          lineHeight: "24px",
+          marginBottom: "16px",
+          marginTop: "32px",
+        }}>
+        {body}
+      </p>
+
+      {!isReminder && (
+        <p
+          style={{
+            fontWeight: 500,
+            lineHeight: "24px",
+            marginBottom: "32px",
+          }}>
+          {language("proration_invoice_email_amount", { amount: amountFormatted })}
+        </p>
+      )}
+
+      <div style={{ display: "flex", justifyContent: "center", marginTop: "24px" }}>
+        <CallToAction label={language("proration_invoice_email_view_invoice")} href={invoiceUrl} />
+      </div>
+
+      <div className="">
+        <p
+          style={{
+            fontWeight: 400,
+            lineHeight: "24px",
+            marginBottom: "32px",
+            marginTop: "32px",
+          }}>
+          {language("email_no_user_signoff", { appName: APP_NAME })}
+        </p>
+      </div>
+
+      <div style={{ borderTop: "1px solid #E1E1E1", marginTop: "32px", paddingTop: "32px" }}>
+        <p style={{ fontWeight: 400, margin: 0 }}>
+          {language("have_any_questions")}{" "}
+          <a href="mailto:support@cal.com" style={{ color: "#3E3E3E" }} target="_blank" rel="noreferrer">
+            {language("contact")}
+          </a>{" "}
+          {language("our_support_team")}
+        </p>
+      </div>
+    </V2BaseEmailHtml>
+  );
+};

--- a/packages/emails/src/templates/index.ts
+++ b/packages/emails/src/templates/index.ts
@@ -46,3 +46,4 @@ export { OrganizationCreationEmail } from "./OrganizationCreationEmail";
 export { OrganizerAddGuestsEmail } from "./OrganizerAddGuestsEmail";
 export { AttendeeAddGuestsEmail } from "./AttendeeAddGuestsEmail";
 export { OrganizationAdminNoSlotsEmail } from "./OrganizationAdminNoSlots";
+export { ProrationInvoiceEmail } from "./ProrationInvoiceEmail";

--- a/packages/emails/templates/proration-invoice-email.ts
+++ b/packages/emails/templates/proration-invoice-email.ts
@@ -1,0 +1,31 @@
+import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
+
+import type { ProrationInvoiceEmailProps } from "../src/templates/ProrationInvoiceEmail";
+import renderEmail from "../src/renderEmail";
+import BaseEmail from "./_base-email";
+
+export default class ProrationInvoiceEmail extends BaseEmail {
+  private emailData: ProrationInvoiceEmailProps;
+
+  constructor(emailData: ProrationInvoiceEmailProps) {
+    super();
+    this.name = emailData.isReminder ? "SEND_PRORATION_INVOICE_REMINDER_EMAIL" : "SEND_PRORATION_INVOICE_EMAIL";
+    this.emailData = emailData;
+  }
+
+  protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const subject = this.emailData.isReminder
+      ? this.emailData.language("proration_invoice_reminder_subject", { teamName: this.emailData.teamName })
+      : this.emailData.language("proration_invoice_email_subject", { teamName: this.emailData.teamName });
+
+    return {
+      to: this.emailData.to,
+      from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
+      subject,
+      html: await renderEmail("ProrationInvoiceEmail", this.emailData),
+      text: "",
+    };
+  }
+}
+
+export type { ProrationInvoiceEmailProps };

--- a/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationSyncTasker.module.ts
+++ b/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationSyncTasker.module.ts
@@ -1,0 +1,19 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { ProrationInvoiceNotificationSyncTasker } from "@calcom/features/ee/billing/service/proration/tasker/ProrationInvoiceNotificationSyncTasker";
+
+import { PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS.SYNC_TASKER;
+const moduleToken = PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS.SYNC_TASKER_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: ProrationInvoiceNotificationSyncTasker,
+});
+
+export const moduleLoader = {
+  token,
+  loadModule,
+} satisfies ModuleLoader;

--- a/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationSyncTasker.module.ts
+++ b/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationSyncTasker.module.ts
@@ -11,6 +11,7 @@ const loadModule = bindModuleToClassOnToken({
   moduleToken,
   token,
   classs: ProrationInvoiceNotificationSyncTasker,
+  depsMap: {},
 });
 
 export const moduleLoader = {

--- a/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationTasker.container.ts
+++ b/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationTasker.container.ts
@@ -1,0 +1,15 @@
+import { createContainer } from "@calcom/features/di/di";
+
+import type { ProrationInvoiceNotificationTasker } from "@calcom/features/ee/billing/service/proration/tasker/ProrationInvoiceNotificationTasker";
+
+import { moduleLoader as prorationInvoiceNotificationTaskerModule } from "./ProrationInvoiceNotificationTasker.module";
+import { PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS } from "./tokens";
+
+const container = createContainer();
+
+export function getProrationInvoiceNotificationTasker(): ProrationInvoiceNotificationTasker {
+  prorationInvoiceNotificationTaskerModule.loadModule(container);
+  return container.get<ProrationInvoiceNotificationTasker>(
+    PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS.TASKER
+  );
+}

--- a/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationTasker.module.ts
+++ b/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationTasker.module.ts
@@ -1,0 +1,25 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { ProrationInvoiceNotificationTasker } from "@calcom/features/ee/billing/service/proration/tasker/ProrationInvoiceNotificationTasker";
+
+import { moduleLoader as syncTaskerModule } from "./ProrationInvoiceNotificationSyncTasker.module";
+import { moduleLoader as triggerTaskerModule } from "./ProrationInvoiceNotificationTriggerTasker.module";
+import { PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS.TASKER;
+const moduleToken = PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS.TASKER_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: ProrationInvoiceNotificationTasker,
+  depsMap: {
+    asyncTasker: triggerTaskerModule,
+    syncTasker: syncTaskerModule,
+  },
+});
+
+export const moduleLoader = {
+  token,
+  loadModule,
+} satisfies ModuleLoader;

--- a/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationTriggerTasker.module.ts
+++ b/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationTriggerTasker.module.ts
@@ -1,0 +1,19 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { ProrationInvoiceNotificationTriggerTasker } from "@calcom/features/ee/billing/service/proration/tasker/ProrationInvoiceNotificationTriggerTasker";
+
+import { PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS.TRIGGER_TASKER;
+const moduleToken = PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS.TRIGGER_TASKER_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: ProrationInvoiceNotificationTriggerTasker,
+});
+
+export const moduleLoader = {
+  token,
+  loadModule,
+} satisfies ModuleLoader;

--- a/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationTriggerTasker.module.ts
+++ b/packages/features/ee/billing/di/tasker/ProrationInvoiceNotificationTriggerTasker.module.ts
@@ -11,6 +11,7 @@ const loadModule = bindModuleToClassOnToken({
   moduleToken,
   token,
   classs: ProrationInvoiceNotificationTriggerTasker,
+  depsMap: {},
 });
 
 export const moduleLoader = {

--- a/packages/features/ee/billing/di/tasker/tokens.ts
+++ b/packages/features/ee/billing/di/tasker/tokens.ts
@@ -6,3 +6,12 @@ export const MONTHLY_PRORATION_TASKER_DI_TOKENS = {
   MONTHLY_PRORATION_TRIGGER_TASKER: Symbol("MonthlyProrationTriggerTasker"),
   MONTHLY_PRORATION_TRIGGER_TASKER_MODULE: Symbol("MonthlyProrationTriggerTaskerModule"),
 };
+
+export const PRORATION_INVOICE_NOTIFICATION_TASKER_DI_TOKENS = {
+  TASKER: Symbol("ProrationInvoiceNotificationTasker"),
+  TASKER_MODULE: Symbol("ProrationInvoiceNotificationTaskerModule"),
+  SYNC_TASKER: Symbol("ProrationInvoiceNotificationSyncTasker"),
+  SYNC_TASKER_MODULE: Symbol("ProrationInvoiceNotificationSyncTaskerModule"),
+  TRIGGER_TASKER: Symbol("ProrationInvoiceNotificationTriggerTasker"),
+  TRIGGER_TASKER_MODULE: Symbol("ProrationInvoiceNotificationTriggerTaskerModule"),
+};

--- a/packages/features/ee/billing/service/billingProvider/IBillingProviderService.ts
+++ b/packages/features/ee/billing/service/billingProvider/IBillingProviderService.ts
@@ -123,4 +123,14 @@ export interface IBillingProviderService {
     current_period_end: number;
     trial_end: number | null;
   } | null>;
+
+  // Invoice queries
+  getInvoice(invoiceId: string): Promise<{
+    id: string;
+    hostedInvoiceUrl: string | null;
+    invoicePdf: string | null;
+    status: string | null;
+    amountDue: number;
+    currency: string;
+  } | null>;
 }

--- a/packages/features/ee/billing/service/billingProvider/StripeBillingService.ts
+++ b/packages/features/ee/billing/service/billingProvider/StripeBillingService.ts
@@ -403,4 +403,23 @@ export class StripeBillingService implements IBillingProviderService {
       trial_end: subscription.trial_end,
     };
   }
+
+  async getInvoice(invoiceId: string) {
+    try {
+      const invoice = await this.stripe.invoices.retrieve(invoiceId);
+      if (!invoice) return null;
+
+      return {
+        id: invoice.id,
+        hostedInvoiceUrl: invoice.hosted_invoice_url ?? null,
+        invoicePdf: invoice.invoice_pdf ?? null,
+        status: invoice.status ?? null,
+        amountDue: invoice.amount_due,
+        currency: invoice.currency,
+      };
+    } catch (error) {
+      log.warn("Failed to retrieve invoice", { invoiceId, error });
+      return null;
+    }
+  }
 }

--- a/packages/features/ee/billing/service/proration/ProrationInvoiceNotificationService.ts
+++ b/packages/features/ee/billing/service/proration/ProrationInvoiceNotificationService.ts
@@ -1,0 +1,206 @@
+import type { TFunction } from "i18next";
+
+import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
+import { getTranslation } from "@calcom/lib/server/i18n";
+import logger from "@calcom/lib/logger";
+import type { PrismaClient } from "@calcom/prisma";
+import { prisma as defaultPrisma } from "@calcom/prisma";
+import { MembershipRole } from "@calcom/prisma/enums";
+import ProrationInvoiceEmail from "@calcom/emails/templates/proration-invoice-email";
+
+import type { IBillingProviderService } from "../billingProvider/IBillingProviderService";
+import { MonthlyProrationRepository } from "../../repository/proration/MonthlyProrationRepository";
+
+const log = logger.getSubLogger({ prefix: ["ProrationInvoiceNotificationService"] });
+
+interface InvoiceNotificationParams {
+  prorationId: string;
+  invoiceId: string;
+  teamId: number;
+}
+
+interface UserWithTranslation {
+  id: number;
+  name: string | null;
+  email: string;
+  t: TFunction;
+}
+
+export class ProrationInvoiceNotificationService {
+  private prisma: PrismaClient;
+  private prorationRepository: MonthlyProrationRepository;
+  private teamRepository: TeamRepository;
+  private billingService: IBillingProviderService;
+
+  constructor(
+    private readonly deps: {
+      prisma?: PrismaClient;
+      billingService: IBillingProviderService;
+    }
+  ) {
+    this.prisma = deps.prisma || defaultPrisma;
+    this.prorationRepository = new MonthlyProrationRepository(this.prisma);
+    this.teamRepository = new TeamRepository(this.prisma);
+    this.billingService = deps.billingService;
+  }
+
+  async sendInvoiceCreatedNotification(params: InvoiceNotificationParams): Promise<void> {
+    const { prorationId, invoiceId, teamId } = params;
+
+    log.info("Sending invoice created notification", { prorationId, invoiceId, teamId });
+
+    const { proration, team, invoice, recipients } = await this.getNotificationData(params);
+
+    if (!proration || !team || !invoice || !recipients.length) {
+      log.warn("Missing data for invoice notification", {
+        prorationId,
+        hasProration: !!proration,
+        hasTeam: !!team,
+        hasInvoice: !!invoice,
+        recipientCount: recipients.length,
+      });
+      return;
+    }
+
+    if (!invoice.hostedInvoiceUrl) {
+      log.warn("Invoice has no hosted URL, skipping notification", { prorationId, invoiceId });
+      return;
+    }
+
+    const amountFormatted = this.formatAmount(invoice.amountDue, invoice.currency);
+
+    for (const recipient of recipients) {
+      try {
+        const email = new ProrationInvoiceEmail({
+          to: recipient.email,
+          language: recipient.t,
+          teamName: team.name || "",
+          seatCount: proration.netSeatIncrease,
+          amountFormatted,
+          invoiceUrl: invoice.hostedInvoiceUrl,
+          isReminder: false,
+        });
+
+        await email.sendEmail();
+
+        log.info("Sent invoice created notification", {
+          prorationId,
+          invoiceId,
+          recipientEmail: recipient.email,
+        });
+      } catch (error) {
+        log.error("Failed to send invoice created notification", {
+          prorationId,
+          invoiceId,
+          recipientEmail: recipient.email,
+          error,
+        });
+      }
+    }
+  }
+
+  async sendInvoiceReminderNotification(params: InvoiceNotificationParams): Promise<void> {
+    const { prorationId, invoiceId, teamId } = params;
+
+    log.info("Sending invoice reminder notification", { prorationId, invoiceId, teamId });
+
+    const { proration, team, invoice, recipients } = await this.getNotificationData(params);
+
+    if (!proration || !team || !invoice || !recipients.length) {
+      log.warn("Missing data for invoice reminder notification", {
+        prorationId,
+        hasProration: !!proration,
+        hasTeam: !!team,
+        hasInvoice: !!invoice,
+        recipientCount: recipients.length,
+      });
+      return;
+    }
+
+    // Skip if invoice is no longer open (paid, voided, etc.)
+    if (invoice.status !== "open") {
+      log.info("Invoice is not open, skipping reminder", {
+        prorationId,
+        invoiceId,
+        status: invoice.status,
+      });
+      return;
+    }
+
+    if (!invoice.hostedInvoiceUrl) {
+      log.warn("Invoice has no hosted URL, skipping reminder", { prorationId, invoiceId });
+      return;
+    }
+
+    const amountFormatted = this.formatAmount(invoice.amountDue, invoice.currency);
+
+    for (const recipient of recipients) {
+      try {
+        const email = new ProrationInvoiceEmail({
+          to: recipient.email,
+          language: recipient.t,
+          teamName: team.name || "",
+          seatCount: proration.netSeatIncrease,
+          amountFormatted,
+          invoiceUrl: invoice.hostedInvoiceUrl,
+          isReminder: true,
+        });
+
+        await email.sendEmail();
+
+        log.info("Sent invoice reminder notification", {
+          prorationId,
+          invoiceId,
+          recipientEmail: recipient.email,
+        });
+      } catch (error) {
+        log.error("Failed to send invoice reminder notification", {
+          prorationId,
+          invoiceId,
+          recipientEmail: recipient.email,
+          error,
+        });
+      }
+    }
+  }
+
+  private async getNotificationData(params: InvoiceNotificationParams) {
+    const { prorationId, invoiceId, teamId } = params;
+
+    const [proration, team, invoice] = await Promise.all([
+      this.prorationRepository.findById(prorationId),
+      this.teamRepository.findById({ id: teamId }),
+      this.billingService.getInvoice(invoiceId),
+    ]);
+
+    if (!team) {
+      return { proration, team: null, invoice, recipients: [] };
+    }
+
+    const permission = team.isOrganization ? "organization.manageBilling" : "team.manageBilling";
+    const users = await this.teamRepository.findTeamMembersWithPermission({
+      teamId,
+      permission,
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
+
+    const recipients: UserWithTranslation[] = await Promise.all(
+      users.map(async (user) => ({
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        t: await getTranslation(user.locale ?? "en", "common"),
+      }))
+    );
+
+    return { proration, team, invoice, recipients };
+  }
+
+  private formatAmount(amountInCents: number, currency: string): string {
+    const amount = amountInCents / 100;
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: currency.toUpperCase(),
+    }).format(amount);
+  }
+}

--- a/packages/features/ee/billing/service/proration/tasker/ProrationInvoiceNotificationSyncTasker.ts
+++ b/packages/features/ee/billing/service/proration/tasker/ProrationInvoiceNotificationSyncTasker.ts
@@ -1,0 +1,26 @@
+import { nanoid } from "nanoid";
+
+import stripe from "@calcom/features/ee/payments/server/stripe";
+
+import { StripeBillingService } from "../../billingProvider/StripeBillingService";
+import { ProrationInvoiceNotificationService } from "../ProrationInvoiceNotificationService";
+import type { IProrationInvoiceNotificationTasker, InvoiceNotificationPayload } from "./types";
+
+export class ProrationInvoiceNotificationSyncTasker implements IProrationInvoiceNotificationTasker {
+  async sendInvoiceCreatedNotification(payload: InvoiceNotificationPayload): Promise<{ runId: string }> {
+    const runId = `sync_created_${nanoid(10)}`;
+    const billingService = new StripeBillingService(stripe);
+    const notificationService = new ProrationInvoiceNotificationService({ billingService });
+    await notificationService.sendInvoiceCreatedNotification(payload);
+    return { runId };
+  }
+
+  async sendInvoiceReminderNotification(
+    _payload: InvoiceNotificationPayload,
+    _options?: { delay?: string }
+  ): Promise<{ runId: string }> {
+    // Sync tasker does not support delayed tasks - skip reminder notifications
+    // Reminders are only sent via the async (Trigger.dev) tasker
+    return { runId: "" };
+  }
+}

--- a/packages/features/ee/billing/service/proration/tasker/ProrationInvoiceNotificationTasker.ts
+++ b/packages/features/ee/billing/service/proration/tasker/ProrationInvoiceNotificationTasker.ts
@@ -1,0 +1,30 @@
+import { Tasker } from "@calcom/lib/tasker/Tasker";
+
+import type { ProrationInvoiceNotificationSyncTasker } from "./ProrationInvoiceNotificationSyncTasker";
+import type { ProrationInvoiceNotificationTriggerTasker } from "./ProrationInvoiceNotificationTriggerTasker";
+import type { IProrationInvoiceNotificationTasker, InvoiceNotificationPayload } from "./types";
+
+export interface ProrationInvoiceNotificationTaskerDependencies {
+  asyncTasker: ProrationInvoiceNotificationTriggerTasker;
+  syncTasker: ProrationInvoiceNotificationSyncTasker;
+}
+
+export class ProrationInvoiceNotificationTasker
+  extends Tasker<IProrationInvoiceNotificationTasker>
+  implements IProrationInvoiceNotificationTasker
+{
+  constructor(dependencies: ProrationInvoiceNotificationTaskerDependencies) {
+    super(dependencies);
+  }
+
+  async sendInvoiceCreatedNotification(payload: InvoiceNotificationPayload): Promise<{ runId: string }> {
+    return await this.dispatch("sendInvoiceCreatedNotification", payload);
+  }
+
+  async sendInvoiceReminderNotification(
+    payload: InvoiceNotificationPayload,
+    options?: { delay?: string }
+  ): Promise<{ runId: string }> {
+    return await this.dispatch("sendInvoiceReminderNotification", payload, options);
+  }
+}

--- a/packages/features/ee/billing/service/proration/tasker/ProrationInvoiceNotificationTriggerTasker.ts
+++ b/packages/features/ee/billing/service/proration/tasker/ProrationInvoiceNotificationTriggerTasker.ts
@@ -1,0 +1,20 @@
+import type { IProrationInvoiceNotificationTasker, InvoiceNotificationPayload } from "./types";
+
+export class ProrationInvoiceNotificationTriggerTasker implements IProrationInvoiceNotificationTasker {
+  async sendInvoiceCreatedNotification(payload: InvoiceNotificationPayload): Promise<{ runId: string }> {
+    const { sendInvoiceCreatedNotification } = await import("./trigger/sendInvoiceCreatedNotification");
+    const handle = await sendInvoiceCreatedNotification.trigger(payload);
+    return { runId: handle.id };
+  }
+
+  async sendInvoiceReminderNotification(
+    payload: InvoiceNotificationPayload,
+    options?: { delay?: string }
+  ): Promise<{ runId: string }> {
+    const { sendInvoiceReminderNotification } = await import("./trigger/sendInvoiceReminderNotification");
+    const handle = await sendInvoiceReminderNotification.trigger(payload, {
+      delay: options?.delay,
+    });
+    return { runId: handle.id };
+  }
+}

--- a/packages/features/ee/billing/service/proration/tasker/trigger/invoiceNotificationSchema.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/invoiceNotificationSchema.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const invoiceNotificationSchema = z.object({
+  prorationId: z.string().min(1),
+  invoiceId: z.string().min(1),
+  teamId: z.number().int().positive(),
+});
+
+export const invoiceEmailSchema = z.object({
+  prorationId: z.string().min(1),
+  invoiceId: z.string().min(1),
+  teamId: z.number().int().positive(),
+  recipientEmail: z.string().email(),
+  recipientLocale: z.string(),
+  teamName: z.string(),
+  seatCount: z.number().int(),
+  amountFormatted: z.string(),
+  invoiceUrl: z.string().url(),
+  isReminder: z.boolean(),
+});

--- a/packages/features/ee/billing/service/proration/tasker/trigger/sendInvoiceCreatedNotification.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/sendInvoiceCreatedNotification.ts
@@ -4,13 +4,12 @@ import { MembershipRole } from "@calcom/prisma/enums";
 
 import { monthlyProrationTaskConfig } from "./config";
 import { invoiceNotificationSchema } from "./invoiceNotificationSchema";
-import { sendInvoiceEmail } from "./sendInvoiceEmail";
 
 export const sendInvoiceCreatedNotification = schemaTask({
   id: "billing.proration-invoice.created-notification",
   ...monthlyProrationTaskConfig,
   schema: invoiceNotificationSchema,
-  run: async (payload, { ctx }) => {
+  run: async (payload) => {
     const { TeamRepository } = await import("@calcom/features/ee/teams/repositories/TeamRepository");
     const { MonthlyProrationRepository } = await import(
       "@calcom/features/ee/billing/repository/proration/MonthlyProrationRepository"
@@ -20,6 +19,7 @@ export const sendInvoiceCreatedNotification = schemaTask({
     );
     const stripe = (await import("@calcom/features/ee/payments/server/stripe")).default;
     const { prisma } = await import("@calcom/prisma");
+    const { sendInvoiceEmail } = await import("./sendInvoiceEmail");
 
     const prorationRepository = new MonthlyProrationRepository(prisma);
     const teamRepository = new TeamRepository(prisma);

--- a/packages/features/ee/billing/service/proration/tasker/trigger/sendInvoiceCreatedNotification.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/sendInvoiceCreatedNotification.ts
@@ -1,0 +1,94 @@
+import { schemaTask } from "@trigger.dev/sdk";
+
+import { MembershipRole } from "@calcom/prisma/enums";
+
+import { monthlyProrationTaskConfig } from "./config";
+import { invoiceNotificationSchema } from "./invoiceNotificationSchema";
+import { sendInvoiceEmail } from "./sendInvoiceEmail";
+
+export const sendInvoiceCreatedNotification = schemaTask({
+  id: "billing.proration-invoice.created-notification",
+  ...monthlyProrationTaskConfig,
+  schema: invoiceNotificationSchema,
+  run: async (payload, { ctx }) => {
+    const { TeamRepository } = await import("@calcom/features/ee/teams/repositories/TeamRepository");
+    const { MonthlyProrationRepository } = await import(
+      "@calcom/features/ee/billing/repository/proration/MonthlyProrationRepository"
+    );
+    const { StripeBillingService } = await import(
+      "@calcom/features/ee/billing/service/billingProvider/StripeBillingService"
+    );
+    const stripe = (await import("@calcom/features/ee/payments/server/stripe")).default;
+    const { prisma } = await import("@calcom/prisma");
+
+    const prorationRepository = new MonthlyProrationRepository(prisma);
+    const teamRepository = new TeamRepository(prisma);
+    const billingService = new StripeBillingService(stripe);
+
+    const [proration, team, invoice] = await Promise.all([
+      prorationRepository.findById(payload.prorationId),
+      teamRepository.findById({ id: payload.teamId }),
+      billingService.getInvoice(payload.invoiceId),
+    ]);
+
+    if (!proration || !team || !invoice) {
+      return {
+        success: false,
+        reason: "Missing data",
+        hasProration: !!proration,
+        hasTeam: !!team,
+        hasInvoice: !!invoice,
+      };
+    }
+
+    if (!invoice.hostedInvoiceUrl) {
+      return { success: false, reason: "Invoice has no hosted URL" };
+    }
+
+    const permission = team.isOrganization ? "organization.manageBilling" : "team.manageBilling";
+    const recipients = await teamRepository.findTeamMembersWithPermission({
+      teamId: payload.teamId,
+      permission,
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
+
+    if (recipients.length === 0) {
+      return { success: false, reason: "No recipients with billing permission" };
+    }
+
+    const amountFormatted = formatAmount(invoice.amountDue, invoice.currency);
+
+    // Batch trigger individual emails for each recipient
+    const emailPayloads = recipients.map((recipient) => ({
+      payload: {
+        prorationId: payload.prorationId,
+        invoiceId: payload.invoiceId,
+        teamId: payload.teamId,
+        recipientEmail: recipient.email,
+        recipientLocale: recipient.locale ?? "en",
+        teamName: team.name ?? "",
+        seatCount: proration.netSeatIncrease,
+        amountFormatted,
+        invoiceUrl: invoice.hostedInvoiceUrl!,
+        isReminder: false,
+      },
+    }));
+
+    const batchResult = await sendInvoiceEmail.batchTrigger(emailPayloads);
+
+    return {
+      success: true,
+      recipientCount: recipients.length,
+      batchId: batchResult.batchId,
+      runs: batchResult.runs.map((run) => run.id),
+    };
+  },
+});
+
+function formatAmount(amountInCents: number, currency: string): string {
+  const amount = amountInCents / 100;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency.toUpperCase(),
+  }).format(amount);
+}

--- a/packages/features/ee/billing/service/proration/tasker/trigger/sendInvoiceEmail.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/sendInvoiceEmail.ts
@@ -1,0 +1,34 @@
+import { schemaTask } from "@trigger.dev/sdk";
+
+import { monthlyProrationTaskConfig } from "./config";
+import { invoiceEmailSchema } from "./invoiceNotificationSchema";
+
+export const sendInvoiceEmail = schemaTask({
+  id: "billing.proration-invoice.send-email",
+  ...monthlyProrationTaskConfig,
+  schema: invoiceEmailSchema,
+  run: async (payload) => {
+    const { getTranslation } = await import("@calcom/lib/server/i18n");
+    const ProrationInvoiceEmail = (await import("@calcom/emails/templates/proration-invoice-email")).default;
+
+    const t = await getTranslation(payload.recipientLocale, "common");
+
+    const email = new ProrationInvoiceEmail({
+      to: payload.recipientEmail,
+      language: t,
+      teamName: payload.teamName,
+      seatCount: payload.seatCount,
+      amountFormatted: payload.amountFormatted,
+      invoiceUrl: payload.invoiceUrl,
+      isReminder: payload.isReminder,
+    });
+
+    await email.sendEmail();
+
+    return {
+      success: true,
+      recipientEmail: payload.recipientEmail,
+      isReminder: payload.isReminder,
+    };
+  },
+});

--- a/packages/features/ee/billing/service/proration/tasker/trigger/sendInvoiceReminderNotification.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/sendInvoiceReminderNotification.ts
@@ -1,0 +1,103 @@
+import { schemaTask } from "@trigger.dev/sdk";
+
+import { MembershipRole } from "@calcom/prisma/enums";
+
+import { monthlyProrationTaskConfig } from "./config";
+import { invoiceNotificationSchema } from "./invoiceNotificationSchema";
+import { sendInvoiceEmail } from "./sendInvoiceEmail";
+
+export const sendInvoiceReminderNotification = schemaTask({
+  id: "billing.proration-invoice.reminder-notification",
+  ...monthlyProrationTaskConfig,
+  schema: invoiceNotificationSchema,
+  run: async (payload) => {
+    const { TeamRepository } = await import("@calcom/features/ee/teams/repositories/TeamRepository");
+    const { MonthlyProrationRepository } = await import(
+      "@calcom/features/ee/billing/repository/proration/MonthlyProrationRepository"
+    );
+    const { StripeBillingService } = await import(
+      "@calcom/features/ee/billing/service/billingProvider/StripeBillingService"
+    );
+    const stripe = (await import("@calcom/features/ee/payments/server/stripe")).default;
+    const { prisma } = await import("@calcom/prisma");
+
+    const prorationRepository = new MonthlyProrationRepository(prisma);
+    const teamRepository = new TeamRepository(prisma);
+    const billingService = new StripeBillingService(stripe);
+
+    const [proration, team, invoice] = await Promise.all([
+      prorationRepository.findById(payload.prorationId),
+      teamRepository.findById({ id: payload.teamId }),
+      billingService.getInvoice(payload.invoiceId),
+    ]);
+
+    if (!proration || !team || !invoice) {
+      return {
+        success: false,
+        reason: "Missing data",
+        hasProration: !!proration,
+        hasTeam: !!team,
+        hasInvoice: !!invoice,
+      };
+    }
+
+    // Skip if invoice is no longer open (paid, voided, etc.)
+    if (invoice.status !== "open") {
+      return {
+        success: true,
+        skipped: true,
+        reason: `Invoice status is ${invoice.status}, not open`,
+      };
+    }
+
+    if (!invoice.hostedInvoiceUrl) {
+      return { success: false, reason: "Invoice has no hosted URL" };
+    }
+
+    const permission = team.isOrganization ? "organization.manageBilling" : "team.manageBilling";
+    const recipients = await teamRepository.findTeamMembersWithPermission({
+      teamId: payload.teamId,
+      permission,
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
+
+    if (recipients.length === 0) {
+      return { success: false, reason: "No recipients with billing permission" };
+    }
+
+    const amountFormatted = formatAmount(invoice.amountDue, invoice.currency);
+
+    // Batch trigger individual reminder emails for each recipient
+    const emailPayloads = recipients.map((recipient) => ({
+      payload: {
+        prorationId: payload.prorationId,
+        invoiceId: payload.invoiceId,
+        teamId: payload.teamId,
+        recipientEmail: recipient.email,
+        recipientLocale: recipient.locale ?? "en",
+        teamName: team.name ?? "",
+        seatCount: proration.netSeatIncrease,
+        amountFormatted,
+        invoiceUrl: invoice.hostedInvoiceUrl!,
+        isReminder: true,
+      },
+    }));
+
+    const batchResult = await sendInvoiceEmail.batchTrigger(emailPayloads);
+
+    return {
+      success: true,
+      recipientCount: recipients.length,
+      batchId: batchResult.batchId,
+      runs: batchResult.runs.map((run) => run.id),
+    };
+  },
+});
+
+function formatAmount(amountInCents: number, currency: string): string {
+  const amount = amountInCents / 100;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency.toUpperCase(),
+  }).format(amount);
+}

--- a/packages/features/ee/billing/service/proration/tasker/trigger/sendInvoiceReminderNotification.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/sendInvoiceReminderNotification.ts
@@ -4,7 +4,6 @@ import { MembershipRole } from "@calcom/prisma/enums";
 
 import { monthlyProrationTaskConfig } from "./config";
 import { invoiceNotificationSchema } from "./invoiceNotificationSchema";
-import { sendInvoiceEmail } from "./sendInvoiceEmail";
 
 export const sendInvoiceReminderNotification = schemaTask({
   id: "billing.proration-invoice.reminder-notification",
@@ -20,6 +19,7 @@ export const sendInvoiceReminderNotification = schemaTask({
     );
     const stripe = (await import("@calcom/features/ee/payments/server/stripe")).default;
     const { prisma } = await import("@calcom/prisma");
+    const { sendInvoiceEmail } = await import("./sendInvoiceEmail");
 
     const prorationRepository = new MonthlyProrationRepository(prisma);
     const teamRepository = new TeamRepository(prisma);

--- a/packages/features/ee/billing/service/proration/tasker/types.ts
+++ b/packages/features/ee/billing/service/proration/tasker/types.ts
@@ -6,3 +6,17 @@ export type MonthlyProrationBatchPayload = {
 export interface IMonthlyProrationTasker {
   processBatch(payload: MonthlyProrationBatchPayload): Promise<{ runId: string }>;
 }
+
+export type InvoiceNotificationPayload = {
+  prorationId: string;
+  invoiceId: string;
+  teamId: number;
+};
+
+export interface IProrationInvoiceNotificationTasker {
+  sendInvoiceCreatedNotification(payload: InvoiceNotificationPayload): Promise<{ runId: string }>;
+  sendInvoiceReminderNotification(
+    payload: InvoiceNotificationPayload,
+    options?: { delay?: string }
+  ): Promise<{ runId: string }>;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds email notifications for monthly proration invoices. Sends an email on invoice creation and a 7-day reminder if payment is still pending.

- **New Features**
  - New proration invoice email template and localized strings (subject, heading, body, CTA).
  - MonthlyProrationService dispatches notifications after invoice creation; reminder only for send_invoice.
  - Tasker setup (sync + Trigger.dev async) with DI modules to send and schedule notifications.
  - Added billing provider getInvoice; Stripe implementation returns hosted URL, status, amount, and currency.
  - Trigger.dev tasks batch email recipients with billing permission (fallback to Admin/Owner), including team name, seats added, amount, and invoice link.

<sup>Written for commit 0f11a716e32c3293b4cd23f4860b17f4afb30e4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

