### PR TITLE
feat: implement soft delete for teams

### DIFF
--- a/packages/app-store/delegationCredential.test.ts
+++ b/packages/app-store/delegationCredential.test.ts
@@ -107,6 +107,7 @@ const mockOrganization = {
   rrResetInterval: null,
   rrTimestampBasis: RRTimestampBasis.CREATED_AT,
   autoOptInFeatures: false,
+  deletedAt: null,
 };
 
 // Credential Builders

--- a/packages/features/ee/teams/lib/tasker/trigger/config.ts
+++ b/packages/features/ee/teams/lib/tasker/trigger/config.ts
@@ -1,0 +1,20 @@
+import { queue, type schemaTask } from "@trigger.dev/sdk";
+
+type TeamCleanupTaskConfig = Pick<Parameters<typeof schemaTask>[0], "machine" | "retry" | "queue">;
+
+export const teamCleanupQueue = queue({
+  name: "team-cleanup",
+  concurrencyLimit: 1,
+});
+
+export const teamCleanupTaskConfig: TeamCleanupTaskConfig = {
+  queue: teamCleanupQueue,
+  machine: "small-2x",
+  retry: {
+    maxAttempts: 3,
+    factor: 2,
+    minTimeoutInMs: 1_000,
+    maxTimeoutInMs: 30_000,
+    randomize: true,
+  },
+};

--- a/packages/features/ee/teams/lib/tasker/trigger/hardDeleteSoftDeletedTeams.test.ts
+++ b/packages/features/ee/teams/lib/tasker/trigger/hardDeleteSoftDeletedTeams.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFindSoftDeletedOlderThan = vi.fn();
+const mockDeleteById = vi.fn();
+const mockLogInfo = vi.fn();
+const mockLogError = vi.fn();
+
+class MockTeamRepository {
+  findSoftDeletedOlderThan = mockFindSoftDeletedOlderThan;
+  deleteById = mockDeleteById;
+}
+
+vi.mock("@calcom/features/ee/teams/repositories/TeamRepository", () => ({
+  TeamRepository: MockTeamRepository,
+}));
+
+vi.mock("@calcom/prisma", () => ({
+  prisma: {},
+}));
+
+class MockTriggerDevLogger {
+  getSubLogger() {
+    return {
+      info: mockLogInfo,
+      error: mockLogError,
+    };
+  }
+}
+
+vi.mock("@calcom/lib/triggerDevLogger", () => ({
+  TriggerDevLogger: MockTriggerDevLogger,
+}));
+
+describe("runHardDeleteSoftDeletedTeams", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return success with 0 deleted count when no teams found", async () => {
+    mockFindSoftDeletedOlderThan.mockResolvedValue([]);
+
+    const { runHardDeleteSoftDeletedTeams } = await import("./hardDeleteSoftDeletedTeams");
+
+    const result = await runHardDeleteSoftDeletedTeams();
+
+    expect(mockFindSoftDeletedOlderThan).toHaveBeenCalledWith({ days: 0 });
+    expect(mockDeleteById).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "success",
+      deletedCount: 0,
+    });
+  });
+
+  it("should hard delete teams that are soft-deleted", async () => {
+    const mockTeams = [
+      { id: 1, name: "Team 1", slug: "team-1", isOrganization: false, deletedAt: new Date() },
+      { id: 2, name: "Team 2", slug: "team-2", isOrganization: false, deletedAt: new Date() },
+    ];
+    mockFindSoftDeletedOlderThan.mockResolvedValue(mockTeams);
+    mockDeleteById.mockResolvedValue({});
+
+    const { runHardDeleteSoftDeletedTeams } = await import("./hardDeleteSoftDeletedTeams");
+
+    const result = await runHardDeleteSoftDeletedTeams();
+
+    expect(mockFindSoftDeletedOlderThan).toHaveBeenCalledWith({ days: 0 });
+    expect(mockDeleteById).toHaveBeenCalledTimes(2);
+    expect(mockDeleteById).toHaveBeenCalledWith({ id: 1 });
+    expect(mockDeleteById).toHaveBeenCalledWith({ id: 2 });
+    expect(result).toEqual({
+      status: "success",
+      totalFound: 2,
+      deletedCount: 2,
+      failedCount: 0,
+      failedTeamIds: [],
+    });
+  });
+
+  it("should handle partial failures when some teams fail to delete", async () => {
+    const mockTeams = [
+      { id: 1, name: "Team 1", slug: "team-1", isOrganization: false, deletedAt: new Date() },
+      { id: 2, name: "Team 2", slug: "team-2", isOrganization: false, deletedAt: new Date() },
+      { id: 3, name: "Team 3", slug: "team-3", isOrganization: false, deletedAt: new Date() },
+    ];
+    mockFindSoftDeletedOlderThan.mockResolvedValue(mockTeams);
+    mockDeleteById
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("Database error"))
+      .mockResolvedValueOnce({});
+
+    const { runHardDeleteSoftDeletedTeams } = await import("./hardDeleteSoftDeletedTeams");
+
+    const result = await runHardDeleteSoftDeletedTeams();
+
+    expect(mockFindSoftDeletedOlderThan).toHaveBeenCalledWith({ days: 0 });
+    expect(mockDeleteById).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({
+      status: "partial_failure",
+      totalFound: 3,
+      deletedCount: 2,
+      failedCount: 1,
+      failedTeamIds: [2],
+    });
+  });
+
+  it("should handle all failures gracefully", async () => {
+    const mockTeams = [
+      { id: 1, name: "Team 1", slug: "team-1", isOrganization: false, deletedAt: new Date() },
+      { id: 2, name: "Team 2", slug: "team-2", isOrganization: false, deletedAt: new Date() },
+    ];
+    mockFindSoftDeletedOlderThan.mockResolvedValue(mockTeams);
+    mockDeleteById.mockRejectedValue(new Error("Database error"));
+
+    const { runHardDeleteSoftDeletedTeams } = await import("./hardDeleteSoftDeletedTeams");
+
+    const result = await runHardDeleteSoftDeletedTeams();
+
+    expect(mockFindSoftDeletedOlderThan).toHaveBeenCalledWith({ days: 0 });
+    expect(mockDeleteById).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      status: "partial_failure",
+      totalFound: 2,
+      deletedCount: 0,
+      failedCount: 2,
+      failedTeamIds: [1, 2],
+    });
+  });
+});
+
+describe("SOFT_DELETE_RETENTION_DAYS", () => {
+  it("should be set to 0 for immediate deletion", async () => {
+    const { SOFT_DELETE_RETENTION_DAYS } = await import("./hardDeleteSoftDeletedTeams");
+    expect(SOFT_DELETE_RETENTION_DAYS).toBe(0);
+  });
+});

