### PR TITLE
fix: disable prefetch on team page event type links to prevent Google rate limits

### DIFF
--- a/apps/web/modules/team/team-view.tsx
+++ b/apps/web/modules/team/team-view.tsx
@@ -69,12 +69,13 @@ function TeamPage({ team, considerUnpublished, isValidOrgDomain }: PageProps) {
             !isEmbed && "bg-default"
           )}>
           <div className="px-6 py-4 ">
-            <Link
-              href={{
-                pathname: `${isValidOrgDomain ? "" : "/team"}/${team.slug}/${type.slug}`,
-                query: queryParamsToForward,
-              }}
-              onClick={async () => {
+              <Link
+                prefetch={false}
+                href={{
+                  pathname: `${isValidOrgDomain ? "" : "/team"}/${team.slug}/${type.slug}`,
+                  query: queryParamsToForward,
+                }}
+                onClick={async () => {
                 sdkActionManager?.fire("eventTypeSelected", {
                   eventType: type,
                 });
@@ -106,7 +107,7 @@ function TeamPage({ team, considerUnpublished, isValidOrgDomain }: PageProps) {
           ).length;
           return (
             <li key={i} className="hover:bg-cal-muted w-full rounded-md transition">
-              <Link href={`/${ch.slug}`} className="flex items-center justify-between">
+              <Link prefetch={false} href={`/${ch.slug}`} className="flex items-center justify-between">
                 <div className="flex items-center px-5 py-5">
                   <div className="ms-3 inline-block truncate">
                     <span className="text-default text-sm font-bold">{ch.name}</span>


### PR DESCRIPTION
## What does this PR do?

Disables Next.js Link prefetching on the team page (`/team/[slug]`) to prevent excessive server-side rendering of event type pages when viewing a team's profile.

When a team has many event types, Next.js automatically prefetches all linked event type pages when they come into the viewport. This triggers server-side rendering for each page, which can make Google Calendar API calls and cause rate limiting issues.

This follows the existing pattern in `users-public-view.tsx` which already has `prefetch={false}` on event type links with the comment: "Don't prefetch till the time we drop the amount of javascript in [user][type] page which is impacting score for [user] page"

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to a team page with multiple event types (e.g., `i.cal.com/engineering`)
2. Open browser DevTools Network tab
3. Observe that event type pages are no longer being prefetched/prerendered when they come into view
4. Verify that clicking on an event type still navigates correctly to the event type page

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

## Human Review Checklist

- [x] Verify `prefetch={false}` is the correct approach to prevent the prerendering behavior shown in the screenshot
- [x] Consider if there are other team-related pages that might need similar treatment
- [x] Note: There's a minor indentation change from the linter - verify this is acceptable

---

Link to Devin run: https://app.devin.ai/sessions/20d6b6950eab4841b44f488bbf30fbc9
Requested by: @emrysal