### PR TITLE
fix: fallback to GOOGLE_API_CREDENTIALS when DB keys are missing

### DIFF
--- a/packages/app-store/googlecalendar/lib/getGoogleAppKeys.ts
+++ b/packages/app-store/googlecalendar/lib/getGoogleAppKeys.ts
@@ -9,5 +9,19 @@ const googleAppKeysSchema = z.object({
 });
 
 export const getGoogleAppKeys = async () => {
-  return getParsedAppKeysFromSlug("google-calendar", googleAppKeysSchema);
+  try {
+    return await getParsedAppKeysFromSlug(
+      "google-calendar",
+      googleAppKeysSchema
+    );
+  } catch (error) {
+    const envCredentials = process.env.GOOGLE_API_CREDENTIALS;
+
+    if (!envCredentials) {
+      throw error;
+    }
+
+    const parsed = JSON.parse(envCredentials);
+    return googleAppKeysSchema.parse(parsed);
+  }
 };

--- a/packages/app-store/googlecalendar/lib/getGoogleAppKeys.ts
+++ b/packages/app-store/googlecalendar/lib/getGoogleAppKeys.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z, ZodError } from "zod";
 
 import getParsedAppKeysFromSlug from "../../_utils/getParsedAppKeysFromSlug";
 
@@ -15,8 +15,11 @@ export const getGoogleAppKeys = async () => {
       googleAppKeysSchema
     );
   } catch (error) {
-    const envCredentials = process.env.GOOGLE_API_CREDENTIALS;
+    if (!(error instanceof ZodError)) {
+      throw error;
+    }
 
+    const envCredentials = process.env.GOOGLE_API_CREDENTIALS;
     if (!envCredentials) {
       throw error;
     }


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the Google Calendar integration fails to load
availability when the App table is not seeded, even if the
`GOOGLE_API_CREDENTIALS` environment variable is correctly set.

The Google Calendar app previously relied solely on database-stored credentials.
This change adds a fallback to read and validate credentials from
`GOOGLE_API_CREDENTIALS` at runtime when database lookup fails.

- Fixes #27292 

### Expected result
- When DB credentials exist, behavior is unchanged.
- When DB credentials are missing, credentials are loaded from the environment variable and availability works as expected.

