### PR TITLE
experiment: failed dwd batched credentials experiment

### DIFF
--- a/packages/app-store/_utils/getCalendar.ts
+++ b/packages/app-store/_utils/getCalendar.ts
@@ -9,7 +9,6 @@ import { isTelemetryEnabled } from "@calcom/lib/sentryWrapper";
 import { prisma } from "@calcom/prisma";
 import type { Calendar, CalendarFetchMode } from "@calcom/types/Calendar";
 import type { CredentialForCalendarService } from "@calcom/types/Credential";
-
 import { CalendarServiceMap } from "../calendar.services.generated";
 
 const log = logger.getSubLogger({ prefix: ["CalendarManager"] });
@@ -18,7 +17,12 @@ export const getCalendar = async (
   credential: CredentialForCalendarService | null,
   mode: CalendarFetchMode = "none"
 ): Promise<Calendar | null> => {
-  if (!credential || !credential.key) return null;
+  if (
+    !credential ||
+    !credential.key ||
+    (typeof credential.key === "object" && Object.keys(credential.key).length === 0)
+  )
+    return null;
   let { type: calendarType } = credential;
   if (calendarType?.endsWith("_other_calendar")) {
     calendarType = calendarType.split("_other_calendar")[0];

--- a/packages/app-store/_utils/oauth/getTokenObjectFromCredential.ts
+++ b/packages/app-store/_utils/oauth/getTokenObjectFromCredential.ts
@@ -1,10 +1,12 @@
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import type { CredentialPayload } from "@calcom/types/Credential";
-
 import { OAuth2TokenResponseInDbSchema } from "./universalSchema";
 
 export function getTokenObjectFromCredential(credential: Pick<CredentialPayload, "key" | "id">) {
+  console.log(
+    `[getTokenObjectFromCredential] ID: ${credential.id}, Key type: ${typeof credential.key}, Keys: ${credential.key && typeof credential.key === "object" ? Object.keys(credential.key) : "N/A"}`
+  );
   const parsedTokenResponse = OAuth2TokenResponseInDbSchema.safeParse(credential.key);
   if (!parsedTokenResponse.success) {
     logger.error(

--- a/packages/app-store/delegationCredential.ts
+++ b/packages/app-store/delegationCredential.ts
@@ -96,6 +96,7 @@ const _buildCommonUserCredential = ({
     teamId: null,
     team: null,
     delegationCredentialId: delegationCredential.id,
+    selectedCalendars: [],
     delegatedTo: delegationCredential.serviceAccountKey
       ? {
           serviceAccountKey: delegationCredential.serviceAccountKey,
@@ -382,26 +383,29 @@ export const buildAllCredentials = ({
     ...buildNonDelegationCredentials(nonDelegationCredentials),
   ];
 
-  const uniqueAllCredentials = allCredentials.reduce((acc, credential) => {
-    if (!credential.delegatedToId) {
-      // Regular credential go as is
-      acc.push(credential);
+  const uniqueAllCredentials = allCredentials.reduce(
+    (acc, credential) => {
+      if (!credential.delegatedToId) {
+        // Regular credential go as is
+        acc.push(credential);
+        return acc;
+      }
+      const existingDelegationCredential = acc.find(
+        (c) => c.delegatedToId === credential.delegatedToId && c.appId === credential.appId
+      );
+      if (!existingDelegationCredential) {
+        acc.push(credential);
+      }
       return acc;
-    }
-    const existingDelegationCredential = acc.find(
-      (c) => c.delegatedToId === credential.delegatedToId && c.appId === credential.appId
-    );
-    if (!existingDelegationCredential) {
-      acc.push(credential);
-    }
-    return acc;
-  }, [] as typeof allCredentials);
+    },
+    [] as typeof allCredentials
+  );
 
   return uniqueAllCredentials;
 };
 
 export async function enrichUsersWithDelegationCredentials<
-  TUser extends { id: number; email: string; credentials: CredentialPayload[] }
+  TUser extends { id: number; email: string; credentials: CredentialPayload[] },
 >({ orgId, users }: { orgId: number | null; users: TUser[] }) {
   const delegationCredentialsMap = await _getDelegationCredentialsMapPerUser({
     organizationId: orgId,
@@ -425,7 +429,7 @@ export async function enrichUsersWithDelegationCredentials<
 
 export const enrichHostsWithDelegationCredentials = async <
   THost extends Host<TUser>,
-  TUser extends { id: number; email: string; credentials: CredentialPayload[] }
+  TUser extends { id: number; email: string; credentials: CredentialPayload[] },
 >({
   orgId,
   hosts,
@@ -466,7 +470,7 @@ export const enrichHostsWithDelegationCredentials = async <
 };
 
 export const enrichUserWithDelegationCredentialsIncludeServiceAccountKey = async <
-  TUser extends { id: number; email: string; credentials: CredentialPayload[] }
+  TUser extends { id: number; email: string; credentials: CredentialPayload[] },
 >({
   user,
 }: {
@@ -486,7 +490,7 @@ export const enrichUserWithDelegationCredentialsIncludeServiceAccountKey = async
 };
 
 export const enrichUserWithDelegationCredentials = async <
-  TUser extends { id: number; email: string; credentials: CredentialPayload[] }
+  TUser extends { id: number; email: string; credentials: CredentialPayload[] },
 >({
   user,
 }: {
@@ -502,7 +506,7 @@ export const enrichUserWithDelegationCredentials = async <
 };
 
 export async function enrichUserWithDelegationConferencingCredentialsWithoutOrgId<
-  TUser extends { id: number; email: string; credentials: CredentialPayload[] }
+  TUser extends { id: number; email: string; credentials: CredentialPayload[] },
 >({ user }: { user: TUser }) {
   const { credentials, ...restUser } = await enrichUserWithDelegationCredentialsIncludeServiceAccountKey({
     user,
@@ -517,7 +521,7 @@ export async function enrichUserWithDelegationConferencingCredentialsWithoutOrgI
  * Either get Delegation credential from delegationCredentials or find regular credential from Credential table
  */
 export async function getDelegationCredentialOrFindRegularCredential<
-  TDelegationCredential extends { delegatedToId?: string | null }
+  TDelegationCredential extends { delegatedToId?: string | null },
 >({
   id,
   delegationCredentials,
@@ -531,17 +535,17 @@ export async function getDelegationCredentialOrFindRegularCredential<
   return id.delegationCredentialId
     ? delegationCredentials.find((cred) => cred.delegatedToId === id.delegationCredentialId)
     : id.credentialId
-    ? await CredentialRepository.findCredentialForCalendarServiceById({
-        id: id.credentialId,
-      })
-    : null;
+      ? await CredentialRepository.findCredentialForCalendarServiceById({
+          id: id.credentialId,
+        })
+      : null;
 }
 
 /**
  * Utility function to find a credential from a list of credentials, supporting both regular and DelegationCredential credentials
  */
 export function getDelegationCredentialOrRegularCredential<
-  TCredential extends { delegatedToId?: string | null; id: number }
+  TCredential extends { delegatedToId?: string | null; id: number },
 >({
   credentials,
   id,

--- a/packages/features/calendars/lib/getBatchCalendarEvents.test.ts
+++ b/packages/features/calendars/lib/getBatchCalendarEvents.test.ts
@@ -1,0 +1,74 @@
+import { getCalendar } from "@calcom/app-store/_utils/getCalendar";
+import { describe, expect, it, vi } from "vitest";
+import { getBatchCalendarEvents } from "./getBatchCalendarEvents";
+
+vi.mock("@calcom/app-store/_utils/getCalendar");
+vi.mock("@calcom/lib/logger", () => ({
+  default: {
+    getSubLogger: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+vi.mock("@calcom/lib/server/perfObserver", () => ({
+  performance: {
+    mark: vi.fn(),
+    measure: vi.fn(),
+  },
+}));
+
+describe("getBatchCalendarEvents", () => {
+  it("should batch credentials and distribute results by source", async () => {
+    const mockGetAvailability = vi.fn().mockResolvedValue([
+      { start: "2023-01-01T10:00:00Z", end: "2023-01-01T11:00:00Z", source: "cal1" },
+      { start: "2023-01-01T12:00:00Z", end: "2023-01-01T13:00:00Z", source: "cal2" },
+    ]);
+
+    (getCalendar as any).mockResolvedValue({
+      getAvailability: mockGetAvailability,
+    });
+
+    const requests = [
+      {
+        credential: { id: 1, type: "google_calendar" } as any,
+        externalIds: ["cal1", "cal2"],
+      },
+      {
+        credential: { id: 2, type: "google_calendar" } as any,
+        externalIds: ["cal3"],
+      },
+    ];
+
+    const result = await getBatchCalendarEvents(requests, "2023-01-01T00:00:00Z", "2023-01-01T23:59:59Z");
+
+    expect(getCalendar).toHaveBeenCalledTimes(2);
+    expect(mockGetAvailability).toHaveBeenCalledTimes(2);
+
+    expect(result["cal1"]).toHaveLength(1);
+    expect(result["cal1"][0].source).toBe("cal1");
+    expect(result["cal2"]).toHaveLength(1);
+    expect(result["cal2"][0].source).toBe("cal2");
+  });
+
+  it("should handle single calendar fallback when source is missing", async () => {
+    const mockGetAvailability = vi.fn().mockResolvedValue([
+      { start: "2023-01-01T10:00:00Z", end: "2023-01-01T11:00:00Z" }, // No source
+    ]);
+
+    (getCalendar as any).mockResolvedValue({
+      getAvailability: mockGetAvailability,
+    });
+
+    const requests = [
+      {
+        credential: { id: 1, type: "other_calendar" } as any,
+        externalIds: ["cal1"],
+      },
+    ];
+
+    const result = await getBatchCalendarEvents(requests, "2023-01-01T00:00:00Z", "2023-01-01T23:59:59Z");
+
+    expect(result["cal1"]).toHaveLength(1);
+  });
+});

--- a/packages/features/calendars/lib/getBatchCalendarEvents.ts
+++ b/packages/features/calendars/lib/getBatchCalendarEvents.ts
@@ -1,0 +1,134 @@
+import { getCalendar } from "@calcom/app-store/_utils/getCalendar";
+import logger from "@calcom/lib/logger";
+import { performance } from "@calcom/lib/server/perfObserver";
+import type { CalendarFetchMode, EventBusyDate, IntegrationCalendar } from "@calcom/types/Calendar";
+import type { CredentialForCalendarService } from "@calcom/types/Credential";
+
+const log = logger.getSubLogger({ prefix: ["getBatchCalendarEvents"] });
+
+interface BatchRequest {
+  credential: CredentialForCalendarService;
+  externalIds: string[];
+}
+
+interface BatchResult {
+  [externalId: string]: EventBusyDate[];
+}
+
+export const getBatchCalendarEvents = async (
+  requests: BatchRequest[],
+  dateFrom: string,
+  dateTo: string,
+  mode: CalendarFetchMode = "slots"
+): Promise<BatchResult> => {
+  performance.mark("getBatchCalendarEventsStart");
+
+  // Group by credential ID to ensure unique credentials
+  // (In practice, caller should probably pass unique credentials, but we can safety check)
+  // Actually, requests might be just list of credentials.
+  const uniqueCredentialRequests = requests;
+
+  const results: BatchResult = {};
+
+  await Promise.all(
+    uniqueCredentialRequests.map(async ({ credential, externalIds }) => {
+      try {
+        // Initialize all IDs as empty in the results map to prevent individual fallbacks later
+        externalIds.forEach((id) => {
+          if (!results[id]) results[id] = [];
+        });
+
+        // For delegation credentials, if we have multiple users, we attempt a subject-less call
+        // which might have broader permissions if configured in the Workspace.
+        const batchCredential = {
+          ...credential,
+          user: externalIds.length > 1 && !!credential.delegatedToId ? null : credential.user,
+        };
+
+        const calendarService = await getCalendar(batchCredential as any, mode);
+        if (!calendarService) {
+          console.log(`getBatchCalendarEvents: No calendar service for credential ${credential.id}`);
+          return;
+        }
+
+        console.log(
+          `getBatchCalendarEvents: Batching ${externalIds.length} IDs for credential ${credential.id}${batchCredential.user ? ` (Subject: ${batchCredential.user.email})` : " (Subject-less)"}: ${externalIds.join(", ")}`
+        );
+
+        // Construct selectedCalendars objects as expected by getAvailability
+        // We only really need externalId and integration for the service to work usually
+        const selectedCalendars: IntegrationCalendar[] = externalIds.map((id) => ({
+          externalId: id,
+          integration: credential.type,
+          // minimal mock of IntegrationCalendar
+        }));
+
+        console.log(
+          `getBatchCalendarEvents: Fetching for credential ${credential.id} with ${externalIds.length} calendars. Key has access_token: ${!!(credential.key as any)?.access_token}`
+        );
+
+        const busyTimes = await calendarService.getAvailability({
+          dateFrom,
+          dateTo,
+          selectedCalendars,
+          mode,
+          fallbackToPrimary: false, // We are specific about what we want
+        });
+
+        // Distribute results back to the map
+        // For Google Calendar, we expect 'source' to be the calendar ID (externalId)
+        // For others, if 'source' is missing, we might have an issue attributing it if we batched multiple.
+        // However, if the adapter returns flattened results without source, we can't do much.
+        // We will assume that if source is present, it matches externalId.
+
+        busyTimes.forEach((busy) => {
+          if (busy.source && externalIds.includes(busy.source)) {
+            if (!results[busy.source]) {
+              results[busy.source] = [];
+            }
+            results[busy.source].push(busy);
+          } else if (externalIds.length === 1) {
+            // If we only asked for one calendar, we can safely attribute all results to it
+            // even if source is missing or different
+            const singleId = externalIds[0];
+            if (!results[singleId]) results[singleId] = [];
+            results[singleId].push(busy);
+          } else {
+            // Warn? Or maybe log debug.
+            // If we batched multiple and got results without source, we drop them or assign to all?
+            // Assigning to all is risky. Dropping is also bad.
+            // For now, let's log.
+            log.debug(`Received busy time without matching source for batched request`, {
+              busy,
+              externalIds,
+            });
+          }
+        });
+
+        const returnedIds = Object.keys(results).filter((id) => externalIds.includes(id));
+        const missingIds = externalIds.filter((id) => !returnedIds.includes(id));
+
+        const resultsSummary = returnedIds.map((id) => `${id}: ${results[id].length} slots`).join(", ");
+        console.log(
+          `getBatchCalendarEvents: Results Summary [Req: ${externalIds.length}, Got: ${returnedIds.length}]`
+        );
+        if (returnedIds.length > 0) console.log(`  - Returned: ${resultsSummary}`);
+        if (missingIds.length > 0)
+          console.log(
+            `  - No busy slots found for: ${missingIds.join(", ")} (User might be free or access denied)`
+          );
+      } catch (error) {
+        log.error(`Failed to batch fetch for credential ${credential.id}`, error);
+      }
+    })
+  );
+
+  performance.mark("getBatchCalendarEventsEnd");
+  performance.measure(
+    `getBatchCalendarEvents took $1`,
+    "getBatchCalendarEventsStart",
+    "getBatchCalendarEventsEnd"
+  );
+
+  return results;
+};

--- a/packages/features/users/lib/getRoutedUsers.ts
+++ b/packages/features/users/lib/getRoutedUsers.ts
@@ -12,7 +12,7 @@ import type { CredentialPayload } from "@calcom/types/Credential";
 const log = logger.getSubLogger({ prefix: ["[getRoutedUsers]"] });
 
 export const getRoutedUsersWithContactOwnerAndFixedUsers = <
-  T extends { id: number; isFixed?: boolean; email: string }
+  T extends { id: number; isFixed?: boolean; email: string },
 >({
   routedTeamMemberIds,
   users,
@@ -130,7 +130,7 @@ export function getNormalizedHosts<User extends BaseUser, Host extends BaseHost<
 type BaseUserWithCredentialPayload = BaseUser & { credentials: CredentialPayload[] };
 export async function getNormalizedHostsWithDelegationCredentials<
   User extends BaseUserWithCredentialPayload,
-  Host extends BaseHost<User>
+  Host extends BaseHost<User>,
 >({
   eventType,
 }: {

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1307,7 +1307,7 @@ export class AvailableSlotsService {
 
         const restrictionTimezone = eventType.useBookerTimezone
           ? input.timeZone
-          : restrictionSchedule.timeZone ?? "UTC";
+          : (restrictionSchedule.timeZone ?? "UTC");
         const eventLength = input.duration || eventType.length;
 
         const restrictionAvailability = restrictionSchedule.availability.map((rule) => ({


### PR DESCRIPTION
Failed POC for DWD for batching

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches calendar availability fetching per credential (including delegation) and wires results into availability and busy-times to cut API calls and avoid per-pointer fallbacks. Adds source-aware busy slots from Google and hardens empty credential handling.

- New Features
  - Added getBatchCalendarEvents to fetch availability for multiple externalIds per credential; returns a map keyed by externalId with tests.
  - UserAvailabilityService groups selected calendars by credential/delegation and calls the batch API; passes per-user results downstream.
  - BusyTimesService accepts connectedCalendarsBusyTimes to skip network fetches when precomputed data is available.

- Refactors
  - GoogleCalendarService now emits source on busy slots, improves filtering/diagnostics, and keeps 90-day chunking logic.
  - getCalendar/oauth paths handle empty credential keys more safely and improve delegation lookup/logging.
  - Delegation credential building de-duplicates entries and sets defaults; minor typing/formatting cleanups.

<sup>Written for commit 8f705bab6370769eedcf1ae86ad855d8b89a4d2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

