### PR TITLE
fix: update API key modal text and reorder developer settings sidebar

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/SettingsLayoutAppDirClient.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/SettingsLayoutAppDirClient.tsx
@@ -143,14 +143,14 @@ const getTabs = (orgBranding: OrganizationBranding | null) => {
           trackingMetadata: { section: "developer", page: "webhooks" },
         },
         {
+          name: "oAuth",
+          href: "/settings/developer/oauth",
+          trackingMetadata: { section: "developer", page: "oauth_clients" },
+        },
+        {
           name: "api_keys",
           href: "/settings/developer/api-keys",
           trackingMetadata: { section: "developer", page: "api_keys" },
-        },
-        {
-          name: "oAuth",
-          href: "/settings/developer/oauth",
-          trackingMetadata: { section: "developer", page: "oauth_clients" }
         },
         {
           name: "admin_api",

--- a/apps/web/modules/ee/api-keys/components/ApiKeyDialogForm.tsx
+++ b/apps/web/modules/ee/api-keys/components/ApiKeyDialogForm.tsx
@@ -164,7 +164,7 @@ export default function ApiKeyDialogForm({
                 <Link
                   target="_blank"
                   rel="noopener noreferrer"
-                  href="https://cal.com/platform"
+                  href="https://cal.com/integrate"
                   className="border-subtle relative flex w-full items-start rounded-[10px] border p-4 text-sm">
                   {t("api_key_modal_subtitle_platform")}
                 </Link>

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1448,7 +1448,7 @@
   "test_failed": "Test failed",
   "provide_api_key": "Provide API key",
   "api_key_modal_subtitle": "API keys allow you to make API calls for your own account.",
-  "api_key_modal_subtitle_platform": "Create a marketplace or platform instead.",
+  "api_key_modal_subtitle_platform": "Create an OAuth app and allow user to schedule.",
   "api_keys_subtitle": "Generate API keys to use for accessing your own account.",
   "create_api_key": "Create an API key",
   "personal_note": "Name this key",


### PR DESCRIPTION
## What does this PR do?

Updates the API key creation modal and developer settings sidebar based on user feedback:

1. **Text update**: Changed the platform link text from "Create a marketplace or platform instead." to "Create an OAuth app and allow user to schedule."
2. **URL update**: Changed the link destination from `cal.com/platform` to `cal.com/integrate`
3. **Sidebar reorder**: Moved OAuth above API keys in the developer settings sidebar navigation

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - text/UI ordering changes only.

## How should this be tested?

1. Navigate to Settings → Developer → API Keys
2. Click "Create an API key" button
3. Verify the modal shows the updated text: "Create an OAuth app and allow user to schedule."
4. Verify clicking the text links to `https://cal.com/integrate`
5. In the developer settings sidebar, verify OAuth appears above API keys

## Human Review Checklist

- [ ] Verify `https://cal.com/integrate` is the correct destination URL
- [ ] Verify the new text accurately describes the OAuth integration flow
- [ ] Confirm the sidebar order (OAuth above API keys) is intentional

---

**Link to Devin run**: https://app.devin.ai/sessions/f3158f87af0a4ee7982f79c10734e945
**Requested by**: @PeerRich