### PR TITLE
fix: atoms breaking

### DIFF
--- a/packages/app-store/hubspot/_metadata.ts
+++ b/packages/app-store/hubspot/_metadata.ts
@@ -1,9 +1,9 @@
-import process from "node:process";
 import type { AppMeta } from "@calcom/types/App";
 import _package from "./package.json";
 
 export const metadata = {
   name: "HubSpot CRM",
+  // biome-ignore lint/correctness/noProcessGlobal: Server-only metadata evaluated at build time
   installed: !!process.env.HUBSPOT_CLIENT_ID,
   description: _package.description,
   type: "hubspot_crm",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a build error in the HubSpot app metadata that was breaking the atoms build. Removes the bad node:process import and uses the global process.env, with a linter ignore since this runs at build time.

<sup>Written for commit 68d3a0c5a3efbd096cac28ddbb71cedc8d9b8f0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

