### PR TITLE
fix: sort team Ids to ensure we don't get flaky tests

### DIFF
--- a/packages/features/insights/services/InsightsBookingBaseService.ts
+++ b/packages/features/insights/services/InsightsBookingBaseService.ts
@@ -406,7 +406,7 @@ export class InsightsBookingBaseService {
       parentId: options.orgId,
       select: { id: true },
     });
-    const teamIds = [options.orgId, ...teamsFromOrg.map((t) => t.id)];
+    const teamIds = [options.orgId, ...teamsFromOrg.map((t) => t.id)].sort((a, b) => a - b);
 
     // Get all users from the organization
     const userIdsFromOrg =
@@ -419,7 +419,7 @@ export class InsightsBookingBaseService {
     const conditions: Prisma.Sql[] = [Prisma.sql`("teamId" = ANY(${teamIds})) AND ("isTeamBooking" = true)`];
 
     if (userIdsFromOrg.length > 0) {
-      const uniqueUserIds = Array.from(new Set(userIdsFromOrg));
+      const uniqueUserIds = Array.from(new Set(userIdsFromOrg)).sort((a, b) => a - b);
       conditions.push(Prisma.sql`("userId" = ANY(${uniqueUserIds})) AND ("isTeamBooking" = false)`);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sorted team and user ID arrays (ascending) in InsightsBookingBaseService to stabilize query inputs and prevent flaky integration tests.
IDs are now deduplicated and sorted before being passed to Prisma ANY conditions.

<sup>Written for commit b646cb23f1797fd30814878ecb57ef79c1400683. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

