### PR TITLE
feat: implement rescheduling workflows as background job

### DIFF
--- a/packages/features/bookings/di/RegularBookingService.module.ts
+++ b/packages/features/bookings/di/RegularBookingService.module.ts
@@ -8,6 +8,7 @@ import { moduleLoader as luckyUserServiceModuleLoader } from "@calcom/features/d
 import { moduleLoader as prismaModuleLoader } from "@calcom/features/di/modules/Prisma";
 import { moduleLoader as userRepositoryModuleLoader } from "@calcom/features/di/modules/User";
 import { DI_TOKENS } from "@calcom/features/di/tokens";
+import { moduleLoader as workflowTaskerModuleLoader } from "@calcom/features/ee/workflows/di/tasker/WorkflowTasker.module";
 import { moduleLoader as hashedLinkServiceModuleLoader } from "@calcom/features/hashedLink/di/HashedLinkService.module";
 
 import { moduleLoader as bookingEmailAndSmsTaskerModuleLoader } from "./tasker/BookingEmailAndSmsTasker.module";
@@ -28,10 +29,11 @@ const loadModule = bindModuleToClassOnToken({
     luckyUserService: luckyUserServiceModuleLoader,
     userRepository: userRepositoryModuleLoader,
     hashedLinkService: hashedLinkServiceModuleLoader,
-    bookingEmailAndSmsTasker: bookingEmailAndSmsTaskerModuleLoader,
-    featuresRepository: featuresRepositoryModuleLoader,
-    bookingEventHandler: bookingEventHandlerModuleLoader,
-  },
+      bookingEmailAndSmsTasker: bookingEmailAndSmsTaskerModuleLoader,
+      featuresRepository: featuresRepositoryModuleLoader,
+      bookingEventHandler: bookingEventHandlerModuleLoader,
+      workflowTasker: workflowTaskerModuleLoader,
+    },
 });
 
 export const moduleLoader = {

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -50,6 +50,7 @@ import AssignmentReasonRecorder from "@calcom/features/ee/round-robin/assignment
 import { BookingLocationService } from "@calcom/features/ee/round-robin/lib/bookingLocationService";
 import { getAllWorkflowsFromEventType } from "@calcom/features/ee/workflows/lib/getAllWorkflowsFromEventType";
 import { WorkflowService } from "@calcom/features/ee/workflows/lib/service/WorkflowService";
+import type { WorkflowTasker } from "@calcom/features/ee/workflows/lib/tasker/WorkflowTasker";
 import { WorkflowRepository } from "@calcom/features/ee/workflows/repositories/WorkflowRepository";
 import { getUsernameList } from "@calcom/features/eventtypes/lib/defaultEvents";
 import { getEventName, updateHostInEventName } from "@calcom/features/eventtypes/lib/eventNaming";
@@ -480,6 +481,7 @@ export interface IBookingServiceDependencies {
   bookingEmailAndSmsTasker: BookingEmailAndSmsTasker;
   featuresRepository: FeaturesRepository;
   bookingEventHandler: BookingEventHandlerService;
+  workflowTasker: WorkflowTasker;
 }
 
 async function validateRescheduleRestrictions({
@@ -2831,37 +2833,58 @@ async function handler(
       isTeamEventType,
     });
 
-    // Unused until we deploy to trigger.dev production
-    // for now we only enable for cal.com org and we keep our current email system
-    // cal.com org members will see emails in double while we test
-    if (ENABLE_ASYNC_TASKER && !noEmail) {
-      try {
-        if (orgId) {
-          const hasTeamFeature = await deps.featuresRepository.checkIfTeamHasFeature(
-            orgId,
-            "booking-email-sms-tasker"
-          );
-          if (hasTeamFeature) {
-            await deps.bookingEmailAndSmsTasker.send({
-              action: bookingEmailsAndSmsTaskerAction,
-              schedulingType: evtWithMetadata.eventType.schedulingType,
-              payload: {
-                bookingId: booking.id,
-                conferenceCredentialId,
-                platformClientId,
-                platformRescheduleUrl,
-                platformCancelUrl,
-                platformBookingUrl,
-                isRescheduledByBooker: reqBody.rescheduledBy === bookerEmail,
-              },
-            });
+      // Unused until we deploy to trigger.dev production
+      // for now we only enable for cal.com org and we keep our current email system
+      // cal.com org members will see emails in double while we test
+      if (ENABLE_ASYNC_TASKER && !noEmail) {
+        try {
+          if (orgId) {
+            const hasTeamFeature = await deps.featuresRepository.checkIfTeamHasFeature(
+              orgId,
+              "booking-email-sms-tasker"
+            );
+            if (hasTeamFeature) {
+              await deps.bookingEmailAndSmsTasker.send({
+                action: bookingEmailsAndSmsTaskerAction,
+                schedulingType: evtWithMetadata.eventType.schedulingType,
+                payload: {
+                  bookingId: booking.id,
+                  conferenceCredentialId,
+                  platformClientId,
+                  platformRescheduleUrl,
+                  platformCancelUrl,
+                  platformBookingUrl,
+                  isRescheduledByBooker: reqBody.rescheduledBy === bookerEmail,
+                },
+              });
+            }
           }
+        } catch (err) {
+          tracingLogger.error("bookingEmailAndSmsTasker error:", err);
         }
-      } catch (err) {
-        tracingLogger.error("bookingEmailAndSmsTasker error:", err);
+      }
+
+      if (ENABLE_ASYNC_TASKER && rescheduleUid) {
+        try {
+          if (orgId) {
+            const hasWorkflowTaskerFeature = await deps.featuresRepository.checkIfTeamHasFeature(
+              orgId,
+              "workflow-tasker"
+            );
+            if (hasWorkflowTaskerFeature) {
+              await deps.workflowTasker.scheduleRescheduleWorkflows({
+                bookingId: booking.id,
+                smsReminderNumber: smsReminderNumber || null,
+                hideBranding: !!eventType.owner?.hideBranding,
+                seatReferenceUid: evt.attendeeSeatId,
+              });
+            }
+          }
+        } catch (err) {
+          tracingLogger.error("workflowTasker error:", err);
+        }
       }
     }
-  }
 
   // TODO: Refactor better so this booking object is not passed
   // all around and instead the individual fields are sent as args.

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1581,14 +1581,54 @@ async updateMany({ where, data }: { where: BookingWhereInput; data: BookingUpdat
     });
   }
 
-  async getBookingForCalEventBuilderFromUid(bookingUid: string) {
-    return this.prismaClient.booking.findUnique({
-      where: { uid: bookingUid },
-      select: selectStatementToGetBookingForCalEventBuilder,
-    });
-  }
+    async getBookingForCalEventBuilderFromUid(bookingUid: string) {
+      return this.prismaClient.booking.findUnique({
+        where: { uid: bookingUid },
+        select: selectStatementToGetBookingForCalEventBuilder,
+      });
+    }
 
-  async findByIdIncludeDestinationCalendar(bookingId: number) {
+    async getBookingForWorkflowTasker(bookingId: number) {
+      return await this.prismaClient.booking.findUnique({
+        where: { id: bookingId },
+        select: {
+          ...selectStatementToGetBookingForCalEventBuilder,
+          id: true,
+          eventType: {
+            select: {
+              ...selectStatementToGetBookingForCalEventBuilder.eventType.select,
+              teamId: true,
+              userId: true,
+              parentId: true,
+              hosts: {
+                select: {
+                  userId: true,
+                  isFixed: true,
+                  user: {
+                    select: {
+                      id: true,
+                      name: true,
+                      email: true,
+                      username: true,
+                      timeZone: true,
+                      locale: true,
+                      timeFormat: true,
+                      destinationCalendar: {
+                        select: {
+                          primaryEmail: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+    }
+
+    async findByIdIncludeDestinationCalendar(bookingId: number) {
     return await this.prismaClient.booking.findUnique({
       where: {
         id: bookingId,

--- a/packages/features/di/tokens.ts
+++ b/packages/features/di/tokens.ts
@@ -1,5 +1,6 @@
 import { BOOKING_DI_TOKENS } from "@calcom/features/bookings/di/tokens";
 import { BOOKING_AUDIT_DI_TOKENS } from "@calcom/features/booking-audit/di/tokens";
+import { WORKFLOW_DI_TOKENS } from "@calcom/features/ee/workflows/di/tokens";
 import { FEATURE_OPT_IN_DI_TOKENS } from "@calcom/features/feature-opt-in/di/tokens";
 import { FLAGS_DI_TOKENS } from "@calcom/features/flags/di/tokens";
 import { HASHED_LINK_DI_TOKENS } from "@calcom/features/hashedLink/di/tokens";
@@ -85,4 +86,5 @@ export const DI_TOKENS = {
   ...WATCHLIST_DI_TOKENS,
   ...ORGANIZATION_DI_TOKENS,
   ...WEBHOOK_TOKENS,
+  ...WORKFLOW_DI_TOKENS,
 };

--- a/packages/features/ee/workflows/di/tasker/WorkflowSyncTasker.module.ts
+++ b/packages/features/ee/workflows/di/tasker/WorkflowSyncTasker.module.ts
@@ -1,0 +1,25 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as loggerServiceModule } from "@calcom/features/di/shared/services/logger.service";
+import { WorkflowSyncTasker } from "@calcom/features/ee/workflows/lib/tasker/WorkflowSyncTasker";
+
+import { moduleLoader as WorkflowTaskServiceModuleLoader } from "./WorkflowTaskService.module";
+import { WORKFLOW_TASKER_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = WORKFLOW_TASKER_DI_TOKENS.WORKFLOW_SYNC_TASKER;
+const moduleToken = WORKFLOW_TASKER_DI_TOKENS.WORKFLOW_SYNC_TASKER_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: WorkflowSyncTasker,
+  depsMap: {
+    logger: loggerServiceModule,
+    workflowTaskService: WorkflowTaskServiceModuleLoader,
+  },
+});
+
+export const moduleLoader = {
+  token,
+  loadModule,
+} satisfies ModuleLoader;

--- a/packages/features/ee/workflows/di/tasker/WorkflowTaskService.module.ts
+++ b/packages/features/ee/workflows/di/tasker/WorkflowTaskService.module.ts
@@ -1,0 +1,25 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as bookingRepositoryModuleLoader } from "@calcom/features/di/modules/Booking";
+import { moduleLoader as loggerServiceModule } from "@calcom/features/di/shared/services/logger.service";
+import { WorkflowTaskService } from "@calcom/features/ee/workflows/lib/tasker/WorkflowTaskService";
+
+import { WORKFLOW_TASKER_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = WORKFLOW_TASKER_DI_TOKENS.WORKFLOW_TASK_SERVICE;
+const moduleToken = WORKFLOW_TASKER_DI_TOKENS.WORKFLOW_TASK_SERVICE_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: WorkflowTaskService,
+  depsMap: {
+    logger: loggerServiceModule,
+    bookingRepository: bookingRepositoryModuleLoader,
+  },
+});
+
+export const moduleLoader = {
+  token,
+  loadModule,
+} satisfies ModuleLoader;

--- a/packages/features/ee/workflows/di/tasker/WorkflowTasker.container.ts
+++ b/packages/features/ee/workflows/di/tasker/WorkflowTasker.container.ts
@@ -1,0 +1,10 @@
+import { createContainer } from "@calcom/features/di/di";
+
+import { type WorkflowTasker, moduleLoader as workflowTaskerModuleLoader } from "./WorkflowTasker.module";
+
+const workflowTaskerContainer = createContainer();
+
+export function getWorkflowTasker(): WorkflowTasker {
+  workflowTaskerModuleLoader.loadModule(workflowTaskerContainer);
+  return workflowTaskerContainer.get<WorkflowTasker>(workflowTaskerModuleLoader.token);
+}

--- a/packages/features/ee/workflows/di/tasker/WorkflowTasker.module.ts
+++ b/packages/features/ee/workflows/di/tasker/WorkflowTasker.module.ts
@@ -1,0 +1,27 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as loggerServiceModule } from "@calcom/features/di/shared/services/logger.service";
+import { WorkflowTasker } from "@calcom/features/ee/workflows/lib/tasker/WorkflowTasker";
+
+import { moduleLoader as WorkflowSyncTasker } from "./WorkflowSyncTasker.module";
+import { moduleLoader as WorkflowTriggerTasker } from "./WorkflowTriggerDevTasker.module";
+import { WORKFLOW_TASKER_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = WORKFLOW_TASKER_DI_TOKENS.WORKFLOW_TASKER;
+const moduleToken = WORKFLOW_TASKER_DI_TOKENS.WORKFLOW_TASKER_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: WorkflowTasker,
+  depsMap: {
+    logger: loggerServiceModule,
+    asyncTasker: WorkflowTriggerTasker,
+    syncTasker: WorkflowSyncTasker,
+  },
+});
+
+export const moduleLoader = {
+  token,
+  loadModule,
+} satisfies ModuleLoader;

--- a/packages/features/ee/workflows/di/tasker/WorkflowTriggerDevTasker.module.ts
+++ b/packages/features/ee/workflows/di/tasker/WorkflowTriggerDevTasker.module.ts
@@ -1,0 +1,23 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as loggerServiceModule } from "@calcom/features/di/shared/services/logger.service";
+import { WorkflowTriggerDevTasker } from "@calcom/features/ee/workflows/lib/tasker/WorkflowTriggerDevTasker";
+
+import { WORKFLOW_TASKER_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = WORKFLOW_TASKER_DI_TOKENS.WORKFLOW_TRIGGER_TASKER;
+const moduleToken = WORKFLOW_TASKER_DI_TOKENS.WORKFLOW_TRIGGER_TASKER_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: WorkflowTriggerDevTasker,
+  depsMap: {
+    logger: loggerServiceModule,
+  },
+});
+
+export const moduleLoader = {
+  token,
+  loadModule,
+} satisfies ModuleLoader;

--- a/packages/features/ee/workflows/di/tasker/tokens.ts
+++ b/packages/features/ee/workflows/di/tasker/tokens.ts
@@ -1,0 +1,10 @@
+export const WORKFLOW_TASKER_DI_TOKENS = {
+  WORKFLOW_SYNC_TASKER: Symbol("WorkflowSyncTasker"),
+  WORKFLOW_SYNC_TASKER_MODULE: Symbol("WorkflowSyncTaskerModule"),
+  WORKFLOW_TASKER: Symbol("WorkflowTasker"),
+  WORKFLOW_TASKER_MODULE: Symbol("WorkflowTaskerModule"),
+  WORKFLOW_TRIGGER_TASKER: Symbol("WorkflowTriggerDevTasker"),
+  WORKFLOW_TRIGGER_TASKER_MODULE: Symbol("WorkflowTriggerDevTaskerModule"),
+  WORKFLOW_TASK_SERVICE: Symbol("WorkflowTaskService"),
+  WORKFLOW_TASK_SERVICE_MODULE: Symbol("WorkflowTaskServiceModule"),
+};

--- a/packages/features/ee/workflows/di/tokens.ts
+++ b/packages/features/ee/workflows/di/tokens.ts
@@ -1,0 +1,5 @@
+import { WORKFLOW_TASKER_DI_TOKENS } from "./tasker/tokens";
+
+export const WORKFLOW_DI_TOKENS = {
+  ...WORKFLOW_TASKER_DI_TOKENS,
+};

--- a/packages/features/ee/workflows/lib/tasker/WorkflowSyncTasker.ts
+++ b/packages/features/ee/workflows/lib/tasker/WorkflowSyncTasker.ts
@@ -1,0 +1,20 @@
+import { nanoid } from "nanoid";
+
+import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
+
+import type { IWorkflowTasker } from "./types";
+import type { WorkflowTaskService } from "./WorkflowTaskService";
+
+export interface IWorkflowSyncTaskerDependencies {
+  workflowTaskService: WorkflowTaskService;
+}
+
+export class WorkflowSyncTasker implements IWorkflowTasker {
+  constructor(public readonly dependencies: ITaskerDependencies & IWorkflowSyncTaskerDependencies) {}
+
+  async scheduleRescheduleWorkflows(payload: Parameters<IWorkflowTasker["scheduleRescheduleWorkflows"]>[0]) {
+    const runId = `sync_${nanoid(10)}`;
+    await this.dependencies.workflowTaskService.scheduleRescheduleWorkflows(payload);
+    return { runId };
+  }
+}

--- a/packages/features/ee/workflows/lib/tasker/WorkflowTaskService.ts
+++ b/packages/features/ee/workflows/lib/tasker/WorkflowTaskService.ts
@@ -1,0 +1,130 @@
+import { eventTypeMetaDataSchemaWithTypedApps } from "@calcom/app-store/zod-utils";
+import type { ExtendedCalendarEvent } from "@calcom/ee/workflows/lib/reminders/reminderScheduler";
+import { scheduleWorkflowReminders } from "@calcom/ee/workflows/lib/reminders/reminderScheduler";
+import type { Workflow } from "@calcom/ee/workflows/lib/types";
+import { CalendarEventBuilder } from "@calcom/features/CalendarEventBuilder";
+import type { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
+import { CreditService } from "@calcom/features/ee/billing/credit-service";
+import { getAllWorkflowsFromEventType } from "@calcom/features/ee/workflows/lib/getAllWorkflowsFromEventType";
+import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
+import { WorkflowTriggerEvents } from "@calcom/prisma/enums";
+
+import type { WorkflowAsyncTasksPayload, WorkflowTasks } from "./types";
+
+export interface IWorkflowTaskServiceDependencies {
+  bookingRepository: BookingRepository;
+}
+
+type EventTypeForWorkflows = {
+  id: number;
+  teamId: number | null;
+  userId: number | null;
+  parentId: number | null;
+  metadata: unknown;
+};
+
+export class WorkflowTaskService implements WorkflowTasks {
+  constructor(
+    public readonly dependencies: { logger: ITaskerDependencies["logger"] } & IWorkflowTaskServiceDependencies
+  ) {}
+
+  private async _getVerifiedBookingData(payload: WorkflowAsyncTasksPayload) {
+    const { bookingId } = payload;
+    const { bookingRepository } = this.dependencies;
+
+    const booking = await bookingRepository.getBookingForWorkflowTasker(bookingId);
+    if (!booking) {
+      throw new Error(`Booking with id '${bookingId}' was not found.`);
+    }
+    if (!booking.eventType) {
+      throw new Error(`EventType of Booking with id '${bookingId}' was not found.`);
+    }
+    if (!booking.user) {
+      throw new Error(`User of Booking with id '${bookingId}' was not found.`);
+    }
+
+        const calendarEvent = (await CalendarEventBuilder.fromBooking(booking, {})).build();
+        if (!calendarEvent) {
+          throw new Error(`CalendarEvent could not be built from Booking with id '${bookingId}'.`);
+        }
+        if (!calendarEvent.bookerUrl) {
+          throw new Error(`CalendarEvent bookerUrl is missing for Booking with id '${bookingId}'.`);
+        }
+
+        const extendedCalendarEvent: ExtendedCalendarEvent = {
+          ...calendarEvent,
+          bookerUrl: calendarEvent.bookerUrl,
+          eventType: {
+            slug: booking.eventType.slug,
+            schedulingType: booking.eventType.schedulingType,
+            hosts: booking.eventType.hosts?.map((host) => ({
+              user: {
+                email: host.user.email,
+                destinationCalendar: host.user.destinationCalendar
+                  ? { primaryEmail: host.user.destinationCalendar.primaryEmail }
+                  : null,
+              },
+            })),
+          },
+        };
+
+    const eventTypeForWorkflows: EventTypeForWorkflows = {
+      id: booking.eventType.id,
+      teamId: booking.eventType.teamId,
+      userId: booking.eventType.userId,
+      parentId: booking.eventType.parentId,
+      metadata: booking.eventType.metadata,
+    };
+
+    return {
+      booking,
+      eventType: eventTypeForWorkflows,
+      calendarEvent: extendedCalendarEvent,
+      organizerId: booking.user.id,
+    };
+  }
+
+  private async _getWorkflowsForEventType(
+    eventType: EventTypeForWorkflows,
+    organizerId: number
+  ): Promise<Workflow[]> {
+    return getAllWorkflowsFromEventType(
+      {
+        ...eventType,
+        metadata: eventTypeMetaDataSchemaWithTypedApps.parse(eventType.metadata),
+      },
+      organizerId
+    );
+  }
+
+  async scheduleRescheduleWorkflows(payload: WorkflowAsyncTasksPayload) {
+    const { booking, eventType, calendarEvent, organizerId } = await this._getVerifiedBookingData(payload);
+
+    const workflows = await this._getWorkflowsForEventType(eventType, organizerId);
+
+    const rescheduleWorkflows = workflows.filter(
+      (workflow) =>
+        workflow.trigger === WorkflowTriggerEvents.RESCHEDULE_EVENT ||
+        workflow.trigger === WorkflowTriggerEvents.BEFORE_EVENT ||
+        workflow.trigger === WorkflowTriggerEvents.AFTER_EVENT
+    );
+
+    if (rescheduleWorkflows.length === 0) {
+      this.dependencies.logger.info(
+        `No reschedule workflows found for booking ${booking.id}, skipping workflow scheduling`
+      );
+      return;
+    }
+
+    const creditService = new CreditService();
+
+    await scheduleWorkflowReminders({
+      workflows: rescheduleWorkflows,
+      smsReminderNumber: payload.smsReminderNumber,
+      calendarEvent,
+      hideBranding: payload.hideBranding,
+      seatReferenceUid: payload.seatReferenceUid,
+      creditCheckFn: creditService.hasAvailableCredits.bind(creditService),
+    });
+  }
+}

--- a/packages/features/ee/workflows/lib/tasker/WorkflowTasker.ts
+++ b/packages/features/ee/workflows/lib/tasker/WorkflowTasker.ts
@@ -1,0 +1,37 @@
+import { Tasker } from "@calcom/lib/tasker/Tasker";
+import type { ILogger } from "@calcom/lib/tasker/types";
+
+import type { IWorkflowTasker, WorkflowTaskPayload } from "./types";
+import type { WorkflowSyncTasker } from "./WorkflowSyncTasker";
+import type { WorkflowTriggerDevTasker } from "./WorkflowTriggerDevTasker";
+
+export interface IWorkflowTaskerDependencies {
+  asyncTasker: WorkflowTriggerDevTasker;
+  syncTasker: WorkflowSyncTasker;
+  logger: ILogger;
+}
+
+export class WorkflowTasker extends Tasker<IWorkflowTasker> {
+  constructor(public readonly dependencies: IWorkflowTaskerDependencies) {
+    super(dependencies);
+  }
+
+  public async scheduleRescheduleWorkflows(payload: WorkflowTaskPayload): Promise<{ runId: string }> {
+    let taskResponse: { runId: string } = { runId: "task-not-found" };
+
+    try {
+      taskResponse = await this.dispatch("scheduleRescheduleWorkflows", payload);
+
+      this.logger.info(`WorkflowTasker scheduleRescheduleWorkflows success:`, taskResponse, {
+        bookingId: payload.bookingId,
+      });
+    } catch {
+      taskResponse = { runId: "task-failed" };
+      this.logger.error(`WorkflowTasker scheduleRescheduleWorkflows failed`, taskResponse, {
+        bookingId: payload.bookingId,
+      });
+    }
+
+    return taskResponse;
+  }
+}

--- a/packages/features/ee/workflows/lib/tasker/WorkflowTriggerDevTasker.ts
+++ b/packages/features/ee/workflows/lib/tasker/WorkflowTriggerDevTasker.ts
@@ -1,0 +1,13 @@
+import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
+
+import type { IWorkflowTasker } from "./types";
+
+export class WorkflowTriggerDevTasker implements IWorkflowTasker {
+  constructor(public readonly dependencies: ITaskerDependencies) {}
+
+  async scheduleRescheduleWorkflows(payload: Parameters<IWorkflowTasker["scheduleRescheduleWorkflows"]>[0]) {
+    const { scheduleRescheduleWorkflows } = await import("./trigger/scheduleRescheduleWorkflows");
+    const handle = await scheduleRescheduleWorkflows.trigger(payload);
+    return { runId: handle.id };
+  }
+}

--- a/packages/features/ee/workflows/lib/tasker/__tests__/WorkflowSyncTasker.test.ts
+++ b/packages/features/ee/workflows/lib/tasker/__tests__/WorkflowSyncTasker.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
+
+import { WorkflowSyncTasker } from "../WorkflowSyncTasker";
+import type { WorkflowTaskService } from "../WorkflowTaskService";
+
+describe("WorkflowSyncTasker", () => {
+  let syncTasker: WorkflowSyncTasker;
+  let mockWorkflowTaskService: WorkflowTaskService;
+  let mockLogger: ITaskerDependencies["logger"];
+
+  beforeEach(() => {
+    mockWorkflowTaskService = {
+      scheduleRescheduleWorkflows: vi.fn().mockResolvedValue(undefined),
+      dependencies: {},
+    } as unknown as WorkflowTaskService;
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      getSubLogger: vi.fn().mockReturnThis(),
+    } as unknown as ITaskerDependencies["logger"];
+
+    syncTasker = new WorkflowSyncTasker({
+      workflowTaskService: mockWorkflowTaskService,
+      logger: mockLogger,
+    });
+  });
+
+  describe("constructor", () => {
+    it("should be instantiable with dependencies", () => {
+      expect(syncTasker).toBeInstanceOf(WorkflowSyncTasker);
+      expect(syncTasker.dependencies.workflowTaskService).toBe(mockWorkflowTaskService);
+      expect(syncTasker.dependencies.logger).toBe(mockLogger);
+    });
+  });
+
+  describe("scheduleRescheduleWorkflows", () => {
+    const basePayload = {
+      bookingId: 123,
+      smsReminderNumber: "+1234567890",
+      hideBranding: false,
+    };
+
+    it("should call workflowTaskService.scheduleRescheduleWorkflows with payload", async () => {
+      await syncTasker.scheduleRescheduleWorkflows(basePayload);
+
+      expect(mockWorkflowTaskService.scheduleRescheduleWorkflows).toHaveBeenCalledWith(basePayload);
+    });
+
+    it("should return a runId with sync_ prefix", async () => {
+      const result = await syncTasker.scheduleRescheduleWorkflows(basePayload);
+
+      expect(result).toHaveProperty("runId");
+      expect(result.runId).toMatch(/^sync_/);
+    });
+
+    it("should generate unique runIds for each call", async () => {
+      const result1 = await syncTasker.scheduleRescheduleWorkflows(basePayload);
+      const result2 = await syncTasker.scheduleRescheduleWorkflows(basePayload);
+
+      expect(result1.runId).not.toBe(result2.runId);
+    });
+
+    it("should propagate errors from workflowTaskService", async () => {
+      const error = new Error("Service failed");
+      vi.mocked(mockWorkflowTaskService.scheduleRescheduleWorkflows).mockRejectedValue(error);
+
+      await expect(syncTasker.scheduleRescheduleWorkflows(basePayload)).rejects.toThrow("Service failed");
+    });
+
+    it("should handle payload with seatReferenceUid", async () => {
+      const payloadWithSeat = {
+        ...basePayload,
+        seatReferenceUid: "seat-789",
+      };
+
+      await syncTasker.scheduleRescheduleWorkflows(payloadWithSeat);
+
+      expect(mockWorkflowTaskService.scheduleRescheduleWorkflows).toHaveBeenCalledWith(payloadWithSeat);
+    });
+
+    it("should handle payload with null smsReminderNumber", async () => {
+      const payloadWithNullSms = {
+        bookingId: 456,
+        smsReminderNumber: null,
+        hideBranding: true,
+      };
+
+      const result = await syncTasker.scheduleRescheduleWorkflows(payloadWithNullSms);
+
+      expect(result).toHaveProperty("runId");
+      expect(mockWorkflowTaskService.scheduleRescheduleWorkflows).toHaveBeenCalledWith(payloadWithNullSms);
+    });
+  });
+});

--- a/packages/features/ee/workflows/lib/tasker/__tests__/WorkflowTaskService.test.ts
+++ b/packages/features/ee/workflows/lib/tasker/__tests__/WorkflowTaskService.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
+import { WorkflowTriggerEvents } from "@calcom/prisma/enums";
+
+import { WorkflowTaskService } from "../WorkflowTaskService";
+
+vi.mock("@calcom/features/ee/workflows/lib/reminders/reminderScheduler", () => ({
+  scheduleWorkflowReminders: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@calcom/features/ee/workflows/lib/getAllWorkflowsFromEventType", () => ({
+  getAllWorkflowsFromEventType: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@calcom/features/ee/billing/credit-service", () => ({
+  CreditService: class MockCreditService {
+    hasAvailableCredits = vi.fn().mockResolvedValue(true);
+  },
+}));
+
+vi.mock("@calcom/features/CalendarEventBuilder", () => ({
+  CalendarEventBuilder: {
+    fromBooking: vi.fn().mockResolvedValue({
+      build: vi.fn().mockReturnValue({
+        bookerUrl: "https://cal.com/test",
+        title: "Test Event",
+        startTime: new Date().toISOString(),
+        endTime: new Date().toISOString(),
+        organizer: { email: "organizer@test.com", name: "Organizer" },
+        attendees: [],
+      }),
+    }),
+  },
+}));
+
+const { scheduleWorkflowReminders } = await import(
+  "@calcom/features/ee/workflows/lib/reminders/reminderScheduler"
+);
+const { getAllWorkflowsFromEventType } = await import(
+  "@calcom/features/ee/workflows/lib/getAllWorkflowsFromEventType"
+);
+
+const mockScheduleWorkflowReminders = vi.mocked(scheduleWorkflowReminders);
+const mockGetAllWorkflowsFromEventType = vi.mocked(getAllWorkflowsFromEventType);
+
+describe("WorkflowTaskService", () => {
+  let service: WorkflowTaskService;
+  let mockBookingRepository: BookingRepository;
+  let mockLogger: { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+
+  const createMockBooking = (overrides = {}) => ({
+    id: 123,
+    uid: "booking-uid-123",
+    title: "Test Booking",
+    startTime: new Date(),
+    endTime: new Date(),
+    user: {
+      id: 1,
+      name: "Test User",
+      email: "test@example.com",
+      username: "testuser",
+      timeZone: "UTC",
+      locale: "en",
+      timeFormat: 12,
+    },
+    eventType: {
+      id: 1,
+      slug: "test-event",
+      title: "Test Event",
+      schedulingType: null,
+      teamId: null,
+      userId: 1,
+      parentId: null,
+      metadata: {},
+      hosts: [
+        {
+          userId: 1,
+          isFixed: true,
+          user: {
+            id: 1,
+            name: "Host",
+            email: "host@example.com",
+            username: "host",
+            timeZone: "UTC",
+            locale: "en",
+            timeFormat: 12,
+            destinationCalendar: {
+              primaryEmail: "host@example.com",
+            },
+          },
+        },
+      ],
+    },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockLogger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    mockBookingRepository = {
+      getBookingForWorkflowTasker: vi.fn().mockResolvedValue(createMockBooking()),
+    } as unknown as BookingRepository;
+
+    service = new WorkflowTaskService({
+      logger: mockLogger,
+      bookingRepository: mockBookingRepository,
+    });
+  });
+
+  describe("constructor", () => {
+    it("should be instantiable with dependencies", () => {
+      expect(service).toBeInstanceOf(WorkflowTaskService);
+      expect(service.dependencies.logger).toBe(mockLogger);
+      expect(service.dependencies.bookingRepository).toBe(mockBookingRepository);
+    });
+  });
+
+  describe("scheduleRescheduleWorkflows", () => {
+    const basePayload = {
+      bookingId: 123,
+      smsReminderNumber: "+1234567890",
+      hideBranding: false,
+    };
+
+    it("should fetch booking data and schedule workflows", async () => {
+      const mockWorkflows = [
+        {
+          id: 1,
+          name: "Reschedule Workflow",
+          trigger: WorkflowTriggerEvents.RESCHEDULE_EVENT,
+          time: null,
+          timeUnit: null,
+          steps: [],
+        },
+      ];
+
+      mockGetAllWorkflowsFromEventType.mockResolvedValue(mockWorkflows);
+
+      await service.scheduleRescheduleWorkflows(basePayload);
+
+      expect(mockBookingRepository.getBookingForWorkflowTasker).toHaveBeenCalledWith(123);
+      expect(mockGetAllWorkflowsFromEventType).toHaveBeenCalled();
+      expect(mockScheduleWorkflowReminders).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflows: mockWorkflows,
+          smsReminderNumber: "+1234567890",
+          hideBranding: false,
+        })
+      );
+    });
+
+    it("should filter workflows to only include RESCHEDULE_EVENT, BEFORE_EVENT, and AFTER_EVENT triggers", async () => {
+      const mockWorkflows = [
+        { id: 1, trigger: WorkflowTriggerEvents.RESCHEDULE_EVENT, steps: [] },
+        { id: 2, trigger: WorkflowTriggerEvents.BEFORE_EVENT, steps: [] },
+        { id: 3, trigger: WorkflowTriggerEvents.AFTER_EVENT, steps: [] },
+        { id: 4, trigger: WorkflowTriggerEvents.NEW_EVENT, steps: [] },
+        { id: 5, trigger: WorkflowTriggerEvents.EVENT_CANCELLED, steps: [] },
+      ];
+
+      mockGetAllWorkflowsFromEventType.mockResolvedValue(mockWorkflows);
+
+      await service.scheduleRescheduleWorkflows(basePayload);
+
+      expect(mockScheduleWorkflowReminders).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflows: expect.arrayContaining([
+            expect.objectContaining({ id: 1 }),
+            expect.objectContaining({ id: 2 }),
+            expect.objectContaining({ id: 3 }),
+          ]),
+        })
+      );
+
+      const calledWorkflows = mockScheduleWorkflowReminders.mock.calls[0][0].workflows;
+      expect(calledWorkflows).toHaveLength(3);
+      expect(calledWorkflows.map((w: { id: number }) => w.id)).toEqual([1, 2, 3]);
+    });
+
+    it("should skip scheduling if no matching workflows found", async () => {
+      mockGetAllWorkflowsFromEventType.mockResolvedValue([
+        { id: 1, trigger: WorkflowTriggerEvents.NEW_EVENT, steps: [] },
+      ]);
+
+      await service.scheduleRescheduleWorkflows(basePayload);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("No reschedule workflows found")
+      );
+      expect(mockScheduleWorkflowReminders).not.toHaveBeenCalled();
+    });
+
+    it("should throw error if booking not found", async () => {
+      vi.mocked(mockBookingRepository.getBookingForWorkflowTasker).mockResolvedValue(null);
+
+      await expect(service.scheduleRescheduleWorkflows(basePayload)).rejects.toThrow(
+        "Booking with id '123' was not found."
+      );
+    });
+
+    it("should throw error if booking has no eventType", async () => {
+      vi.mocked(mockBookingRepository.getBookingForWorkflowTasker).mockResolvedValue(
+        createMockBooking({ eventType: null })
+      );
+
+      await expect(service.scheduleRescheduleWorkflows(basePayload)).rejects.toThrow(
+        "EventType of Booking with id '123' was not found."
+      );
+    });
+
+    it("should throw error if booking has no user", async () => {
+      vi.mocked(mockBookingRepository.getBookingForWorkflowTasker).mockResolvedValue(
+        createMockBooking({ user: null })
+      );
+
+      await expect(service.scheduleRescheduleWorkflows(basePayload)).rejects.toThrow(
+        "User of Booking with id '123' was not found."
+      );
+    });
+
+    it("should include seatReferenceUid in workflow scheduling if provided", async () => {
+      const mockWorkflows = [
+        { id: 1, trigger: WorkflowTriggerEvents.RESCHEDULE_EVENT, steps: [] },
+      ];
+      mockGetAllWorkflowsFromEventType.mockResolvedValue(mockWorkflows);
+
+      await service.scheduleRescheduleWorkflows({
+        ...basePayload,
+        seatReferenceUid: "seat-123",
+      });
+
+      expect(mockScheduleWorkflowReminders).toHaveBeenCalledWith(
+        expect.objectContaining({
+          seatReferenceUid: "seat-123",
+        })
+      );
+    });
+
+    it("should handle workflows with empty steps array", async () => {
+      const mockWorkflows = [
+        { id: 1, trigger: WorkflowTriggerEvents.RESCHEDULE_EVENT, steps: [] },
+      ];
+      mockGetAllWorkflowsFromEventType.mockResolvedValue(mockWorkflows);
+
+      await service.scheduleRescheduleWorkflows(basePayload);
+
+      expect(mockScheduleWorkflowReminders).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/features/ee/workflows/lib/tasker/__tests__/WorkflowTasker.test.ts
+++ b/packages/features/ee/workflows/lib/tasker/__tests__/WorkflowTasker.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ILogger } from "@calcom/lib/tasker/types";
+
+import type { WorkflowSyncTasker } from "../WorkflowSyncTasker";
+import { WorkflowTasker } from "../WorkflowTasker";
+import type { WorkflowTriggerDevTasker } from "../WorkflowTriggerDevTasker";
+
+describe("WorkflowTasker", () => {
+  let tasker: WorkflowTasker;
+  let mockAsyncTasker: WorkflowTriggerDevTasker;
+  let mockSyncTasker: WorkflowSyncTasker;
+  let mockLogger: ILogger;
+
+  beforeEach(() => {
+    mockAsyncTasker = {
+      scheduleRescheduleWorkflows: vi.fn().mockResolvedValue({ runId: "async-run-123" }),
+      dependencies: {},
+    } as unknown as WorkflowTriggerDevTasker;
+
+    mockSyncTasker = {
+      scheduleRescheduleWorkflows: vi.fn().mockResolvedValue({ runId: "sync-run-123" }),
+      dependencies: {},
+    } as unknown as WorkflowSyncTasker;
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      getSubLogger: vi.fn().mockReturnThis(),
+    } as unknown as ILogger;
+
+    tasker = new WorkflowTasker({
+      asyncTasker: mockAsyncTasker,
+      syncTasker: mockSyncTasker,
+      logger: mockLogger,
+    });
+  });
+
+  describe("constructor", () => {
+    it("should be instantiable with dependencies", () => {
+      expect(tasker).toBeInstanceOf(WorkflowTasker);
+      expect(tasker.dependencies.asyncTasker).toBe(mockAsyncTasker);
+      expect(tasker.dependencies.syncTasker).toBe(mockSyncTasker);
+      expect(tasker.dependencies.logger).toBe(mockLogger);
+    });
+  });
+
+  describe("scheduleRescheduleWorkflows", () => {
+    const basePayload = {
+      bookingId: 123,
+      smsReminderNumber: "+1234567890",
+      hideBranding: false,
+    };
+
+    it("should dispatch and return runId on success", async () => {
+      const result = await tasker.scheduleRescheduleWorkflows(basePayload);
+
+      expect(result).toHaveProperty("runId");
+      expect(result.runId).not.toBe("task-not-found");
+      expect(result.runId).not.toBe("task-failed");
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("scheduleRescheduleWorkflows success"),
+        expect.any(Object),
+        expect.objectContaining({ bookingId: 123 })
+      );
+    });
+
+    it("should return task-failed runId when dispatch fails", async () => {
+      vi.mocked(mockSyncTasker.scheduleRescheduleWorkflows).mockRejectedValue(
+        new Error("Dispatch failed")
+      );
+
+      const result = await tasker.scheduleRescheduleWorkflows(basePayload);
+
+      expect(result).toEqual({ runId: "task-failed" });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("scheduleRescheduleWorkflows failed"),
+        expect.objectContaining({ runId: "task-failed" }),
+        expect.objectContaining({ bookingId: 123 })
+      );
+    });
+
+    it("should pass payload correctly to dispatch", async () => {
+      const payloadWithSeat = {
+        ...basePayload,
+        seatReferenceUid: "seat-456",
+      };
+
+      await tasker.scheduleRescheduleWorkflows(payloadWithSeat);
+
+      expect(mockSyncTasker.scheduleRescheduleWorkflows).toHaveBeenCalledWith(payloadWithSeat);
+    });
+
+    it("should handle null smsReminderNumber", async () => {
+      const payloadWithNullSms = {
+        bookingId: 123,
+        smsReminderNumber: null,
+        hideBranding: true,
+      };
+
+      const result = await tasker.scheduleRescheduleWorkflows(payloadWithNullSms);
+
+      expect(result).toHaveProperty("runId");
+      expect(result.runId).not.toBe("task-failed");
+      expect(mockSyncTasker.scheduleRescheduleWorkflows).toHaveBeenCalledWith(payloadWithNullSms);
+    });
+  });
+});

--- a/packages/features/ee/workflows/lib/tasker/__tests__/WorkflowTriggerDevTasker.test.ts
+++ b/packages/features/ee/workflows/lib/tasker/__tests__/WorkflowTriggerDevTasker.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
+
+import { WorkflowTriggerDevTasker } from "../WorkflowTriggerDevTasker";
+
+vi.mock("../trigger/scheduleRescheduleWorkflows", () => ({
+  scheduleRescheduleWorkflows: {
+    trigger: vi.fn().mockResolvedValue({ id: "trigger-run-123" }),
+  },
+}));
+
+describe("WorkflowTriggerDevTasker", () => {
+  let triggerDevTasker: WorkflowTriggerDevTasker;
+  let mockLogger: ITaskerDependencies["logger"];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      getSubLogger: vi.fn().mockReturnThis(),
+    } as unknown as ITaskerDependencies["logger"];
+
+    triggerDevTasker = new WorkflowTriggerDevTasker({
+      logger: mockLogger,
+    });
+  });
+
+  describe("constructor", () => {
+    it("should be instantiable with dependencies", () => {
+      expect(triggerDevTasker).toBeInstanceOf(WorkflowTriggerDevTasker);
+      expect(triggerDevTasker.dependencies.logger).toBe(mockLogger);
+    });
+  });
+
+  describe("scheduleRescheduleWorkflows", () => {
+    const basePayload = {
+      bookingId: 123,
+      smsReminderNumber: "+1234567890",
+      hideBranding: false,
+    };
+
+    it("should trigger the scheduleRescheduleWorkflows task and return runId", async () => {
+      const result = await triggerDevTasker.scheduleRescheduleWorkflows(basePayload);
+
+      expect(result).toEqual({ runId: "trigger-run-123" });
+    });
+
+    it("should pass payload to trigger.dev task", async () => {
+      const { scheduleRescheduleWorkflows } = await import("../trigger/scheduleRescheduleWorkflows");
+
+      await triggerDevTasker.scheduleRescheduleWorkflows(basePayload);
+
+      expect(scheduleRescheduleWorkflows.trigger).toHaveBeenCalledWith(basePayload);
+    });
+
+    it("should handle payload with seatReferenceUid", async () => {
+      const { scheduleRescheduleWorkflows } = await import("../trigger/scheduleRescheduleWorkflows");
+
+      const payloadWithSeat = {
+        ...basePayload,
+        seatReferenceUid: "seat-456",
+      };
+
+      await triggerDevTasker.scheduleRescheduleWorkflows(payloadWithSeat);
+
+      expect(scheduleRescheduleWorkflows.trigger).toHaveBeenCalledWith(payloadWithSeat);
+    });
+
+    it("should handle payload with null smsReminderNumber", async () => {
+      const { scheduleRescheduleWorkflows } = await import("../trigger/scheduleRescheduleWorkflows");
+
+      const payloadWithNullSms = {
+        bookingId: 789,
+        smsReminderNumber: null,
+        hideBranding: true,
+      };
+
+      await triggerDevTasker.scheduleRescheduleWorkflows(payloadWithNullSms);
+
+      expect(scheduleRescheduleWorkflows.trigger).toHaveBeenCalledWith(payloadWithNullSms);
+    });
+
+    it("should propagate errors from trigger.dev", async () => {
+      const { scheduleRescheduleWorkflows } = await import("../trigger/scheduleRescheduleWorkflows");
+      vi.mocked(scheduleRescheduleWorkflows.trigger).mockRejectedValueOnce(new Error("Trigger failed"));
+
+      await expect(triggerDevTasker.scheduleRescheduleWorkflows(basePayload)).rejects.toThrow(
+        "Trigger failed"
+      );
+    });
+  });
+});

--- a/packages/features/ee/workflows/lib/tasker/trigger/config.ts
+++ b/packages/features/ee/workflows/lib/tasker/trigger/config.ts
@@ -1,0 +1,24 @@
+import type { schemaTask } from "@trigger.dev/sdk";
+import { queue } from "@trigger.dev/sdk";
+
+type WorkflowTask = Pick<Parameters<typeof schemaTask>[0], "machine" | "retry" | "queue">;
+
+export const workflowTasksQueue = queue({
+  name: "workflow-tasks",
+  concurrencyLimit: 20,
+});
+
+export const workflowTaskConfig: WorkflowTask = {
+  queue: workflowTasksQueue,
+  machine: "small-2x",
+  retry: {
+    maxAttempts: 3,
+    factor: 1.8,
+    minTimeoutInMs: 500,
+    maxTimeoutInMs: 30_000,
+    randomize: true,
+    outOfMemory: {
+      machine: "medium-1x",
+    },
+  },
+};

--- a/packages/features/ee/workflows/lib/tasker/trigger/scheduleRescheduleWorkflows.ts
+++ b/packages/features/ee/workflows/lib/tasker/trigger/scheduleRescheduleWorkflows.ts
@@ -1,0 +1,24 @@
+import { schemaTask } from "@trigger.dev/sdk";
+
+import { workflowTaskConfig } from "./config";
+import { workflowTaskSchema } from "./schema";
+
+export const scheduleRescheduleWorkflows = schemaTask({
+  id: "workflow.schedule.reschedule",
+  ...workflowTaskConfig,
+  schema: workflowTaskSchema,
+  run: async (payload) => {
+    const { TriggerDevLogger } = await import("@calcom/lib/triggerDevLogger");
+    const { BookingRepository } = await import("@calcom/features/bookings/repositories/BookingRepository");
+    const { prisma } = await import("@calcom/prisma");
+    const { WorkflowTaskService } = await import("../WorkflowTaskService");
+
+    const triggerDevLogger = new TriggerDevLogger();
+    const bookingRepo = new BookingRepository(prisma);
+    const workflowTaskService = new WorkflowTaskService({
+      logger: triggerDevLogger,
+      bookingRepository: bookingRepo,
+    });
+    await workflowTaskService.scheduleRescheduleWorkflows(payload);
+  },
+});

--- a/packages/features/ee/workflows/lib/tasker/trigger/schema.ts
+++ b/packages/features/ee/workflows/lib/tasker/trigger/schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const workflowTaskSchema = z.object({
+  bookingId: z.number(),
+  smsReminderNumber: z.string().nullable(),
+  hideBranding: z.boolean(),
+  seatReferenceUid: z.string().optional(),
+});

--- a/packages/features/ee/workflows/lib/tasker/types.ts
+++ b/packages/features/ee/workflows/lib/tasker/types.ts
@@ -1,0 +1,32 @@
+import type { ExtendedCalendarEvent } from "@calcom/ee/workflows/lib/reminders/reminderScheduler";
+import type { Workflow } from "@calcom/ee/workflows/lib/types";
+import type { CreditCheckFn } from "@calcom/features/ee/billing/credit-service";
+
+export type WorkflowTaskPayload = {
+  bookingId: number;
+  smsReminderNumber: string | null;
+  hideBranding: boolean;
+  seatReferenceUid?: string;
+};
+
+export interface IWorkflowTasker {
+  scheduleRescheduleWorkflows(payload: WorkflowTaskPayload): Promise<{ runId: string }>;
+}
+
+export type WorkflowSyncSendPayload = {
+  workflows: Workflow[];
+  smsReminderNumber: string | null;
+  calendarEvent: ExtendedCalendarEvent;
+  hideBranding: boolean;
+  seatReferenceUid?: string;
+  isDryRun?: boolean;
+  creditCheckFn: CreditCheckFn;
+};
+
+export type WorkflowAsyncTasksPayload = WorkflowTaskPayload;
+
+type WithVoidReturns<T> = {
+  [K in keyof T]: T[K] extends (...args: infer P) => unknown ? (...args: P) => void : T[K];
+};
+
+export type WorkflowTasks = WithVoidReturns<IWorkflowTasker>;

--- a/packages/features/flags/config.ts
+++ b/packages/features/flags/config.ts
@@ -31,8 +31,9 @@ export type AppFlags = {
   "onboarding-v3": boolean;
   "booker-botid": boolean;
   "booking-calendar-view": boolean;
-  "booking-email-sms-tasker": boolean;
-  "bookings-v3": boolean;
+    "booking-email-sms-tasker": boolean;
+    "workflow-tasker": boolean;
+    "bookings-v3": boolean;
   "booking-audit": boolean;
   "monthly-proration": boolean;
   "sidebar-tips": boolean;

--- a/packages/features/flags/hooks/index.ts
+++ b/packages/features/flags/hooks/index.ts
@@ -31,6 +31,7 @@ const initialData: AppFlags = {
   "booker-botid": false,
   "booking-calendar-view": false,
   "booking-email-sms-tasker": false,
+  "workflow-tasker": false,
   "bookings-v3": false,
   "booking-audit": false,
   "monthly-proration": false,


### PR DESCRIPTION
## What does this PR do?

Implements rescheduling workflows as a background job using the existing email/SMS tasker pattern as inspiration. This moves workflow scheduling for reschedule events to trigger.dev for async execution, reducing latency in the booking response.

The implementation follows the same 3-layer architecture used by `BookingEmailAndSmsTasker`:
- `WorkflowTasker` - Main orchestrator that dispatches to async or sync tasker
- `WorkflowTriggerDevTasker` - Async implementation via trigger.dev
- `WorkflowSyncTasker` - Sync fallback implementation  
- `WorkflowTaskService` - Contains the actual business logic (calls `scheduleWorkflowReminders`)

Key changes:
- Added `workflow-tasker` feature flag to `AppFlags`
- Created DI modules and tokens for workflow tasker components
- Added `getBookingForWorkflowTasker` repository method to fetch booking data with required relations
- Integrated `WorkflowTasker` into `RegularBookingService` for reschedule events
- Created trigger.dev task `workflow.schedule.reschedule`
- Added comprehensive unit tests (27 tests across 4 test files)

The feature is gated behind the `workflow-tasker` feature flag and only triggers for organizations that have the flag enabled.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Enable the `workflow-tasker` feature flag for a test organization
2. Create a booking with a workflow that triggers on `RESCHEDULE_EVENT`
3. Reschedule the booking
4. Verify the workflow is scheduled via trigger.dev (check trigger.dev dashboard)
5. Verify the workflow executes correctly (email/SMS sent)

Environment variables needed:
- `TRIGGER_API_KEY` and `TRIGGER_API_URL` for trigger.dev integration
- Feature flag `workflow-tasker` must be enabled for the org

## Checklist for Human Review

- [ ] Verify `ExtendedCalendarEvent` construction in `WorkflowTaskService` matches what `scheduleWorkflowReminders` expects
- [ ] Check if task registration in `packages/features/tasker/tasks/index.ts` is needed for trigger.dev
- [ ] Review workflow filtering logic - currently includes `RESCHEDULE_EVENT`, `BEFORE_EVENT`, and `AFTER_EVENT` triggers
- [ ] Review indentation changes in `RegularBookingService.ts`, `BookingRepository.ts`, and `config.ts` - some appear to be formatting-only changes that may need cleanup

---

Link to Devin run: https://app.devin.ai/sessions/43d17dbab131473883f6421be9ebc5fd
Requested by: @sean-brydon