### PR TITLE
fix(Docs): fix local dev path

### DIFF
--- a/docs/developing/local-development.mdx
+++ b/docs/developing/local-development.mdx
@@ -141,7 +141,7 @@ We recommend using the admin UI/wizard instead of the seeder to enable app store
 Copy the .env files from their respective example files depending on the version of the API (v1 or v2):
 
 ```bash
-cp apps/api/.env.example apps/api/{version}/.env
+cp apps/api/{version}/.env.example apps/api/{version}/.env
 cp .env.example .env
 ```
 


### PR DESCRIPTION
### What does this PR do?

Fixes a broken command in the Local Development documentation.

The guide previously instructed users to run cp apps/api/.env.example apps/api/{version}/.env. However, the file apps/api/.env.example does not exist. The .env.example files are located within the specific version subdirectories (v1 and v2).

This PR updates the command to copy from the correct source path: cp apps/api/{version}/.env.example apps/api/{version}/.env

### What changed - 

**Before (Fails):**

cp apps/api/.env.example apps/api/{version}/.env
cp: apps/api/.env.example: No such file or directory

**After (Works):**

cp apps/api/{version}/.env.example apps/api/{version}/.env

### Mandatory Tasks (DO NOT REMOVE)

-  I have self-reviewed the code (A decent size PR without self-review might be rejected).
-  N/A - This PR is a documentation fix.
-  N/A - Documentation fix only.

### How should this be tested?

1. Open  docs/developing/local-development.mdx .
2. Verify the cp command in the "API" section now points to a valid source file path.
3. Try running the command in your terminal (replacing {version} with v1 or v2) to confirm it works.

### Checklist
