### PR TITLE
fix: Salesforce tokens add `token_lifetime`

### DIFF
--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -17,6 +17,8 @@ import type { CalendarEvent, CalEventResponses } from "@calcom/types/Calendar";
 import type { CredentialPayload } from "@calcom/types/Credential";
 import type { CRM, Contact, CrmEvent } from "@calcom/types/CrmService";
 
+import { CredentialRepository } from "@calcom/features/credentials/repositories/CredentialRepository";
+
 import type { ParseRefreshTokenResponse } from "../../_utils/oauth/parseRefreshTokenResponse";
 import parseRefreshTokenResponse from "../../_utils/oauth/parseRefreshTokenResponse";
 import { findFieldValueByIdentifier } from "../../routing-forms/lib/findFieldValueByIdentifier";
@@ -50,6 +52,7 @@ export interface SalesforceCRM extends CRM {
   getAllPossibleAccountWebsiteFromEmailDomain(emailDomain: string): string;
 }
 import { getSalesforceAppKeys } from "./getSalesforceAppKeys";
+import { getSalesforceTokenLifetime } from "./getSalesforceTokenLifetime";
 import { SalesforceGraphQLClient } from "./graphql/SalesforceGraphQLClient";
 import getAllPossibleWebsiteValuesFromEmailDomain from "./utils/getAllPossibleWebsiteValuesFromEmailDomain";
 import getDominantAccountId from "./utils/getDominantAccountId";
