### PR TITLE
chore: Remove noProcessGlobal for atoms

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -358,6 +358,9 @@
       "includes": ["packages/platform/atoms/**/*.{ts,tsx,js,jsx,mts,mjs,cjs,cts}"],
       "linter": {
         "rules": {
+          "correctness": {
+            "noProcessGlobal": "off"
+          },
           "style": {
             "noRestrictedImports": {
               "level": "error",


### PR DESCRIPTION
## What does this PR do?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled Biome’s noProcessGlobal rule for the atoms package to allow use of the process global without lint errors. This change is scoped to atoms in biome.json and does not affect other packages.

<sup>Written for commit 78df2a0a5ec7053f3e996901fdf71dd17a0ab2e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

