### PR TITLE
chore: remove unused env vars and duplicates from turbo.json globalEnv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,12 +33,6 @@ DATABASE_URL="postgresql://postgres:@localhost:5450/calendso"
 DATABASE_DIRECT_URL="postgresql://postgres:@localhost:5450/calendso"
 INSIGHTS_DATABASE_URL=
 
-# Uncomment to enable a dedicated connection pool for Prisma using Prisma Data Proxy
-# Cold boots will be faster and you'll be able to scale your DB independently of your app.
-# @see https://www.prisma.io/docs/data-platform/data-proxy/use-data-proxy
-# PRISMA_GENERATE_DATAPROXY=true
-PRISMA_GENERATE_DATAPROXY=
-
 # ***********************************************************************************************************
 
 # - SHARED **************************************************************************************************
@@ -47,7 +41,6 @@ PRISMA_GENERATE_DATAPROXY=
 NEXT_PUBLIC_WEBAPP_URL='http://localhost:3000'
 # Change to 'http://localhost:3001' if running the website simultaneously
 NEXT_PUBLIC_WEBSITE_URL='http://localhost:3000'
-NEXT_PUBLIC_CONSOLE_URL='http://localhost:3004'
 NEXT_PUBLIC_EMBED_LIB_URL='http://localhost:3000/embed/embed.js'
 
 # To enable SAML login, set both these variables

--- a/turbo.json
+++ b/turbo.json
@@ -32,7 +32,6 @@
     "CALCOM_TELEMETRY_DISABLED",
     "CALCOM_CREDENTIAL_SYNC_HEADER_NAME",
     "CALENDSO_ENCRYPTION_KEY",
-    "CALCOM_CREDENTIAL_SYNC_SECRET",
     "CI",
     "CLOSECOM_CLIENT_ID",
     "CLOSECOM_CLIENT_SECRET",
@@ -90,7 +89,6 @@
     "INTEGRATION_TEST_MODE",
     "INTEGRATION_TESTS",
     "INTERCOM_SECRET",
-    "INTERCOM_SECRET",
     "INSIGHTS_DATABASE_URL",
     "IP_BANLIST",
     "LARK_OPEN_APP_ID",
@@ -102,7 +100,6 @@
     "NEXT_PUBLIC_APP_NAME",
     "NEXT_PUBLIC_CALCOM_VERSION",
     "NEXT_PUBLIC_COMPANY_NAME",
-    "NEXT_PUBLIC_CONSOLE_URL",
     "NEXT_PUBLIC_LOGGER_LEVEL",
     "NEXT_PUBLIC_DISABLE_SIGNUP",
     "NEXT_PUBLIC_EMBED_LIB_URL",
@@ -119,10 +116,8 @@
     "NEXT_PUBLIC_SENTRY_DSN_CLIENT",
     "NEXT_PUBLIC_STRIPE_PUBLIC_KEY",
     "NEXT_PUBLIC_STRIPE_PREMIUM_PLAN_PRICE_MONTHLY",
-    "NEXT_PUBLIC_STRIPE_PRICING_TABLE_PUBLISHABLE_KEY",
     "NEXT_PUBLIC_STRIPE_CREDITS_PRICE_ID",
     "ORG_MONTHLY_CREDITS",
-    "NEXT_PUBLIC_PLAIN_CHAT_EXCLUDED_PATHS",
     "NEXT_PUBLIC_BOOKER_NUMBER_OF_DAYS_TO_LOAD",
     "NEXT_PUBLIC_SUPPORT_MAIL_ADDRESS",
     "NEXT_PUBLIC_TEAM_IMPERSONATION",
@@ -130,8 +125,6 @@
     "NEXT_PUBLIC_CAL_AI_PHONE_NUMBER_MONTHLY_PRICE",
     "NEXT_PUBLIC_CLOUDFLARE_SITEKEY",
     "NEXT_PUBLIC_CLOUDFLARE_USE_TURNSTILE_IN_BOOKER",
-    "NEXT_PUBLIC_VERCEL_ENV",
-    "NEXT_PUBLIC_VERCEL_BRANCH_URL",
     "NEXT_PUBLIC_GTM_ID",
     "NEXT_PUBLIC_ORGANIZATIONS_SELF_SERVE_PRICE_NEW",
     "NEXT_PUBLIC_WEBSITE_PRIVACY_POLICY_URL",
@@ -148,8 +141,6 @@
     "PAYMENT_FEE_PERCENTAGE",
     "PLAYWRIGHT_HEADLESS",
     "PLAYWRIGHT_TEST_BASE_URL",
