### PR TITLE
feat(companion): add app store rating prompts for iOS and Android

### DIFF
--- a/companion/bun.lock
+++ b/companion/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cal-companion",
@@ -33,6 +34,7 @@
         "expo-secure-store": "15.0.9-canary-20251230-fc48ddc",
         "expo-splash-screen": "31.0.14-canary-20251230-fc48ddc",
         "expo-status-bar": "3.0.10-canary-20251230-fc48ddc",
+        "expo-store-review": "9.0.10-canary-20251230-fc48ddc",
         "expo-web-browser": "15.0.11-canary-20251230-fc48ddc",
         "lucide-react-native": "0.562.0",
         "nativewind": "4.2.1",
@@ -1132,6 +1134,8 @@
     "expo-splash-screen": ["expo-splash-screen@31.0.14-canary-20251230-fc48ddc", "", { "dependencies": { "@expo/prebuild-config": "54.0.9-canary-20251230-fc48ddc" }, "peerDependencies": { "expo": "55.0.0-canary-20251230-fc48ddc" } }, "sha512-t6aBi/2u4JjAJ2GlqwO2+OZzwEY3vgV/JVeff0M+cZTM7v7ezaBtbuR/f/43KAvBWduNh+26sPlQC1lMO/pu3w=="],
 
     "expo-status-bar": ["expo-status-bar@3.0.10-canary-20251230-fc48ddc", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.2.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Lkbb3e6yyRtkmjpTfwIYbO9XDmhPeSipyJLBa5nADq8eiGf7kXZ1pmaLEelPl05azCPY3109bJzhvbonz86sIg=="],
+
+    "expo-store-review": ["expo-store-review@9.0.10-canary-20251230-fc48ddc", "", { "peerDependencies": { "expo": "55.0.0-canary-20251230-fc48ddc", "react-native": "*" } }, "sha512-n100Y4mTa2EnYbJItbtV8rMYPMimnV9Qgaz44s6g8zk59Jv1Qtv1fsCEXwD1M82QQc6YYmDHkOsN3fbi4ASrEQ=="],
 
     "expo-symbols": ["expo-symbols@1.1.0-canary-20251230-fc48ddc", "", { "dependencies": { "@expo-google-fonts/material-symbols": "^0.4.1", "sf-symbols-typescript": "^2.0.0" }, "peerDependencies": { "expo": "55.0.0-canary-20251230-fc48ddc", "expo-font": "14.1.0-canary-20251230-fc48ddc", "react": "*", "react-native": "*" } }, "sha512-3cDn97a5NP6bBBHhN/U9/QKZrvqoSUOYtaTPbfH/WBDJC/kM6hzD8/BQBNe7Vt9ygcAh2iFx3w5DcFlxsMyKAw=="],
 

--- a/companion/hooks/useAppStoreRating.ts
+++ b/companion/hooks/useAppStoreRating.ts
@@ -1,0 +1,102 @@
+import { useCallback } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Platform } from "react-native";
+
+/**
+ * Rating triggers - add new triggers here as needed.
+ * Each trigger will only prompt the user once (tracked via AsyncStorage).
+ */
+export const RatingTrigger = {
+  EVENT_TYPE_SAVED: "event_type_saved",
+  BOOKING_CONFIRMED: "booking_confirmed",
+  BOOKING_REJECTED: "booking_rejected",
+} as const;
+
+export type RatingTriggerType = (typeof RatingTrigger)[keyof typeof RatingTrigger];
+
+const STORAGE_KEY_PREFIX = "app_rating_triggered_";
+
+function getStorageKey(trigger: RatingTriggerType): string {
+  return `${STORAGE_KEY_PREFIX}${trigger}`;
+}
+
+async function requestReviewIfAvailable(): Promise<boolean> {
+  // Only available on native platforms (iOS/Android)
+  if (Platform.OS === "web") {
+    return false;
+  }
+
+  try {
+    // Dynamic import to avoid bundling issues on web
+    const StoreReview = await import("expo-store-review");
+    const isAvailable = await StoreReview.isAvailableAsync();
+    if (isAvailable) {
+      await StoreReview.requestReview();
+      return true;
+    }
+    return false;
+  } catch (error) {
+    console.warn("Failed to request app store review:", error);
+    return false;
+  }
+}
+
+async function hasAlreadyTriggered(trigger: RatingTriggerType): Promise<boolean> {
+  try {
+    const value = await AsyncStorage.getItem(getStorageKey(trigger));
+    return value === "true";
+  } catch (error) {
+    console.warn("Failed to check rating trigger status:", error);
+    return false;
+  }
+}
+
+async function markAsTriggered(trigger: RatingTriggerType): Promise<void> {
+  try {
+    await AsyncStorage.setItem(getStorageKey(trigger), "true");
+  } catch (error) {
+    console.warn("Failed to mark rating as triggered:", error);
+  }
+}
+
+/**
+ * Request an app store rating for a specific trigger.
+ * Only prompts the user once per trigger type.
+ *
+ * @param trigger - The trigger type from RatingTrigger
+ * @returns true if the rating dialog was shown, false otherwise
+ *
+ * @example
+ * // Request rating after first event type save
+ * await requestRating(RatingTrigger.EVENT_TYPE_SAVED);
+ *
+ * // Request rating after first booking confirmation
+ * await requestRating(RatingTrigger.BOOKING_CONFIRMED);
+ */
+export async function requestRating(trigger: RatingTriggerType): Promise<boolean> {
+  const alreadyTriggered = await hasAlreadyTriggered(trigger);
+  if (alreadyTriggered) {
+    return false;
+  }
+
+  await markAsTriggered(trigger);
+  return requestReviewIfAvailable();
+}
+
+/**
+ * Hook for requesting app store ratings.
+ * Provides a memoized callback for use in React components.
+ */
+export function useAppStoreRating() {
+  const requestRatingCallback = useCallback(
+    async (trigger: RatingTriggerType): Promise<boolean> => {
+      return requestRating(trigger);
+    },
+    []
+  );
+
+  return {
+    requestRating: requestRatingCallback,
+    RatingTrigger,
+  };
+}

