### PR TITLE
feat: add tooltip to `assigned` badge

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -214,9 +214,11 @@ const Item = ({
         </Badge>
       )}
       {showAssignedBadge && (
-        <Badge variant="blue" className="ml-2" data-testid="assigned-badge">
-          {t("assigned")}
-        </Badge>
+        <Tooltip content={t("you_are_assigned_to_this_event")}>
+          <Badge variant="blue" className="ml-2" data-testid="assigned-badge">
+            {t("assigned")}
+          </Badge>
+        </Tooltip>
       )}
     </div>
   );
@@ -256,9 +258,11 @@ const Item = ({
                 </Badge>
               )}
               {showAssignedBadge && (
-                <Badge variant="blue" className="ml-2" data-testid="assigned-badge">
-                  {t("assigned")}
-                </Badge>
+                <Tooltip content={t("you_are_assigned_to_this_event")}>
+                  <Badge variant="blue" className="ml-2" data-testid="assigned-badge">
+                    {t("assigned")}
+                  </Badge>
+                </Tooltip>
               )}
             </div>
             <EventTypeDescription

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1001,6 +1001,7 @@
   "hidden": "Hidden",
   "readonly": "Read only",
   "assigned": "Assigned",
+  "you_are_assigned_to_this_event": "You are assigned to this event",
   "one_time_link": "One-time link",
   "plan_description": "You're currently on the {{plan}} plan.",
   "plan_upgrade_invitation": "Upgrade your account to the PRO plan to unlock all of the features we have to offer.",


### PR DESCRIPTION

https://github.com/user-attachments/assets/ddf5a277-8fd5-43cd-81f2-33becb1a205b



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a tooltip to the Assigned badge in the Event Types list to clarify that you are assigned to the event. Added the “you_are_assigned_to_this_event” translation string.

<sup>Written for commit ab769c42c8ea2312d472bcd5cb71e9115d2d46e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

