### PR TITLE
test: verify UI config persists on second modal open

### DIFF
--- a/packages/embeds/embed-core/playwright/lib/testUtils.ts
+++ b/packages/embeds/embed-core/playwright/lib/testUtils.ts
@@ -83,7 +83,14 @@ export const getEmbedIframe = async ({
     },
     { polling: 500 }
   );
-  const embedIframe = page.frame(`cal-embed=${calNamespace}`);
+
+  const iframeSelector = `iframe[name="cal-embed=${calNamespace}"]`;
+  // In case of modal we don't cleanup previous iframe on repeat click, so we should read the last one by default as that would be the one actie
+  const targetIframeElement = page.locator(iframeSelector).last();
+  await targetIframeElement.waitFor();
+  const elementHandle = await targetIframeElement.elementHandle();
+  const embedIframe = await elementHandle?.contentFrame();
+
   if (!embedIframe) {
     return null;
   }


### PR DESCRIPTION
## What does this PR do?

Adds comprehensive tests to verify the bug fix in parent PR #27419 where `iframeDoQueue` was being completely cleared after processing actions instead of preserving UI-related commands. This caused UI config (like `hideEventTypeDetails`) to not be applied when the modal was reopened.

**Stacked on:** #27419

## Test Changes

### E2E Test (`action-based.e2e.ts`)

Extended the existing test "should open embed iframe on click - Configured with hide eventType details" with three steps:
1. **First modal open** - Opens the embed modal and verifies `hideEventTypeDetails` config is applied
2. **Close the modal** - Closes the modal using the close button
3. **Second modal open** - Reopens the modal and verifies the UI config STILL persists

### Unit Tests (`embed.test.ts`)

Added new `resetQueue` test suite with 5 tests:
- `should preserve UI commands in the queue after reset`
- `should remove non-UI commands from the queue after reset`
- `should preserve UI commands while removing other commands after reset`
- `should preserve UI commands when iframeReset is called`
- `should preserve UI commands in the queue after __iframeReady event is fired` (directly tests the bug scenario)

**TDD Verification Completed:**
- With fix reverted (`this.iframeDoQueue = []`), the `__iframeReady` unit test fails
- With fix applied (`this.resetQueue()`), all tests pass

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - test only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Unit Tests (recommended - fast feedback)
```bash
TZ=UTC yarn test packages/embeds/embed-core/src/embed.test.ts -t "resetQueue"
```

### TDD Verification
1. Revert the fix in `packages/embeds/embed-core/src/embed.ts` (change `this.resetQueue()` back to `this.iframeDoQueue = []` in the `__iframeReady` handler at ~line 476)
2. Run `TZ=UTC yarn test packages/embeds/embed-core/src/embed.test.ts -t "__iframeReady"`
3. Test should FAIL (queue length is 0 instead of 2)
4. Restore the fix and run again - test should PASS

### E2E Test
```bash
yarn e2e:embed --grep "should open embed iframe on click - Configured with hide eventType details"
```

## Human Review Checklist

- [ ] Verify the unit test for `__iframeReady` correctly simulates the bug scenario
- [ ] Verify the E2E test modal close selector `cal-modal-box .close` is reliable
- [ ] Confirm this should be merged into `fix-embed-queue-issue-another-place` branch, not main

---

Link to Devin run: https://app.devin.ai/sessions/68e5af17a22649418201305e18056b71
Requested by: @hariombalhara