### PR TITLE
perf: add composite index on (formId, createdAt) for App_RoutingForms_FormResponse

### DIFF
--- a/packages/prisma/migrations/20260126173100_add_form_response_formid_createdat_index/migration.sql
+++ b/packages/prisma/migrations/20260126173100_add_form_response_formid_createdat_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "App_RoutingForms_FormResponse_formId_createdAt_idx" ON "App_RoutingForms_FormResponse"("formId", "createdAt");

--- a/packages/prisma/migrations/20260126173100_add_form_response_formid_createdat_index/migration.sql
+++ b/packages/prisma/migrations/20260126173100_add_form_response_formid_createdat_index/migration.sql
@@ -1,2 +1,2 @@
 -- CreateIndex
-CREATE INDEX CONCURRENTLY "App_RoutingForms_FormResponse_formId_createdAt_idx" ON "App_RoutingForms_FormResponse"("formId", "createdAt");
+CREATE INDEX "App_RoutingForms_FormResponse_formId_createdAt_idx" ON "App_RoutingForms_FormResponse"("formId", "createdAt");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1348,6 +1348,7 @@ model App_RoutingForms_FormResponse {
   @@unique([formFillerId, formId])
   @@index([formFillerId])
   @@index([formId])
+  @@index([formId, createdAt])
   @@index([routedToBookingUid])
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a composite index on `(formId, createdAt)` to the `App_RoutingForms_FormResponse` table to improve query performance.

This addresses a query that was causing `LWLock:BufferIO` contention on the database:

```sql
SELECT id, response FROM App_RoutingForms_FormResponse 
WHERE formId = $1 
  AND createdAt >= $2 
  AND createdAt < $3 
  AND routedToBookingUid IS NOT NULL 
  AND id != $4
OFFSET $5
```

The existing indexes only covered individual columns (`formId`, `routedToBookingUid`), forcing PostgreSQL to use the `formId` index and then scan all matching rows to filter by `createdAt`. This is quite slow when there's hundreds of thousands (and will be millions of records) to be filtered. The new composite index allows efficient range queries on both columns together.

## Changes

- Added `@@index([formId, createdAt])` to the Prisma schema

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - schema-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - index addition doesn't require tests.

## How should this be tested?

This is a database index addition. After migration:
1. Run the problematic query with `EXPLAIN ANALYZE` to verify the new index is being used
2. Monitor `LWLock:BufferIO` wait events to confirm reduction in I/O contention

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [x] Verify the composite index column order matches the query pattern (formId equality, then createdAt range) - ✅ Correct order
- [x] Consider if a partial index (`WHERE routedToBookingUid IS NOT NULL`) would be more efficient for this specific query (optional future optimization)

---

**Link to Devin run**: https://app.devin.ai/sessions/0812b1e9b0c34d99bf32ab45521304c4
**Requested by**: @keithwillcode