### PR TITLE
docs: clarify bookerReopened and bookerReloaded are for prerendered modals

### DIFF
--- a/packages/embeds/LIFECYCLE.md
+++ b/packages/embeds/LIFECYCLE.md
@@ -122,12 +122,14 @@ The embed system carefully manages visibility to prevent visual glitches:
     - Indicates: Booker has been reopened after modal was closed
     - Triggers: On subsequent linkReady events (viewId > 1) when modal is reopened without reload
     - Note: Distinguishes between first view (bookerViewed) and reopen (bookerReopened). Uses viewId to determine if it's a reopen.
+    - Applicability: Only applicable for prerendered modals that are now visible.
 
 13. **bookerReloaded Event**
     - Fired by: Iframe
     - Indicates: Booker has been reloaded (full page reload within modal)
     - Triggers: On linkReady after fullReload action is taken (when reloadInitiated flag is set)
     - Note: Distinguishes between first view (bookerViewed), reopen (bookerReopened), and reload (bookerReloaded). Fires only once per reload.
+    - Applicability: Only applicable for prerendered modals that are now visible.
 
 14. **bookerReady Event**
     - Fired by: Iframe


### PR DESCRIPTION
## What does this PR do?

Updates the embed lifecycle documentation to clarify that `bookerReopened` and `bookerReloaded` events are only applicable for prerendered modals that are now visible.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - this PR is itself a documentation update.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - documentation only change.

## How should this be tested?

This is a documentation-only change. Review the accuracy of the added "Applicability" notes for both events.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

### Reviewer Checklist
- [ ] Verify that the documentation accurately reflects when `bookerReopened` and `bookerReloaded` events fire (only for prerendered modals)

---

> [!NOTE]
> **Link to Devin run**: https://app.devin.ai/sessions/35a0c5d4d5fc4feb9a5af2d8d340b9c5
> **Requested by**: @hariombalhara