### PR TITLE
fix: reset embed iframe queue consistently to preserve UI commands

### DIFF
--- a/packages/embeds/embed-core/playwright/lib/testUtils.ts
+++ b/packages/embeds/embed-core/playwright/lib/testUtils.ts
@@ -83,7 +83,14 @@ export const getEmbedIframe = async ({
     },
     { polling: 500 }
   );
-  const embedIframe = page.frame(`cal-embed=${calNamespace}`);
+
+  const iframeSelector = `iframe[name="cal-embed=${calNamespace}"]`;
+  // In case of modal we don't cleanup previous iframe on repeat click, so we should read the last one by default as that would be the one actie
+  const targetIframeElement = page.locator(iframeSelector).last();
+  await targetIframeElement.waitFor();
+  const elementHandle = await targetIframeElement.elementHandle();
+  const embedIframe = await elementHandle?.contentFrame();
+
   if (!embedIframe) {
     return null;
   }

--- a/packages/embeds/embed-core/playwright/lib/testUtils.ts
+++ b/packages/embeds/embed-core/playwright/lib/testUtils.ts
@@ -87,14 +87,19 @@ export const getEmbedIframe = async ({
   const iframeSelector = `iframe[name="cal-embed=${calNamespace}"]`;
   // In case of modal we don't cleanup previous iframe on repeat click, so we should read the last one by default as that would be the one actie
   const targetIframeElement = page.locator(iframeSelector).last();
-  await targetIframeElement.waitFor();
-  const elementHandle = await targetIframeElement.elementHandle();
-  const embedIframe = await elementHandle?.contentFrame();
+  let elementHandle = await targetIframeElement.elementHandle();
+  let embedIframe = await elementHandle?.contentFrame();
 
   if (!embedIframe) {
     return null;
   }
-  const u = new URL(embedIframe.url());
+  let url = embedIframe.url();
+  if (!url) {
+    // If iframe hasn't even initiated loading yet, wait for it to be visible
+    await targetIframeElement.waitFor();
+    url = embedIframe.url();
+  }
+  const u = new URL(url);
   if (u.pathname === `${pathname}/embed`) {
     return embedIframe;
   }

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -412,12 +412,16 @@ export class Cal {
     }
   }
 
-  iframeReset() {
-    this.iframeReady = false;
+  resetQueue() {
     // Only keep UI related instructions in the queue, as we want to ensure that newly loaded iframe has the same UI configuration applied automatically
     this.iframeDoQueue = this.iframeDoQueue.filter((doInIframeArg) => 
       this.commandsPersistAcrossIframeResets.includes(doInIframeArg.method)
     );
+  }
+
+  iframeReset() {
+    this.iframeReady = false;
+    this.resetQueue();
   }
 
   constructor(namespace: string, q: Queue) {
@@ -469,7 +473,7 @@ export class Cal {
       this.iframeDoQueue.forEach((doInIframeArg) => {
         this.doInIframe(doInIframeArg);
       });
-      this.iframeDoQueue = [];
+      this.resetQueue();
     });
 
     this.actionManager.on("__routeChanged", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes inconsistent queue reset behavior in the embed iframe. Previously, after processing queued actions, the queue was completely cleared (`this.iframeDoQueue = []`), while `iframeReset()` preserved UI-related commands. This PR extracts the queue filtering logic into a reusable `resetQueue()` method and uses it in both places to ensure consistent behavior.

**The problem**: When queued actions were processed, all commands including UI configuration commands were cleared. This meant UI settings wouldn't persist correctly across certain scenarios.

**The fix**: Extract the queue filtering logic into `resetQueue()` and call it both in `iframeReset()` and after processing queued actions, ensuring only commands in `commandsPersistAcrossIframeResets` are preserved.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal implementation change only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create an embed with UI configuration commands (e.g., `Cal("ui", {...})`)
2. Trigger actions that cause the queue to be processed
3. Verify that UI configuration persists after queue processing
4. Verify that non-UI commands are properly cleared

## Human Review Checklist

- [ ] Verify that preserving UI commands after processing queued actions (not just during iframe reset) is the intended behavior change
- [ ] Confirm `commandsPersistAcrossIframeResets` contains the correct set of commands that should persist

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make embed iframe queue reset consistent so only UI-related commands persist after reloads. This prevents stale actions and keeps UI config in sync across iframe resets.

- Bug Fixes
  - Added resetQueue() and used it in iframeReset and after processing queued actions, filtering the queue to only keep commands that should persist across resets.

<sup>Written for commit 9a135945d93f6ad811c85404c9aebb8a02905431. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27419">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
