### PR TITLE
feat: enable PBAC feature flag globally via migration

### DIFF
--- a/packages/prisma/migrations/20260129090913_enable_pbac_globally/migration.sql
+++ b/packages/prisma/migrations/20260129090913_enable_pbac_globally/migration.sql
@@ -1,0 +1,4 @@
+-- Enable PBAC feature flag globally
+UPDATE "Feature"
+SET enabled = true
+WHERE slug = 'pbac';


### PR DESCRIPTION
## What does this PR do?

Enables the PBAC (Permission-Based Access Control) feature flag globally via a database migration. This updates the `Feature` table to set `enabled = true` for the 'pbac' slug.

The PBAC feature was previously added with `enabled: false` in migration `20250521070158_add_pbac_feature_flags`. This migration enables it for all instances.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the migration: `yarn workspace @calcom/prisma db-migrate`
2. Verify the feature flag is enabled:
   ```sql
   SELECT * FROM "Feature" WHERE slug = 'pbac';
   ```
   Should show `enabled = true`
3. Monitor e2e tests for any PBAC-related failures after enabling

## Human Review Checklist

- [ ] Confirm enabling PBAC globally is the intended behavior
- [ ] Verify all PBAC-related code paths work correctly with the feature enabled
- [ ] Check if there are any known edge cases or issues when PBAC is enabled globally
- [ ] Ensure monitoring is in place for post-deployment

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized (4 lines changed)

---

**Link to Devin run:** https://app.devin.ai/sessions/efe54642f0d44c5e9b1413c9fdee7485
**Requested by:** @sean-brydon