### PR TITLE
fix: clamp negative topOffsetMinutes in weekly view to prevent slot c…

### DIFF
--- a/apps/web/modules/calendars/weeklyview/components/event/Empty.tsx
+++ b/apps/web/modules/calendars/weeklyview/components/event/Empty.tsx
@@ -27,7 +27,8 @@ export function EmptyCell(props: EmptyCellProps) {
     timezone: props.timezone,
   });
 
-  const minutesFromStart = (cellToDate.hour() - props.startHour) * 60 + cellToDate.minute();
+  // Clamp to 0 to prevent negative offset when timezone causes slot to be before startHour
+  const minutesFromStart = Math.max(0, (cellToDate.hour() - props.startHour) * 60 + cellToDate.minute());
 
   return <Cell topOffsetMinutes={minutesFromStart} timeSlot={dayjs(cellToDate).tz(props.timezone)} />;
 }
@@ -60,7 +61,8 @@ export function AvailableCellsForDay({ timezone, availableSlots, day, startHour 
 
     slotsForToday?.forEach((slot, index) => {
       const startTime = dayjs(slot.start).tz(timezone);
-      const topOffsetMinutes = (startTime.hour() - startHour) * 60 + startTime.minute();
+      // Clamp to 0 to prevent negative offset when timezone causes slot to be before startHour
+      const topOffsetMinutes = Math.max(0, (startTime.hour() - startHour) * 60 + startTime.minute());
       calculatedSlots.push({ slot, topOffsetMinutes });
 
       if (!slot.away) {


### PR DESCRIPTION
## What does this PR do?
Fixes #14208

When user's timezone differs from the event timezone, `topOffsetMinutes` could become negative, causing time slots to be positioned above the visible calendar area and get clipped.

## Changes
- Added `Math.max(0, ...)` to clamp `topOffsetMinutes` in [Empty.tsx](cci:7://file:///c:/Users/hp/Downloads/G2/cal.com/apps/web/modules/calendars/weeklyview/components/event/Empty.tsx:0:0-0:0) to prevent negative values
- Applied fix in both [EmptyCell](cci:1://file:///c:/Users/hp/Downloads/G2/cal.com/apps/web/modules/calendars/weeklyview/components/event/Empty.tsx:19:0-33:1) and [AvailableCellsForDay](cci:1://file:///c:/Users/hp/Downloads/G2/cal.com/apps/web/modules/calendars/weeklyview/components/event/Empty.tsx:41:0-131:1) functions

### File Modified:
[apps/web/modules/calendars/weeklyview/components/event/Empty.tsx](cci:7://file:///c:/Users/hp/Downloads/G2/cal.com/apps/web/modules/calendars/weeklyview/components/event/Empty.tsx:0:0-0:0)

## How should this be tested?
1. Set your system timezone different from event (e.g., Asia/Kolkata vs UTC)
2. Go to any booking page and switch to **weekly view**
3. Verify time slots are visible and not clipped at the top

## Mandatory Tasks
- [x] Code follows project conventions
- [x] Self-reviewed code

/claim #14208
