### PR TITLE
fix: align feature opt-in toggle labels with enable/disable wording

### DIFF
--- a/apps/web/modules/feature-opt-in/hooks/useOrganizationFeatureOptIn.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useOrganizationFeatureOptIn.ts
@@ -86,7 +86,7 @@ export function useOrganizationFeatureOptIn(): UseFeatureOptInResult {
     setAutoOptIn,
     isStateMutationPending: setStateMutation.isPending,
     isAutoOptInMutationPending: setAutoOptInMutation.isPending,
-    toggleLabels: { enabled: t("allow"), disabled: t("block"), inherit: t("let_users_decide") },
+    toggleLabels: { enabled: t("enable"), disabled: t("disable"), inherit: t("let_users_decide") },
     autoOptInDescription: t("auto_opt_in_experimental_description_org"),
     getBlockedWarning: getOrgBlockedWarning,
     isBlockedByHigherLevel: isOrgBlockedByHigherLevel,

--- a/apps/web/modules/feature-opt-in/hooks/useTeamFeatureOptIn.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useTeamFeatureOptIn.ts
@@ -120,7 +120,7 @@ export function useTeamFeatureOptIn(teamId: number): UseFeatureOptInResult {
     setAutoOptIn,
     isStateMutationPending: setStateMutation.isPending,
     isAutoOptInMutationPending: setAutoOptInMutation.isPending,
-    toggleLabels: { enabled: t("allow"), disabled: t("block"), inherit: t("let_users_decide") },
+    toggleLabels: { enabled: t("enable"), disabled: t("disable"), inherit: t("let_users_decide") },
     autoOptInDescription: t("auto_opt_in_experimental_description_team"),
     getBlockedWarning,
     isBlockedByHigherLevel,


### PR DESCRIPTION
## What does this PR do?

This PR rewords the "Allow" / "Disallow" toggle buttons for feature opt-in to "Enable" / "Disable" for clarity.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

