### PR TITLE
fix: remove unnecessary border when event type details are hidden

### DIFF
--- a/apps/web/modules/bookings/components/Booker.tsx
+++ b/apps/web/modules/bookings/components/Booker.tsx
@@ -252,12 +252,12 @@ const BookerComponent = ({
 
   const unavailableTimeSlots = isQuickAvailabilityCheckFeatureEnabled
     ? allSelectedTimeslots.filter((slot) => {
-        return !isTimeSlotAvailable({
-          scheduleData: schedule?.data ?? null,
-          slotToCheckInIso: slot,
-          quickAvailabilityChecks: slots.quickAvailabilityChecks,
-        });
-      })
+      return !isTimeSlotAvailable({
+        scheduleData: schedule?.data ?? null,
+        slotToCheckInIso: slot,
+        quickAvailabilityChecks: slots.quickAvailabilityChecks,
+      });
+    })
     : [];
 
   const slot = getQueryParam("slot");
@@ -400,7 +400,7 @@ const BookerComponent = ({
                 className={classNames(
                   layout === BookerLayouts.MONTH_VIEW && "fixed top-4 z-10 ltr:right-4 rtl:left-4",
                   (layout === BookerLayouts.COLUMN_VIEW || layout === BookerLayouts.WEEK_VIEW) &&
-                    "bg-default dark:bg-cal-muted sticky top-0 z-10"
+                  "bg-default dark:bg-cal-muted sticky top-0 z-10"
                 )}>
                 {isPlatform && layout === BookerLayouts.MONTH_VIEW ? (
                   <></>
@@ -502,7 +502,7 @@ const BookerComponent = ({
               visible={bookerState !== "booking" && layout === BookerLayouts.MONTH_VIEW}
               {...fadeInLeft}
               initial="visible"
-              className="md:border-subtle -ml-px h-full shrink px-5 py-3 md:border-l lg:w-(--booker-main-width)">
+              className={classNames("md:border-subtle -ml-px h-full shrink px-5 py-3  lg:w-(--booker-main-width)", hideEventTypeDetails ? "" : "md:border-l")}>
               <DatePicker
                 classNames={customClassNames?.datePickerCustomClassNames}
                 event={event}
@@ -538,7 +538,7 @@ const BookerComponent = ({
               className={classNames(
                 "border-subtle rtl:border-default flex h-full w-full flex-col overflow-x-auto px-5 py-3 pb-0 rtl:border-r ltr:md:border-l",
                 layout === BookerLayouts.MONTH_VIEW &&
-                  "h-full overflow-hidden md:w-(--booker-timeslots-width)",
+                "h-full overflow-hidden md:w-(--booker-timeslots-width)",
                 layout !== BookerLayouts.MONTH_VIEW && "sticky top-0"
               )}
               ref={timeslotsRef}


### PR DESCRIPTION
## What does this PR do?

This PR fixes an unnecessary left border that appears on the date picker section when the `hideEventTypeDetails` option is enabled. When event type details are hidden, the left border (`md:border-l`) should not be displayed since there's no content on the left side to separate from.

The fix conditionally applies the `md:border-l` class only when `hideEventTypeDetails` is false, ensuring a cleaner UI when event details are intentionally hidden.

## Before 
<img width="460" height="492" alt="image" src="https://github.com/user-attachments/assets/df0521fd-fe3c-4573-a759-5f255546d4a0" />

## After fix 
Desktop
<img width="360" height="368" alt="image" src="https://github.com/user-attachments/assets/1a13b6f9-2510-423b-95af-626feddf97a2" />
<img width="1258" height="468" alt="image" src="https://github.com/user-attachments/assets/f924a325-e432-4148-9082-32421259ec20" />

Mobile
<img width="612" height="802" alt="image" src="https://github.com/user-attachments/assets/45b64891-1f88-44a6-bbe7-f45a52fcfa3a" />
<img width="628" height="740" alt="image" src="https://github.com/user-attachments/assets/49e246ab-746f-4b7f-8603-ea2f7d731b1b" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Create or use an event type with `hideEventTypeDetails` enabled
2. Navigate to the booking page for that event type
3. Verify that there is no unnecessary left border on the date picker section
4. Compare with an event type that has `hideEventTypeDetails` disabled to confirm the border appears correctly when needed

## Checklist

- [x] I have self-reviewed the code
- [x] N/A - No documentation changes required
- [x] The fix is straightforward and tested visually as shown in the screenshots
