### PR TITLE
fix: ooo reason select dropdown opening in wrong direction

### DIFF
--- a/apps/web/modules/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
+++ b/apps/web/modules/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
@@ -312,6 +312,7 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
                       className="mb-0 mt-1 text-white"
                       name="reason"
                       data-testid="reason_select"
+                      menuPlacement="bottom"
                       value={reasonList.find((reason) => reason.value === value)}
                       placeholder={t("ooo_select_reason")}
                       options={reasonList}


### PR DESCRIPTION
## Summary

## Fixes


Fixes #27278 
Fixes CAL-7132

<img width="1512" height="982" alt="Screenshot 2026-01-30 at 6 48 23 PM" src="https://github.com/user-attachments/assets/32ead922-e6a9-48d1-a269-45db02e4c607" />



- Add `menuPlacement="bottom"` to the reason Select in the OOO modal to ensure dropdown opens downwards consistently with other selects in the modal

## What changed
PR #26736 added `menuPlacement="bottom"` to the team member Selects but missed the reason Select. This caused the reason dropdown to open upwards (due to `"auto"` default calculating insufficient space below in the modal).

## Test plan
- [ ] Open OOO modal
- [ ] Click on the reason dropdown
- [ ] Verify it opens downwards instead of upwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)