### PR TITLE
fix: validate optional email fields when input is provided

### DIFF
--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -216,7 +216,11 @@ function preprocess<T extends z.ZodType>({
         }
 
         if (bookingField.type === "email") {
-          if (!bookingField.hidden && (checkOptional || bookingField.required)) {
+          // Determine if the email field needs validation
+          const needsValidation = isRequired || (value && value.trim() !== "");
+
+          // Validate email if the field is not hidden and requires validation
+          if (!bookingField.hidden && needsValidation) {
             // Email RegExp to validate if the input is a valid email
             if (!emailSchema.safeParse(value).success) {
               ctx.addIssue({


### PR DESCRIPTION
## What does this PR do?

Fixed optional email booking questions accepting any text wihout validating email format.

Optional email fields were skipping validation entirely, allowing invalid input to be submitted.

Applied the same validation pattern used for optional phone fields: (
```
const needsValidation = isRequired || (value && value.trim() !== "");
```
Empty input is still allowed in optional field.


- Fixes #27299
- Fixes [CAL-7141](https://linear.app/calcom/issue/CAL-7141/optional-email-field-still-requires-verification)

## Visual Demo (For contributors especially)

- before: (optional email field accepts any value )

https://github.com/user-attachments/assets/0136e71c-4a35-4580-9b62-cc3298ee9c40

- after: 

https://github.com/user-attachments/assets/9fe5a8fb-4408-494b-a65d-35d88d1274cb



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change]NA
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Add an optional email question to an event type
- Try booking with invalid text like "asdf"
- Should now show email validation error