--- a/packages/features/ee/teams/lib/tasker/trigger/hardDeleteSoftDeletedTeams.ts
+++ b/packages/features/ee/teams/lib/tasker/trigger/hardDeleteSoftDeletedTeams.ts
@@ -2,7 +2,90 @@ import { schedules } from "@trigger.dev/sdk";
 
 import { teamCleanupTaskConfig } from "./config";
 
-const SOFT_DELETE_RETENTION_DAYS = 15;
+export const SOFT_DELETE_RETENTION_DAYS = 0;
+
+export type HardDeleteResult =
+  | { status: "success"; deletedCount: 0 }
+  | {
+      status: "success" | "partial_failure";
+      totalFound: number;
+      deletedCount: number;
+      failedCount: number;
+      failedTeamIds: number[];
+    };
+
+export async function runHardDeleteSoftDeletedTeams(): Promise<HardDeleteResult> {
+  const { TriggerDevLogger } = await import("@calcom/lib/triggerDevLogger");
+  const { TeamRepository } = await import("@calcom/features/ee/teams/repositories/TeamRepository");
+  const { prisma } = await import("@calcom/prisma");
+
+  const triggerDevLogger = new TriggerDevLogger();
+  const log = triggerDevLogger.getSubLogger({
+    name: "HardDeleteSoftDeletedTeams",
+  });
+
+  log.info(`Starting hard delete of teams soft-deleted more than ${SOFT_DELETE_RETENTION_DAYS} days ago`);
+
+  const teamRepository = new TeamRepository(prisma);
+  const teamsToDelete = await teamRepository.findSoftDeletedOlderThan({
+    days: SOFT_DELETE_RETENTION_DAYS,
+  });
+
+  if (teamsToDelete.length === 0) {
+    log.info("No teams found for hard deletion");
+    return {
+      status: "success",
+      deletedCount: 0,
+    };
+  }
+
+  log.info(`Found ${teamsToDelete.length} teams to hard delete`, {
+    teamIds: teamsToDelete.map((t) => t.id),
+  });
+
+  let successCount = 0;
+  let failedCount = 0;
+  const failedTeamIds: number[] = [];
+
+  for (const team of teamsToDelete) {
+    try {
+      log.info(`Hard deleting team ${team.id} (${team.name})`, {
+        teamId: team.id,
+        teamName: team.name,
+        teamSlug: team.slug,
+        isOrganization: team.isOrganization,
+        deletedAt: team.deletedAt,
+      });
+
+      await teamRepository.deleteById({ id: team.id });
+      successCount++;
+
+      log.info(`Successfully hard deleted team ${team.id}`);
+    } catch (error) {
+      failedCount++;
+      failedTeamIds.push(team.id);
+      log.error(`Failed to hard delete team ${team.id}`, {
+        teamId: team.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  log.info("Hard delete job completed", {
+    totalFound: teamsToDelete.length,
+    successCount,
+    failedCount,
+    failedTeamIds,
+  });
+
+  return {
+    status: failedCount === 0 ? "success" : "partial_failure",
+    totalFound: teamsToDelete.length,
+    deletedCount: successCount,
+    failedCount,
+    failedTeamIds,
+  };
+}
 
 export const hardDeleteSoftDeletedTeams = schedules.task({
   id: "teams.hard-delete-soft-deleted",
@@ -11,78 +94,5 @@ export const hardDeleteSoftDeletedTeams = schedules.task({
     pattern: "0 3 * * *",
     timezone: "UTC",
   },
-  run: async () => {
-    const { TriggerDevLogger } = await import("@calcom/lib/triggerDevLogger");
-    const { TeamRepository } = await import(
-      "@calcom/features/ee/teams/repositories/TeamRepository"
-    );
-    const { prisma } = await import("@calcom/prisma");
-
-    const triggerDevLogger = new TriggerDevLogger();
-    const log = triggerDevLogger.getSubLogger({
-      name: "HardDeleteSoftDeletedTeams",
-    });
-
-    log.info(`Starting hard delete of teams soft-deleted more than ${SOFT_DELETE_RETENTION_DAYS} days ago`);
-
-    const teamRepository = new TeamRepository(prisma);
-    const teamsToDelete = await teamRepository.findSoftDeletedOlderThan({
-      days: SOFT_DELETE_RETENTION_DAYS,
-    });
-
-    if (teamsToDelete.length === 0) {
-      log.info("No teams found for hard deletion");
-      return {
-        status: "success",
-        deletedCount: 0,
-      };
-    }
-
-    log.info(`Found ${teamsToDelete.length} teams to hard delete`, {
-      teamIds: teamsToDelete.map((t) => t.id),
-    });
-
-    let successCount = 0;
-    let failedCount = 0;
-    const failedTeamIds: number[] = [];
-
-    for (const team of teamsToDelete) {
-      try {
-        log.info(`Hard deleting team ${team.id} (${team.name})`, {
-          teamId: team.id,
-          teamName: team.name,
-          teamSlug: team.slug,
-          isOrganization: team.isOrganization,
-          deletedAt: team.deletedAt,
-        });
-
-        await teamRepository.deleteById({ id: team.id });
-        successCount++;
-
-        log.info(`Successfully hard deleted team ${team.id}`);
-      } catch (error) {
-        failedCount++;
-        failedTeamIds.push(team.id);
-        log.error(`Failed to hard delete team ${team.id}`, {
-          teamId: team.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-
-    log.info("Hard delete job completed", {
-      totalFound: teamsToDelete.length,
-      successCount,
-      failedCount,
-      failedTeamIds,
-    });
-
-    return {
-      status: failedCount === 0 ? "success" : "partial_failure",
-      totalFound: teamsToDelete.length,
-      deletedCount: successCount,
-      failedCount,
-      failedTeamIds,
-    };
-  },
+  run: runHardDeleteSoftDeletedTeams,
 });

--- a/packages/features/ee/teams/lib/tasker/trigger/hardDeleteSoftDeletedTeams.ts
+++ b/packages/features/ee/teams/lib/tasker/trigger/hardDeleteSoftDeletedTeams.ts
@@ -1,0 +1,88 @@
+import { schedules } from "@trigger.dev/sdk";
+
+import { teamCleanupTaskConfig } from "./config";
+
+const SOFT_DELETE_RETENTION_DAYS = 15;
+
+export const hardDeleteSoftDeletedTeams = schedules.task({
+  id: "teams.hard-delete-soft-deleted",
+  ...teamCleanupTaskConfig,
+  cron: {
+    pattern: "0 3 * * *",
+    timezone: "UTC",
+  },
+  run: async () => {
+    const { TriggerDevLogger } = await import("@calcom/lib/triggerDevLogger");
+    const { TeamRepository } = await import(
+      "@calcom/features/ee/teams/repositories/TeamRepository"
+    );
+    const { prisma } = await import("@calcom/prisma");
+
+    const triggerDevLogger = new TriggerDevLogger();
+    const log = triggerDevLogger.getSubLogger({
+      name: "HardDeleteSoftDeletedTeams",
+    });
+
+    log.info(`Starting hard delete of teams soft-deleted more than ${SOFT_DELETE_RETENTION_DAYS} days ago`);
+
+    const teamRepository = new TeamRepository(prisma);
+    const teamsToDelete = await teamRepository.findSoftDeletedOlderThan({
+      days: SOFT_DELETE_RETENTION_DAYS,
+    });
+
+    if (teamsToDelete.length === 0) {
+      log.info("No teams found for hard deletion");
+      return {
+        status: "success",
+        deletedCount: 0,
+      };
+    }
+
+    log.info(`Found ${teamsToDelete.length} teams to hard delete`, {
+      teamIds: teamsToDelete.map((t) => t.id),
+    });
+
+    let successCount = 0;
+    let failedCount = 0;
+    const failedTeamIds: number[] = [];
+
+    for (const team of teamsToDelete) {
+      try {
+        log.info(`Hard deleting team ${team.id} (${team.name})`, {
+          teamId: team.id,
+          teamName: team.name,
+          teamSlug: team.slug,
+          isOrganization: team.isOrganization,
+          deletedAt: team.deletedAt,
+        });
+
+        await teamRepository.deleteById({ id: team.id });
+        successCount++;
+
+        log.info(`Successfully hard deleted team ${team.id}`);
+      } catch (error) {
+        failedCount++;
+        failedTeamIds.push(team.id);
+        log.error(`Failed to hard delete team ${team.id}`, {
+          teamId: team.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    log.info("Hard delete job completed", {
+      totalFound: teamsToDelete.length,
+      successCount,
+      failedCount,
+      failedTeamIds,
+    });
+
+    return {
+      status: failedCount === 0 ? "success" : "partial_failure",
+      totalFound: teamsToDelete.length,
+      deletedCount: successCount,
+      failedCount,
+      failedTeamIds,
+    };
+  },
+});

--- a/packages/features/ee/teams/repositories/TeamRepository.test.ts
+++ b/packages/features/ee/teams/repositories/TeamRepository.test.ts
@@ -138,7 +138,7 @@ describe("TeamRepository", () => {
       prismaMock.team.findMany.mockResolvedValue(mockTeams as unknown as Team[]);
       const result = await teamRepository.findAllByParentId({ parentId: 1 });
       expect(prismaMock.team.findMany).toHaveBeenCalledWith({
-        where: { parentId: 1, deletedAt: null },
+        where: { parentId: 1 },
         select: {
           id: true,
           name: true,
@@ -161,7 +161,7 @@ describe("TeamRepository", () => {
       prismaMock.team.findFirst.mockResolvedValue(mockTeam as unknown as Team & { members: [] });
       const result = await teamRepository.findTeamWithMembers(1);
       expect(prismaMock.team.findFirst).toHaveBeenCalledWith({
-        where: { id: 1, deletedAt: null },
+        where: { id: 1 },
         select: {
           members: {
             select: {
@@ -205,7 +205,6 @@ describe("getOrg", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
-        deletedAt: null,
         slug: "test-slug",
         isOrganization: true,
       },
@@ -245,7 +244,6 @@ describe("getOrg", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
-        deletedAt: null,
         slug: "test-slug",
         isOrganization: true,
       },
@@ -316,7 +314,6 @@ describe("getTeam", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
-        deletedAt: null,
         slug: "test-slug",
       },
       select: {
@@ -359,7 +356,6 @@ describe("getTeam", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
-        deletedAt: null,
         slug: "test-slug",
       },
       select: {
@@ -401,7 +397,6 @@ describe("getTeam", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
-        deletedAt: null,
         slug: "team-in-test-org",
         parent: {
           OR: [
@@ -445,7 +440,6 @@ describe("getTeam", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
-        deletedAt: null,
         slug: "test-team",
         parent: {
           isOrganization: true,

--- a/packages/features/ee/teams/repositories/TeamRepository.test.ts
+++ b/packages/features/ee/teams/repositories/TeamRepository.test.ts
@@ -59,7 +59,7 @@ describe("TeamRepository", () => {
 
   describe("findById", () => {
     it("should return null if team is not found", async () => {
-      prismaMock.team.findUnique.mockResolvedValue(null);
+      prismaMock.team.findFirst.mockResolvedValue(null);
       const result = await teamRepository.findById({ id: 1 });
       expect(result).toBeNull();
     });
@@ -79,7 +79,7 @@ describe("TeamRepository", () => {
         isPlatform: true,
         requestedSlug: null,
       };
-      prismaMock.team.findUnique.mockResolvedValue(mockTeam as unknown as Team);
+      prismaMock.team.findFirst.mockResolvedValue(mockTeam as unknown as Team);
       const result = await teamRepository.findById({ id: 1 });
       expect(result).toEqual(mockTeam);
     });
@@ -138,7 +138,7 @@ describe("TeamRepository", () => {
       prismaMock.team.findMany.mockResolvedValue(mockTeams as unknown as Team[]);
       const result = await teamRepository.findAllByParentId({ parentId: 1 });
       expect(prismaMock.team.findMany).toHaveBeenCalledWith({
-        where: { parentId: 1 },
+        where: { parentId: 1, deletedAt: null },
         select: {
           id: true,
           name: true,
@@ -158,10 +158,10 @@ describe("TeamRepository", () => {
   describe("findTeamWithMembers", () => {
     it("should return team with its members", async () => {
       const mockTeam = { id: 1, members: [] };
-      prismaMock.team.findUnique.mockResolvedValue(mockTeam as unknown as Team & { members: [] });
+      prismaMock.team.findFirst.mockResolvedValue(mockTeam as unknown as Team & { members: [] });
       const result = await teamRepository.findTeamWithMembers(1);
-      expect(prismaMock.team.findUnique).toHaveBeenCalledWith({
-        where: { id: 1 },
+      expect(prismaMock.team.findFirst).toHaveBeenCalledWith({
+        where: { id: 1, deletedAt: null },
         select: {
           members: {
             select: {
@@ -205,6 +205,7 @@ describe("getOrg", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
+        deletedAt: null,
         slug: "test-slug",
         isOrganization: true,
       },
@@ -244,6 +245,7 @@ describe("getOrg", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
+        deletedAt: null,
         slug: "test-slug",
         isOrganization: true,
       },
@@ -314,6 +316,7 @@ describe("getTeam", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
+        deletedAt: null,
         slug: "test-slug",
       },
       select: {
@@ -356,6 +359,7 @@ describe("getTeam", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
+        deletedAt: null,
         slug: "test-slug",
       },
       select: {
@@ -397,6 +401,7 @@ describe("getTeam", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
+        deletedAt: null,
         slug: "team-in-test-org",
         parent: {
           OR: [
@@ -440,6 +445,7 @@ describe("getTeam", () => {
 
     expect(firstFindManyCallArguments[0]).toEqual({
       where: {
+        deletedAt: null,
         slug: "test-team",
         parent: {
           isOrganization: true,

--- a/packages/features/ee/teams/repositories/TeamRepository.ts
+++ b/packages/features/ee/teams/repositories/TeamRepository.ts
@@ -290,6 +290,11 @@ export class TeamRepository {
         // This became necessary when we started migrating user to Org, without migrating some teams of the user to the org
         // Also, we would allow a user to be part of multiple orgs, then also it would be necessary.
         userId: userId,
+        // Filter out soft-deleted teams at the database level
+        // Note: Prisma extensions don't intercept relation queries, so we filter here
+        team: {
+          deletedAt: null,
+        },
       },
       include: {
         team: {
@@ -348,6 +353,11 @@ export class TeamRepository {
         accepted: true,
         role: {
           in: [MembershipRole.OWNER, MembershipRole.ADMIN],
+        },
+        // Filter out soft-deleted teams at the database level
+        // Note: Prisma extensions don't intercept relation queries, so we filter here
+        team: {
+          deletedAt: null,
         },
       },
       include: {

--- a/packages/features/ee/teams/services/teamService.test.ts
+++ b/packages/features/ee/teams/services/teamService.test.ts
@@ -58,18 +58,19 @@ describe("TeamService", () => {
   });
 
   describe("delete", () => {
-    it("should delete team, cancel billing, and clean up", async () => {
-      const mockDeletedTeam = {
+    it("should soft delete team, cancel billing, and clean up", async () => {
+      const mockSoftDeletedTeam = {
         id: 1,
         name: "Deleted Team",
         isOrganization: true,
         slug: "deleted-team",
+        deletedAt: new Date(),
       };
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       const mockTeamRepo = {
-        deleteById: vi.fn().mockResolvedValue(mockDeletedTeam),
-      } as Pick<TeamRepository, "deleteById">;
+        softDelete: vi.fn().mockResolvedValue(mockSoftDeletedTeam),
+      } as Pick<TeamRepository, "softDelete">;
       vi.mocked(TeamRepository).mockImplementation(function () {
         return mockTeamRepo;
       });
@@ -79,9 +80,9 @@ describe("TeamService", () => {
       expect(mockTeamBillingFactory.findAndInit).toHaveBeenCalledWith(1);
       expect(mockTeamBilling.cancel).toHaveBeenCalled();
       expect(WorkflowService.deleteWorkflowRemindersOfRemovedTeam).toHaveBeenCalledWith(1);
-      expect(mockTeamRepo.deleteById).toHaveBeenCalledWith({ id: 1 });
+      expect(mockTeamRepo.softDelete).toHaveBeenCalledWith({ id: 1 });
       expect(deleteDomain).toHaveBeenCalledWith("deleted-team");
-      expect(result).toEqual(mockDeletedTeam);
+      expect(result).toEqual(mockSoftDeletedTeam);
     });
   });
 

--- a/packages/features/membership/repositories/MembershipRepository.ts
+++ b/packages/features/membership/repositories/MembershipRepository.ts
@@ -190,7 +190,14 @@ export class MembershipRepository {
     );
 
     return await prisma.membership.findMany({
-      where: prismaWhere,
+      where: {
+        ...prismaWhere,
+        // Filter out soft-deleted teams at the database level
+        // Note: Prisma extensions don't intercept relation queries, so we filter here
+        team: {
+          deletedAt: null,
+        },
+      },
       include: {
         team: {
           include: {
@@ -301,7 +308,14 @@ export class MembershipRepository {
     } satisfies Prisma.MembershipSelect;
 
     return await prisma.membership.findMany({
-      where: prismaWhere,
+      where: {
+        ...prismaWhere,
+        // Filter out soft-deleted teams at the database level
+        // Note: Prisma extensions don't intercept relation queries, so we filter here
+        team: {
+          deletedAt: null,
+        },
+      },
       select,
     });
   }
@@ -316,7 +330,14 @@ export class MembershipRepository {
     }
 
     return await prisma.membership.findMany({
-      where: prismaWhere,
+      where: {
+        ...prismaWhere,
+        // Filter out soft-deleted teams at the database level
+        // Note: Prisma extensions don't intercept relation queries, so we filter here
+        team: {
+          deletedAt: null,
+        },
+      },
       include: {
         team: {
           include: {
@@ -523,6 +544,11 @@ export class MembershipRepository {
         userId,
         ...(filters?.accepted !== undefined && { accepted: filters.accepted }),
         ...(filters?.roles && { role: { in: filters.roles } }),
+        // Filter out soft-deleted teams at the database level
+        // Note: Prisma extensions don't intercept relation queries, so we filter here
+        team: {
+          deletedAt: null,
+        },
       },
       select: {
         teamId: true,
@@ -605,6 +631,9 @@ export class MembershipRepository {
         userId,
         team: {
           isOrganization: false,
+          // Filter out soft-deleted teams at the database level
+          // Note: Prisma extensions don't intercept relation queries, so we filter here
+          deletedAt: null,
         },
       },
       select: {

--- a/packages/features/trigger.config.ts
+++ b/packages/features/trigger.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     "./calendars/lib/tasker/trigger",
     "./ee/billing/service/proration/tasker/trigger",
     "./ee/organizations/lib/billing/tasker/trigger",
+    "./ee/teams/lib/tasker/trigger",
   ], // Customize based on your project structure
 
   // Retry configuration

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -127,6 +127,11 @@ export class UserRepository {
     const teamMemberships = await this.prismaClient.membership.findMany({
       where: {
         userId: userId,
+        // Filter out soft-deleted teams at the database level
+        // Note: Prisma extensions don't intercept relation queries, so we filter here
+        team: {
+          deletedAt: null,
+        },
       },
       include: {
         team: {

--- a/packages/prisma/extensions/exclude-soft-deleted-teams.test.ts
+++ b/packages/prisma/extensions/exclude-soft-deleted-teams.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { excludeSoftDeletedTeams } from "./exclude-soft-deleted-teams";
+
+describe("excludeSoftDeletedTeams", () => {
+  let mockQuery: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockQuery = vi.fn().mockResolvedValue({ id: 1, name: "Test Team" });
+  });
+
+  describe("automatic soft delete filtering", () => {
+    it("should add deletedAt: null filter when no deletedAt is specified", async () => {
+      const args = { where: { id: 1 } };
+      await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(mockQuery).toHaveBeenCalledWith({
+        where: { id: 1, deletedAt: null },
+      });
+    });
+
+    it("should add deletedAt: null filter when where clause is empty", async () => {
+      const args = { where: {} };
+      await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(mockQuery).toHaveBeenCalledWith({
+        where: { deletedAt: null },
+      });
+    });
+
+    it("should add deletedAt: null filter when where clause is undefined", async () => {
+      const args = {};
+      await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(mockQuery).toHaveBeenCalledWith({
+        where: { deletedAt: null },
+      });
+    });
+  });
+
+  describe("bypass soft delete filter when deletedAt is explicitly specified", () => {
+    it("should NOT add deletedAt: null when deletedAt is already in where clause", async () => {
+      const args = {
+        where: {
+          deletedAt: { not: null },
+        },
+      };
+      await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(mockQuery).toHaveBeenCalledWith({
+        where: { deletedAt: { not: null } },
+      });
+    });
+
+    it("should NOT add deletedAt: null when deletedAt is explicitly set to a date filter", async () => {
+      const cutoffDate = new Date();
+      const args = {
+        where: {
+          deletedAt: { not: null, lt: cutoffDate },
+        },
+      };
+      await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(mockQuery).toHaveBeenCalledWith({
+        where: { deletedAt: { not: null, lt: cutoffDate } },
+      });
+    });
+
+    it("should NOT add deletedAt: null when deletedAt is explicitly set to null", async () => {
+      const args = {
+        where: {
+          id: 1,
+          deletedAt: null,
+        },
+      };
+      await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(mockQuery).toHaveBeenCalledWith({
+        where: { id: 1, deletedAt: null },
+      });
+    });
+  });
+
+  describe("complex where clauses", () => {
+    it("should add deletedAt: null to complex where clauses with nested conditions", async () => {
+      const args = {
+        where: {
+          OR: [{ slug: "team-1" }, { slug: "team-2" }],
+          isOrganization: true,
+        },
+      };
+      await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(mockQuery).toHaveBeenCalledWith({
+        where: {
+          OR: [{ slug: "team-1" }, { slug: "team-2" }],
+          isOrganization: true,
+          deletedAt: null,
+        },
+      });
+    });
+
+    it("should preserve existing filters when adding deletedAt: null", async () => {
+      const args = {
+        where: {
+          id: 1,
+          members: { some: { userId: 123 } },
+        },
+      };
+      await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(mockQuery).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+          members: { some: { userId: 123 } },
+          deletedAt: null,
+        },
+      });
+    });
+
+    it("should handle where clause with parentId filter", async () => {
+      const args = {
+        where: {
+          parentId: 1,
+        },
+      };
+      await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(mockQuery).toHaveBeenCalledWith({
+        where: {
+          parentId: 1,
+          deletedAt: null,
+        },
+      });
+    });
+  });
+
+  describe("return value", () => {
+    it("should return the result from the query function", async () => {
+      const expectedResult = { id: 1, name: "Test Team", slug: "test-team" };
+      mockQuery.mockResolvedValue(expectedResult);
+
+      const args = { where: { id: 1 } };
+      const result = await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it("should return null when query returns null", async () => {
+      mockQuery.mockResolvedValue(null);
+
+      const args = { where: { id: 999 } };
+      const result = await excludeSoftDeletedTeams(args, mockQuery);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/prisma/extensions/exclude-soft-deleted-teams.ts
+++ b/packages/prisma/extensions/exclude-soft-deleted-teams.ts
@@ -32,7 +32,7 @@ function safeJSONStringify(x: unknown) {
   }
 }
 
-async function excludeSoftDeletedTeams(
+export async function excludeSoftDeletedTeams(
   args:
     | Prisma.TeamFindUniqueArgs
     | Prisma.TeamFindFirstArgs

--- a/packages/prisma/extensions/exclude-soft-deleted-teams.ts
+++ b/packages/prisma/extensions/exclude-soft-deleted-teams.ts
@@ -1,0 +1,51 @@
+import { Prisma } from "../client";
+
+export function excludeSoftDeletedTeamsExtension() {
+  return Prisma.defineExtension({
+    query: {
+      team: {
+        async findUnique({ args, query }) {
+          return excludeSoftDeletedTeams(args, query);
+        },
+        async findFirst({ args, query }) {
+          return excludeSoftDeletedTeams(args, query);
+        },
+        async findMany({ args, query }) {
+          return excludeSoftDeletedTeams(args, query);
+        },
+        async findUniqueOrThrow({ args, query }) {
+          return excludeSoftDeletedTeams(args, query);
+        },
+        async findFirstOrThrow({ args, query }) {
+          return excludeSoftDeletedTeams(args, query);
+        },
+      },
+    },
+  });
+}
+
+function safeJSONStringify(x: unknown) {
+  try {
+    return JSON.stringify(x);
+  } catch {
+    return "";
+  }
+}
+
+async function excludeSoftDeletedTeams(
+  args:
+    | Prisma.TeamFindUniqueArgs
+    | Prisma.TeamFindFirstArgs
+    | Prisma.TeamFindManyArgs
+    | Prisma.TeamFindUniqueOrThrowArgs
+    | Prisma.TeamFindFirstOrThrowArgs,
+  query: <T>(args: T) => Promise<unknown>
+) {
+  args.where = args.where || {};
+  const whereString = safeJSONStringify(args.where);
+  const shouldIncludeDeleted = whereString.includes('"deletedAt":');
+  if (!shouldIncludeDeleted) {
+    args.where.deletedAt = null;
+  }
+  return query(args);
+}

--- a/packages/prisma/index.ts
+++ b/packages/prisma/index.ts
@@ -5,6 +5,7 @@ import { bookingIdempotencyKeyExtension } from "./extensions/booking-idempotency
 import { disallowUndefinedDeleteUpdateManyExtension } from "./extensions/disallow-undefined-delete-update-many";
 import { excludeLockedUsersExtension } from "./extensions/exclude-locked-users";
 import { excludePendingPaymentsExtension } from "./extensions/exclude-pending-payment-teams";
+import { excludeSoftDeletedTeamsExtension } from "./extensions/exclude-soft-deleted-teams";
 import { PrismaClient, type Prisma } from "./generated/prisma/client";
 
 const connectionString = process.env.DATABASE_URL || "";
@@ -67,6 +68,7 @@ export const customPrisma = (options?: Prisma.PrismaClientOptions) => {
   return new PrismaClient(finalOptions)
     .$extends(excludeLockedUsersExtension())
     .$extends(excludePendingPaymentsExtension())
+    .$extends(excludeSoftDeletedTeamsExtension())
     .$extends(bookingIdempotencyKeyExtension())
     .$extends(disallowUndefinedDeleteUpdateManyExtension()) as unknown as PrismaClient;
 };
@@ -79,6 +81,7 @@ export const customPrisma = (options?: Prisma.PrismaClientOptions) => {
 export const prisma: PrismaClient = baseClient
   .$extends(excludeLockedUsersExtension())
   .$extends(excludePendingPaymentsExtension())
+  .$extends(excludeSoftDeletedTeamsExtension())
   .$extends(bookingIdempotencyKeyExtension())
   .$extends(disallowUndefinedDeleteUpdateManyExtension()) as unknown as PrismaClient;
 

--- a/packages/prisma/migrations/20260126193046_add_team_deleted_at/migration.sql
+++ b/packages/prisma/migrations/20260126193046_add_team_deleted_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "public"."Team" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "Team_deletedAt_idx" ON "public"."Team"("deletedAt");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -647,8 +647,12 @@ model Team {
   seatChangeLogs    SeatChangeLog[]
   monthlyProrations MonthlyProration[]
 
+  // Soft delete support - when set, the team is considered deleted
+  deletedAt DateTime?
+
   @@unique([slug, parentId])
   @@index([parentId])
+  @@index([deletedAt])
 }
 
 model CreditBalance {


### PR DESCRIPTION
## What does this PR do?

Implements soft delete functionality for Teams to mitigate database performance issues caused by CASCADE deletes. When a team has large amounts of related data (bookings, attendees, form responses), hard deleting triggers massive cascade operations that can cause lock escalation, WAL bloat, and replication lag.

**Changes:**
- Adds `deletedAt` column to Team model with index for efficient filtering
- **Adds a Prisma Client extension (`excludeSoftDeletedTeamsExtension`) that automatically filters soft-deleted teams on ALL Team queries globally** - this avoids needing to update ~100 files with direct `prisma.team.find*` calls
- Changes TeamService.delete to set `deletedAt` timestamp instead of hard deleting
- Creates a trigger.dev scheduled job that runs every night at 3AM UTC to hard delete soft-deleted teams
- Adds comprehensive unit tests for the scheduled cleanup job and Prisma extension

**Behavior:**
- When a team is deleted, billing is cancelled immediately and `deletedAt` is set
- The team no longer appears in any queries (filtered globally via Prisma extension)
- That same night at 3AM UTC, the scheduled job performs the actual hard delete (triggering cascades)
- This spreads cascade operations over time rather than executing them all at once

**Prisma Extension Details:**
- The extension intercepts `findUnique`, `findFirst`, `findMany`, `findUniqueOrThrow`, and `findFirstOrThrow` on the Team model
- It automatically adds `deletedAt: null` to the where clause unless the query already includes a `deletedAt` filter
- The cleanup job bypasses the filter by explicitly querying for `deletedAt: { not: null, lt: cutoffDate }`

## Updates since last revision

**Latest changes (comprehensive relation query filtering):**
- Added explicit `team: { deletedAt: null }` filters to ALL repository methods that fetch teams through relation includes:
  - `MembershipRepository`: `findAllByUpIdIncludeTeamWithMembersAndEventTypes`, `findAllByUpIdIncludeMinimalEventTypes`, `findAllByUpIdIncludeTeam`, `findAllByUserId`, `hasAnyTeamMembershipByUserId`
  - `UserRepository`: `findTeamsByUserId`
  - `TeamRepository`: `findTeamsByUserId`, `findOwnedTeamsByUserId`
- Added unit tests verifying soft delete filtering in relation queries (4 new tests in TeamRepository.test.ts)

**Previous changes:**
- Fixed e2e test failure "Can disband team" - soft-deleted teams were still appearing in team listings
- Added comprehensive unit tests for `excludeSoftDeletedTeams` function (11 tests)
- Changed `SOFT_DELETE_RETENTION_DAYS` from 15 to 0 (teams are hard deleted the same night they're soft deleted)
- Removed redundant `deletedAt` filters from TeamRepository methods since the Prisma extension handles direct queries globally

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal implementation change
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Soft delete behavior:**
   - Delete a team via the UI or API
   - Verify the team no longer appears in team listings
   - Check database: team should have `deletedAt` set, but record still exists

2. **Query filtering (Prisma extension):**
   - Verify soft-deleted teams don't appear in ANY team queries across the codebase
   - Test both TeamRepository methods and direct `prisma.team.find*` calls

3. **Relation query filtering:**
   - Verify soft-deleted teams don't appear when fetched through membership includes
   - Test `findTeamsByUserId`, `findOwnedTeamsByUserId`, and MembershipRepository methods

4. **Scheduled job (manual trigger):**
   - Soft delete a team
   - Trigger the `teams.hard-delete-soft-deleted` job manually in trigger.dev
   - Verify the team is now fully deleted from the database

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the Prisma extension correctly adds `deletedAt: null` to all Team find queries
- [ ] Verify the cleanup job's `findSoftDeletedOlderThan` method bypasses the extension filter correctly (it includes `deletedAt` in the where clause)
- [ ] Check if the JSON stringify approach for detecting `deletedAt` in queries handles edge cases (nested queries, complex where clauses)
- [ ] Confirm the 0-day retention period (immediate deletion same night) and 3AM UTC schedule are correct
- [ ] Verify billing cancellation and domain cleanup still happen immediately on soft delete
- [x] ~~Consider if queries through relations are also filtered~~ - **Fixed:** Added explicit filters to all relation query methods in MembershipRepository, UserRepository, and TeamRepository
- [ ] Note: The extension only intercepts `find*` queries, not `count`, `aggregate`, etc. - verify this is acceptable

## Known CI Notes

- Pre-existing type errors in `embed-react/inline.tsx` exist on main branch and are unrelated to this PR

---

Link to Devin run: https://app.devin.ai/sessions/37e655eaeda0477985c7df9906a41834
Requested by: @keithwillcode