### PR TITLE
fix: validate email format for optional email fields

### DIFF
--- a/apps/web/playwright/email-validation.e2e.ts
+++ b/apps/web/playwright/email-validation.e2e.ts
@@ -1,0 +1,113 @@
+import { expect } from "@playwright/test";
+
+import { test } from "./lib/fixtures";
+import { selectFirstAvailableTimeSlotNextMonth } from "./lib/testUtils";
+
+test.describe.configure({ mode: "parallel" });
+
+test.describe("Email field validation", () => {
+  test.afterEach(async ({ users }) => {
+    await users.deleteAll();
+  });
+
+  // This test demonstrates a validation gap: email format is not validated when the field is optional
+  test("should validate email format even when email field is optional", async ({ page, users }) => {
+    const user = await users.create({
+      eventTypes: [
+        {
+          title: "Phone Only Event",
+          slug: "phone-only",
+          length: 30,
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              label: "your_name",
+              sources: [{ id: "default", type: "default", label: "Default" }],
+              editable: "system",
+              required: true,
+              defaultLabel: "your_name",
+            },
+            {
+              name: "email",
+              type: "email",
+              label: "email_address",
+              sources: [{ id: "default", type: "default", label: "Default" }],
+              editable: "system-but-optional",
+              required: false,
+              defaultLabel: "email_address",
+            },
+            {
+              name: "attendeePhoneNumber",
+              type: "phone",
+              label: "phone_number",
+              sources: [{ id: "default", type: "default", label: "Default" }],
+              editable: "system-but-optional",
+              required: true,
+              defaultLabel: "phone_number",
+            },
+            {
+              name: "notes",
+              type: "textarea",
+              label: "additional_notes",
+              sources: [{ id: "default", type: "default", label: "Default" }],
+              editable: "system-but-optional",
+              required: false,
+              defaultLabel: "additional_notes",
+            },
+            {
+              name: "guests",
+              type: "multiemail",
+              label: "additional_guests",
+              sources: [{ id: "default", type: "default", label: "Default" }],
+              editable: "system-but-optional",
+              required: false,
+              defaultLabel: "additional_guests",
+            },
+            {
+              name: "rescheduleReason",
+              type: "textarea",
+              label: "reason_for_reschedule",
+              sources: [{ id: "default", type: "default", label: "Default" }],
+              editable: "system-but-optional",
+              required: false,
+              defaultLabel: "reason_for_reschedule",
+              views: [{ id: "reschedule", label: "Reschedule View" }],
+            },
+          ],
+        },
+      ],
+      overrideDefaultEventTypes: true,
+    });
+
+    await page.goto(`/${user.username}/phone-only`);
+    await selectFirstAvailableTimeSlotNextMonth(page);
+
+    await page.fill('[name="name"]', "Test User");
+    await page.fill('[name="email"]', "+393496191286");
+    await page.fill('[name="attendeePhoneNumber"]', "+393496191286");
+
+    await page.locator('[data-testid="confirm-book-button"]').click();
+
+    const emailError = page.locator('[data-fob-field-name="email"] [role="alert"]');
+    await expect(emailError).toBeVisible({ timeout: 5000 });
+  });
+
+  test("should show validation error when phone number is entered in required email field", async ({
+    page,
+    users,
+  }) => {
+    const user = await users.create();
+
+    await page.goto(`/${user.username}/30-min`);
+    await selectFirstAvailableTimeSlotNextMonth(page);
+
+    await page.fill('[name="name"]', "Test User");
+    await page.fill('[name="email"]', "+393496191286");
+
+    await page.locator('[data-testid="confirm-book-button"]').click();
+
+    const emailError = page.locator('[data-fob-field-name="email"] [role="alert"]');
+    await expect(emailError).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/apps/web/playwright/email-validation.e2e.ts
+++ b/apps/web/playwright/email-validation.e2e.ts
@@ -16,15 +16,15 @@ test.describe("Email field validation", () => {
     const user = await users.create();
     await user.apiLogin();
 
-    // Get the first event type ID
-    const eventTypes = await user.getEventTypes();
-    const eventTypeId = eventTypes[0].id;
+    // Get the first event type (30-min is the default)
+    const eventType = user.eventTypes.find((e) => e.slug === "30-min");
+    if (!eventType) throw new Error("Event type not found");
 
     // Configure the event type to have phone required and email optional
-    await markPhoneNumberAsRequiredAndEmailAsOptional(page, eventTypeId);
+    await markPhoneNumberAsRequiredAndEmailAsOptional(page, eventType.id);
 
     // Go to the booking page
-    await page.goto(`/${user.username}/${eventTypes[0].slug}`);
+    await page.goto(`/${user.username}/${eventType.slug}`);
     await selectFirstAvailableTimeSlotNextMonth(page);
 
     // Fill in the form with a phone number in the email field

--- a/apps/web/playwright/email-validation.e2e.ts
+++ b/apps/web/playwright/email-validation.e2e.ts
@@ -10,7 +10,7 @@ test.describe("Email field validation", () => {
     await users.deleteAll();
   });
 
-  // This test demonstrates a validation gap: email format is not validated when the field is optional
+  // This test verifies that email format is validated even when the email field is optional
   test("should validate email format even when email field is optional", async ({ page, users }) => {
     const user = await users.create({
       eventTypes: [

--- a/apps/web/playwright/email-validation.e2e.ts
+++ b/apps/web/playwright/email-validation.e2e.ts
@@ -89,7 +89,7 @@ test.describe("Email field validation", () => {
 
     await page.locator('[data-testid="confirm-book-button"]').click();
 
-    const emailError = page.locator('[data-fob-field-name="email"] [role="alert"]');
+    const emailError = page.locator('[data-testid="error-message-email"]');
     await expect(emailError).toBeVisible({ timeout: 5000 });
   });
 
@@ -107,7 +107,7 @@ test.describe("Email field validation", () => {
 
     await page.locator('[data-testid="confirm-book-button"]').click();
 
-    const emailError = page.locator('[data-fob-field-name="email"] [role="alert"]');
+    const emailError = page.locator('[data-testid="error-message-email"]');
     await expect(emailError).toBeVisible({ timeout: 5000 });
   });
 });

--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -176,6 +176,74 @@ describe("getBookingResponsesSchema", () => {
         );
       });
 
+      test(`optional email field should validate format when non-empty value is provided`, async () => {
+        const schema = getBookingResponsesSchema({
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              required: true,
+            },
+            {
+              name: "email",
+              type: "email",
+              required: false,
+            },
+            {
+              name: "attendeePhoneNumber",
+              type: "phone",
+              required: true,
+            },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+          view: "ALL_VIEWS",
+        });
+        // Phone number in email field should fail validation even if email is optional
+        const parsedResponses = await schema.safeParseAsync({
+          name: "John",
+          email: "+393496191286",
+          attendeePhoneNumber: "+919999999999",
+        });
+        expect(parsedResponses.success).toBe(false);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        expect(parsedResponses.error.issues[0]).toEqual(
+          expect.objectContaining({
+            message: `{email}${CUSTOM_EMAIL_VALIDATION_ERROR_MSG}`,
+            code: "custom",
+          })
+        );
+      });
+
+      test(`optional email field should allow empty value`, async () => {
+        const schema = getBookingResponsesSchema({
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              required: true,
+            },
+            {
+              name: "email",
+              type: "email",
+              required: false,
+            },
+            {
+              name: "attendeePhoneNumber",
+              type: "phone",
+              required: true,
+            },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+          view: "ALL_VIEWS",
+        });
+        // Empty email should be allowed when email is optional
+        const parsedResponses = await schema.safeParseAsync({
+          name: "John",
+          email: "",
+          attendeePhoneNumber: "+919999999999",
+        });
+        expect(parsedResponses.success).toBe(true);
+      });
+
       test(`hidden required email field should not be validated`, async () => {
         const schema = getBookingResponsesSchema({
           bookingFields: [

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -216,7 +216,11 @@ function preprocess<T extends z.ZodType>({
         }
 
         if (bookingField.type === "email") {
-          if (!bookingField.hidden && (checkOptional || bookingField.required)) {
+          // Determine if the email field needs validation (same pattern as phone field)
+          const needsValidation =
+            checkOptional || bookingField.required || (value && String(value).trim() !== "");
+
+          if (!bookingField.hidden && needsValidation) {
             // Email RegExp to validate if the input is a valid email
             if (!emailSchema.safeParse(value).success) {
               ctx.addIssue({

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -217,8 +217,7 @@ function preprocess<T extends z.ZodType>({
 
         if (bookingField.type === "email") {
           // Determine if the email field needs validation (same pattern as phone field)
-          const needsValidation =
-            checkOptional || bookingField.required || (value && String(value).trim() !== "");
+          const needsValidation = isRequired || (value && String(value).trim() !== "");
 
           if (!bookingField.hidden && needsValidation) {
             // Email RegExp to validate if the input is a valid email

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -217,7 +217,7 @@ function preprocess<T extends z.ZodType>({
 
         if (bookingField.type === "email") {
           // Determine if the email field needs validation (same pattern as phone field)
-          const needsValidation = isRequired || (value && String(value).trim() !== "");
+          const needsValidation = isRequired || (value && value.trim() !== "");
 
           if (!bookingField.hidden && needsValidation) {
             // Email RegExp to validate if the input is a valid email


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/calcom/cal.com/issues/27299

This PR fixes a validation gap where phone numbers could be entered in optional email fields without any format validation, causing 500 errors during iCal generation and silent email sending failures.

Related to #27217 which fixes the error handling for this issue.

## The Fix

In `getBookingResponsesSchema.ts`, email format validation now runs whenever a non-empty value is provided, even if the field is optional. This follows the exact same pattern already used for phone field validation (lines 326-337):

```typescript
// Determine if the email field needs validation (same pattern as phone field)
const needsValidation = isRequired || (value && value.trim() !== "");

if (!bookingField.hidden && needsValidation) {
  // Email RegExp to validate if the input is a valid email
  if (!emailSchema.safeParse(value).success) {
    ctx.addIssue({...});
  }
}
```

Since `getBookingResponsesSchema` is shared between frontend (`useBookingForm.ts`) and backend, this fix validates on both sides.

## Context

When an event type has the email field configured as optional (phone-only bookings), users could enter a phone number in the email field. Neither frontend nor backend validated the email format for optional fields, which later caused:
- **Initial booking**: Organizer doesn't receive confirmation email (fails silently)
- **Reschedule**: Returns 500 error to user (booking succeeds but user sees error)

## Tests Added

**Unit tests** in `getBookingResponsesSchema.test.ts`:
- `optional email field should validate format when non-empty value is provided` - verifies phone numbers in optional email fields fail validation
- `optional email field should allow empty value` - verifies empty optional email fields pass validation

**E2E tests** in `email-validation.e2e.ts`:
1. **"should validate email format even when email field is optional"** - Creates a user, configures event type through UI to have phone required and email optional, enters a phone number in the email field, and expects a validation error.
2. **"should show validation error when phone number is entered in required email field"** - Uses a default event type with required email field.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - validation fix only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the unit tests:
```bash
TZ=UTC yarn test packages/features/bookings/lib/getBookingResponsesSchema.test.ts -t "optional email field"
```

Run the e2e test:
```bash
PLAYWRIGHT_HEADLESS=1 yarn e2e apps/web/playwright/email-validation.e2e.ts
```

Manual testing:
1. Create a phone-only event type (email field optional, phone required)
2. Book the event and enter a phone number in the email field
3. Should see validation error preventing submission
4. Verify empty email field still works (no validation error when left empty)

## Human Review Checklist

- [ ] Verify the `isRequired` variable correctly handles all edge cases (hidden fields, view applicability)
- [ ] Verify empty optional email fields still work (no validation error when left empty)
- [ ] Confirm the validation pattern matches the existing phone field validation logic exactly (lines 326-337)
- [ ] Check that e2e test selector `[data-testid="error-message-email"]` matches FormBuilderField error rendering

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---


**Link to Devin run:** https://app.devin.ai/sessions/cbaf3621d7f143688ae0ad35e196096a
**Requested by:** @hbjORbj