### PR TITLE
refactor: optimize team booking limits query with in-app filtering

### DIFF
--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1369,19 +1369,23 @@ export class BookingRepository implements IBookingRepository {
       },
     };
 
-    const teamBookings = await this.prismaClient.booking.findMany({
-      where: whereTeamEventTypes,
-      select,
-    });
-
     if (!includeManagedEvents) {
-      return teamBookings;
+      return this.prismaClient.booking.findMany({
+        where: whereTeamEventTypes,
+        select,
+      });
     }
 
-    const managedBookings = await this.prismaClient.booking.findMany({
-      where: whereManagedEventTypes,
-      select,
-    });
+    const [teamBookings, managedBookings] = await Promise.all([
+      this.prismaClient.booking.findMany({
+        where: whereTeamEventTypes,
+        select,
+      }),
+      this.prismaClient.booking.findMany({
+        where: whereManagedEventTypes,
+        select,
+      }),
+    ]);
 
     return [...teamBookings, ...managedBookings];
   }

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1303,6 +1303,89 @@ export class BookingRepository implements IBookingRepository {
     ];
   }
 
+  /**
+   * Finds all accepted bookings for a team within a date range.
+   * This method queries by eventType.teamId (indexed) instead of attendee emails,
+   * providing better performance for large teams.
+   *
+   * The caller is responsible for filtering results by user involvement
+   * (as organizer or attendee) in application code.
+   */
+  async findByTeamIdAndDateRangeIncludeAttendees({
+    teamId,
+    startDate,
+    endDate,
+    excludedUid,
+    includeManagedEvents,
+  }: {
+    teamId: number;
+    startDate: Date;
+    endDate: Date;
+    excludedUid?: string | null;
+    includeManagedEvents: boolean;
+  }) {
+    const baseWhere: Prisma.BookingWhereInput = {
+      status: BookingStatus.ACCEPTED,
+      startTime: {
+        gte: startDate,
+      },
+      endTime: {
+        lte: endDate,
+      },
+      ...(excludedUid && {
+        uid: {
+          not: excludedUid,
+        },
+      }),
+    };
+
+    const whereTeamEventTypes: Prisma.BookingWhereInput = {
+      ...baseWhere,
+      eventType: {
+        teamId,
+      },
+    };
+
+    const whereManagedEventTypes: Prisma.BookingWhereInput = {
+      ...baseWhere,
+      eventType: {
+        parent: {
+          teamId,
+        },
+      },
+    };
+
+    const select = {
+      id: true,
+      startTime: true,
+      endTime: true,
+      title: true,
+      eventTypeId: true,
+      userId: true,
+      attendees: {
+        select: {
+          email: true,
+        },
+      },
+    };
+
+    const teamBookings = await this.prismaClient.booking.findMany({
+      where: whereTeamEventTypes,
+      select,
+    });
+
+    if (!includeManagedEvents) {
+      return teamBookings;
+    }
+
+    const managedBookings = await this.prismaClient.booking.findMany({
+      where: whereManagedEventTypes,
+      select,
+    });
+
+    return [...teamBookings, ...managedBookings];
+  }
+
   async getValidBookingFromEventTypeForAttendee({
     eventTypeId,
     bookerEmail,


### PR DESCRIPTION
## What does this PR do?

Optimizes the team booking limits query in `_getBusyTimesFromTeamLimitsForUsers` by replacing an expensive `attendee.email IN (64+ emails)` SQL pattern with indexed `eventType.teamId` filtering and in-application user filtering.

**Problem**: The original query generated an expensive EXISTS subquery scanning attendees for each booking with 64+ email parameters, which is slow for large teams.

**Solution**: 
- Query all team bookings by `eventType.teamId` (indexed column)
- Filter in application code using Sets for O(1) lookups to find bookings where users are organizers or attendees
- Run team and managed event queries in parallel with `Promise.all`

**Changes**:
- Add `findByTeamIdAndDateRangeIncludeAttendees` to `BookingRepository`
- Refactor `_getBusyTimesFromTeamLimitsForUsers` to use the new method with in-app filtering

**Trade-off**: Returns slightly more data from DB (all team bookings vs only user-relevant), but the query is significantly faster due to using indexed columns instead of expensive EXISTS subqueries.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - internal optimization only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Test team booking limits functionality with a team that has multiple members
2. Verify availability slots are correctly calculated when team booking limits are configured
3. Compare query performance before/after for teams with 50+ members

**Key verification points**:
- Bookings where user is the organizer (`userId`) should be counted toward limits
- Bookings where user is an attendee (email match) should be counted toward limits
- Managed event bookings should be included when `includeManagedEvents` is true

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the in-app filtering logic correctly replicates the original query behavior (organizer OR attendee matching)
- [ ] Check edge case: `booking.userId` can be null - code handles this with `booking.userId && userIdSet.has(booking.userId)`
- [ ] Consider if existing tests adequately cover this code path
- [ ] Evaluate the trade-off for teams with many bookings but few relevant users

---

Link to Devin run: https://app.devin.ai/sessions/65b1815aa6b74057959160047de5e8f3
Requested by: @emrysal