### PR TITLE
feat: apply Frame component to webhooks settings page

### DIFF
--- a/apps/web/modules/webhooks/components/WebhookListItem.tsx
+++ b/apps/web/modules/webhooks/components/WebhookListItem.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import Link from "next/link";
-
-import { getWebhookVersionLabel, getWebhookVersionDocsUrl } from "@calcom/features/webhooks/lib/constants";
+import { getWebhookVersionDocsUrl, getWebhookVersionLabel } from "@calcom/features/webhooks/lib/constants";
 import type { Webhook } from "@calcom/features/webhooks/lib/dto/types";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
@@ -23,6 +21,9 @@ import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import { revalidateEventTypeEditPage } from "@calcom/web/app/(use-page-wrapper)/event-types/[type]/actions";
 import { revalidateWebhooksList } from "@calcom/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/(with-loader)/actions";
+import Link from "next/link";
+
+const MAX_BADGES_TWO_ROWS = 8; // Approximately 2 rows of badges
 
 export default function WebhookListItem(props: {
   webhook: Webhook;
@@ -105,7 +106,7 @@ export default function WebhookListItem(props: {
         </div>
         <Tooltip content={t("triggers_when")}>
           <div className="flex w-4/5 flex-wrap">
-            {webhook.eventTriggers.map((trigger) => (
+            {webhook.eventTriggers.slice(0, MAX_BADGES_TWO_ROWS).map((trigger) => (
               <Badge
                 key={trigger}
                 className="mt-2.5 basis-1/5 ltr:mr-2 rtl:ml-2"
@@ -114,6 +115,22 @@ export default function WebhookListItem(props: {
                 {t(`${trigger.toLowerCase()}`)}
               </Badge>
             ))}
+            {webhook.eventTriggers.length > MAX_BADGES_TWO_ROWS && (
+              <Tooltip
+                content={
+                  <div className="flex flex-col gap-1 p-1">
+                    {webhook.eventTriggers.slice(MAX_BADGES_TWO_ROWS).map((trigger) => (
+                      <span key={trigger} className="text-xs">
+                        {t(`${trigger.toLowerCase()}`)}
+                      </span>
+                    ))}
+                  </div>
+                }>
+                <Badge className="mt-2.5 cursor-help ltr:mr-2 rtl:ml-2" variant="gray">
+                  +{webhook.eventTriggers.length - MAX_BADGES_TWO_ROWS} {t("more")}
+                </Badge>
+              </Tooltip>
+            )}
           </div>
         </Tooltip>
       </div>

--- a/apps/web/modules/webhooks/views/webhooks-view.tsx
+++ b/apps/web/modules/webhooks/views/webhooks-view.tsx
@@ -1,17 +1,15 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-
 import { useBookerUrl } from "@calcom/features/bookings/hooks/useBookerUrl";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { APP_NAME, WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RouterOutputs } from "@calcom/trpc/react";
-import classNames from "@calcom/ui/classNames";
 import { Avatar } from "@calcom/ui/components/avatar";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
-
-import { WebhookListItem, CreateNewWebhookButton } from "../components";
+import { Frame, FramePanel } from "@coss/ui/components/frame";
+import { useRouter } from "next/navigation";
+import { CreateNewWebhookButton, WebhookListItem } from "../components";
 
 type WebhooksByViewer = RouterOutputs["viewer"]["webhook"]["getByViewer"];
 
@@ -42,11 +40,11 @@ const WebhooksList = ({ webhooksByViewer }: { webhooksByViewer: WebhooksByViewer
       CTA={<CreateNewWebhookButton />}
       borderInShellHeader={true}>
       {webhookGroups.length ? (
-        <div>
+        <Frame>
           {webhookGroups.map((group) => (
-            <div key={group.teamId}>
+            <FramePanel key={group.teamId}>
               {hasTeams && (
-                <div className="items-centers flex">
+                <div className="mb-4 flex items-center">
                   <Avatar
                     alt={group.profile.image || ""}
                     imageSrc={group.profile.image || `${bookerUrl}/${group.profile.name}/avatar.png`}
@@ -58,27 +56,25 @@ const WebhooksList = ({ webhooksByViewer }: { webhooksByViewer: WebhooksByViewer
                   </div>
                 </div>
               )}
-              <div className="flex flex-col" key={group.profile.slug}>
-                <div className={classNames("border-subtle mb-8 rounded-b-lg border border-t-0", hasTeams && "mt-3")}>
-                  {group.webhooks.map((webhook, index) => (
-                    <WebhookListItem
-                      key={webhook.id}
-                      webhook={webhook}
-                      lastItem={group.webhooks.length === index + 1}
-                      permissions={{
-                        canEditWebhook: group?.metadata?.canModify ?? false,
-                        canDeleteWebhook: group?.metadata?.canDelete ?? false,
-                      }}
-                      onEditWebhook={() =>
-                        router.push(`${WEBAPP_URL}/settings/developer/webhooks/${webhook.id}`)
-                      }
-                    />
-                  ))}
-                </div>
+              <div className="flex flex-col">
+                {group.webhooks.map((webhook, index) => (
+                  <WebhookListItem
+                    key={webhook.id}
+                    webhook={webhook}
+                    lastItem={group.webhooks.length === index + 1}
+                    permissions={{
+                      canEditWebhook: group?.metadata?.canModify ?? false,
+                      canDeleteWebhook: group?.metadata?.canDelete ?? false,
+                    }}
+                    onEditWebhook={() =>
+                      router.push(`${WEBAPP_URL}/settings/developer/webhooks/${webhook.id}`)
+                    }
+                  />
+                ))}
               </div>
-            </div>
+            </FramePanel>
           ))}
-        </div>
+        </Frame>
       ) : (
         <EmptyScreen
           Icon="link"

--- a/apps/web/modules/webhooks/views/webhooks-view.tsx
+++ b/apps/web/modules/webhooks/views/webhooks-view.tsx
@@ -35,7 +35,7 @@ const WebhooksList = ({ webhooksByViewer }: { webhooksByViewer: WebhooksByViewer
 
   return (
     <Frame>
-      <FrameHeader className="flex-row items-center justify-between">
+      <FrameHeader className="mb-2 flex-row items-center justify-between">
         <div>
           <FrameTitle className="text-lg">{t("webhooks")}</FrameTitle>
           <FrameDescription>{t("add_webhook_description", { appName: APP_NAME })}</FrameDescription>
@@ -60,7 +60,7 @@ const WebhooksList = ({ webhooksByViewer }: { webhooksByViewer: WebhooksByViewer
                 </div>
               )}
               {group.webhooks.map((webhook) => (
-                <FramePanel key={webhook.id}>
+                <FramePanel key={webhook.id} className="mt-2">
                   <WebhookListItem
                     webhook={webhook}
                     lastItem={true}

--- a/apps/web/modules/webhooks/views/webhooks-view.tsx
+++ b/apps/web/modules/webhooks/views/webhooks-view.tsx
@@ -8,6 +8,7 @@ import { Avatar } from "@calcom/ui/components/avatar";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
 import { Frame, FrameDescription, FrameHeader, FramePanel, FrameTitle } from "@coss/ui/components/frame";
 import { useRouter } from "next/navigation";
+import React from "react";
 import { CreateNewWebhookButton, WebhookListItem } from "../components";
 
 type WebhooksByViewer = RouterOutputs["viewer"]["webhook"]["getByViewer"];
@@ -44,9 +45,9 @@ const WebhooksList = ({ webhooksByViewer }: { webhooksByViewer: WebhooksByViewer
       {webhookGroups.length ? (
         <>
           {webhookGroups.map((group) => (
-            <FramePanel key={group.teamId}>
+            <React.Fragment key={group.teamId}>
               {hasTeams && (
-                <div className="mb-4 flex items-center">
+                <div className="mb-2 mt-4 flex items-center px-1">
                   <Avatar
                     alt={group.profile.image || ""}
                     imageSrc={group.profile.image || `${bookerUrl}/${group.profile.name}/avatar.png`}
@@ -58,12 +59,11 @@ const WebhooksList = ({ webhooksByViewer }: { webhooksByViewer: WebhooksByViewer
                   </div>
                 </div>
               )}
-              <div className="flex flex-col">
-                {group.webhooks.map((webhook, index) => (
+              {group.webhooks.map((webhook) => (
+                <FramePanel key={webhook.id}>
                   <WebhookListItem
-                    key={webhook.id}
                     webhook={webhook}
-                    lastItem={group.webhooks.length === index + 1}
+                    lastItem={true}
                     permissions={{
                       canEditWebhook: group?.metadata?.canModify ?? false,
                       canDeleteWebhook: group?.metadata?.canDelete ?? false,
@@ -72,9 +72,9 @@ const WebhooksList = ({ webhooksByViewer }: { webhooksByViewer: WebhooksByViewer
                       router.push(`${WEBAPP_URL}/settings/developer/webhooks/${webhook.id}`)
                     }
                   />
-                ))}
-              </div>
-            </FramePanel>
+                </FramePanel>
+              ))}
+            </React.Fragment>
           ))}
         </>
       ) : (

--- a/apps/web/modules/webhooks/views/webhooks-view.tsx
+++ b/apps/web/modules/webhooks/views/webhooks-view.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useBookerUrl } from "@calcom/features/bookings/hooks/useBookerUrl";
-import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { APP_NAME, WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { Avatar } from "@calcom/ui/components/avatar";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
-import { Frame, FramePanel } from "@coss/ui/components/frame";
+import { Frame, FrameDescription, FrameHeader, FramePanel, FrameTitle } from "@coss/ui/components/frame";
 import { useRouter } from "next/navigation";
 import { CreateNewWebhookButton, WebhookListItem } from "../components";
 
@@ -34,13 +33,16 @@ const WebhooksList = ({ webhooksByViewer }: { webhooksByViewer: WebhooksByViewer
   const hasTeams = profiles && profiles.length > 1;
 
   return (
-    <SettingsHeader
-      title={t("webhooks")}
-      description={t("add_webhook_description", { appName: APP_NAME })}
-      CTA={<CreateNewWebhookButton />}
-      borderInShellHeader={true}>
+    <Frame>
+      <FrameHeader className="flex-row items-center justify-between">
+        <div>
+          <FrameTitle className="text-lg">{t("webhooks")}</FrameTitle>
+          <FrameDescription>{t("add_webhook_description", { appName: APP_NAME })}</FrameDescription>
+        </div>
+        <CreateNewWebhookButton />
+      </FrameHeader>
       {webhookGroups.length ? (
-        <Frame>
+        <>
           {webhookGroups.map((group) => (
             <FramePanel key={group.teamId}>
               {hasTeams && (
@@ -74,17 +76,18 @@ const WebhooksList = ({ webhooksByViewer }: { webhooksByViewer: WebhooksByViewer
               </div>
             </FramePanel>
           ))}
-        </Frame>
+        </>
       ) : (
-        <EmptyScreen
-          Icon="link"
-          headline={t("create_your_first_webhook")}
-          description={t("create_your_first_webhook_description", { appName: APP_NAME })}
-          className="rounded-b-lg rounded-t-none border-t-0"
-          buttonRaw={<CreateNewWebhookButton />}
-        />
+        <FramePanel>
+          <EmptyScreen
+            Icon="link"
+            headline={t("create_your_first_webhook")}
+            description={t("create_your_first_webhook_description", { appName: APP_NAME })}
+            buttonRaw={<CreateNewWebhookButton />}
+          />
+        </FramePanel>
       )}
-    </SettingsHeader>
+    </Frame>
   );
 };
 


### PR DESCRIPTION
## What does this PR do?

Applies the `<Frame>` component from coss ui to the `/settings/developer/webhooks` page, replacing the previous `SettingsHeader` wrapper with the standardized Frame component pattern. Also improves the badge presentation for webhook event triggers.

Reference: https://coss.com/ui/docs/components/frame

### Changes:
- Replaced `SettingsHeader` with `Frame` component as the main container
- Added `FrameHeader` with `FrameTitle` and `FrameDescription` to include the section header and description inside the Frame
- Wrapped each individual webhook in its own `<FramePanel>` component for visual separation
- Wrapped empty state with `<FramePanel>` for consistent styling
- Removed unused `classNames` and `SettingsHeader` imports
- Fixed typo: `items-centers` → `items-center`

### Updates since last revision:
- Implemented two-row badge limit with overflow tooltip for webhook event triggers
- Shows first 8 badges (approximately 2 rows), with remaining triggers displayed in a tooltip on hover via "+X more" badge
- Added improved spacing between webhook items (`mt-2`) and between header and first item (`mb-2`) for better visual hierarchy

## Visual Demo

### Webhooks page with Frame component and improved spacing
![Webhooks page with improved spacing](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2NzZmMmQyOTMyMWE5NmU4OGU1MTg0ZTciLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi83ZDNjYjc5Zi1kYWQyLTQ4ZTgtOTZkMC00YTM4ZmQ0N2ZjZWYiLCJpYXQiOjE3Njk1MjE2ODgsImV4cCI6MTc3MDEyNjQ4OH0.2MaeO9ZQDfHUxLM7diUf5Ow-e0tNpYJgrMaC60ncPEs)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to `/settings/developer/webhooks`
2. Verify the Frame header displays the title "Webhooks" and description correctly
3. Verify the "+ New" button is positioned correctly in the header
4. Verify spacing between header and first webhook panel looks appropriate
5. Create multiple webhooks and verify each displays in its own separate FramePanel with proper spacing between them
6. If you have multiple teams, verify the team headers display correctly above their respective webhook panels
7. Delete all webhooks and verify the empty state displays correctly within a FramePanel
8. Create a webhook with many event triggers (>8) and verify:
   - Only the first 8 badges are shown
   - A "+X more" badge appears showing the count of remaining triggers
   - Hovering over the "+X more" badge shows a tooltip with the remaining trigger names

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small (<500 lines and <10 files)

## Human Review Checklist

- [ ] Verify each webhook appearing in its own FramePanel looks correct visually
- [ ] Verify spacing between header and first item (`mb-2`) looks appropriate
- [ ] Verify spacing between webhook items (`mt-2`) provides good visual separation
- [ ] Verify team headers display correctly between panels (when user has multiple teams)
- [ ] Verify the Frame component styling matches the expected coss ui design
- [ ] Verify the header layout (title, description, CTA button) is correct
- [ ] Verify empty state appearance is correct
- [ ] Verify the two-row badge limit (8 badges max) displays correctly
- [ ] Verify the "+X more" tooltip shows remaining triggers on hover
- [ ] Verify `lastItem={true}` is correct since each webhook is now in its own FramePanel (no border needed between items)

---

### Link to Devin run
https://app.devin.ai/sessions/881e7eaa382243558fe8e2ccd632ee1d

### Requested by
@PeerRich