### PR TITLE
refactor: platform billing jobs tasks constants

### DIFF
--- a/apps/api/v2/src/modules/billing/services/billing.service.ts
+++ b/apps/api/v2/src/modules/billing/services/billing.service.ts
@@ -1,3 +1,4 @@
+import { getIncrementUsageIdempotencyKey, getIncrementUsageJobTag } from "@calcom/platform-libraries/tasker";
 import { InjectQueue } from "@nestjs/bull";
 import {
   BadRequestException,
@@ -453,8 +454,8 @@ export class BillingService implements IBillingService, OnModuleDestroy {
         payload: { userId },
         options: {
           delay: startTime,
-          tags: [`platform.billing.usage.${uid}`],
-          idempotencyKey: `platform.billing.usage.${uid}-${userId}`,
+          tags: [getIncrementUsageJobTag(uid)],
+          idempotencyKey: getIncrementUsageIdempotencyKey(uid, userId),
         },
       });
       return true;

--- a/apps/api/v2/tsconfig.json
+++ b/apps/api/v2/tsconfig.json
@@ -33,7 +33,8 @@
       "@calcom/platform-libraries/private-links": ["../../../packages/platform/libraries/private-links.ts"],
       "@calcom/platform-libraries/organizations": ["../../../packages/platform/libraries/organizations.ts"],
       "@calcom/platform-libraries/errors": ["../../../packages/platform/libraries/errors.ts"],
-      "@calcom/platform-libraries/calendars": ["../../../packages/platform/libraries/calendars.ts"]
+      "@calcom/platform-libraries/calendars": ["../../../packages/platform/libraries/calendars.ts"],
+      "@calcom/platform-libraries/tasker": ["../../../packages/platform/libraries/tasker.ts"]
     },
     "incremental": true,
     "skipLibCheck": true,

--- a/packages/features/ee/organizations/lib/billing/tasker/constants.ts
+++ b/packages/features/ee/organizations/lib/billing/tasker/constants.ts
@@ -1,0 +1,9 @@
+export const INCREMENT_USAGE_JOB_ID = "platform.billing.increment-usage";
+export const RESCHEDULE_USAGE_INCREMENT_JOB_ID = "platform.billing.reschedule-usage-increment";
+export const CANCEL_USAGE_INCREMENT_JOB_ID = "platform.billing.cancel-usage-increment";
+const INCREMENT_USAGE_JOB_TAG = "platform.billing.usage.";
+export const getIncrementUsageJobTag = (bookingUid: string): string =>
+  `${INCREMENT_USAGE_JOB_TAG}${bookingUid}`;
+const INCREMENT_USAGE_IDEMPOTENCY_KEY = `platform.billing.usage.`;
+export const getIncrementUsageIdempotencyKey = (bookingUid: string, userId: number): string =>
+  `${INCREMENT_USAGE_IDEMPOTENCY_KEY}${bookingUid}-${userId}`;

--- a/packages/features/ee/organizations/lib/billing/tasker/trigger/cancel-usage-increment.ts
+++ b/packages/features/ee/organizations/lib/billing/tasker/trigger/cancel-usage-increment.ts
@@ -1,10 +1,8 @@
 import { logger, runs, schemaTask, type TaskWithSchema } from "@trigger.dev/sdk";
 import type { z } from "zod";
-
+import { CANCEL_USAGE_INCREMENT_JOB_ID, getIncrementUsageJobTag } from "../constants";
 import { platformBillingTaskConfig } from "./config";
 import { platformBillingCancelUsageIncrementTaskSchema } from "./schema";
-
-export const CANCEL_USAGE_INCREMENT_JOB_ID = "platform.billing.cancel-usage-increment";
 
 export const cancelUsageIncrement: TaskWithSchema<
   typeof CANCEL_USAGE_INCREMENT_JOB_ID,
