### PR TITLE
feat: add index on channelId for SelectedCalendar

### DIFF
--- a/packages/prisma/migrations/20260130000000_add_selected_calendar_channel_id_index/migration.sql
+++ b/packages/prisma/migrations/20260130000000_add_selected_calendar_channel_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "SelectedCalendar_channelId_idx" ON "SelectedCalendar"("channelId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1052,6 +1052,7 @@ model SelectedCalendar {
   @@index([externalId])
   @@index([eventTypeId])
   @@index([credentialId])
+  @@index([channelId])
   // Composite indices to optimize calendar-cache queries
   @@index([integration, googleChannelExpiration, error, watchAttempts, maxAttempts], name: "SelectedCalendar_watch_idx")
   @@index([integration, googleChannelExpiration, error, unwatchAttempts, maxAttempts], name: "SelectedCalendar_unwatch_idx")


### PR DESCRIPTION
## Summary
- Add database index on `channelId` column in `SelectedCalendar` table
- Improves lookup performance for watched calendar channel queries

## Test plan
- [ ] Migration runs successfully: `yarn workspace @calcom/prisma db-migrate`
- [ ] Verify index exists: `\d "SelectedCalendar"` in psql