### PR TITLE
fix: skip retry when Trigger.dev deployment is already current

### DIFF
--- a/apps/api/v2/src/vercel-webhook.controller.ts
+++ b/apps/api/v2/src/vercel-webhook.controller.ts
@@ -92,6 +92,12 @@ export class VercelWebhookController {
         if (error instanceof Error) {
           errorMessage = error.message;
         }
+
+        if (errorMessage.includes("Deployment is already the current deployment")) {
+          this.logger.log(`Deployment ${version} is already the current deployment, skipping retry`);
+          return;
+        }
+
         this.logger.error(`Promotion attempt ${attempt} failed: ${errorMessage}`);
         if (attempt === maxRetries) throw error;
 


### PR DESCRIPTION
## What does this PR do?

When promoting a Trigger.dev deployment via the Vercel webhook, if the deployment is already the current deployment, the Trigger.dev API returns a 400 error with the message "Deployment is already the current deployment." Previously, this would cause unnecessary retries and eventually throw an error.

This PR detects this specific error condition and returns successfully instead of retrying, since the desired state (deployment being current) is already achieved.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - this is a simple error handling change for an external API integration.

## How should this be tested?

1. Trigger a Vercel deployment promotion webhook when the Trigger.dev deployment is already current
2. Verify that the endpoint returns 200 with the version instead of retrying and eventually failing
3. Check logs to confirm the message "Deployment X is already the current deployment, skipping retry" appears

## Human Review Checklist

- [ ] Verify the error message string "Deployment is already the current deployment" matches what Trigger.dev actually returns (based on the error log provided in the request)
- [ ] Confirm that treating this as a success (returning early) is the correct behavior

---

Link to Devin run: https://app.devin.ai/sessions/56b01b1777cf4db39b32bfb82700e498
Requested by: @ThyMinimalDev