### PR TITLE
chore: Backfills old app credentials to new models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -486,6 +486,13 @@ DATABASE_CHUNK_SIZE=
 # You can use: `openssl rand -base64 24` to generate one
 CALCOM_SERVICE_ACCOUNT_ENCRYPTION_KEY=
 
+# Keyring configuration for encrypting credentials
+# CALCOM_KEYRING_CREDENTIALS_CURRENT describes the current key ID (e.g. K1)
+# CALCOM_KEYRING_CREDENTIALS_<ID> describes the actual key material (32 bytes, base64url encoded)
+# You can use: `openssl rand -base64 32 | tr '+/' '-_' | tr -d '='` to generate a base64url key
+CALCOM_KEYRING_CREDENTIALS_CURRENT=
+# CALCOM_KEYRING_CREDENTIALS_K1=
+
 SALESFORCE_GRAPHQL_DELAY_MS=500
 SALESFORCE_GRAPHQL_MAX_DELAY_MS=2000
 SALESFORCE_GRAPHQL_MAX_RETRIES=3

--- a/scripts/backfill-encrypt-old-app-credentials.ts
+++ b/scripts/backfill-encrypt-old-app-credentials.ts
@@ -1,0 +1,103 @@
+import process from "node:process";
+import { encryptSecret } from "@calcom/lib/crypto/keyring";
+import { prisma } from "@calcom/prisma";
+
+async function main(): Promise<void> {
+  const CHUNK_SIZE = 1000;
+  let cursorId = 0;
+  let totalProcessed = 0;
+  let totalUpdated = 0;
+
+  console.log("🚀 Starting backfill for Credential encryption...");
+
+  try {
+    // Check if we have the necessary environment variables
+    if (!process.env.CALCOM_KEYRING_CREDENTIALS_CURRENT) {
+      console.warn(
+        "⚠️  CALCOM_KEYRING_CREDENTIALS_CURRENT is not set. Encryption might fail if it relies on it."
+      );
+    }
+
+    while (true) {
+      // Fetch a chunk of credentials that haven't been encrypted yet
+      const credentials = await prisma.credential.findMany({
+        where: {
+          id: { gt: cursorId },
+          encryptedKey: null,
+        },
+        take: CHUNK_SIZE,
+        orderBy: { id: "asc" },
+        select: {
+          id: true,
+          type: true,
+          key: true,
+        },
+      });
+
+      if (credentials.length === 0) {
+        break;
+      }
+
+      for (const credential of credentials) {
+        try {
+          // Skip if key is missing, not an object, or an empty object
+          if (
+            !credential.key ||
+            typeof credential.key !== "object" ||
+            Object.keys(credential.key).length === 0
+          ) {
+            console.log(`⏩ Skipping credential ${credential.id}: Missing, invalid, or empty key data.`);
+            cursorId = credential.id;
+            continue;
+          }
+
+          const aad = { type: credential.type };
+          const plaintext = JSON.stringify(credential.key);
+
+          const envelope = encryptSecret({
+            ring: "CREDENTIALS",
+            plaintext,
+            aad,
+          });
+
+          await prisma.credential.update({
+            where: { id: credential.id },
+            data: {
+              encryptedKey: JSON.stringify(envelope),
+            },
+          });
+
+          totalUpdated++;
+        } catch (error) {
+          let errorMessage: string;
+          if (error instanceof Error) {
+            errorMessage = error.message;
+          } else {
+            errorMessage = String(error);
+          }
+          console.error(`❌ Failed to encrypt credential ${credential.id}:`, errorMessage);
+        }
+        cursorId = credential.id;
+      }
+
+      totalProcessed += credentials.length;
+      console.log(
+        `📊 Progress: Processed ${totalProcessed} records, Updated ${totalUpdated}. Last ID: ${cursorId}`
+      );
+    }
+
+    console.log(`✅ Backfill completed! Total updated: ${totalUpdated}`);
+  } catch (error) {
+    console.error("💥 Fatal error during backfill:", error);
+    process.exit(1);
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## What does this PR do?
Adds a script to backfill and encrypt legacy app credentials into the new credential model. Updates .env.example with keyring variables needed to run the backfill.

- **New Features**
  - Encrypts legacy credentials where encryptedKey is null using the CREDENTIALS keyring.
  - Skips invalid or empty keys; logs progress and errors.
  - Uses chunked processing (1000) with an ID cursor for safe resumability.

- **Migration**
  - Set CALCOM_KEYRING_CREDENTIALS_CURRENT and at least one key (e.g., CALCOM_KEYRING_CREDENTIALS_K1) in .env.
  - Run scripts/backfill-encrypt-old-app-credentials.ts against your database.
  - Confirm encryptedKey is populated on affected credential rows.

Example usage:
```bash
npx tsx scripts/backfill-encrypt-old-app-credentials.ts
```
```
🚀 Starting backfill for Credential encryption...
📊 Progress: Processed 2 records, Updated 2. Last ID: 7
✅ Backfill completed! Total updated: 2
```
