### PR TITLE
fix: prevent infinite redirect loop when session fetch fails

### DIFF
--- a/apps/web/modules/auth/hooks/useRedirectToLoginIfUnauthenticated.tsx
+++ b/apps/web/modules/auth/hooks/useRedirectToLoginIfUnauthenticated.tsx
@@ -2,26 +2,67 @@
 
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
+
+const REDIRECT_LOOP_STORAGE_KEY = "cal_auth_redirect_attempt";
+const REDIRECT_LOOP_THRESHOLD_MS = 5000; // 5 seconds window to detect loops
 
 export function useRedirectToLoginIfUnauthenticated(isPublic = false) {
   const { data: session, status } = useSession();
   const loading = status === "loading";
   const router = useRouter();
+  const hasAttemptedRedirect = useRef(false);
+
   useEffect(() => {
     if (isPublic) {
       return;
     }
 
     if (!loading && !session) {
+      // Prevent infinite redirect loops by checking if we've recently redirected
+      // This can happen when the session fetch fails due to DB issues but the user
+      // has a valid session cookie, causing login page to redirect back
+      if (typeof window !== "undefined") {
+        const lastRedirectAttempt = sessionStorage.getItem(REDIRECT_LOOP_STORAGE_KEY);
+        const now = Date.now();
+
+        if (lastRedirectAttempt) {
+          const timeSinceLastRedirect = now - parseInt(lastRedirectAttempt, 10);
+          if (timeSinceLastRedirect < REDIRECT_LOOP_THRESHOLD_MS) {
+            // We've redirected very recently, likely in a loop
+            // Don't redirect again to break the loop
+            console.warn(
+              "[useRedirectToLoginIfUnauthenticated] Detected potential redirect loop, skipping redirect"
+            );
+            return;
+          }
+        }
+
+        // Only redirect once per component mount to prevent multiple redirects
+        if (hasAttemptedRedirect.current) {
+          return;
+        }
+        hasAttemptedRedirect.current = true;
+
+        // Store the redirect attempt timestamp
+        sessionStorage.setItem(REDIRECT_LOOP_STORAGE_KEY, now.toString());
+      }
+
       const urlSearchParams = new URLSearchParams();
       urlSearchParams.set("callbackUrl", `${WEBAPP_URL}${location.pathname}${location.search}`);
       router.replace(`/auth/login?${urlSearchParams.toString()}`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, session, isPublic]);
+
+  // Clear the redirect loop detection when session is successfully loaded
+  useEffect(() => {
+    if (session && typeof window !== "undefined") {
+      sessionStorage.removeItem(REDIRECT_LOOP_STORAGE_KEY);
+    }
+  }, [session]);
 
   return {
     loading: loading && !session,


### PR DESCRIPTION
## What does this PR do?

Fixes an infinite redirect loop that occurs when visiting `/bookings/upcoming` (or other authenticated pages) while the database is struggling. When the session fetch fails due to DB issues, `useSession()` returns null, triggering a redirect to `/auth/login`. However, the login page's server-side code reads the session from the JWT cookie (which succeeds), and redirects back to the original page, creating an infinite loop that further destroys the database.

This PR adds loop detection to the `useRedirectToLoginIfUnauthenticated` hook:
- Uses sessionStorage to track redirect attempts within a 5-second window
- If a redirect was attempted within the last 5 seconds, skips the redirect to break the loop
- Uses a ref to prevent multiple redirects per component mount
- Clears the detection flag when session is successfully loaded

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This is difficult to test without simulating DB failures. Manual testing approach:

1. Visit an authenticated page like `/bookings/upcoming`
2. Simulate a session fetch failure (e.g., by temporarily blocking the `/api/auth/session` endpoint or causing DB issues)
3. Verify that the page does not enter an infinite redirect loop
4. Check browser console for the warning message: `[useRedirectToLoginIfUnauthenticated] Detected potential redirect loop, skipping redirect`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Is the 5-second threshold (`REDIRECT_LOOP_THRESHOLD_MS`) appropriate? Could legitimate use cases require faster redirects?
- [ ] Could this cause issues for users who genuinely need to be redirected to login?
- [ ] The `console.warn` will appear in production when a loop is detected - is this acceptable for debugging purposes?
- [ ] Consider whether automated tests should be added for this hook

---

Link to Devin run: https://app.devin.ai/sessions/0bea6110468f4e0e89d4e9a2d67f4308
Requested by: @keithwillcode