### PR TITLE
fix: booking limit reached error for overlapping and pending bookings #27261

### DIFF
--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1337,33 +1337,34 @@ export class BookingRepository implements IBookingRepository {
     });
   }
 
-  async countBookingsByEventTypeAndDateRange({
-    eventTypeId,
-    startDate,
-    endDate,
-    excludedUid,
-  }: {
-    eventTypeId: number;
-    startDate: Date;
-    endDate: Date;
-    excludedUid?: string;
-  }) {
-    return await this.prismaClient.booking.count({
-      where: {
-        status: BookingStatus.ACCEPTED,
-        eventTypeId,
-        startTime: {
-          gte: startDate,
-        },
-        endTime: {
-          lte: endDate,
-        },
-        uid: {
-          not: excludedUid,
-        },
+ async countBookingsByEventTypeAndDateRange({
+  eventTypeId,
+  startDate,
+  endDate,
+  excludedUid,
+}: {
+  eventTypeId: number;
+  startDate: Date;
+  endDate: Date;
+  excludedUid?: string;
+}) {
+  return await this.prismaClient.booking.count({
+    where: {
+      // 1. Check both Accepted and Pending status
+      status: { in: [BookingStatus.ACCEPTED, BookingStatus.PENDING] },
+      eventTypeId,
+      // 2. Only check the start time to see if it is in the dasys window.
+      startTime: {
+        gte: startDate,
+        lte: endDate,
       },
-    });
-  }
+      // 3. Keep the exclusion for the current booking for reschedules
+      uid: {
+        not: excludedUid,
+      },
+    },
+  });
+}
 
   async findAcceptedBookingByEventTypeId({
     eventTypeId,


### PR DESCRIPTION
What does this PR do?

Fixes https://github.com/calcom/cal.com/issues/27261

Fixes #27261

Fixes CAL-7129

Summary: This PR resolves an issue where the booking_limit_reached error was incorrectly triggered due to logic gaps in the daily limit calculation. I have refactored the BookingRepository to include PENDING statuses in the count and simplified the startTime validation to fix timezone and midnight overlaps.

How to Reproduce:

Set a Limit: Create an Event Type with a "Booking Limit" of 1 per day.

Initial Booking: Book a slot that requires manual confirmation so it stays PENDING.

The Bug: Previously, attempting to book a second slot on the same day would be allowed because PENDING bookings were ignored.

The Fix: The second attempt will now correctly trigger the booking_limit_reached error.

Verification:

Verified locally with 11 passed tests in the specific suite and 977 passed across the full repository.

<img width="1031" height="394" alt="Screenshot 2026-02-01 153024" src="https://github.com/user-attachments/assets/e2344be1-c045-41ac-9c64-4454675f7d4d" />
