### PR TITLE
fix: updated User Profile Dropdown chevron to reflect menu state

### DIFF
--- a/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
+++ b/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
@@ -167,7 +167,7 @@ export function UserDropdown({ small }: UserDropdownProps) {
               </span>
             </span>
             <Icon
-              name="chevron-down"
+              name={menuOpen ? "chevron-up" : "chevron-down"}
               className="group-hover:text-subtle text-muted h-4 w-4 shrink-0 transition rtl:mr-4"
               aria-hidden="true"
             />


### PR DESCRIPTION
## What does this PR do?
Fixes #27475 

This PR resolves a visual inconsistency in the sidebar where the chevron arrow next to the user profile remained in a downward direction even when the dropdown menu was open. I have implemented a state-driven icon swap (chevron-up / chevron-down) tied to the menuOpen state, aligning this component with the logic used in NavigationItem.tsx for other sidebar items.

- Fixes #27475  (GitHub issue number)
- Fixes [CAL-7163](https://linear.app/calcom/issue/CAL-7163/bug-user-profile-chevron-arrow-direction-does-not-update-on-dropdown)(Linear issue number)

## Visual Demo (For contributors especially)
- Before Fix:
<img width="344" height="468" alt="image" src="https://github.com/user-attachments/assets/e30fd745-6a5e-4984-9df1-9d7c818affaa" />

- After Fix:
<img width="326" height="455" alt="image" src="https://github.com/user-attachments/assets/6da7a29a-ee5e-49b8-a646-1875702a7fb7" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs. (N/A, UI-only Bug)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (N/A, UI only bug - manually tested)

## How should this be tested?

1. Log into the dashboard (http://localhost:3000/event-types).
2. Locate the user profile dropdown in the sidebar in left.
3. Click the profile to open the menu.
4. Expected Outcome: The chevron icon should immediately change to an upward arrow and remain upward even as you move your mouse through the menu items.
5. Click outside the menu.
6. Expected Outcome: The menu closes and the arrow reverts to a downward direction.
