### PR TITLE
perf: increase Office365 calendarView page size to 999 to minimize pagination

### DIFF
--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -369,7 +369,9 @@ class Office365CalendarService implements Calendar {
       dateFromParsed.toISOString()
     )}&endDateTime=${encodeURIComponent(dateToParsed.toISOString())}`;
 
-    const calendarSelectParams = "$select=showAs,start,end";
+    // Request maximum page size (999) to minimize pagination rounds
+    // Microsoft Graph allows up to 999 items per page for calendarView
+    const calendarSelectParams = "$select=showAs,start,end&$top=999";
 
     try {
       const selectedCalendarIds = selectedCalendars.reduce((calendarIds, calendar) => {


### PR DESCRIPTION
## What does this PR do?

Increases the Microsoft Graph API page size for calendarView requests from the default (~10-100 items) to the maximum allowed (999 items) to minimize pagination rounds during availability checks.

**Context**: Investigation revealed that Office365 calendar availability checks were significantly slower than Google Calendar because each pagination round requires a sequential API call. By requesting the maximum page size, we can fetch up to 999 events per calendar in a single request, eliminating most pagination overhead.

For example, if a user has 500 events across their calendars in the date range:
- Before: ~50 pagination rounds (default ~10 items/page)
- After: ~1 pagination round (999 items/page)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - this is a query parameter change that doesn't affect existing test coverage.

## How should this be tested?

1. Connect an Office365 calendar with multiple calendars containing many events
2. Check availability for a date range that spans many events
3. Monitor network requests - should see significantly fewer `/$batch` POST requests to Microsoft Graph API
4. Verify availability data is still returned correctly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

> [!NOTE]
> This PR was created by [Devin](https://app.devin.ai/sessions/23d4eec0ac43409a95c09a0e5cac10f2) at the request of @keithwillcode