### PR TITLE
fix: cache already-enabled feature opt-in status in local storage

### DIFF
--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
@@ -3,8 +3,7 @@
 import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
 import { getOptInFeatureConfig, shouldDisplayFeatureAt } from "@calcom/features/feature-opt-in/config";
 import { trpc } from "@calcom/trpc/react";
-import { useCallback, useMemo, useState } from "react";
-
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   getFeatureOptInTimestamp,
   isFeatureDismissed,
@@ -64,6 +63,15 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
       staleTime: 1000 * 60 * 5,
     }
   );
+
+  // When the server reports the feature is already enabled, cache it locally
+  // to avoid repeated API calls on subsequent page loads
+  useEffect(() => {
+    if (eligibilityQuery.data?.status === "already_enabled") {
+      setFeatureOptedIn(featureId);
+      setIsOptedIn(true);
+    }
+  }, [eligibilityQuery.data?.status, featureId]);
 
   const setUserStateMutation = trpc.viewer.featureOptIn.setUserState.useMutation();
   const setTeamStateMutation = trpc.viewer.featureOptIn.setTeamState.useMutation();


### PR DESCRIPTION
## Summary
- When the feature opt-in eligibility check returns `already_enabled` status, the result is now cached in local storage
- This prevents repeated API calls on subsequent page loads for users who have already opted into a feature
- Uses the existing `setFeatureOptedIn` storage function to mark the feature as opted-in client-side

## Test plan
- [ ] User opts into a feature via settings → verify banner doesn't show and no API calls made on reload
- [ ] User has feature already enabled via org/team → verify eligibility check is called once, then cached
- [ ] Clear local storage → verify eligibility check is called again

🤖 Generated with [Claude Code](https://claude.com/claude-code)