### PR TITLE
test: add unit tests for getTotalBookingDurationForUsers and yearly duration pre-fetching

### DIFF
--- a/packages/features/bookings/repositories/BookingRepository.test.ts
+++ b/packages/features/bookings/repositories/BookingRepository.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import type { PrismaClient } from "@calcom/prisma";
+
+import { BookingRepository } from "./BookingRepository";
+
+describe("BookingRepository", () => {
+  let repository: BookingRepository;
+  let mockPrismaClient: {
+    $queryRaw: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockPrismaClient = {
+      $queryRaw: vi.fn(),
+    };
+
+    repository = new BookingRepository(mockPrismaClient as unknown as PrismaClient);
+  });
+
+  describe("getTotalBookingDurationForUsers", () => {
+    it("should return empty map when userIds array is empty", async () => {
+      const result = await repository.getTotalBookingDurationForUsers({
+        eventId: 1,
+        userIds: [],
+        startDate: new Date("2026-01-01"),
+        endDate: new Date("2026-12-31"),
+      });
+
+      expect(result).toEqual(new Map());
+      expect(mockPrismaClient.$queryRaw).not.toHaveBeenCalled();
+    });
+
+    it("should return map with user durations for single user", async () => {
+      mockPrismaClient.$queryRaw.mockResolvedValue([{ userId: 1, totalMinutes: 120 }]);
+
+      const result = await repository.getTotalBookingDurationForUsers({
+        eventId: 52,
+        userIds: [1],
+        startDate: new Date("2026-01-01"),
+        endDate: new Date("2026-12-31"),
+      });
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get(1)).toBe(120);
+      expect(mockPrismaClient.$queryRaw).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return map with user durations for multiple users", async () => {
+      mockPrismaClient.$queryRaw.mockResolvedValue([
+        { userId: 29, totalMinutes: 60 },
+        { userId: 31, totalMinutes: 180 },
+      ]);
+
+      const result = await repository.getTotalBookingDurationForUsers({
+        eventId: 52,
+        userIds: [29, 31],
+        startDate: new Date("2026-01-01"),
+        endDate: new Date("2026-12-31"),
+      });
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get(29)).toBe(60);
+      expect(result.get(31)).toBe(180);
+      expect(mockPrismaClient.$queryRaw).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return 0 for users with no bookings (null totalMinutes)", async () => {
+      mockPrismaClient.$queryRaw.mockResolvedValue([{ userId: 1, totalMinutes: null }]);
+
+      const result = await repository.getTotalBookingDurationForUsers({
+        eventId: 52,
+        userIds: [1],
+        startDate: new Date("2026-01-01"),
+        endDate: new Date("2026-12-31"),
+      });
+
+      expect(result.get(1)).toBe(0);
+    });
+
+    it("should not include user in map if they have no bookings in the period", async () => {
+      mockPrismaClient.$queryRaw.mockResolvedValue([{ userId: 29, totalMinutes: 60 }]);
+
+      const result = await repository.getTotalBookingDurationForUsers({
+        eventId: 52,
+        userIds: [29, 31],
+        startDate: new Date("2026-01-01"),
+        endDate: new Date("2026-12-31"),
+      });
+
+      expect(result.get(29)).toBe(60);
+      expect(result.has(31)).toBe(false);
+    });
+
+    it("should exclude reschedule booking when rescheduleUid is provided", async () => {
+      mockPrismaClient.$queryRaw.mockResolvedValue([{ userId: 1, totalMinutes: 90 }]);
+
+      const result = await repository.getTotalBookingDurationForUsers({
+        eventId: 52,
+        userIds: [1],
+        startDate: new Date("2026-01-01"),
+        endDate: new Date("2026-12-31"),
+        rescheduleUid: "existing-booking-uid",
+      });
+
+      expect(result.get(1)).toBe(90);
+      expect(mockPrismaClient.$queryRaw).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle empty results from database", async () => {
+      mockPrismaClient.$queryRaw.mockResolvedValue([]);
+
+      const result = await repository.getTotalBookingDurationForUsers({
+        eventId: 52,
+        userIds: [1, 2, 3],
+        startDate: new Date("2026-01-01"),
+        endDate: new Date("2026-12-31"),
+      });
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    it("should handle large number of users efficiently", async () => {
+      const userIds = Array.from({ length: 100 }, (_, i) => i + 1);
+      const mockResults = userIds.map((userId) => ({
+        userId,
+        totalMinutes: userId * 10,
+      }));
+      mockPrismaClient.$queryRaw.mockResolvedValue(mockResults);
+
+      const result = await repository.getTotalBookingDurationForUsers({
+        eventId: 52,
+        userIds,
+        startDate: new Date("2026-01-01"),
+        endDate: new Date("2026-12-31"),
+      });
+
+      expect(result.size).toBe(100);
+      expect(result.get(1)).toBe(10);
+      expect(result.get(100)).toBe(1000);
+      expect(mockPrismaClient.$queryRaw).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/trpc/server/routers/viewer/slots/getBusyTimesFromLimitsForUsers.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/getBusyTimesFromLimitsForUsers.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import dayjs from "@calcom/dayjs";
+import type { IntervalLimit } from "@calcom/lib/intervalLimits/intervalLimitSchema";
+
+import type { IAvailableSlotsService } from "./util";
+import { AvailableSlotsService } from "./util";
+
+describe("AvailableSlotsService - _getBusyTimesFromLimitsForUsers", () => {
+  let service: AvailableSlotsService;
+  let mockDependencies: {
+    bookingRepo: {
+      getTotalBookingDuration: ReturnType<typeof vi.fn>;
+      getTotalBookingDurationForUsers: ReturnType<typeof vi.fn>;
+    };
+    busyTimesService: {
+      getStartEndDateforLimitCheck: ReturnType<typeof vi.fn>;
+      getBusyTimesForLimitChecks: ReturnType<typeof vi.fn>;
+    };
+    userAvailabilityService: {
+      getPeriodStartDatesBetween: ReturnType<typeof vi.fn>;
+    };
+    checkBookingLimitsService: {
+      checkBookingLimit: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDependencies = {
+      bookingRepo: {
+        getTotalBookingDuration: vi.fn(),
+        getTotalBookingDurationForUsers: vi.fn(),
+      },
+      busyTimesService: {
+        getStartEndDateforLimitCheck: vi.fn().mockReturnValue({
+          limitDateFrom: dayjs("2026-01-01"),
+          limitDateTo: dayjs("2026-12-31"),
+        }),
+        getBusyTimesForLimitChecks: vi.fn().mockResolvedValue([]),
+      },
+      userAvailabilityService: {
+        getPeriodStartDatesBetween: vi.fn().mockReturnValue([dayjs("2026-01-01")]),
+      },
+      checkBookingLimitsService: {
+        checkBookingLimit: vi.fn(),
+      },
+    };
+
+    service = new AvailableSlotsService(mockDependencies as unknown as IAvailableSlotsService);
+  });
+
+  describe("yearly duration limit pre-fetching optimization", () => {
+    const users = [
+      { id: 29, email: "user29@example.com" },
+      { id: 31, email: "user31@example.com" },
+    ];
+    const eventType = { id: 52, length: 30 };
+    const dateFrom = dayjs("2026-01-01");
+    const dateTo = dayjs("2026-12-31");
+    const timeZone = "UTC";
+
+    it("should call getTotalBookingDurationForUsers once for yearly duration limits instead of N times", async () => {
+      const durationLimits: IntervalLimit = { PER_YEAR: 480 };
+      const yearlyDurationMap = new Map<number, number>();
+      yearlyDurationMap.set(29, 60);
+      yearlyDurationMap.set(31, 120);
+
+      mockDependencies.bookingRepo.getTotalBookingDurationForUsers.mockResolvedValue(yearlyDurationMap);
+
+      await (service as unknown as { _getBusyTimesFromLimitsForUsers: Function })._getBusyTimesFromLimitsForUsers(
+        users,
+        null,
+        durationLimits,
+        dateFrom,
+        dateTo,
+        30,
+        eventType,
+        timeZone
+      );
+
+      expect(mockDependencies.bookingRepo.getTotalBookingDurationForUsers).toHaveBeenCalledTimes(1);
+      expect(mockDependencies.bookingRepo.getTotalBookingDurationForUsers).toHaveBeenCalledWith({
+        eventId: 52,
+        userIds: [29, 31],
+        startDate: expect.any(Date),
+        endDate: expect.any(Date),
+        rescheduleUid: undefined,
+      });
+
+      expect(mockDependencies.bookingRepo.getTotalBookingDuration).not.toHaveBeenCalled();
+    });
+
+    it("should not call getTotalBookingDurationForUsers when no PER_YEAR duration limit", async () => {
+      const durationLimits: IntervalLimit = { PER_DAY: 120 };
+
+      await (service as unknown as { _getBusyTimesFromLimitsForUsers: Function })._getBusyTimesFromLimitsForUsers(
+        users,
+        null,
+        durationLimits,
+        dateFrom,
+        dateTo,
+        30,
+        eventType,
+        timeZone
+      );
+
+      expect(mockDependencies.bookingRepo.getTotalBookingDurationForUsers).not.toHaveBeenCalled();
+    });
+
+    it("should not call getTotalBookingDurationForUsers when no duration limits at all", async () => {
+      await (service as unknown as { _getBusyTimesFromLimitsForUsers: Function })._getBusyTimesFromLimitsForUsers(
+        users,
+        null,
+        null,
+        dateFrom,
+        dateTo,
+        30,
+        eventType,
+        timeZone
+      );
+
+      expect(mockDependencies.bookingRepo.getTotalBookingDurationForUsers).not.toHaveBeenCalled();
+    });
+
+    it("should pass rescheduleUid to getTotalBookingDurationForUsers when provided", async () => {
+      const durationLimits: IntervalLimit = { PER_YEAR: 480 };
+      const rescheduleUid = "existing-booking-uid";
+
+      mockDependencies.bookingRepo.getTotalBookingDurationForUsers.mockResolvedValue(new Map());
+
+      await (service as unknown as { _getBusyTimesFromLimitsForUsers: Function })._getBusyTimesFromLimitsForUsers(
+        users,
+        null,
+        durationLimits,
+        dateFrom,
+        dateTo,
+        30,
+        eventType,
+        timeZone,
+        rescheduleUid
+      );
+
+      expect(mockDependencies.bookingRepo.getTotalBookingDurationForUsers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rescheduleUid: "existing-booking-uid",
+        })
+      );
+    });
+
+    it("should call getTotalBookingDurationForUsers for each year when date range spans multiple years", async () => {
+      const durationLimits: IntervalLimit = { PER_YEAR: 480 };
+      const multiYearDateFrom = dayjs("2025-12-01");
+      const multiYearDateTo = dayjs("2026-02-28");
+
+      mockDependencies.userAvailabilityService.getPeriodStartDatesBetween.mockReturnValue([
+        dayjs("2025-01-01"),
+        dayjs("2026-01-01"),
+      ]);
+
+      mockDependencies.bookingRepo.getTotalBookingDurationForUsers.mockResolvedValue(new Map());
+
+      await (service as unknown as { _getBusyTimesFromLimitsForUsers: Function })._getBusyTimesFromLimitsForUsers(
+        users,
+        null,
+        durationLimits,
+        multiYearDateFrom,
+        multiYearDateTo,
+        30,
+        eventType,
+        timeZone
+      );
+
+      expect(mockDependencies.bookingRepo.getTotalBookingDurationForUsers).toHaveBeenCalledTimes(2);
+    });
+
+    it("should mark user as busy when yearly duration limit is exceeded", async () => {
+      const durationLimits: IntervalLimit = { PER_YEAR: 100 };
+      const yearlyDurationMap = new Map<number, number>();
+      yearlyDurationMap.set(29, 90);
+      yearlyDurationMap.set(31, 50);
+
+      mockDependencies.bookingRepo.getTotalBookingDurationForUsers.mockResolvedValue(yearlyDurationMap);
+
+      const result = await (
+        service as unknown as { _getBusyTimesFromLimitsForUsers: Function }
+      )._getBusyTimesFromLimitsForUsers(users, null, durationLimits, dateFrom, dateTo, 30, eventType, timeZone);
+
+      expect(result.get(29)).toBeDefined();
+      expect(result.get(29)?.length).toBeGreaterThan(0);
+    });
+
+    it("should not mark user as busy when yearly duration limit is not exceeded", async () => {
+      const durationLimits: IntervalLimit = { PER_YEAR: 500 };
+      const yearlyDurationMap = new Map<number, number>();
+      yearlyDurationMap.set(29, 60);
+      yearlyDurationMap.set(31, 120);
+
+      mockDependencies.bookingRepo.getTotalBookingDurationForUsers.mockResolvedValue(yearlyDurationMap);
+
+      const result = await (
+        service as unknown as { _getBusyTimesFromLimitsForUsers: Function }
+      )._getBusyTimesFromLimitsForUsers(users, null, durationLimits, dateFrom, dateTo, 30, eventType, timeZone);
+
+      expect(result.get(29) ?? []).toHaveLength(0);
+      expect(result.get(31) ?? []).toHaveLength(0);
+    });
+
+    it("should handle users with no bookings (0 duration) correctly", async () => {
+      const durationLimits: IntervalLimit = { PER_YEAR: 100 };
+      const yearlyDurationMap = new Map<number, number>();
+
+      mockDependencies.bookingRepo.getTotalBookingDurationForUsers.mockResolvedValue(yearlyDurationMap);
+
+      const result = await (
+        service as unknown as { _getBusyTimesFromLimitsForUsers: Function }
+      )._getBusyTimesFromLimitsForUsers(users, null, durationLimits, dateFrom, dateTo, 30, eventType, timeZone);
+
+      expect(result.get(29) ?? []).toHaveLength(0);
+      expect(result.get(31) ?? []).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds unit tests for PR #27383 to ensure no regression in the `getTotalBookingDurationForUsers` optimization that fixes the N+1 query problem when checking yearly duration limits.

**Tests added:**

1. **BookingRepository.test.ts** (8 tests) - Tests for the new `getTotalBookingDurationForUsers` method:
   - Returns empty map when userIds array is empty
   - Returns correct durations for single and multiple users
   - Handles null totalMinutes (returns 0)
   - Handles users with no bookings in the period
   - Correctly passes rescheduleUid to exclude rescheduled bookings
   - Handles empty database results
   - Verifies single query call for large user counts (efficiency)

2. **getBusyTimesFromLimitsForUsers.test.ts** (8 tests) - Tests for the yearly duration pre-fetching optimization in AvailableSlotsService:
   - Verifies single batch call instead of N+1 calls for yearly limits
   - Skips batch call when no PER_YEAR duration limit
   - Skips batch call when no duration limits at all
   - Correctly passes rescheduleUid
   - Handles multi-year date ranges
   - Correctly marks users as busy when limit exceeded
   - Does not mark users as busy when limit not exceeded
   - Handles users with no bookings

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a documentation change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the tests locally:
```bash
TZ=UTC yarn test packages/features/bookings/repositories/BookingRepository.test.ts
TZ=UTC yarn test packages/trpc/server/routers/viewer/slots/getBusyTimesFromLimitsForUsers.test.ts
```

All 16 tests should pass.

## Human Review Checklist

- [ ] Verify test cases adequately cover the N+1 optimization (single call vs multiple calls)
- [ ] Check that mocking approach is appropriate for unit testing these components
- [ ] Note: Tests use type casting (`as unknown as`) to access private methods - this is intentional for testing internal logic

---

Link to Devin run: https://app.devin.ai/sessions/2f89c112dea248d38fb17ecc32d43cf3
Requested by: @Udit-takkar