### PR TITLE
fix: filter KBar bookings to show only current user's upcoming bookings

### DIFF
--- a/apps/web/modules/shell/Kbar.tsx
+++ b/apps/web/modules/shell/Kbar.tsx
@@ -1,9 +1,10 @@
+import { useSession } from "next-auth/react";
+
 import { appStoreMetadata } from "@calcom/app-store/appStoreMetaData";
 import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { isMac } from "@calcom/lib/isMac";
 import { trpc } from "@calcom/trpc/react";
-import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
 import { Icon } from "@calcom/ui/components/icon";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import type { Action } from "kbar";
@@ -266,21 +267,22 @@ function useEventTypesAction(): void {
 
 function useUpcomingBookingsAction(): void {
   const router = useRouter();
-  const { data: me } = useMeQuery();
+  const session = useSession();
+  const userId = session.data?.user.id;
 
   const { data } = trpc.viewer.bookings.get.useQuery(
     {
       filters: {
         status: "upcoming",
         afterStartDate: dayjs().startOf("day").toISOString(),
-        userIds: me?.id ? [me.id] : undefined,
+        userIds: userId ? [userId] : undefined,
       },
       limit: 100,
     },
     {
       refetchOnWindowFocus: false,
       staleTime: 5 * 60 * 1000,
-      enabled: !!me?.id,
+      enabled: !!userId,
     }
   );
 

--- a/apps/web/modules/shell/Kbar.tsx
+++ b/apps/web/modules/shell/Kbar.tsx
@@ -3,6 +3,7 @@ import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { isMac } from "@calcom/lib/isMac";
 import { trpc } from "@calcom/trpc/react";
+import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
 import { Icon } from "@calcom/ui/components/icon";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import type { Action } from "kbar";
@@ -265,18 +266,21 @@ function useEventTypesAction(): void {
 
 function useUpcomingBookingsAction(): void {
   const router = useRouter();
+  const { data: me } = useMeQuery();
 
   const { data } = trpc.viewer.bookings.get.useQuery(
     {
       filters: {
         status: "upcoming",
         afterStartDate: dayjs().startOf("day").toISOString(),
+        userIds: me?.id ? [me.id] : undefined,
       },
       limit: 100,
     },
     {
       refetchOnWindowFocus: false,
       staleTime: 5 * 60 * 1000,
+      enabled: !!me?.id,
     }
   );
 


### PR DESCRIPTION
## What does this PR do?

Fixes the KBar (command palette) to show only the current user's upcoming bookings instead of all team members' bookings.

Previously, users with team/org admin permissions would see all team members' bookings in the KBar search results. This PR adds a `userIds` filter to scope the bookings query to only the current user.

## Changes

- Uses `useSession` from `next-auth/react` to get the current user's ID (more efficient than making an additional tRPC call)
- Added `userIds: [userId]` filter to the bookings query to restrict results to the current user only
- Added `enabled: !!userId` to prevent the query from running until session data is loaded

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Log in as a user who is an admin/owner of a team or organization
2. Open the KBar (Cmd+K / Ctrl+K)
3. Search for bookings or scroll to the "upcoming" section
4. **Before this PR**: All team members' upcoming bookings would appear
5. **After this PR**: Only the current user's upcoming bookings should appear

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small and focused

---

> **Link to Devin run**: https://app.devin.ai/sessions/485e04de7eea4446b713ec8d4b2f7093
> **Requested by**: Volnei Munhoz (volnei@cal.com) (@volnei)