-    "PRISMA_FIELD_ENCRYPTION_KEY",
-    "PRISMA_GENERATE_DATAPROXY",
     "PROJECT_ID_VERCEL",
     "QUICK",
     "RAILWAY_STATIC_URL",
@@ -188,7 +179,6 @@
     "STRIPE_ORG_MONTHLY_PRICE_ID",
     "STRIPE_ORG_PRODUCT_ID",
     "STRIPE_ORG_TRIAL_DAYS",
-    "ORG_MONTHLY_CREDITS",
     "TANDEM_BASE_URL",
     "TANDEM_CLIENT_ID",
     "TANDEM_CLIENT_SECRET",
@@ -240,7 +230,6 @@
     "NEXT_PUBLIC_QUICK_AVAILABILITY_ROLLOUT",
     "NEXT_PUBLIC_HEAD_SCRIPTS",
     "NEXT_PUBLIC_BODY_SCRIPTS",
-    "NEXT_PUBLIC_ORG_SELF_SERVE_ENABLED",
     "NEXT_PUBLIC_API_V2_ROOT_URL",
     "NEXT_PUBLIC_VAPID_PUBLIC_KEY",
     "VAPID_PRIVATE_KEY",
@@ -250,7 +239,6 @@
     "CAL_VIDEO_MEETING_LINK_FOR_TESTING",
     "NEXT_PUBLIC_POSTHOG_KEY",
     "NEXT_PUBLIC_POSTHOG_HOST",
-    "VAPID_PRIVATE_KEY",
     "HUDDLE01_API_TOKEN",
     "LINGO_DOT_DEV_API_KEY",
     "DIRECTORY_IDS_TO_LOG",
@@ -287,7 +275,6 @@
     "TRIGGER_DEV_VERCEL_PROJECT_ID",
     "TRIGGER_DEV_VERCEL_TEAM_ID",
     "ENABLE_ASYNC_TASKER",
-    "STRIPE_ORG_PRODUCT_ID",
     "GOOGLE_ADS_ENABLED",
     "LINKEDIN_ADS_ENABLED",
     "SEED_PLATFORM_OAUTH_CLIENT_ID",
@@ -546,7 +533,10 @@
     },
     "post-install": {
       "dependsOn": [],
-      "outputs": ["../../node_modules/@prisma/client/**", "../../node_modules/@prisma/admin-client/**"],
+      "outputs": [
+        "../../node_modules/@prisma/client/**",
+        "../../node_modules/@prisma/admin-client/**"
+      ],
       "inputs": ["./schema.prisma", "./prisma/schema.prisma"],
       "env": ["PRISMA_GENERATE_DATAPROXY"]
     },
@@ -587,7 +577,10 @@
         "../../packages/app-store/**/pages/**",
         "../../packages/app-store-cli/src/**"
       ],
-      "outputs": ["../../packages/app-store/*.generated.ts", "../../packages/app-store/*.generated.tsx"]
+      "outputs": [
+        "../../packages/app-store/*.generated.ts",
+        "../../packages/app-store/*.generated.tsx"
+      ]
     },
     "@calcom/embed-react#type-check": {
       "dependsOn": ["@calcom/embed-core#build", "@calcom/embed-snippet#build"],


### PR DESCRIPTION
## Summary
- Remove 7 environment variables no longer referenced in the codebase from `turbo.json` `globalEnv` and `.env.example`
- Deduplicate 6 entries that appeared twice in `globalEnv`
- Reduces `globalEnv` from 321 to 308 entries, lowering the surface for unnecessary Turbo cache invalidation

### Removed (unused)
- `NEXT_PUBLIC_CONSOLE_URL`
- `NEXT_PUBLIC_STRIPE_PRICING_TABLE_PUBLISHABLE_KEY`
- `NEXT_PUBLIC_PLAIN_CHAT_EXCLUDED_PATHS`
- `NEXT_PUBLIC_VERCEL_ENV`
- `NEXT_PUBLIC_VERCEL_BRANCH_URL`
- `PRISMA_FIELD_ENCRYPTION_KEY`
- `PRISMA_GENERATE_DATAPROXY`

### Deduplicated
- `CALCOM_CREDENTIAL_SYNC_SECRET`
- `INTERCOM_SECRET`
- `NEXT_PUBLIC_ORG_SELF_SERVE_ENABLED`
- `ORG_MONTHLY_CREDITS`
- `STRIPE_ORG_PRODUCT_ID`
- `VAPID_PRIVATE_KEY`

## Test plan
- [ ] Verify `turbo.json` is valid JSON
- [ ] Verify CI build passes (no missing env vars)
- [ ] Confirm removed vars have no references in codebase via `grep -r "VAR_NAME" --include='*.ts' --include='*.tsx'`