### PR TITLE
fix: reduce forcedSlowMode rate limit from 30s to 1s

### DIFF
--- a/apps/api/v2/src/modules/organizations/organizations/organizations-organizations.controller.ts
+++ b/apps/api/v2/src/modules/organizations/organizations/organizations-organizations.controller.ts
@@ -142,7 +142,7 @@ export class OrganizationsOrganizationsController {
   @Roles("ORG_ADMIN")
   @PlatformPlan(SCALE)
   @Delete("/:managedOrganizationId")
-  @Throttle({ limit: 1, ttl: 30000, blockDuration: 30000, name: "organizations_delete" })
+  @Throttle({ limit: 1, ttl: 1000, blockDuration: 1000, name: "organizations_delete" })
   @ApiOperation({
     summary: "Delete an organization within an organization",
     description:

--- a/apps/api/v2/src/modules/organizations/teams/index/organizations-teams.controller.ts
+++ b/apps/api/v2/src/modules/organizations/teams/index/organizations-teams.controller.ts
@@ -121,7 +121,7 @@ export class OrganizationsTeamsController {
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
   @Delete("/:teamId")
-  @Throttle({ limit: 1, ttl: 30000, blockDuration: 30000, name: "org_teams_delete" })
+  @Throttle({ limit: 1, ttl: 1000, blockDuration: 1000, name: "org_teams_delete" })
   @ApiOperation({ summary: "Delete a team" })
   async deleteTeam(
     @Param("orgId", ParseIntPipe) orgId: number,

--- a/apps/api/v2/src/modules/teams/teams/controllers/teams.controller.ts
+++ b/apps/api/v2/src/modules/teams/teams/controllers/teams.controller.ts
@@ -98,7 +98,7 @@ export class TeamsController {
 
   @UseGuards(RolesGuard)
   @Delete("/:teamId")
-  @Throttle({ limit: 1, ttl: 30000, blockDuration: 30000, name: "teams_delete" })
+  @Throttle({ limit: 1, ttl: 1000, blockDuration: 1000, name: "teams_delete" })
   @ApiOperation({ summary: "Delete a team" })
   @Roles("TEAM_OWNER")
   async deleteTeam(@Param("teamId", ParseIntPipe) teamId: number): Promise<OrgTeamOutputResponseDto> {

--- a/packages/lib/rateLimit.ts
+++ b/packages/lib/rateLimit.ts
@@ -84,7 +84,7 @@ export function rateLimiter() {
       rootKey: UNKEY_ROOT_KEY,
       namespace: "forcedSlowMode",
       limit: 1,
-      duration: "30s",
+      duration: "1s",
       timeout,
       onError,
     }),

--- a/packages/lib/rateLimit.ts
+++ b/packages/lib/rateLimit.ts
@@ -84,7 +84,7 @@ export function rateLimiter() {
       rootKey: UNKEY_ROOT_KEY,
       namespace: "forcedSlowMode",
       limit: 1,
-      duration: "1s",
+      duration: "30s",
       timeout,
       onError,
     }),


### PR DESCRIPTION
## What does this PR do?

Reduces the rate limit on Team and Organization DELETE endpoints in API v2 from 1 request per 30 seconds to 1 request per 1 second (30x increase in allowed frequency). This is a follow-up to #27258 which initially added rate limiting to these endpoints.

**Changes:**
- API v2 DELETE endpoint throttle decorators: Changed `ttl` and `blockDuration` from `30000` to `1000` (milliseconds)

**Endpoints affected:**
- `DELETE /v2/teams/:teamId`
- `DELETE /v2/organizations/:orgId/teams/:teamId`
- `DELETE /v2/organizations/:orgId/organizations/:managedOrganizationId`

### Updates since last revision

- Reverted changes to `packages/lib/rateLimit.ts` per reviewer request - only API v2 controller throttle decorators are modified

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - configuration change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. Existing test infrastructure from #27258 covers these endpoints.

## How should this be tested?

1. Make a DELETE request to any of the affected endpoints
2. Immediately make another DELETE request to the same endpoint
3. The second request should be rate limited with a 429 response
4. Wait 1 second and try again - should succeed

## Human Review Checklist

- [ ] Verify the rate limit values (1 req/1s with 1s block duration) are appropriate for DELETE operations
- [ ] Note: `packages/lib/rateLimit.ts` still has `forcedSlowMode` with `duration: "30s"` - confirm this is intentional (API v2 throttle decorators are separate from the general rate limiter)

---

Link to Devin run: https://app.devin.ai/sessions/9577e992624c4d6e803c62a04419bb4f
Requested by: @emrysal