@@ -104,12 +107,13 @@ type Attendee = { email: string; name: string };
 
 const salesforceTokenSchema = z.object({
   id: z.string(),
-  issued_at: z.string(),
+  issued_at: z.string(), // Salesforce returns this in milliseconds as a string
   instance_url: z.string(),
   signature: z.string(),
   access_token: z.string(),
   scope: z.string(),
   token_type: z.string(),
+  token_lifetime: z.number().optional(), // Token lifetime in seconds (from introspection)
 });
 
 class SalesforceCRMService implements CRM {
@@ -122,9 +126,12 @@ class SalesforceCRMService implements CRM {
   private fallbackToContact = false;
   private accessToken: string;
   private instanceUrl: string;
+  private hasAttemptedRefresh = false;
+  private credentialId: number;
 
   constructor(credential: CredentialPayload, appOptions: z.infer<typeof appDataSchema>, testMode = false) {
     this.integrationName = "salesforce_other_calendar";
+    this.credentialId = credential.id;
     if (!testMode) {
       this.conn = this.getClient(credential).then((c) => c);
     }
@@ -139,44 +146,104 @@ class SalesforceCRMService implements CRM {
     return this.appOptions;
   }
 
+  /**
+   * Refreshes the Salesforce access token and optionally introspects to get/update token_lifetime.
+   * @param forceIntrospection - If true, always introspect to recalibrate token_lifetime (e.g., after unexpected expiry)
+   * @param existingTokenLifetime - The current token_lifetime to reuse if not forcing introspection
+   */
+  private refreshAccessToken = async ({
+    refreshToken,
+    forceIntrospection,
+    existingTokenLifetime,
+  }: {
+    refreshToken: string;
+    forceIntrospection: boolean;
+    existingTokenLifetime?: number;
+  }) => {
+    const { consumer_key, consumer_secret } = await getSalesforceAppKeys();
+
+    const response = await fetch("https://login.salesforce.com/services/oauth2/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: consumer_key,
+        client_secret: consumer_secret,
+        refresh_token: refreshToken,
+      }),
+    });
+
+    if (!response.ok) {
+      const message = `${response.statusText}: ${JSON.stringify(await response.json())}`;
+      throw new Error(message);
+    }
+
+    const accessTokenJson = await response.json();
+    const accessTokenParsed = parseRefreshTokenResponse(accessTokenJson, salesforceTokenSchema);
+
+    // Introspect if forced or if we don't have a token_lifetime yet
+    let tokenLifetime = existingTokenLifetime;
+    if (forceIntrospection || !tokenLifetime) {
+      tokenLifetime = await getSalesforceTokenLifetime({
+        accessToken: accessTokenParsed.access_token,
+        instanceUrl: accessTokenParsed.instance_url,
+      });
+    }
+
+    // Update credential in database
+    const updatedKey = {
+      ...accessTokenParsed,
+      refresh_token: refreshToken,
+      token_lifetime: tokenLifetime,
+    };
+
+    await CredentialRepository.updateWhereId({
+      id: this.credentialId,
+      data: { key: updatedKey },
+    });
+
+    return {
+      accessToken: accessTokenParsed.access_token,
+      instanceUrl: accessTokenParsed.instance_url,
+      issuedAt: accessTokenParsed.issued_at,
+      tokenLifetime,
+    };
+  };
+
   private getClient = async (credential: CredentialPayload) => {
     const { consumer_key, consumer_secret } = await getSalesforceAppKeys();
-    const credentialKey = credential.key as unknown as ExtendedTokenResponse;
+    const credentialKey = credential.key as unknown as ExtendedTokenResponse & { token_lifetime?: number };
 
     if (!credentialKey.refresh_token)
       throw new Error(`Refresh token is missing for credential ${credential.id}`);
 
-    try {
-      /* XXX: This code results in 'Bad Request', which indicates something is wrong with our salesforce integration.
-              Needs further investigation ASAP */
-      const response = await fetch("https://login.salesforce.com/services/oauth2/token", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: new URLSearchParams({
-          grant_type: "refresh_token",
-          client_id: consumer_key,
-          client_secret: consumer_secret,
-          refresh_token: credentialKey.refresh_token,
-        }),
-      });
-      if (!response.ok) {
-        const message = `${response.statusText}: ${JSON.stringify(await response.json())}`;
-        throw new Error(message);
+    // Check if token is still valid
+    // issued_at is in milliseconds (string), token_lifetime is in seconds
+    const BUFFER_MS = 5 * 60 * 1000; // 5 minutes buffer before expiry
+    const issuedAt = parseInt(credentialKey.issued_at, 10);
+    const tokenLifetimeMs = (credentialKey.token_lifetime || 0) * 1000;
+    const expiryTime = issuedAt + tokenLifetimeMs;
+    const isTokenValid = credentialKey.token_lifetime && Date.now() < expiryTime - BUFFER_MS;
+
+    if (!isTokenValid) {
+      try {
+        const result = await this.refreshAccessToken({
+          refreshToken: credentialKey.refresh_token,
+          forceIntrospection: false,
+          existingTokenLifetime: credentialKey.token_lifetime,
+        });
+
+        // Update instance variables and credentialKey for the connection
+        this.accessToken = result.accessToken;
+        this.instanceUrl = result.instanceUrl;
+        credentialKey.access_token = result.accessToken;
+        credentialKey.issued_at = result.issuedAt;
+        credentialKey.token_lifetime = result.tokenLifetime;
+      } catch (err: unknown) {
+        console.error(err); // log but proceed
       }
-
-      const accessTokenJson = await response.json();
-
-      const accessTokenParsed: ParseRefreshTokenResponse<typeof salesforceTokenSchema> =
-        parseRefreshTokenResponse(accessTokenJson, salesforceTokenSchema);
-
-      await prisma.credential.update({
-        where: { id: credential.id },
-        data: { key: { ...accessTokenParsed, refresh_token: credentialKey.refresh_token } },
-      });
-    } catch (err: unknown) {
-      console.error(err); // log but proceed
     }
 
     return new jsforce.Connection({
@@ -188,6 +255,28 @@ class SalesforceCRMService implements CRM {
       instanceUrl: credentialKey.instance_url,
       accessToken: credentialKey.access_token,
       refreshToken: credentialKey.refresh_token,
+      refreshFn: async (conn, callback) => {
+        // Only attempt refresh once to avoid infinite loops
+        if (this.hasAttemptedRefresh) {
+          return callback(new Error("Token refresh already attempted"));
+        }
+        this.hasAttemptedRefresh = true;
+
+        try {
+          // Force introspection to recalibrate token_lifetime after unexpected expiry
+          const result = await this.refreshAccessToken({
+            refreshToken: credentialKey.refresh_token,
+            forceIntrospection: true,
+          });
+
+          this.accessToken = result.accessToken;
+          this.instanceUrl = result.instanceUrl;
+
+          callback(null, result.accessToken);
+        } catch (err) {
+          callback(err instanceof Error ? err : new Error(String(err)));
+        }
+      },
     });
   };
 

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -219,6 +219,8 @@ class SalesforceCRMService implements CRM {
     if (!credentialKey.refresh_token)
       throw new Error(`Refresh token is missing for credential ${credential.id}`);
 
+    const refreshToken = credentialKey.refresh_token;
+
     // Check if token is still valid
     // issued_at is in milliseconds (string), token_lifetime is in seconds
     const BUFFER_MS = 5 * 60 * 1000; // 5 minutes buffer before expiry
@@ -230,7 +232,7 @@ class SalesforceCRMService implements CRM {
     if (!isTokenValid) {
       try {
         const result = await this.refreshAccessToken({
-          refreshToken: credentialKey.refresh_token,
+          refreshToken,
           forceIntrospection: false,
           existingTokenLifetime: credentialKey.token_lifetime,
         });
@@ -265,7 +267,7 @@ class SalesforceCRMService implements CRM {
         try {
           // Force introspection to recalibrate token_lifetime after unexpected expiry
           const result = await this.refreshAccessToken({
-            refreshToken: credentialKey.refresh_token,
+            refreshToken,
             forceIntrospection: true,
           });
 

--- a/packages/app-store/salesforce/lib/__tests__/CrmService.integration.test.ts
+++ b/packages/app-store/salesforce/lib/__tests__/CrmService.integration.test.ts
@@ -55,14 +55,27 @@ vi.mock("../getSalesforceAppKeys", () => ({
   }),
 }));
 
+vi.mock("../getSalesforceTokenLifetime", () => ({
+  getSalesforceTokenLifetime: vi.fn().mockResolvedValue(7200),
+}));
+
+vi.mock("@calcom/features/credentials/repositories/CredentialRepository", () => ({
+  CredentialRepository: {
+    updateWhereId: vi.fn().mockResolvedValue({}),
+  },
+}));
+
 // Helper to create mock credential
-const createMockCredential = () => {
+const createMockCredential = (options?: { tokenLifetime?: number; issuedAt?: string }) => {
+  const now = Date.now();
   return {
     id: 1,
     key: {
       access_token: "test_access_token",
       refresh_token: "test_refresh_token",
       instance_url: "https://test.salesforce.com",
+      issued_at: options?.issuedAt ?? String(now),
+      token_lifetime: options?.tokenLifetime ?? 7200,
     },
     type: "salesforce_other_calendar",
     user: {
@@ -352,6 +365,168 @@ describe("SalesforceCRMService", () => {
         const allContactsInSalesforce = salesforceMock.getContacts();
         expect(allContactsInSalesforce).toHaveLength(0);
       });
+    });
+  });
+
+  describe("Token lifecycle management", () => {
+    it("should not refresh token when token_lifetime is valid and not expired", async () => {
+      const now = Date.now();
+      const credential = createMockCredential({
+        issuedAt: String(now),
+        tokenLifetime: 7200,
+      });
+      const { appOptions } = salesforceSettingScenario.createOnLeadAndSearchOnAccount();
+
+      fetchMock.mockReset();
+
+      const crmService = createSalesforceCrmServiceWithSalesforceType(credential, appOptions);
+
+      salesforceMock.addLead({
+        Email: "test@example.com",
+        FirstName: "Test",
+        LastName: "User",
+      });
+
+      await crmService.getContacts({ emails: "test@example.com" });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("should refresh token when token is expired", async () => {
+      const oneHourAgo = Date.now() - 60 * 60 * 1000;
+      const credential = createMockCredential({
+        issuedAt: String(oneHourAgo),
+        tokenLifetime: 1800,
+      });
+      const { appOptions } = salesforceSettingScenario.createOnLeadAndSearchOnAccount();
+
+      fetchMock.mockReset();
+      fetchMock.mockReturnValueOnce(
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: "abc",
+              issued_at: String(Date.now()),
+              instance_url: "https://test.salesforce.com",
+              signature: "123",
+              access_token: "new_access_token",
+              scope: "123",
+              token_type: "123",
+            }),
+            { status: 200 }
+          )
+        )
+      );
+
+      const crmService = createSalesforceCrmServiceWithSalesforceType(credential, appOptions);
+
+      salesforceMock.addLead({
+        Email: "test@example.com",
+        FirstName: "Test",
+        LastName: "User",
+      });
+
+      await crmService.getContacts({ emails: "test@example.com" });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://login.salesforce.com/services/oauth2/token",
+        expect.objectContaining({
+          method: "POST",
+        })
+      );
+    });
+
+    it("should refresh token when token_lifetime is missing (legacy credentials)", async () => {
+      const credential = {
+        id: 1,
+        key: {
+          access_token: "test_access_token",
+          refresh_token: "test_refresh_token",
+          instance_url: "https://test.salesforce.com",
+          issued_at: String(Date.now()),
+        },
+        type: "salesforce_other_calendar",
+        user: { email: "test@example.com" },
+        userId: 1,
+        teamId: 1,
+        appId: "test_app_id",
+        invalid: false,
+        delegationCredentialId: null,
+      };
+      const { appOptions } = salesforceSettingScenario.createOnLeadAndSearchOnAccount();
+
+      fetchMock.mockReset();
+      fetchMock.mockReturnValueOnce(
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: "abc",
+              issued_at: String(Date.now()),
+              instance_url: "https://test.salesforce.com",
+              signature: "123",
+              access_token: "new_access_token",
+              scope: "123",
+              token_type: "123",
+            }),
+            { status: 200 }
+          )
+        )
+      );
+
+      const crmService = createSalesforceCrmServiceWithSalesforceType(credential, appOptions);
+
+      salesforceMock.addLead({
+        Email: "test@example.com",
+        FirstName: "Test",
+        LastName: "User",
+      });
+
+      await crmService.getContacts({ emails: "test@example.com" });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should use 5-minute buffer before token expiry", async () => {
+      const tokenLifetime = 7200;
+      const bufferMs = 5 * 60 * 1000;
+      const issuedAt = Date.now() - (tokenLifetime * 1000 - bufferMs + 1000);
+
+      const credential = createMockCredential({
+        issuedAt: String(issuedAt),
+        tokenLifetime,
+      });
+      const { appOptions } = salesforceSettingScenario.createOnLeadAndSearchOnAccount();
+
+      fetchMock.mockReset();
+      fetchMock.mockReturnValueOnce(
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: "abc",
+              issued_at: String(Date.now()),
+              instance_url: "https://test.salesforce.com",
+              signature: "123",
+              access_token: "new_access_token",
+              scope: "123",
+              token_type: "123",
+            }),
+            { status: 200 }
+          )
+        )
+      );
+
+      const crmService = createSalesforceCrmServiceWithSalesforceType(credential, appOptions);
+
+      salesforceMock.addLead({
+        Email: "test@example.com",
+        FirstName: "Test",
+        LastName: "User",
+      });
+
+      await crmService.getContacts({ emails: "test@example.com" });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/app-store/salesforce/lib/__tests__/getSalesforceTokenLifetime.test.ts
+++ b/packages/app-store/salesforce/lib/__tests__/getSalesforceTokenLifetime.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { getSalesforceTokenLifetime } from "../getSalesforceTokenLifetime";
+
+vi.mock("../getSalesforceAppKeys", () => ({
+  getSalesforceAppKeys: vi.fn().mockResolvedValue({
+    consumer_key: "test_consumer_key",
+    consumer_secret: "test_consumer_secret",
+  }),
+}));
+
+describe("getSalesforceTokenLifetime", () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("should return token lifetime calculated from exp and iat", async () => {
+    const iat = 1700000000;
+    const exp = 1700003600; // 1 hour later (3600 seconds)
+    const expectedLifetime = exp - iat;
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ iat, exp }),
+    });
+
+    const result = await getSalesforceTokenLifetime({
+      accessToken: "test_access_token",
+      instanceUrl: "https://test.salesforce.com",
+    });
+
+    expect(result).toBe(expectedLifetime);
+    expect(result).toBe(3600);
+  });
+
+  it("should call the introspection endpoint with correct parameters", async () => {
+    const iat = 1700000000;
+    const exp = 1700007200;
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ iat, exp }),
+    });
+
+    await getSalesforceTokenLifetime({
+      accessToken: "my_access_token",
+      instanceUrl: "https://my-instance.salesforce.com",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://my-instance.salesforce.com/services/oauth2/introspect",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: expect.stringMatching(/^Basic /),
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
+      })
+    );
+
+    const callArgs = mockFetch.mock.calls[0];
+    const body = callArgs[1].body as URLSearchParams;
+    expect(body.get("token")).toBe("my_access_token");
+    expect(body.get("token_type_hint")).toBe("access_token");
+  });
+
+  it("should use Basic auth with base64 encoded credentials", async () => {
+    const iat = 1700000000;
+    const exp = 1700007200;
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ iat, exp }),
+    });
+
+    await getSalesforceTokenLifetime({
+      accessToken: "test_token",
+      instanceUrl: "https://test.salesforce.com",
+    });
+
+    const expectedAuth = `Basic ${Buffer.from("test_consumer_key:test_consumer_secret").toString("base64")}`;
+    const callArgs = mockFetch.mock.calls[0];
+    expect(callArgs[1].headers.Authorization).toBe(expectedAuth);
+  });
+
+  it("should throw error when introspection fails", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      statusText: "Unauthorized",
+    });
+
+    await expect(
+      getSalesforceTokenLifetime({
+        accessToken: "invalid_token",
+        instanceUrl: "https://test.salesforce.com",
+      })
+    ).rejects.toThrow("Token introspection failed: Unauthorized");
+  });
+
+  it("should handle different token lifetimes", async () => {
+    const iat = 1700000000;
+    const exp = 1700086400; // 24 hours later (86400 seconds)
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ iat, exp }),
+    });
+
+    const result = await getSalesforceTokenLifetime({
+      accessToken: "test_token",
+      instanceUrl: "https://test.salesforce.com",
+    });
+
+    expect(result).toBe(86400);
+  });
+});

