### PR TITLE
fix: fix-proxy-route-order

### DIFF
--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -11,8 +11,9 @@ const apiProxyV2 = createProxyMiddleware({
 });
 
 const app = connect();
-app.use("/", apiProxyV1);
 
+// Order matters: "/v2" must be handled before "/".This ensures v2 requests are correctly proxied and not captured by the root handler
 app.use("/v2", apiProxyV2);
+app.use("/", apiProxyV1);
 
 http.createServer(app).listen(3002);

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -12,7 +12,6 @@ const apiProxyV2 = createProxyMiddleware({
 
 const app = connect();
 
-// Order matters: "/v2" must be handled before "/".This ensures v2 requests are correctly proxied and not captured by the root handler
 app.use("/v2", apiProxyV2);
 app.use("/", apiProxyV1);
 


### PR DESCRIPTION
Order matters: "/v2" must be handled before "/".
This ensures v2 requests are correctly proxied and not captured by the root handler.

## What does this PR do?

This PR fixes an issue where requests to `/v2/*` could be incorrectly
proxied to the v1 service because the root (`"/"`) proxy middleware
matches all routes. By reordering the proxy middleware, more specific routes (`/v2`)
are handled before the generic root route.


N/A — this change affects internal proxy routing logic and does not
introduce user-facing UI changes..


## Mandatory Tasks 
-  I have self-reviewed the code.
-  I have updated the developer docs in /docs if required (N/A).
-  I confirm automated tests are in place or manual verification
      was performed to validate this change.


## How should this be tested?

1. Start the v1 service on port 3003.
2. Start the v2 service on port 3004.
3. Start the API gateway.

### Test cases

- Send a request to `/v2/*`
  - Expected: request is proxied to the v2 service.
- Send a request to any non-v2 route (e.g. `/health`, `/api`)
  - Expected: request is proxied to the v1 service.

### Notes

- No additional environment variables are required.
- This change does not affect existing v1 routes.

## Checklist

-  I have read the contributing guide.
-  My code follows the style guidelines of this project.
-  I have commented my code where necessary.
-  I have checked that my changes introduce no new warnings.
- This PR is small and focused.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
