### PR TITLE
fix: use LOGO constant for generic OG images

### DIFF
--- a/packages/lib/OgImages.tsx
+++ b/packages/lib/OgImages.tsx
@@ -67,7 +67,7 @@ const OG_ASSETS = {
   },
   generic: {
     id: "generic-og-image-v1", // Bump version when changing Generic component structure/styling
-    logo: "cal-logo-word-black.svg",
+    logo: LOGO,
     logoWidth: "350",
     variant: "light" as const,
   },


### PR DESCRIPTION
This PR fixes the issue where generic OG images always display the default Cal.com logo instead of the custom logo for self-hosted instances. The generic type in OG_ASSETS previously hardcoded "cal-logo-word-black.svg". Now it uses the LOGO constant, like meeting and app types.

Fixes #27355

Fixes CAL-7147

How should this be tested?

Set up a self-hosted Cal.com instance.

Replace /apps/web/public/logo.png with a custom logo.

Set NEXT_PUBLIC_WEBAPP_URL to your domain.

Open a generic page (e.g., /auth/login) and generate its OG image.

It should display the custom logo instead of the default Cal.com logo.

Verify meeting pages still show the correct custom logo.
