### PR TITLE
chore: add uuid column to CreditBalance model

### DIFF
--- a/packages/prisma/migrations/20260126133815_add_credit_balance_uuid_column/migration.sql
+++ b/packages/prisma/migrations/20260126133815_add_credit_balance_uuid_column/migration.sql
@@ -1,0 +1,48 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[uuid]` on the table `CreditBalance` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."CreditBalance" ADD COLUMN     "uuid" UUID;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CreditBalance_uuid_key" ON "public"."CreditBalance"("uuid");
+
+-- Backfill UUIDs in batches to avoid table locking on large datasets
+-- Uses FOR UPDATE SKIP LOCKED to prevent blocking other transactions
+-- Processes 1000 rows at a time with small delays between batches
+DO $$
+DECLARE
+  batch_size INT := 1000;
+  rows_updated INT;
+  total_updated INT := 0;
+BEGIN
+  LOOP
+    WITH batch AS (
+      SELECT id
+      FROM "public"."CreditBalance"
+      WHERE uuid IS NULL
+      LIMIT batch_size
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE "public"."CreditBalance"
+    SET uuid = gen_random_uuid()
+    FROM batch
+    WHERE "public"."CreditBalance".id = batch.id;
+    
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+    total_updated := total_updated + rows_updated;
+    
+    EXIT WHEN rows_updated = 0;
+    
+    PERFORM pg_sleep(0.01);
+    
+    IF total_updated % 10000 = 0 THEN
+      RAISE NOTICE 'Updated % CreditBalance records with UUIDs', total_updated;
+    END IF;
+  END LOOP;
+  
+  RAISE NOTICE 'Completed: Updated % total CreditBalance records with UUIDs', total_updated;
+END $$;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -653,6 +653,7 @@ model Team {
 
 model CreditBalance {
   id                String              @id @default(uuid())
+  uuid              String?             @unique @default(uuid()) @db.Uuid
   team              Team?               @relation(fields: [teamId], references: [id], onDelete: Cascade)
   teamId            Int?                @unique
   // user credit balances will be supported in the future


### PR DESCRIPTION
## What does this PR do?

Adds a `uuid` column to the `CreditBalance` model, following the same pattern established in #24659 for the User table. This enables consistent UUID-based identification across models.

- The column is nullable to support existing rows
- New rows automatically get a UUID via `@default(uuid())`
- Existing rows are backfilled via a batched migration script

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - schema change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - schema migration only, follows established pattern from #24659.

## How should this be tested?

1. Run the migration: `yarn workspace @calcom/prisma db-migrate`
2. Verify the `uuid` column exists on `CreditBalance` table
3. Verify existing rows have UUIDs populated
4. Verify new `CreditBalance` records automatically get UUIDs

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the migration SQL follows the batched backfill pattern from #24659
- [ ] Confirm the `FOR UPDATE SKIP LOCKED` approach is appropriate for production safety
- [ ] Check schema change aligns with User table uuid implementation

---

### Link to Devin run
https://app.devin.ai/sessions/b698f871056c40bfba12e70d2f6b1f6c

### Requested by
@emrysal