### PR TITLE
chore: Reduce circular dependencies in tsconfig resolution

### DIFF
--- a/apps/api/v1/tsconfig.json
+++ b/apps/api/v1/tsconfig.json
@@ -5,7 +5,7 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "~/*": ["*"],
+      "~/*": ["./*"],
       "@prisma/client/*": ["@calcom/prisma/client/*"],
       "@calcom/testing/*": ["../../../packages/testing/src/*"]
     },

--- a/packages/features/tsconfig.json
+++ b/packages/features/tsconfig.json
@@ -5,12 +5,21 @@
     "moduleResolution": "bundler",
     "baseUrl": ".",
     "paths": {
-      "~/*": ["/*"]
+      "~/*": ["./*"]
     },
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "experimentalDecorators": true
   },
   "include": [".", "../types/next-auth.d.ts", "../types/tanstack-table.d.ts"],
-  "exclude": ["dist", "build", "**/node_modules/**", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*", "auth", "ee"]
+  "exclude": [
+    "dist",
+    "build",
+    "**/node_modules/**",
+    "**/*.test.*",
+    "**/__mocks__/*",
+    "**/__tests__/*",
+    "auth",
+    "ee"
+  ]
 }

--- a/packages/platform/atoms/tsconfig.json
+++ b/packages/platform/atoms/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "~/*": ["/*"],
+      "~/*": ["./*"],
       "@/*": ["./src/*"],
       "@calcom/lib": ["../../lib"],
       "@calcom/lib/*": ["../../lib/*"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized the ~ alias to resolve from the current package (./*) in tsconfig across api/v1, features, and platform/atoms. This reduces circular resolution and makes local imports consistent.

<sup>Written for commit ff8cf73928978291641691772816e0a5e71eb848. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