--- a/companion/hooks/useBookings.ts
+++ b/companion/hooks/useBookings.ts
@@ -12,6 +12,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CACHE_CONFIG, queryKeys } from "@/config/cache.config";
 import { type Booking, CalComAPIService } from "@/services/calcom";
+import { requestRating, RatingTrigger } from "@/hooks/useAppStoreRating";
 
 /**
  * Filter options for fetching bookings
@@ -225,6 +226,9 @@ export function useConfirmBooking() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.bookings.detail(variables.uid),
       });
+
+      // Request app store rating on first booking confirmation
+      requestRating(RatingTrigger.BOOKING_CONFIRMED);
     },
     onError: (_error) => {
       console.error("Failed to confirm booking");
@@ -258,6 +262,9 @@ export function useDeclineBooking() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.bookings.detail(variables.uid),
       });
+
+      // Request app store rating on first booking rejection
+      requestRating(RatingTrigger.BOOKING_REJECTED);
     },
     onError: (_error) => {
       console.error("Failed to decline booking");

--- a/companion/hooks/useEventTypes.ts
+++ b/companion/hooks/useEventTypes.ts
@@ -12,6 +12,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CACHE_CONFIG, queryKeys } from "@/config/cache.config";
 import { CalComAPIService, type CreateEventTypeInput, type EventType } from "@/services/calcom";
+import { requestRating, RatingTrigger } from "@/hooks/useAppStoreRating";
 
 /**
  * Hook to fetch all event types
@@ -94,6 +95,9 @@ export function useCreateEventType() {
 
       // Optionally, add the new event type to cache immediately
       queryClient.setQueryData(queryKeys.eventTypes.detail(newEventType.id), newEventType);
+
+      // Request app store rating on first event type save
+      requestRating(RatingTrigger.EVENT_TYPE_SAVED);
     },
     onError: (error) => {
       console.error("Failed to create event type");
@@ -180,6 +184,9 @@ export function useUpdateEventType() {
         // If list cache doesn't exist, invalidate to trigger refetch when user navigates to list
         queryClient.invalidateQueries({ queryKey: queryKeys.eventTypes.lists() });
       }
+
+      // Request app store rating on first event type save
+      requestRating(RatingTrigger.EVENT_TYPE_SAVED);
     },
     onError: (error, variables, context) => {
       // Rollback to previous values on error

--- a/companion/package.json
+++ b/companion/package.json
@@ -78,6 +78,7 @@
     "expo-secure-store": "15.0.9-canary-20251230-fc48ddc",
     "expo-splash-screen": "31.0.14-canary-20251230-fc48ddc",
     "expo-status-bar": "3.0.10-canary-20251230-fc48ddc",
+    "expo-store-review": "9.0.8-canary-20251230-fc48ddc",
     "expo-web-browser": "15.0.11-canary-20251230-fc48ddc",
     "lucide-react-native": "0.562.0",
     "nativewind": "4.2.1",

--- a/companion/package.json
+++ b/companion/package.json
@@ -78,7 +78,7 @@
     "expo-secure-store": "15.0.9-canary-20251230-fc48ddc",
     "expo-splash-screen": "31.0.14-canary-20251230-fc48ddc",
     "expo-status-bar": "3.0.10-canary-20251230-fc48ddc",
-    "expo-store-review": "9.0.8-canary-20251230-fc48ddc",
+    "expo-store-review": "9.0.10-canary-20251230-fc48ddc",
     "expo-web-browser": "15.0.11-canary-20251230-fc48ddc",
     "lucide-react-native": "0.562.0",
     "nativewind": "4.2.1",


### PR DESCRIPTION
## What does this PR do?

Adds app store rating prompts to the Cal.com companion mobile app. The rating dialog will be shown to users on their first:
- Event type save (create or update)
- Booking confirmation
- Booking rejection/decline

The implementation uses `expo-store-review` which provides native iOS (SKStoreReviewController) and Android (ReviewManager) APIs for in-app reviews. Rating prompt state is persisted using AsyncStorage to ensure users are only prompted once per trigger type.

## Key Changes

- **New `useAppStoreRating` hook** with a generalized `requestRating(trigger)` function for easy extensibility
- **`RatingTrigger` const** with typed trigger values - adding new triggers only requires adding to this const
- Integrated rating prompts into `useCreateEventType`, `useUpdateEventType`, `useConfirmBooking`, and `useDeclineBooking` hooks
- Added `expo-store-review` package dependency

## Visual Demo

N/A - Store review APIs only work on real devices with apps installed from the App Store/Play Store. The rating dialog cannot be demonstrated in development or simulators.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Build the companion app for iOS or Android
2. Install on a physical device (simulators won't show the rating dialog)
3. Create or update an event type - rating prompt should appear on first occurrence
4. Confirm a pending booking - rating prompt should appear on first occurrence
5. Decline a pending booking - rating prompt should appear on first occurrence
6. Repeat the same actions - rating prompt should NOT appear again (tracked via AsyncStorage)

**Note:** The native store review APIs have rate limiting built in by Apple/Google, so the dialog may not always appear even when requested.

## Human Review Checklist

- [ ] Verify `expo-store-review` version `9.0.10-canary-20251230-fc48ddc` matches the canary date pattern used by other expo packages
- [ ] Confirm fire-and-forget pattern (no `await` on `requestRating()` calls) is acceptable
- [ ] Review that the trigger points match the requirements (first event type save, first booking confirm/reject)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

Link to Devin run: https://app.devin.ai/sessions/c5b4208f757648fbb5608242765593c8
Requested by: @PeerRich