### PR TITLE
refactor: move CalendarCache feature flag check to GetUserAvailabilityInitialData

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -159,6 +159,7 @@ export type GetUserAvailabilityInitialData = {
     bookingLimits?: unknown;
     includeManagedEventsInLimits: boolean;
   } | null;
+  shouldServeCache?: boolean;
 };
 
 export type GetAvailabilityUser = GetUserAvailabilityInitialData["user"];
@@ -597,6 +598,7 @@ export class UserAvailabilityService {
         bypassBusyCalendarTimes,
         silentlyHandleCalendarFailures,
         mode,
+        shouldServeCache: initialData?.shouldServeCache,
       });
     } catch (error) {
       log.error(`Error fetching busy times for user ${username}:`, error);

--- a/packages/features/busyTimes/services/getBusyTimes.ts
+++ b/packages/features/busyTimes/services/getBusyTimes.ts
@@ -53,6 +53,7 @@ export class BusyTimesService {
     bypassBusyCalendarTimes: boolean;
     silentlyHandleCalendarFailures?: boolean;
     mode?: CalendarFetchMode;
+    shouldServeCache?: boolean;
   }) {
     const {
       credentials,
@@ -71,6 +72,7 @@ export class BusyTimesService {
       bypassBusyCalendarTimes = false,
       silentlyHandleCalendarFailures = false,
       mode,
+      shouldServeCache,
     } = params;
 
     logger.silly(
@@ -194,7 +196,9 @@ export class BusyTimesService {
         startTime,
         endTime,
         selectedCalendars,
-        mode
+        mode,
+        undefined,
+        shouldServeCache
       );
 
       if (!calendarBusyTimesQuery.success) {

--- a/packages/features/calendars/lib/CalendarManager.ts
+++ b/packages/features/calendars/lib/CalendarManager.ts
@@ -303,7 +303,8 @@ export const getBusyCalendarTimes = async (
   dateTo: string,
   selectedCalendars: SelectedCalendar[],
   mode?: CalendarFetchMode,
-  includeTimeZone?: boolean
+  includeTimeZone?: boolean,
+  shouldServeCache?: boolean
 ) => {
   let results: (EventBusyDate & { timeZone?: string })[][] = [];
 
@@ -332,7 +333,8 @@ export const getBusyCalendarTimes = async (
         deduplicatedCredentials,
         startDate,
         endDate,
-        selectedCalendars
+        selectedCalendars,
+        shouldServeCache
       );
     } else {
       results = await getCalendarsEvents(
@@ -340,7 +342,8 @@ export const getBusyCalendarTimes = async (
         startDate,
         endDate,
         selectedCalendars,
-        mode ?? "slots"
+        mode ?? "slots",
+        shouldServeCache
       );
     }
   } catch (e) {

--- a/packages/features/calendars/lib/getCalendarsEvents.ts
+++ b/packages/features/calendars/lib/getCalendarsEvents.ts
@@ -20,7 +20,8 @@ export const getCalendarsEventsWithTimezones = async (
   withCredentials: CredentialForCalendarService[],
   dateFrom: string,
   dateTo: string,
-  selectedCalendars: SelectedCalendar[]
+  selectedCalendars: SelectedCalendar[],
+  shouldServeCache?: boolean
 ): Promise<(EventBusyDate & { timeZone: string })[][]> => {
   const calendarCredentials = withCredentials
     .filter((credential) => credential.type === "google_calendar")
@@ -29,7 +30,7 @@ export const getCalendarsEventsWithTimezones = async (
 
   const calendarAndCredentialPairs = await Promise.all(
     calendarCredentials.map(async (credential) => {
-      const calendar = await getCalendar(credential, "slots");
+      const calendar = await getCalendar(credential, "slots", shouldServeCache);
       return [calendar, credential] as const;
     })
   );
@@ -93,7 +94,8 @@ const getCalendarsEvents = async (
   dateFrom: string,
   dateTo: string,
   selectedCalendars: SelectedCalendar[],
-  mode: CalendarFetchMode
+  mode: CalendarFetchMode,
+  shouldServeCache?: boolean
 ): Promise<EventBusyDate[][]> => {
   const calendarCredentials = withCredentials
     .filter((credential) => credential.type.endsWith("_calendar"))
@@ -127,7 +129,8 @@ const getCalendarsEvents = async (
           // use encrypted secret to get unencrypted calendar creds
           key,
         },
-        mode
+        mode,
+        shouldServeCache
       );
       return [calendar, credential] as const;
     })


### PR DESCRIPTION
## What does this PR do?

Moves the CalendarCache feature flag check from being nested inside `getCalendar()` (called per-credential) to the `AvailableSlotsService` level, so the feature flag is checked once per request instead of once per credential.

**Changes:**
- Add `shouldServeCache` parameter to `GetUserAvailabilityInitialData` type
- Check CalendarCache feature flags once at `AvailableSlotsService._getAvailableSlots()` level
- Pass `shouldServeCache` through the call chain: `getUserAvailability` → `getBusyTimes` → `getBusyCalendarTimes` → `getCalendarsEvents` → `getCalendar`
- Maintain backward compatibility: if `shouldServeCache` is undefined, fall back to checking feature flags internally

**Link to Devin run:** https://app.devin.ai/sessions/721158618ad7496aa89b3a6ae0e6f407
**Requested by:** @emrysal

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - refactoring existing logic, existing tests should cover this.
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A

## How should this be tested?

1. Enable the `calendar-subscription-cache` feature flag globally and for a test user
2. Create an event type with multiple hosts
3. Request available slots and verify:
   - Feature flag is checked once at the initial data level (check logs for "Using shouldServeCache from initial data")
   - Calendar cache is served correctly when enabled
4. Verify backward compatibility by testing code paths that don't pass `shouldServeCache` (should fall back to internal feature flag check)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] **Semantic change verification**: The new logic checks if ANY user has the feature enabled, then applies cache to ALL users' credentials. Previously, cache was applied per-credential based on each user's feature flag. Verify this is the intended behavior.
- [ ] Verify the call chain is complete (no code paths bypass the new `shouldServeCache` parameter)
- [ ] Verify the backward compatibility fallback works correctly when `shouldServeCache` is undefined