### PR TITLE
fix: Improve the error handling in Stripe collectCard method

### DIFF
--- a/packages/app-store/stripepayment/lib/PaymentService.ts
+++ b/packages/app-store/stripepayment/lib/PaymentService.ts
@@ -220,33 +220,7 @@ class StripePaymentService implements IAbstractPaymentService {
         safeStringify(error)
       );
 
-      const errorMappings: Record<string, string> = {
-        "no such customer": "stripe_customer_not_found",
-        "invalid api key": "stripe_invalid_api_key",
-        "rate limit": "stripe_rate_limit_exceeded",
-        "account has been deactivated": "stripe_account_deactivated",
-        "this account cannot currently make live charges": "stripe_account_cannot_make_charges",
-      };
-
-      let userMessage = "could_not_collect_payment_method";
-
-      if (error instanceof Error) {
-        const errorMessage = error.message.toLowerCase();
-
-        for (const [key, message] of Object.entries(errorMappings)) {
-          if (errorMessage.includes(key)) {
-            userMessage = message;
-            break;
-          }
-        }
-      }
-
-      const stripeError = error as { type?: string; code?: string };
-      if (stripeError.type === "StripeCardError" || stripeError.code) {
-        userMessage = (stripeError as Stripe.errors.StripeError).message || userMessage;
-      }
-
-      throw new ErrorWithCode(ErrorCode.CollectCardFailure, userMessage);
+      throw new ErrorWithCode(ErrorCode.CollectCardFailure, "Stripe: Payment method could not be collected");
     }
   }
 

--- a/packages/app-store/stripepayment/lib/PaymentService.ts
+++ b/packages/app-store/stripepayment/lib/PaymentService.ts
@@ -219,7 +219,34 @@ class StripePaymentService implements IAbstractPaymentService {
         bookingId,
         safeStringify(error)
       );
-      throw new Error("Stripe: Payment method could not be collected");
+
+      const errorMappings: Record<string, string> = {
+        "no such customer": "stripe_customer_not_found",
+        "invalid api key": "stripe_invalid_api_key",
+        "rate limit": "stripe_rate_limit_exceeded",
+        "account has been deactivated": "stripe_account_deactivated",
+        "this account cannot currently make live charges": "stripe_account_cannot_make_charges",
+      };
+
+      let userMessage = "could_not_collect_payment_method";
+
+      if (error instanceof Error) {
+        const errorMessage = error.message.toLowerCase();
+
+        for (const [key, message] of Object.entries(errorMappings)) {
+          if (errorMessage.includes(key)) {
+            userMessage = message;
+            break;
+          }
+        }
+      }
+
+      const stripeError = error as { type?: string; code?: string };
+      if (stripeError.type === "StripeCardError" || stripeError.code) {
+        userMessage = (stripeError as Stripe.errors.StripeError).message || userMessage;
+      }
+
+      throw new ErrorWithCode(ErrorCode.CollectCardFailure, userMessage);
     }
   }
 

--- a/packages/lib/errorCodes.ts
+++ b/packages/lib/errorCodes.ts
@@ -10,6 +10,7 @@ export enum ErrorCode {
   PaymentCreationFailure = "payment_not_created_error",
   NoAvailableUsersFound = "no_available_users_found_error",
   ChargeCardFailure = "couldnt_charge_card_error",
+  CollectCardFailure = "couldnt_collect_card_error",
   RequestBodyWithouEnd = "request_body_end_time_internal_error",
   AlreadySignedUpForBooking = "already_signed_up_for_this_booking_error",
   FixedHostsUnavailableForBooking = "fixed_hosts_unavailable_for_booking",

--- a/packages/lib/errorCodes.ts
+++ b/packages/lib/errorCodes.ts
@@ -9,7 +9,9 @@ export enum ErrorCode {
   // Domain-specific error codes
   PaymentCreationFailure = "payment_not_created_error",
   NoAvailableUsersFound = "no_available_users_found_error",
+  // Thrown when charging a card fails (e.g., insufficient funds, card declined during actual payment)
   ChargeCardFailure = "couldnt_charge_card_error",
+  // Thrown when collecting/verifying a payment method fails (e.g., card setup failed during HOLD payment flow)
   CollectCardFailure = "couldnt_collect_card_error",
   RequestBodyWithouEnd = "request_body_end_time_internal_error",
   AlreadySignedUpForBooking = "already_signed_up_for_this_booking_error",

--- a/packages/lib/server/getServerErrorFromUnknown.test.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.test.ts
@@ -20,6 +20,7 @@ const test400Codes = [
   ErrorCode.BookerLimitExceeded,
   ErrorCode.BookerLimitExceededReschedule,
   ErrorCode.ChargeCardFailure,
+  ErrorCode.CollectCardFailure,
 ];
 
 const test404Codes = [

--- a/packages/lib/server/getServerErrorFromUnknown.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.ts
@@ -151,6 +151,7 @@ export function getHttpStatusCode(cause: Error | ErrorWithCode): number {
     case ErrorCode.EventTypeNoHosts:
     case ErrorCode.RequestBodyInvalid:
     case ErrorCode.ChargeCardFailure:
+    case ErrorCode.CollectCardFailure:
       return 400;
     // 409 Conflict
     case ErrorCode.NoAvailableUsersFound:


### PR DESCRIPTION
## What does this PR do?

Uses `ErrorWithCode` instead of a generic `Error` in the Stripe `collectCard` method, so failures return HTTP 400 instead of 500.

Changes:
- Add `CollectCardFailure` error code (distinct from `ChargeCardFailure` for actual payment charges)
- Map `CollectCardFailure` to HTTP 400 in `getHttpStatusCode`
- Add unit test coverage

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
