### PR TITLE
refactor: join teams with feature enabled directly in findNextSubscriptionBatch query

### DIFF
--- a/packages/features/calendar-subscription/lib/CalendarSubscriptionService.ts
+++ b/packages/features/calendar-subscription/lib/CalendarSubscriptionService.ts
@@ -440,14 +440,10 @@ export class CalendarSubscriptionService {
    */
   // biome-ignore lint/nursery/useExplicitType: return type is void
   async checkForNewSubscriptions() {
-    const teamIds = await this.deps.featuresRepository.getTeamsWithFeatureEnabled(
-        CalendarSubscriptionService.CALENDAR_SUBSCRIPTION_CACHE_FEATURE
-      );
-
     const rows = await this.deps.selectedCalendarRepository.findNextSubscriptionBatch({
       take: 100,
       integrations: this.deps.adapterFactory.getProviders(),
-      teamIds,
+      featureId: CalendarSubscriptionService.CALENDAR_SUBSCRIPTION_CACHE_FEATURE,
       genericCalendarSuffixes: this.deps.adapterFactory.getGenericCalendarSuffixes(),
     });
     log.debug("checkForNewSubscriptions", { count: rows.length });

--- a/packages/features/calendar-subscription/lib/CalendarSubscriptionService.ts
+++ b/packages/features/calendar-subscription/lib/CalendarSubscriptionService.ts
@@ -443,7 +443,7 @@ export class CalendarSubscriptionService {
     const rows = await this.deps.selectedCalendarRepository.findNextSubscriptionBatch({
       take: 100,
       integrations: this.deps.adapterFactory.getProviders(),
-      featureId: CalendarSubscriptionService.CALENDAR_SUBSCRIPTION_CACHE_FEATURE,
+      featureIds: [CalendarSubscriptionService.CALENDAR_SUBSCRIPTION_CACHE_FEATURE],
       genericCalendarSuffixes: this.deps.adapterFactory.getGenericCalendarSuffixes(),
     });
     log.debug("checkForNewSubscriptions", { count: rows.length });

--- a/packages/features/calendar-subscription/lib/__tests__/CalendarSubscriptionService.test.ts
+++ b/packages/features/calendar-subscription/lib/__tests__/CalendarSubscriptionService.test.ts
@@ -422,13 +422,10 @@ describe("CalendarSubscriptionService", () => {
 
       await service.checkForNewSubscriptions();
 
-      expect(mockFeaturesRepository.getTeamsWithFeatureEnabled).toHaveBeenCalledWith(
-        "calendar-subscription-cache"
-      );
       expect(mockSelectedCalendarRepository.findNextSubscriptionBatch).toHaveBeenCalledWith({
         take: 100,
         integrations: ["google_calendar", "office365_calendar"],
-        teamIds: [1, 2, 3],
+        featureId: "calendar-subscription-cache",
         genericCalendarSuffixes: [
           "@group.v.calendar.google.com",
           "@group.calendar.google.com",
@@ -439,11 +436,9 @@ describe("CalendarSubscriptionService", () => {
       expect(subscribeSpy).toHaveBeenCalledWith(mockSelectedCalendar.id);
     });
 
-    test("should handle mixed cache scenario where some teams have cache enabled and some do not", async () => {
+    test("should handle multiple calendars returned from batch", async () => {
       const calendarWithCache = { ...mockSelectedCalendar, id: "calendar-with-cache", userId: 1 };
       const calendarWithCache2 = { ...mockSelectedCalendar, id: "calendar-with-cache-2", userId: 2 };
-
-      mockFeaturesRepository.getTeamsWithFeatureEnabled.mockResolvedValue([10, 20]);
 
       mockSelectedCalendarRepository.findNextSubscriptionBatch.mockResolvedValue([
         calendarWithCache,
@@ -454,13 +449,10 @@ describe("CalendarSubscriptionService", () => {
 
       await service.checkForNewSubscriptions();
 
-      expect(mockFeaturesRepository.getTeamsWithFeatureEnabled).toHaveBeenCalledWith(
-        "calendar-subscription-cache"
-      );
       expect(mockSelectedCalendarRepository.findNextSubscriptionBatch).toHaveBeenCalledWith({
         take: 100,
         integrations: ["google_calendar", "office365_calendar"],
-        teamIds: [10, 20],
+        featureId: "calendar-subscription-cache",
         genericCalendarSuffixes: [
           "@group.v.calendar.google.com",
           "@group.calendar.google.com",
@@ -473,58 +465,17 @@ describe("CalendarSubscriptionService", () => {
       expect(subscribeSpy).toHaveBeenCalledWith("calendar-with-cache-2");
     });
 
-    test("should only fetch calendars for teams with feature enabled, not entire organization hierarchy", async () => {
-      const teamId = 100;
-      const parentOrgId = 1;
-
-      mockFeaturesRepository.getTeamsWithFeatureEnabled.mockResolvedValue([teamId]);
-
-      const calendarForTeamMember = { ...mockSelectedCalendar, id: "team-member-calendar", userId: 5 };
-      mockSelectedCalendarRepository.findNextSubscriptionBatch.mockResolvedValue([calendarForTeamMember]);
-
-      const subscribeSpy = vi.spyOn(service, "subscribe").mockResolvedValue(undefined);
-
-      await service.checkForNewSubscriptions();
-
-      expect(mockFeaturesRepository.getTeamsWithFeatureEnabled).toHaveBeenCalledWith(
-        "calendar-subscription-cache"
-      );
-      expect(mockSelectedCalendarRepository.findNextSubscriptionBatch).toHaveBeenCalledWith({
-        take: 100,
-        integrations: ["google_calendar", "office365_calendar"],
-        teamIds: [teamId],
-        genericCalendarSuffixes: [
-          "@group.v.calendar.google.com",
-          "@group.calendar.google.com",
-          "@import.calendar.google.com",
-          "@resource.calendar.google.com",
-        ],
-      });
-      expect(mockSelectedCalendarRepository.findNextSubscriptionBatch).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          teamIds: expect.arrayContaining([parentOrgId]),
-        })
-      );
-      expect(subscribeSpy).toHaveBeenCalledTimes(1);
-      expect(subscribeSpy).toHaveBeenCalledWith("team-member-calendar");
-    });
-
-    test("should not process any calendars when no teams have the feature enabled", async () => {
-      mockFeaturesRepository.getTeamsWithFeatureEnabled.mockResolvedValue([]);
-
+    test("should not process any calendars when no calendars are returned", async () => {
       mockSelectedCalendarRepository.findNextSubscriptionBatch.mockResolvedValue([]);
 
       const subscribeSpy = vi.spyOn(service, "subscribe").mockResolvedValue(undefined);
 
       await service.checkForNewSubscriptions();
 
-      expect(mockFeaturesRepository.getTeamsWithFeatureEnabled).toHaveBeenCalledWith(
-        "calendar-subscription-cache"
-      );
       expect(mockSelectedCalendarRepository.findNextSubscriptionBatch).toHaveBeenCalledWith({
         take: 100,
         integrations: ["google_calendar", "office365_calendar"],
-        teamIds: [],
+        featureId: "calendar-subscription-cache",
         genericCalendarSuffixes: [
           "@group.v.calendar.google.com",
           "@group.calendar.google.com",

--- a/packages/features/calendar-subscription/lib/__tests__/CalendarSubscriptionService.test.ts
+++ b/packages/features/calendar-subscription/lib/__tests__/CalendarSubscriptionService.test.ts
@@ -425,7 +425,7 @@ describe("CalendarSubscriptionService", () => {
       expect(mockSelectedCalendarRepository.findNextSubscriptionBatch).toHaveBeenCalledWith({
         take: 100,
         integrations: ["google_calendar", "office365_calendar"],
-        featureId: "calendar-subscription-cache",
+        featureIds: ["calendar-subscription-cache"],
         genericCalendarSuffixes: [
           "@group.v.calendar.google.com",
           "@group.calendar.google.com",
@@ -452,7 +452,7 @@ describe("CalendarSubscriptionService", () => {
       expect(mockSelectedCalendarRepository.findNextSubscriptionBatch).toHaveBeenCalledWith({
         take: 100,
         integrations: ["google_calendar", "office365_calendar"],
-        featureId: "calendar-subscription-cache",
+        featureIds: ["calendar-subscription-cache"],
         genericCalendarSuffixes: [
           "@group.v.calendar.google.com",
           "@group.calendar.google.com",
@@ -475,7 +475,7 @@ describe("CalendarSubscriptionService", () => {
       expect(mockSelectedCalendarRepository.findNextSubscriptionBatch).toHaveBeenCalledWith({
         take: 100,
         integrations: ["google_calendar", "office365_calendar"],
-        featureId: "calendar-subscription-cache",
+        featureIds: ["calendar-subscription-cache"],
         genericCalendarSuffixes: [
           "@group.v.calendar.google.com",
           "@group.calendar.google.com",

--- a/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.interface.ts
+++ b/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.interface.ts
@@ -20,21 +20,21 @@ export interface ISelectedCalendarRepository {
    *  Will check if syncSubscribedAt is null or channelExpiration is greater than current date
    *  Calendars with recent subscription errors (last 24h) are skipped
    *  Calendars with 3+ subscription errors are skipped entirely
-   *  Joins with TeamFeatures to filter users belonging to teams with the specified feature enabled
+   *  Joins with TeamFeatures to filter users belonging to teams with any of the specified features enabled
    *
    * @param take the number of calendars to take
-   * @param featureId the feature ID to filter teams by
+   * @param featureIds the feature IDs to filter teams by (users in teams with any of these features enabled)
    * @param integrations the list of integrations
    * @param genericCalendarSuffixes the list of generic calendar suffixes to exclude
    */
   findNextSubscriptionBatch({
     take,
-    featureId,
+    featureIds,
     integrations,
     genericCalendarSuffixes,
   }: {
     take: number;
-    featureId: string;
+    featureIds: string[];
     integrations: string[];
     genericCalendarSuffixes?: string[];
   }): Promise<SelectedCalendar[]>;

--- a/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.interface.ts
+++ b/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.interface.ts
@@ -20,19 +20,21 @@ export interface ISelectedCalendarRepository {
    *  Will check if syncSubscribedAt is null or channelExpiration is greater than current date
    *  Calendars with recent subscription errors (last 24h) are skipped
    *  Calendars with 3+ subscription errors are skipped entirely
+   *  Joins with TeamFeatures to filter users belonging to teams with the specified feature enabled
    *
    * @param take the number of calendars to take
+   * @param featureId the feature ID to filter teams by
    * @param integrations the list of integrations
    * @param genericCalendarSuffixes the list of generic calendar suffixes to exclude
    */
   findNextSubscriptionBatch({
     take,
-    teamIds,
+    featureId,
     integrations,
     genericCalendarSuffixes,
   }: {
     take: number;
-    teamIds: number[];
+    featureId: string;
     integrations: string[];
     genericCalendarSuffixes?: string[];
   }): Promise<SelectedCalendar[]>;

--- a/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.test.ts
+++ b/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.test.ts
@@ -117,7 +117,7 @@ describe("SelectedCalendarRepository", () => {
 
       const result = await repository.findNextSubscriptionBatch({
         take: 10,
-        featureId: "calendar-subscription-cache",
+        featureIds: ["calendar-subscription-cache"],
         integrations: ["google_calendar", "office365_calendar"],
       });
 
@@ -131,7 +131,7 @@ describe("SelectedCalendarRepository", () => {
                 team: {
                   teamFeatures: {
                     some: {
-                      featureId: "calendar-subscription-cache",
+                      featureId: { in: ["calendar-subscription-cache"] },
                       enabled: true,
                     },
                   },
@@ -170,7 +170,7 @@ describe("SelectedCalendarRepository", () => {
 
       const result = await repository.findNextSubscriptionBatch({
         take: 5,
-        featureId: "calendar-subscription-cache",
+        featureIds: ["calendar-subscription-cache"],
         integrations: [],
       });
 
@@ -184,7 +184,7 @@ describe("SelectedCalendarRepository", () => {
                 team: {
                   teamFeatures: {
                     some: {
-                      featureId: "calendar-subscription-cache",
+                      featureId: { in: ["calendar-subscription-cache"] },
                       enabled: true,
                     },
                   },
@@ -225,7 +225,7 @@ describe("SelectedCalendarRepository", () => {
 
       const result = await repository.findNextSubscriptionBatch({
         take: 10,
-        featureId: "calendar-subscription-cache",
+        featureIds: ["calendar-subscription-cache"],
         integrations: ["google_calendar"],
         genericCalendarSuffixes: genericSuffixes,
       });
@@ -240,7 +240,7 @@ describe("SelectedCalendarRepository", () => {
                 team: {
                   teamFeatures: {
                     some: {
-                      featureId: "calendar-subscription-cache",
+                      featureId: { in: ["calendar-subscription-cache"] },
                       enabled: true,
                     },
                   },

--- a/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.test.ts
+++ b/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.test.ts
@@ -129,7 +129,7 @@ describe("SelectedCalendarRepository", () => {
               some: {
                 accepted: true,
                 team: {
-                  teamFeatures: {
+                  features: {
                     some: {
                       featureId: { in: ["calendar-subscription-cache"] },
                       enabled: true,
@@ -182,7 +182,7 @@ describe("SelectedCalendarRepository", () => {
               some: {
                 accepted: true,
                 team: {
-                  teamFeatures: {
+                  features: {
                     some: {
                       featureId: { in: ["calendar-subscription-cache"] },
                       enabled: true,
@@ -238,7 +238,7 @@ describe("SelectedCalendarRepository", () => {
               some: {
                 accepted: true,
                 team: {
-                  teamFeatures: {
+                  features: {
                     some: {
                       featureId: { in: ["calendar-subscription-cache"] },
                       enabled: true,

--- a/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.test.ts
+++ b/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.test.ts
@@ -117,7 +117,7 @@ describe("SelectedCalendarRepository", () => {
 
       const result = await repository.findNextSubscriptionBatch({
         take: 10,
-        teamIds: [1, 2, 3],
+        featureId: "calendar-subscription-cache",
         integrations: ["google_calendar", "office365_calendar"],
       });
 
@@ -127,8 +127,15 @@ describe("SelectedCalendarRepository", () => {
           user: {
             teams: {
               some: {
-                teamId: { in: [1, 2, 3] },
                 accepted: true,
+                team: {
+                  teamFeatures: {
+                    some: {
+                      featureId: "calendar-subscription-cache",
+                      enabled: true,
+                    },
+                  },
+                },
               },
             },
           },
@@ -163,7 +170,7 @@ describe("SelectedCalendarRepository", () => {
 
       const result = await repository.findNextSubscriptionBatch({
         take: 5,
-        teamIds: [10, 20],
+        featureId: "calendar-subscription-cache",
         integrations: [],
       });
 
@@ -173,8 +180,15 @@ describe("SelectedCalendarRepository", () => {
           user: {
             teams: {
               some: {
-                teamId: { in: [10, 20] },
                 accepted: true,
+                team: {
+                  teamFeatures: {
+                    some: {
+                      featureId: "calendar-subscription-cache",
+                      enabled: true,
+                    },
+                  },
+                },
               },
             },
           },
@@ -203,52 +217,6 @@ describe("SelectedCalendarRepository", () => {
       expect(result).toEqual(mockCalendars);
     });
 
-    test("should handle empty teamIds array", async () => {
-      const mockCalendars: SelectedCalendar[] = [];
-      vi.mocked(mockPrismaClient.selectedCalendar.findMany).mockResolvedValue(mockCalendars);
-
-      const result = await repository.findNextSubscriptionBatch({
-        take: 10,
-        teamIds: [],
-        integrations: ["google_calendar"],
-      });
-
-      expect(mockPrismaClient.selectedCalendar.findMany).toHaveBeenCalledWith({
-        where: {
-          integration: { in: ["google_calendar"] },
-          user: {
-            teams: {
-              some: {
-                teamId: { in: [] },
-                accepted: true,
-              },
-            },
-          },
-          AND: [
-            {
-              OR: [
-                { syncSubscribedAt: null },
-                { channelExpiration: null },
-                { channelExpiration: { lte: expect.any(Date) } },
-              ],
-            },
-            {
-              OR: [
-                { syncSubscribedErrorAt: null },
-                { syncSubscribedErrorAt: { lt: expect.any(Date) } },
-              ],
-            },
-            {
-              syncSubscribedErrorCount: { lt: 3 },
-            },
-          ],
-        },
-        take: 10,
-      });
-
-      expect(result).toEqual(mockCalendars);
-    });
-
     test("should filter out generic calendars when genericCalendarSuffixes is provided", async () => {
       const mockCalendars = [mockSelectedCalendar];
       vi.mocked(mockPrismaClient.selectedCalendar.findMany).mockResolvedValue(mockCalendars);
@@ -257,7 +225,7 @@ describe("SelectedCalendarRepository", () => {
 
       const result = await repository.findNextSubscriptionBatch({
         take: 10,
-        teamIds: [1, 2],
+        featureId: "calendar-subscription-cache",
         integrations: ["google_calendar"],
         genericCalendarSuffixes: genericSuffixes,
       });
@@ -268,8 +236,15 @@ describe("SelectedCalendarRepository", () => {
           user: {
             teams: {
               some: {
-                teamId: { in: [1, 2] },
                 accepted: true,
+                team: {
+                  teamFeatures: {
+                    some: {
+                      featureId: "calendar-subscription-cache",
+                      enabled: true,
+                    },
+                  },
+                },
               },
             },
           },

--- a/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.ts
+++ b/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.ts
@@ -19,12 +19,12 @@ export class SelectedCalendarRepository implements ISelectedCalendarRepository {
 
   async findNextSubscriptionBatch({
     take,
-    teamIds,
+    featureId,
     integrations,
     genericCalendarSuffixes,
   }: {
     take: number;
-    teamIds: number[];
+    featureId: string;
     integrations: string[];
     genericCalendarSuffixes?: string[];
   }) {
@@ -65,8 +65,15 @@ export class SelectedCalendarRepository implements ISelectedCalendarRepository {
         user: {
           teams: {
             some: {
-              teamId: { in: teamIds },
               accepted: true,
+              team: {
+                teamFeatures: {
+                  some: {
+                    featureId,
+                    enabled: true,
+                  },
+                },
+              },
             },
           },
         },

--- a/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.ts
+++ b/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.ts
@@ -67,7 +67,7 @@ export class SelectedCalendarRepository implements ISelectedCalendarRepository {
             some: {
               accepted: true,
               team: {
-                teamFeatures: {
+                features: {
                   some: {
                     featureId: { in: featureIds },
                     enabled: true,

--- a/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.ts
+++ b/packages/features/selectedCalendar/repositories/SelectedCalendarRepository.ts
@@ -19,12 +19,12 @@ export class SelectedCalendarRepository implements ISelectedCalendarRepository {
 
   async findNextSubscriptionBatch({
     take,
-    featureId,
+    featureIds,
     integrations,
     genericCalendarSuffixes,
   }: {
     take: number;
-    featureId: string;
+    featureIds: string[];
     integrations: string[];
     genericCalendarSuffixes?: string[];
   }) {
@@ -69,7 +69,7 @@ export class SelectedCalendarRepository implements ISelectedCalendarRepository {
               team: {
                 teamFeatures: {
                   some: {
-                    featureId,
+                    featureId: { in: featureIds },
                     enabled: true,
                   },
                 },


### PR DESCRIPTION
## What does this PR do?

Refactors the `CalendarSubscriptionService.checkForNewSubscriptions()` method to use a single database query instead of two separate queries when fetching calendars for subscription.

**Before:** 
1. Query `TeamFeatures` to get team IDs with the feature enabled
2. Pass those team IDs to `findNextSubscriptionBatch` to filter calendars

**After:**
1. Single query that joins `SelectedCalendar -> User -> Membership -> Team -> TeamFeatures` directly

### Changes:
- Changed `findNextSubscriptionBatch` to accept `featureIds: string[]` instead of `teamIds: number[]`
- Updated the Prisma query to join with `TeamFeatures` table directly using `featureId: { in: featureIds }`
- Removed the separate `getTeamsWithFeatureEnabled` call from `checkForNewSubscriptions`
- Updated tests to reflect the new query structure

### Updates since last revision:
- Changed from single `featureId: string` to `featureIds: string[]` array per reviewer feedback, allowing flexibility to filter by multiple features in the future

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
- N/A - No documentation changes required.

## How should this be tested?

1. Unit tests pass: `yarn test packages/features/selectedCalendar/repositories/SelectedCalendarRepository.test.ts packages/features/calendar-subscription/lib/__tests__/CalendarSubscriptionService.test.ts`
2. The calendar subscription cron job should continue to work correctly, subscribing only to calendars for users in teams with the `calendar-subscription-cache` feature enabled

## Important Review Notes

⚠️ **Behavioral consideration**: The original implementation called `getTeamsWithFeatureEnabled` which internally checks if the feature is globally enabled first (returns empty array if globally disabled). The new query joins directly on `TeamFeatures` without this global check. Please verify this is the intended behavior.

### Human Review Checklist
- [ ] Verify the Prisma `{ in: featureIds }` syntax correctly filters teams with any of the specified features enabled
- [ ] Confirm the removal of the global feature check is acceptable for this use case
- [ ] Check that the join path `User -> Membership -> Team -> TeamFeatures` correctly identifies users in teams with the feature

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized

---
**Link to Devin run:** https://app.devin.ai/sessions/8029982093e14e709856212927656866
**Requested by:** Volnei Munhoz (@volnei)