### PR TITLE
feat: rename Automation category to AI & Automation

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1299,7 +1299,7 @@
   "disconnect": "Disconnect",
   "embed_your_calendar": "Embed your calendar within your webpage",
   "connect_your_favourite_apps": "Connect your favourite apps.",
-  "automation": "Automation",
+  "automation": "AI & Automation",
   "configure_how_your_event_types_interact": "Configure how your event types should interact with your calendars.",
   "toggle_calendars_conflict": "Toggle the calendars you want to check for conflicts to prevent double bookings.",
   "connect_additional_calendar": "Connect additional calendar",

--- a/packages/app-store-cli/src/components/AppCreateUpdateForm.tsx
+++ b/packages/app-store-cli/src/components/AppCreateUpdateForm.tsx
@@ -87,7 +87,7 @@ export const AppForm = ({
       options: [
         // Manually sorted alphabetically
         { label: "Analytics", value: "analytics" },
-        { label: "Automation", value: "automation" },
+        { label: "AI & Automation", value: "automation" },
         { label: "Calendar", value: "calendar" },
         { label: "Conferencing", value: "conferencing" },
         { label: "CRM", value: "crm" },


### PR DESCRIPTION
## What does this PR do?

Renames the "Automation" app category display name to "AI & Automation" while preserving the `automation` slug/identifier.

Changes made:
- Updated the translation string in `common.json` from "Automation" to "AI & Automation"
- Updated the CLI category label in `AppCreateUpdateForm.tsx` from "Automation" to "AI & Automation"

The category slug remains `automation` in both places - only the user-facing display strings are changed.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - simple string change.

## How should this be tested?

1. Navigate to `/apps/categories/automation` and verify the category displays as "AI & Automation"
2. Run the app-store CLI (`yarn create-app`) and verify the category dropdown shows "AI & Automation" as an option

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized (2 files, 4 lines changed)

---

### Human Review Checklist
- [ ] Verify the translation key `automation` renders correctly in the apps UI
- [ ] Confirm no other display strings reference "Automation" that should also be updated

---

**Link to Devin run:** https://app.devin.ai/sessions/c97268e3009a4732aab1b02266d7b7e1
**Requested by:** @PeerRich