### PR TITLE
feat: implement next-cycle billing for monthly seat-based plans

### DIFF
--- a/packages/features/ee/billing/service/teams/TeamBillingService.ts
+++ b/packages/features/ee/billing/service/teams/TeamBillingService.ts
@@ -173,13 +173,23 @@ export class TeamBillingService implements ITeamBillingService {
         return;
       }
 
+      const shouldUseNextCycleBilling = await billingPeriodService.shouldUseNextCycleBilling(teamId);
+
       await updateSubscriptionQuantity({
         billingService: this.billingProviderService,
         subscriptionId,
         subscriptionItemId,
         quantity: membershipCount,
+        prorationBehavior: shouldUseNextCycleBilling ? "none" : undefined,
       });
-      log.info(`Updated subscription ${subscriptionId} for team ${teamId} to ${membershipCount} seats.`);
+
+      if (shouldUseNextCycleBilling) {
+        log.info(
+          `Updated subscription ${subscriptionId} for team ${teamId} to ${membershipCount} seats (next-cycle billing, no proration).`
+        );
+      } else {
+        log.info(`Updated subscription ${subscriptionId} for team ${teamId} to ${membershipCount} seats.`);
+      }
     } catch (error) {
       this.logErrorFromUnknown(error);
     }

--- a/packages/features/ee/billing/teams/internal-team-billing.test.ts
+++ b/packages/features/ee/billing/teams/internal-team-billing.test.ts
@@ -22,10 +22,12 @@ vi.mock("@calcom/features/ee/teams/lib/payments", () => ({
 }));
 
 const shouldApplyMonthlyProration = vi.fn().mockResolvedValue(false);
+const shouldUseNextCycleBilling = vi.fn().mockResolvedValue(false);
 
 vi.mock("../service/billingPeriod/BillingPeriodService", () => ({
   BillingPeriodService: class {
     shouldApplyMonthlyProration = shouldApplyMonthlyProration;
+    shouldUseNextCycleBilling = shouldUseNextCycleBilling;
   },
 }));
 const mockTeam = {

--- a/packages/features/flags/config.ts
+++ b/packages/features/flags/config.ts
@@ -35,6 +35,7 @@ export type AppFlags = {
   "bookings-v3": boolean;
   "booking-audit": boolean;
   "monthly-proration": boolean;
+  "monthly-seat-billing": boolean;
   "sidebar-tips": boolean;
 };
 

--- a/packages/features/flags/hooks/index.ts
+++ b/packages/features/flags/hooks/index.ts
@@ -34,6 +34,7 @@ const initialData: AppFlags = {
   "bookings-v3": false,
   "booking-audit": false,
   "monthly-proration": false,
+  "monthly-seat-billing": false,
   "sidebar-tips": false,
 };
 

--- a/packages/prisma/migrations/20260128221718_seed_monthly_seat_billing_feature/migration.sql
+++ b/packages/prisma/migrations/20260128221718_seed_monthly_seat_billing_feature/migration.sql
@@ -1,0 +1,9 @@
+INSERT INTO
+  "Feature" (slug, enabled, description, "type")
+VALUES
+  (
+    'monthly-seat-billing',
+    false,
+    'Enables next-cycle billing for monthly seat-based plans. When enabled, seat changes update subscription quantity without immediate proration - Stripe charges the full amount at the next billing cycle.',
+    'OPERATIONAL'
+  ) ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
## What does this PR do?

Implements the "Next Cycle" billing model for monthly seat-based plans. When enabled via feature flag, seat changes on monthly plans update the subscription quantity without immediate proration - Stripe charges the full amount at the next billing cycle, creating clean invoices without messy line items.

This complements the existing batched monthly proration system for annual plans by providing a simpler approach for monthly billing cycles.

**Key changes:**
- Add `shouldUseNextCycleBilling()` method to `BillingPeriodService` that checks if a team has monthly billing and the feature is enabled
- Modify `TeamBillingService.updateQuantity()` to pass `prorationBehavior: "none"` to Stripe for monthly plans
- Add `monthly-seat-billing` feature flag (disabled by default)
- Add migration to seed the feature flag

## Updates since last revision

- Fixed missing `monthly-seat-billing` entry in `initialData` object in `packages/features/flags/hooks/index.ts` (was causing CI type check failure)
- Added `shouldUseNextCycleBilling` mock to `internal-team-billing.test.ts` (was causing CI unit test failure)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal billing feature
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Enable the `monthly-seat-billing` feature flag in the database
2. Create/use a team with monthly billing (not annual, not in trial)
3. Add or remove team members
4. Verify in Stripe dashboard that:
   - Subscription quantity is updated immediately
   - No proration invoice items are created
   - The new seat count will be charged at the next billing cycle

**Test configuration:**
- Feature flag must be enabled: `UPDATE "Feature" SET enabled = true WHERE slug = 'monthly-seat-billing'`
- Team must have `billingPeriod = 'MONTHLY'` in `TeamBilling` or `OrganizationBilling`
- Team must not be in trial period

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is not too large (<500 lines, 6 files)

## Human Review Checklist

- [ ] Verify `prorationBehavior: "none"` is the correct Stripe setting for this use case
- [ ] Confirm feature flag rollout strategy (disabled by default is intentional)
- [ ] Review interaction with existing `shouldApplyMonthlyProration` for annual plans - they should be mutually exclusive (annual uses batched proration, monthly uses next-cycle)
- [ ] Verify error handling in `shouldUseNextCycleBilling` - returns `false` on error, which is safe but may silently fall back to default billing behavior
- [ ] Test files use `as any` type casting for Prisma mocks - verify this is acceptable for test code

---

Link to Devin run: https://app.devin.ai/sessions/d6ca4b31412049198d0f9fa2f0efdf79
Requested by: @sean-brydon