### PR TITLE
feat: add tooltip for disabled Cancel button on past bookings

### DIFF
--- a/apps/web/components/booking/actions/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/actions/BookingActionsDropdown.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@calcom/ui/components/dropdown";
+import { Tooltip } from "@calcom/ui/components/tooltip";
 import type { ActionType } from "@calcom/ui/components/table";
 import { showToast } from "@calcom/ui/components/toast";
 
@@ -745,25 +746,30 @@ export function BookingActionsDropdown({
               )}
             </>
             <DropdownMenuSeparator />
-            <DropdownMenuItem
-              className="rounded-lg"
-              key={cancelEventAction.id}
-              disabled={cancelEventAction.disabled}>
-              <DropdownItem
-                type="button"
-                color={cancelEventAction.color}
-                StartIcon={cancelEventAction.icon}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setIsCancelDialogOpen(true);
-                }}
-                disabled={cancelEventAction.disabled}
-                data-booking-uid={cancelEventAction.bookingUid}
-                data-testid={cancelEventAction.id}
-                className={cancelEventAction.disabled ? "text-muted" : undefined}>
-                {cancelEventAction.label}
-              </DropdownItem>
-            </DropdownMenuItem>
+            <Tooltip
+              content={isBookingInPast ? t("cannot_cancel_past_booking") : ""}
+              side="left"
+              open={isBookingInPast && cancelEventAction.disabled ? undefined : false}>
+              <DropdownMenuItem
+                className="rounded-lg"
+                key={cancelEventAction.id}
+                disabled={cancelEventAction.disabled}>
+                <DropdownItem
+                  type="button"
+                  color={cancelEventAction.color}
+                  StartIcon={cancelEventAction.icon}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsCancelDialogOpen(true);
+                  }}
+                  disabled={cancelEventAction.disabled}
+                  data-booking-uid={cancelEventAction.bookingUid}
+                  data-testid={cancelEventAction.id}
+                  className={cancelEventAction.disabled ? "text-muted" : undefined}>
+                  {cancelEventAction.label}
+                </DropdownItem>
+              </DropdownMenuItem>
+            </Tooltip>
           </DropdownMenuContent>
         </ConditionalPortal>
       </Dropdown>

--- a/apps/web/components/booking/actions/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/actions/BookingActionsDropdown.tsx
@@ -260,6 +260,7 @@ export function BookingActionsDropdown({
   } as BookingActionContext;
 
   const cancelEventAction = getCancelEventAction(actionContext);
+  const showPastBookingCancelTooltip = isBookingInPast && cancelEventAction.disabled;
 
   // Get pending actions (accept/reject) - only for details context
   const shouldShowPending = shouldShowPendingActions(actionContext);
@@ -749,7 +750,7 @@ export function BookingActionsDropdown({
             <Tooltip
               content={isBookingInPast ? t("cannot_cancel_past_booking") : ""}
               side="left"
-              open={isBookingInPast && cancelEventAction.disabled ? undefined : false}>
+              open={showPastBookingCancelTooltip ? undefined : false}>
               <DropdownMenuItem
                 className="rounded-lg"
                 key={cancelEventAction.id}

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -509,6 +509,7 @@
   "cancellation_successful": "Cancellation successful",
   "really_cancel_booking": "Really cancel your booking?",
   "cannot_cancel_booking": "You cannot cancel this booking",
+  "cannot_cancel_past_booking": "You cannot cancel a past booking",
   "reschedule_instead": "Instead, you could also reschedule it.",
   "event_is_in_the_past": "The event is in the past",
   "cancelling_event_recurring": "The event is one instance of a recurring event.",


### PR DESCRIPTION
## What does this PR do?

Adds a tooltip to the disabled "Cancel" dropdown item that appears for past bookings, explaining that "You cannot cancel a past booking". This improves the UX by making it clear why the action is disabled.

## Demo

list view

<img width="1334" height="794" alt="Screenshot 2026-01-30 at 14 43 21" src="https://github.com/user-attachments/assets/0eceda55-e2cf-450c-b0b3-6c94d04c5de7" />

calendar view

<img width="776" height="709" alt="Screenshot 2026-01-30 at 14 46 19" src="https://github.com/user-attachments/assets/85fe55df-a9d4-475c-8b83-e7e008eaae83" />


## How should this be tested?

1. Navigate to a past booking in the booking details view
2. Hover over the disabled "Cancel" button in the actions dropdown
3. Verify that a tooltip appears with the message "You cannot cancel a past booking"

## Checklist

- [x] I have self-reviewed the code
- [x] N/A: No documentation changes needed
- [x] This is a UI enhancement with no additional test infrastructure needed