--- a/packages/app-store/salesforce/lib/getSalesforceTokenLifetime.ts
+++ b/packages/app-store/salesforce/lib/getSalesforceTokenLifetime.ts
@@ -1,0 +1,41 @@
+import { getSalesforceAppKeys } from "./getSalesforceAppKeys";
+
+/**
+ * Calls Salesforce's token introspection endpoint to get the token lifetime.
+ * Returns token lifetime in seconds (calculated from exp - iat).
+ *
+ * @see https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oidc_token_introspection_endpoint.htm
+ */
+export async function getSalesforceTokenLifetime({
+  accessToken,
+  instanceUrl,
+}: {
+  accessToken: string;
+  instanceUrl: string;
+}): Promise<number> {
+  const { consumer_key, consumer_secret } = await getSalesforceAppKeys();
+
+  const response = await fetch(`${instanceUrl}/services/oauth2/introspect`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${consumer_key}:${consumer_secret}`).toString("base64")}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      token: accessToken,
+      token_type_hint: "access_token",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Token introspection failed: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+
+  // Calculate lifetime from exp and iat (both in seconds)
+  // exp = expiration timestamp, iat = issued at timestamp
+  const tokenLifetime = data.exp - data.iat;
+
+  return tokenLifetime;
+}


### PR DESCRIPTION
## What does this PR do?

Currently, Salesforce OAuth tokens do not include an expiry date. This means we refresh Salesforce tokens on every request, which is inefficient and can cause rate limiting issues.

This PR adds token lifetime tracking by:
1. Calling Salesforce's token introspection endpoint during OAuth connect to get the token lifetime
2. Storing `token_lifetime` in the credential alongside the access token
3. Checking if the token is still valid before making requests (using `issued_at + token_lifetime` with a 5-minute buffer)
4. Only refreshing when the token is actually expired
5. Adding a `refreshFn` to the jsforce connection that handles unexpected expiry by re-introspecting to recalibrate the lifetime

## Visual Demo (For contributors especially)

N/A - Backend-only change with no UI impact.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Connect a Salesforce account via the integrations page
2. Verify the credential is stored with a `token_lifetime` value
3. Make API calls that use Salesforce (e.g., CRM lookups during booking)
4. Verify tokens are not refreshed on every request (check logs or network traffic)
5. Wait for token to expire (or manually set `issued_at` to an old value) and verify refresh works correctly

## Human Review Checklist

- [ ] Verify time unit handling: `issued_at` is in milliseconds (string), `token_lifetime` is in seconds
- [ ] Verify the introspection endpoint URL format (`${instanceUrl}/services/oauth2/introspect`) is correct
- [ ] Check that `hasAttemptedRefresh` flag doesn't cause issues if the service instance is reused across multiple requests
- [ ] Verify `CredentialRepository.updateWhereId` exists and works as expected

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

## Updates since last revision

Added comprehensive test coverage:
- **`getSalesforceTokenLifetime.test.ts`**: Unit tests for the new introspection function (5 tests covering lifetime calculation, endpoint parameters, Basic auth, error handling, and different lifetimes)
- **`CrmService.integration.test.ts`**: Added "Token lifecycle management" test suite (4 tests covering valid token skip, expired token refresh, legacy credentials without token_lifetime, and 5-minute buffer behavior)
- Fixed type error in `CrmService.ts` by extracting `refreshToken` variable after the null check to ensure type safety in the `refreshFn` callback

---

**Link to Devin run**: https://app.devin.ai/sessions/649172013c17485889563f15ca2c83e6
**Requested by**: joe@cal.com (@joeauyeung)