### PR TITLE
fix: allow wildcard prefix in domain validation

### DIFF
--- a/packages/features/blocklist/components/CreateBlocklistEntryModal.tsx
+++ b/packages/features/blocklist/components/CreateBlocklistEntryModal.tsx
@@ -72,7 +72,8 @@ export function CreateBlocklistEntryModal({
         return t("invalid_email_address");
       }
     } else if (watchType === WatchlistType.DOMAIN) {
-      if (!domainRegex.test(value)) {
+      const domainToValidate = value.startsWith("*.") ? value.slice(2) : value;
+      if (!domainRegex.test(domainToValidate)) {
         return t("invalid_domain_format");
       }
     }

--- a/packages/features/watchlist/lib/service/WatchlistOperationsService.ts
+++ b/packages/features/watchlist/lib/service/WatchlistOperationsService.ts
@@ -56,8 +56,11 @@ export abstract class WatchlistOperationsService {
       throw WatchlistErrors.invalidEmail("Invalid email address format");
     }
 
-    if (type === WatchlistType.DOMAIN && !domainRegex.test(value)) {
-      throw WatchlistErrors.invalidDomain("Invalid domain format (e.g., example.com)");
+    if (type === WatchlistType.DOMAIN) {
+      const domainToValidate = value.startsWith("*.") ? value.slice(2) : value;
+      if (!domainRegex.test(domainToValidate)) {
+        throw WatchlistErrors.invalidDomain("Invalid domain format (e.g., example.com or *.example.com)");
+      }
     }
   }
 

--- a/packages/features/watchlist/lib/utils/normalization.test.ts
+++ b/packages/features/watchlist/lib/utils/normalization.test.ts
@@ -41,10 +41,23 @@ describe("normalization", () => {
       expect(normalizeDomain("company.com.au")).toBe("company.com.au");
     });
 
+    test("should accept and preserve wildcard prefix", () => {
+      expect(normalizeDomain("*.cal.com")).toBe("*.cal.com");
+      expect(normalizeDomain("*.EXAMPLE.COM")).toBe("*.example.com");
+      expect(normalizeDomain("  *.domain.org  ")).toBe("*.domain.org");
+      expect(normalizeDomain("*.sub.domain.co.uk")).toBe("*.sub.domain.co.uk");
+    });
+
     test("should throw on invalid domains", () => {
       expect(() => normalizeDomain("invalid..domain")).toThrow("Invalid domain format");
       expect(() => normalizeDomain(".domain.com")).toThrow("Invalid domain format");
       expect(() => normalizeDomain("domain.")).toThrow("Invalid domain format");
+    });
+
+    test("should throw on invalid wildcard domains", () => {
+      expect(() => normalizeDomain("*.")).toThrow("Invalid domain format");
+      expect(() => normalizeDomain("*..domain.com")).toThrow("Invalid domain format");
+      expect(() => normalizeDomain("*.invalid..domain")).toThrow("Invalid domain format");
     });
   });
 

--- a/packages/features/watchlist/lib/utils/normalization.ts
+++ b/packages/features/watchlist/lib/utils/normalization.ts
@@ -33,13 +33,14 @@ export function normalizeEmail(email: string): string {
  * 1. Convert to lowercase
  * 2. Trim whitespace
  * 3. Remove @ prefix if present
+ * 4. Preserve *. prefix for wildcard domains
  *
  * Note: Domains are stored without @ prefix (e.g., mail.google.com, example.co.uk)
  * Wildcard matching is configurable:
  * - `*.cal.com` blocks all subdomains (app.cal.com, sub.app.cal.com, etc.)
  * - `cal.com` only blocks exact matches
  *
- * @param domain - Raw domain (with or without @ prefix)
+ * @param domain - Raw domain (with or without @ prefix, with or without *. prefix)
  * @returns Normalized domain without @ prefix
  */
 export function normalizeDomain(domain: string): string {
@@ -49,13 +50,22 @@ export function normalizeDomain(domain: string): string {
     normalized = normalized.slice(1);
   }
 
+  // Check for wildcard prefix and validate the domain part separately
+  let isWildcard = false;
+  let domainToValidate = normalized;
+
+  if (normalized.startsWith("*.")) {
+    isWildcard = true;
+    domainToValidate = normalized.slice(2); // Remove "*." for validation
+  }
+
   const domainRegex =
     /^[a-zA-Z0-9\u00a1-\uffff]([a-zA-Z0-9\u00a1-\uffff-]*[a-zA-Z0-9\u00a1-\uffff])?(\.[a-zA-Z0-9\u00a1-\uffff]([a-zA-Z0-9\u00a1-\uffff-]*[a-zA-Z0-9\u00a1-\uffff])?)*$/;
-  if (!domainRegex.test(normalized)) {
+  if (!domainRegex.test(domainToValidate)) {
     throw new Error(`Invalid domain format: ${domain}`);
   }
 
-  return normalized;
+  return isWildcard ? `*.${domainToValidate}` : domainToValidate;
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Follow-up to #27409 (wildcard domain matching feature). Domain validation was rejecting wildcard domains like `*.cal.com` because the regex requires domains to start with an alphanumeric character, but wildcard domains start with `*`.

This PR updates domain validation in three places to handle the `*.` prefix:
1. **`normalizeDomain()`** - Detects `*.` prefix, validates the domain part after it, preserves the prefix in output
2. **`WatchlistOperationsService.validateEmailOrDomain()`** - Server-side validation when creating watchlist entries
3. **`CreateBlocklistEntryModal`** - Client-side validation in the blocklist UI

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the unit tests:
   ```bash
   TZ=UTC yarn test packages/features/watchlist/lib/utils/normalization.test.ts
   ```

2. Verify the new test cases pass:
   - `normalizeDomain("*.cal.com")` returns `"*.cal.com"`
   - `normalizeDomain("*.EXAMPLE.COM")` returns `"*.example.com"` (lowercase)
   - `normalizeDomain("*.")` throws "Invalid domain format"
   - `normalizeDomain("*..domain.com")` throws "Invalid domain format"

3. Manual testing (optional):
   - Try adding `*.example.com` as a domain entry in the blocklist UI
   - Should now be accepted instead of showing "Invalid domain format"

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small and focused

---

> **Human Review Checklist:**
> - [ ] Verify the wildcard detection logic (`value.startsWith("*.") ? value.slice(2) : value`) is consistent across all 3 files
> - [ ] Confirm no existing callers of `normalizeDomain` are broken by this change
> - [ ] Check if there are any other places using `domainRegex` that might need similar handling

Link to Devin run: https://app.devin.ai/sessions/6e8ccae0a0fe4c0d84ada5e1e2ade813
Requested by: @pkreissel