### PR TITLE
perf: optimize event type settings page by lazy loading hosts into form

### DIFF
--- a/apps/web/modules/event-types/components/tabs/assignment/EventTeamAssignmentTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/assignment/EventTeamAssignmentTab.tsx
@@ -615,6 +615,7 @@ type HostsCustomClassNames = {
 
 // Maps eventType.hosts (from API) to Host[] (form type)
 // The API type has nullable priority/weight, form type requires non-nullable
+// Note: location is omitted as API type structure differs from HostLocation (missing userId/eventTypeId)
 const mapEventTypeHostsToFormHosts = (hosts: EventTypeSetup["hosts"]): Host[] => {
   return hosts.map((host) => ({
     isFixed: host.isFixed,
@@ -623,7 +624,6 @@ const mapEventTypeHostsToFormHosts = (hosts: EventTypeSetup["hosts"]): Host[] =>
     weight: host.weight ?? 100, // Default weight
     scheduleId: host.scheduleId,
     groupId: host.groupId,
-    location: host.location ?? null,
   }));
 };
 

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -100,7 +100,10 @@ export const useEventTypeForm = ({
       allowReschedulingPastBookings: eventType.allowReschedulingPastBookings,
       hideOrganizerEmail: eventType.hideOrganizerEmail,
       metadata: eventType.metadata,
-      hosts: eventType.hosts.sort((a, b) => sortHosts(a, b, eventType.isRRWeightsEnabled)),
+      // hosts is intentionally not loaded into the form initially for performance optimization.
+      // The UI renders hosts from eventType.hosts prop, and only populates this field when hosts are modified.
+      // This prevents slowness on the event type settings page when there are many hosts.
+      hosts: undefined,
       hostGroups: eventType.hostGroups || [],
       successRedirectUrl: eventType.successRedirectUrl || "",
       forwardParamsSuccessRedirect: eventType.forwardParamsSuccessRedirect,


### PR DESCRIPTION
## What does this PR do?

Optimizes the event type settings page performance by changing how hosts are loaded into React Hook Form. Previously, all hosts were loaded into the form state upfront, causing slowness when there are many hosts.

**Changes:**
- Set `hosts: undefined` in form defaultValues instead of loading all hosts
- Pass `eventType.hosts` as a prop to the `Hosts` component for rendering
- Only populate the form's hosts field when hosts are actually modified (added/removed)
- Update child components (`FixedHosts`, `RoundRobinHosts`) to use the `value` prop instead of `getValues("hosts")`
- Add `mapEventTypeHostsToFormHosts` helper to map API type to form type (handles nullable priority/weight)
- Memoize mapped hosts with `useMemo` to avoid recalculating on every render

The UI continues to render hosts from `eventType.hosts` prop, but the form only tracks changes when modifications are made. The backend update handler already handles this correctly by checking `if (teamId && hosts)` before processing host changes.

### Updates since last revision
- Fixed type error: Added `mapEventTypeHostsToFormHosts` function to properly map `EventTypeSetup["hosts"]` (API type with nullable priority/weight) to `Host[]` (form type with non-nullable values)
- Default values used: `priority: 2`, `weight: 100` when API values are null
- Omitted `location` field in mapping as API type structure differs from `HostLocation` (missing `userId`/`eventTypeId` fields)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to an event type settings page for a team event with multiple hosts
2. Verify the page loads faster than before (especially noticeable with many hosts)
3. Test adding/removing hosts and verify changes are saved correctly
4. Test changing scheduling type (Collective ↔ Round Robin) and verify hosts reset correctly
5. Test submitting the form without modifying hosts - verify no unintended changes occur

## Human Review Checklist

- [ ] Verify the default values in `mapEventTypeHostsToFormHosts` are correct (`priority: 2`, `weight: 100`)
- [ ] Verify form submission works when hosts are NOT modified (hosts stays undefined in form state)
- [ ] Verify form submission works when hosts ARE modified (hosts gets populated on change)
- [ ] Verify the backend correctly skips host updates when hosts is undefined
- [ ] Verify scheduling type changes correctly reset hosts to empty array
- [ ] Verify omitting `location` field doesn't break any functionality
- [ ] Test with a large number of hosts to confirm performance improvement

---

Link to Devin run: https://app.devin.ai/sessions/9fe4d65598fa4168b1c40979d09de2e9
Requested by: @joeauyeung