@@ -16,7 +14,7 @@ export const cancelUsageIncrement: TaskWithSchema<
   run: async (payload: z.infer<typeof platformBillingCancelUsageIncrementTaskSchema>) => {
     const runId: string = (
       await runs.list({
-        tag: `increment-${payload.bookingUid}`,
+        tag: getIncrementUsageJobTag(payload.bookingUid),
         limit: 1,
       })
     )?.data?.[0]?.id;

--- a/packages/features/ee/organizations/lib/billing/tasker/trigger/increment-usage.ts
+++ b/packages/features/ee/organizations/lib/billing/tasker/trigger/increment-usage.ts
@@ -1,10 +1,9 @@
 import { ErrorWithCode } from "@calcom/lib/errors";
 import { logger, schemaTask, type TaskWithSchema } from "@trigger.dev/sdk";
 import type { z } from "zod";
+import { INCREMENT_USAGE_JOB_ID } from "../constants";
 import { platformBillingTaskConfig } from "./config";
 import { platformBillingTaskSchema } from "./schema";
-
-export const INCREMENT_USAGE_JOB_ID = "platform.billing.increment-usage";
 
 export const incrementUsage: TaskWithSchema<typeof INCREMENT_USAGE_JOB_ID, typeof platformBillingTaskSchema> =
   schemaTask({

--- a/packages/features/ee/organizations/lib/billing/tasker/trigger/reschedule-usage-increment.ts
+++ b/packages/features/ee/organizations/lib/billing/tasker/trigger/reschedule-usage-increment.ts
@@ -1,9 +1,8 @@
 import { logger, runs, schemaTask, type TaskWithSchema } from "@trigger.dev/sdk";
 import type z from "zod";
+import { getIncrementUsageJobTag, RESCHEDULE_USAGE_INCREMENT_JOB_ID } from "../constants";
 import { platformBillingTaskConfig } from "./config";
 import { platformBillingRescheduleUsageIncrementTaskSchema } from "./schema";
-
-export const RESCHEDULE_USAGE_INCREMENT_JOB_ID = "platform.billing.reschedule-usage-increment";
 
 export const rescheduleUsageIncrement: TaskWithSchema<
   typeof RESCHEDULE_USAGE_INCREMENT_JOB_ID,
@@ -15,7 +14,7 @@ export const rescheduleUsageIncrement: TaskWithSchema<
   run: async (payload: z.infer<typeof platformBillingRescheduleUsageIncrementTaskSchema>) => {
     const runId: string = (
       await runs.list({
-        tag: `platform.billing.usage.${payload.bookingUid}`,
+        tag: getIncrementUsageJobTag(payload.bookingUid),
         limit: 1,
       })
     )?.data?.[0]?.id;

--- a/packages/platform/libraries/package.json
+++ b/packages/platform/libraries/package.json
@@ -109,6 +109,11 @@
       "import": "./dist/calendars.js",
       "require": "./dist/calendars.cjs",
       "types": "./dist/calendars.d.ts"
+    },
+    "./tasker": {
+      "import": "./dist/tasker.js",
+      "require": "./dist/tasker.cjs",
+      "types": "./dist/tasker.d.ts"
     }
   },
   "typesVersions": {
@@ -154,6 +159,9 @@
       ],
       "calendars": [
         "dist/calendars.d.ts"
+      ],
+      "tasker": [
+        "dist/tasker.d.ts"
       ]
     }
   }

--- a/packages/platform/libraries/tasker.ts
+++ b/packages/platform/libraries/tasker.ts
@@ -1,0 +1,7 @@
+export {
+  CANCEL_USAGE_INCREMENT_JOB_ID,
+  getIncrementUsageIdempotencyKey,
+  getIncrementUsageJobTag,
+  INCREMENT_USAGE_JOB_ID,
+  RESCHEDULE_USAGE_INCREMENT_JOB_ID,
+} from "@calcom/features/ee/organizations/lib/billing/tasker/constants";

--- a/packages/platform/libraries/vite.config.js
+++ b/packages/platform/libraries/vite.config.js
@@ -44,6 +44,7 @@ export default defineConfig({
         pbac: resolve(__dirname, "./pbac.ts"),
         errors: resolve(__dirname, "./errors.ts"),
         calendars: resolve(__dirname, "./calendars.ts"),
+        tasker: resolve(__dirname, "./tasker.ts"),
       },
       name: "calcom-lib",
       fileName: "calcom-lib",


### PR DESCRIPTION
## What does this PR do?

Centralizes platform billing job/task constants and helper functions to ensure consistent tags and idempotency keys across the API v2 BillingService and Trigger.dev tasks.

**Changes:**
- Creates new `constants.ts` with shared job IDs (`INCREMENT_USAGE_JOB_ID`, `RESCHEDULE_USAGE_INCREMENT_JOB_ID`, `CANCEL_USAGE_INCREMENT_JOB_ID`) and helper functions (`getIncrementUsageJobTag`, `getIncrementUsageIdempotencyKey`)
- Updates Trigger.dev tasks to import constants from the shared file instead of defining them locally
- Updates `BillingService` to use the shared helpers instead of hardcoded template strings
- Adds new `@calcom/platform-libraries/tasker` entry point to expose these utilities

## Visual Demo (For contributors especially)

N/A - This is a refactor with no UI changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This is a refactor that centralizes constants. Existing tests should continue to pass. No special environment setup required.

## Human Review Checklist

- [ ] Verify the tag format change in `cancel-usage-increment.ts` is correct: changed from `increment-${bookingUid}` to `platform.billing.usage.${bookingUid}` (aligns with the format used in `reschedule-usage-increment.ts` and `BillingService`)

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized platform billing job/task constants and helpers to ensure consistent tags and idempotency keys across the API and Trigger.dev tasks. Added a new platform library entry point to expose these utilities.

- **Refactors**
  - Added shared constants and helpers (job IDs, getIncrementUsageJobTag, getIncrementUsageIdempotencyKey) and exported them via @calcom/platform-libraries/tasker.
  - Updated BillingService and usage increment/cancel/reschedule tasks to use the shared helpers instead of hard-coded strings.
  - Added the new tasker entry to platform libraries (exports, types, path alias, and Vite build config).

<sup>Written for commit e6d0dfccbe724e923a6657f2e5cd7bbe6be5908b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->