### PR TITLE
feat(routing-forms): add inverted index approach for attribute-based team member lookup

### DIFF
--- a/packages/features/routing-forms/lib/findTeamMembersByAttributeValue.test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersByAttributeValue.test.ts
@@ -1,12 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import type { Attribute } from "@calcom/app-store/routing-forms/types/types";
 import type { AttributeType } from "@calcom/prisma/enums";
 import type { AttributesQueryValue } from "@calcom/routing-forms/types/types";
-
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  findTeamMembersByAttributeValue,
   canUseInvertedIndexApproach,
+  findTeamMembersByAttributeValue,
 } from "./findTeamMembersByAttributeValue";
 
 // Mock Prisma

--- a/packages/features/routing-forms/lib/findTeamMembersByAttributeValue.test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersByAttributeValue.test.ts
@@ -1,0 +1,511 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { Attribute } from "@calcom/app-store/routing-forms/types/types";
+import type { AttributeType } from "@calcom/prisma/enums";
+import type { AttributesQueryValue } from "@calcom/routing-forms/types/types";
+
+import {
+  findTeamMembersByAttributeValue,
+  canUseInvertedIndexApproach,
+} from "./findTeamMembersByAttributeValue";
+
+// Mock Prisma
+vi.mock("@calcom/prisma", () => ({
+  default: {
+    attributeOption: {
+      findMany: vi.fn(),
+    },
+    attributeToUser: {
+      findMany: vi.fn(),
+    },
+    membership: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import prisma from "@calcom/prisma";
+
+const orgId = 1001;
+const teamId = 100;
+
+function buildSelectTypeFieldQueryValue({
+  rules,
+  conjunction = "AND",
+}: {
+  rules: {
+    raqbFieldId: string;
+    value: string | number | string[] | [string[]];
+    operator: string;
+    valueType?: string[];
+  }[];
+  conjunction?: "AND" | "OR";
+}) {
+  const queryValue = {
+    id: "query-id-1",
+    type: "group",
+    properties: {
+      conjunction,
+    },
+    children1: rules.reduce(
+      (acc, rule, index) => {
+        acc[`rule-${index + 1}`] = {
+          type: "rule",
+          properties: {
+            field: rule.raqbFieldId,
+            value: rule.value instanceof Array ? rule.value : [rule.value],
+            operator: rule.operator,
+            valueSrc: ["value"],
+            valueType: rule.valueType ?? ["select"],
+          },
+        };
+        return acc;
+      },
+      {} as Record<string, unknown>
+    ),
+  };
+
+  return queryValue as AttributesQueryValue;
+}
+
+function createAttribute({
+  id,
+  name,
+  type,
+  options,
+}: {
+  id: string;
+  name: string;
+  type: AttributeType;
+  options: { id: string; value: string; slug: string }[];
+}): Attribute {
+  return {
+    id,
+    name,
+    type,
+    slug: name.toLowerCase().replace(/\s+/g, "-"),
+    options: options.map((opt) => ({
+      ...opt,
+      attributeId: id,
+      isGroup: false,
+      contains: [],
+    })),
+  };
+}
+
+describe("findTeamMembersByAttributeValue", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("canUseInvertedIndexApproach", () => {
+    it("should return false for null query value", () => {
+      expect(canUseInvertedIndexApproach(null)).toBe(false);
+    });
+
+    it("should return false for empty query value", () => {
+      const queryValue = { type: "group" } as AttributesQueryValue;
+      expect(canUseInvertedIndexApproach(queryValue)).toBe(false);
+    });
+
+    it("should return true for simple flat rules", () => {
+      const queryValue = buildSelectTypeFieldQueryValue({
+        rules: [
+          {
+            raqbFieldId: "attr1",
+            value: ["option1"],
+            operator: "select_equals",
+          },
+        ],
+      });
+      expect(canUseInvertedIndexApproach(queryValue)).toBe(true);
+    });
+
+    it("should return false for nested groups", () => {
+      const queryValue = {
+        type: "group",
+        children1: {
+          "rule-1": {
+            type: "group", // Nested group
+            children1: {},
+          },
+        },
+      } as unknown as AttributesQueryValue;
+      expect(canUseInvertedIndexApproach(queryValue)).toBe(false);
+    });
+  });
+
+  describe("findTeamMembersByAttributeValue", () => {
+    it("should return null userIds when attributesQueryValue is null", async () => {
+      const result = await findTeamMembersByAttributeValue({
+        teamId,
+        orgId,
+        attributesQueryValue: null,
+        attributesOfTheOrg: [],
+      });
+
+      expect(result.userIds).toBeNull();
+    });
+
+    it("should return null userIds when query value has no rules", async () => {
+      const queryValue = { type: "group" } as AttributesQueryValue;
+
+      const result = await findTeamMembersByAttributeValue({
+        teamId,
+        orgId,
+        attributesQueryValue: queryValue,
+        attributesOfTheOrg: [],
+      });
+
+      expect(result.userIds).toBeNull();
+    });
+
+    it("should find members matching a single select_equals rule", async () => {
+      const Option1 = { id: "opt1", value: "Option 1", slug: "option-1" };
+      const Attribute1 = createAttribute({
+        id: "attr1",
+        name: "Attribute 1",
+        type: "SINGLE_SELECT",
+        options: [Option1],
+      });
+
+      const queryValue = buildSelectTypeFieldQueryValue({
+        rules: [
+          {
+            raqbFieldId: Attribute1.id,
+            // After resolution, the value will be the label (lowercase)
+            value: ["option 1"],
+            operator: "select_equals",
+          },
+        ],
+      });
+
+      // Mock attributeOption.findMany to return the matching option
+      vi.mocked(prisma.attributeOption.findMany).mockResolvedValue([
+        {
+          id: Option1.id,
+          value: Option1.value,
+          isGroup: false,
+          contains: [],
+          attributeId: Attribute1.id,
+          slug: Option1.slug,
+        },
+      ]);
+
+      // Mock attributeToUser.findMany to return members with this option
+      vi.mocked(prisma.attributeToUser.findMany).mockResolvedValue([
+        { member: { userId: 1 } },
+        { member: { userId: 2 } },
+      ] as never);
+
+      const result = await findTeamMembersByAttributeValue({
+        teamId,
+        orgId,
+        attributesQueryValue: queryValue,
+        attributesOfTheOrg: [Attribute1],
+      });
+
+      expect(result.userIds).toEqual([1, 2]);
+      expect(result.timeTaken).toBeGreaterThan(0);
+    });
+
+    it("should find members matching select_any_in rule", async () => {
+      const Option1 = { id: "opt1", value: "Option 1", slug: "option-1" };
+      const Option2 = { id: "opt2", value: "Option 2", slug: "option-2" };
+      const Attribute1 = createAttribute({
+        id: "attr1",
+        name: "Attribute 1",
+        type: "SINGLE_SELECT",
+        options: [Option1, Option2],
+      });
+
+      const queryValue = buildSelectTypeFieldQueryValue({
+        rules: [
+          {
+            raqbFieldId: Attribute1.id,
+            value: [["option 1", "option 2"]],
+            operator: "select_any_in",
+            valueType: ["multiselect"],
+          },
+        ],
+      });
+
+      vi.mocked(prisma.attributeOption.findMany).mockResolvedValue([
+        {
+          id: Option1.id,
+          value: Option1.value,
+          isGroup: false,
+          contains: [],
+          attributeId: Attribute1.id,
+          slug: Option1.slug,
+        },
+        {
+          id: Option2.id,
+          value: Option2.value,
+          isGroup: false,
+          contains: [],
+          attributeId: Attribute1.id,
+          slug: Option2.slug,
+        },
+      ]);
+
+      vi.mocked(prisma.attributeToUser.findMany).mockResolvedValue([
+        { member: { userId: 1 } },
+        { member: { userId: 2 } },
+        { member: { userId: 3 } },
+      ] as never);
+
+      const result = await findTeamMembersByAttributeValue({
+        teamId,
+        orgId,
+        attributesQueryValue: queryValue,
+        attributesOfTheOrg: [Attribute1],
+      });
+
+      expect(result.userIds).toEqual([1, 2, 3]);
+    });
+
+    it("should handle AND conjunction correctly", async () => {
+      const Option1 = { id: "opt1", value: "Option 1", slug: "option-1" };
+      const Option2 = { id: "opt2", value: "Option 2", slug: "option-2" };
+      const Attribute1 = createAttribute({
+        id: "attr1",
+        name: "Attribute 1",
+        type: "SINGLE_SELECT",
+        options: [Option1],
+      });
+      const Attribute2 = createAttribute({
+        id: "attr2",
+        name: "Attribute 2",
+        type: "SINGLE_SELECT",
+        options: [Option2],
+      });
+
+      const queryValue = buildSelectTypeFieldQueryValue({
+        rules: [
+          {
+            raqbFieldId: Attribute1.id,
+            value: ["option 1"],
+            operator: "select_equals",
+          },
+          {
+            raqbFieldId: Attribute2.id,
+            value: ["option 2"],
+            operator: "select_equals",
+          },
+        ],
+        conjunction: "AND",
+      });
+
+      // First rule matches users 1, 2, 3
+      // Second rule matches users 2, 3, 4
+      // AND should return 2, 3
+      vi.mocked(prisma.attributeOption.findMany)
+        .mockResolvedValueOnce([
+          {
+            id: Option1.id,
+            value: Option1.value,
+            isGroup: false,
+            contains: [],
+            attributeId: Attribute1.id,
+            slug: Option1.slug,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: Option2.id,
+            value: Option2.value,
+            isGroup: false,
+            contains: [],
+            attributeId: Attribute2.id,
+            slug: Option2.slug,
+          },
+        ]);
+
+      vi.mocked(prisma.attributeToUser.findMany)
+        .mockResolvedValueOnce([
+          { member: { userId: 1 } },
+          { member: { userId: 2 } },
+          { member: { userId: 3 } },
+        ] as never)
+        .mockResolvedValueOnce([
+          { member: { userId: 2 } },
+          { member: { userId: 3 } },
+          { member: { userId: 4 } },
+        ] as never);
+
+      const result = await findTeamMembersByAttributeValue({
+        teamId,
+        orgId,
+        attributesQueryValue: queryValue,
+        attributesOfTheOrg: [Attribute1, Attribute2],
+      });
+
+      expect(result.userIds).toEqual([2, 3]);
+    });
+
+    it("should handle OR conjunction correctly", async () => {
+      const Option1 = { id: "opt1", value: "Option 1", slug: "option-1" };
+      const Option2 = { id: "opt2", value: "Option 2", slug: "option-2" };
+      const Attribute1 = createAttribute({
+        id: "attr1",
+        name: "Attribute 1",
+        type: "SINGLE_SELECT",
+        options: [Option1],
+      });
+      const Attribute2 = createAttribute({
+        id: "attr2",
+        name: "Attribute 2",
+        type: "SINGLE_SELECT",
+        options: [Option2],
+      });
+
+      const queryValue = buildSelectTypeFieldQueryValue({
+        rules: [
+          {
+            raqbFieldId: Attribute1.id,
+            value: ["option 1"],
+            operator: "select_equals",
+          },
+          {
+            raqbFieldId: Attribute2.id,
+            value: ["option 2"],
+            operator: "select_equals",
+          },
+        ],
+        conjunction: "OR",
+      });
+
+      // First rule matches users 1, 2
+      // Second rule matches users 3, 4
+      // OR should return 1, 2, 3, 4
+      vi.mocked(prisma.attributeOption.findMany)
+        .mockResolvedValueOnce([
+          {
+            id: Option1.id,
+            value: Option1.value,
+            isGroup: false,
+            contains: [],
+            attributeId: Attribute1.id,
+            slug: Option1.slug,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: Option2.id,
+            value: Option2.value,
+            isGroup: false,
+            contains: [],
+            attributeId: Attribute2.id,
+            slug: Option2.slug,
+          },
+        ]);
+
+      vi.mocked(prisma.attributeToUser.findMany)
+        .mockResolvedValueOnce([{ member: { userId: 1 } }, { member: { userId: 2 } }] as never)
+        .mockResolvedValueOnce([{ member: { userId: 3 } }, { member: { userId: 4 } }] as never);
+
+      const result = await findTeamMembersByAttributeValue({
+        teamId,
+        orgId,
+        attributesQueryValue: queryValue,
+        attributesOfTheOrg: [Attribute1, Attribute2],
+      });
+
+      expect(result.userIds).toEqual(expect.arrayContaining([1, 2, 3, 4]));
+      expect(result.userIds?.length).toBe(4);
+    });
+
+    it("should return empty array when no matching options found", async () => {
+      const Option1 = { id: "opt1", value: "Option 1", slug: "option-1" };
+      const Attribute1 = createAttribute({
+        id: "attr1",
+        name: "Attribute 1",
+        type: "SINGLE_SELECT",
+        options: [Option1],
+      });
+
+      const queryValue = buildSelectTypeFieldQueryValue({
+        rules: [
+          {
+            raqbFieldId: Attribute1.id,
+            value: ["nonexistent option"],
+            operator: "select_equals",
+          },
+        ],
+      });
+
+      // No matching options
+      vi.mocked(prisma.attributeOption.findMany).mockResolvedValue([]);
+
+      const result = await findTeamMembersByAttributeValue({
+        teamId,
+        orgId,
+        attributesQueryValue: queryValue,
+        attributesOfTheOrg: [Attribute1],
+      });
+
+      expect(result.userIds).toEqual([]);
+    });
+
+    it("should handle group options by including contained options", async () => {
+      const Option1 = { id: "opt1", value: "Option 1", slug: "option-1" };
+      const Option2 = { id: "opt2", value: "Option 2", slug: "option-2" };
+      const GroupOption = { id: "group-opt", value: "Group Option", slug: "group-option" };
+      const Attribute1 = createAttribute({
+        id: "attr1",
+        name: "Attribute 1",
+        type: "SINGLE_SELECT",
+        options: [Option1, Option2, GroupOption],
+      });
+
+      const queryValue = buildSelectTypeFieldQueryValue({
+        rules: [
+          {
+            raqbFieldId: Attribute1.id,
+            value: ["group option"],
+            operator: "select_equals",
+          },
+        ],
+      });
+
+      // Group option contains opt1 and opt2
+      vi.mocked(prisma.attributeOption.findMany).mockResolvedValue([
+        {
+          id: GroupOption.id,
+          value: GroupOption.value,
+          isGroup: true,
+          contains: [Option1.id, Option2.id],
+          attributeId: Attribute1.id,
+          slug: GroupOption.slug,
+        },
+      ]);
+
+      // Members with any of the contained options
+      vi.mocked(prisma.attributeToUser.findMany).mockResolvedValue([
+        { member: { userId: 1 } },
+        { member: { userId: 2 } },
+      ] as never);
+
+      const result = await findTeamMembersByAttributeValue({
+        teamId,
+        orgId,
+        attributesQueryValue: queryValue,
+        attributesOfTheOrg: [Attribute1],
+      });
+
+      // Should have searched for group-opt, opt1, and opt2
+      expect(vi.mocked(prisma.attributeToUser.findMany)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            attributeOptionId: {
+              in: expect.arrayContaining([GroupOption.id, Option1.id, Option2.id]),
+            },
+          }),
+        })
+      );
+
+      expect(result.userIds).toEqual([1, 2]);
+    });
+  });
+});

--- a/packages/features/routing-forms/lib/findTeamMembersByAttributeValue.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersByAttributeValue.ts
@@ -1,5 +1,5 @@
-import type { Attribute } from "@calcom/app-store/routing-forms/types/types";
 import { resolveQueryValue } from "@calcom/app-store/routing-forms/lib/resolveQueryValue";
+import type { Attribute } from "@calcom/app-store/routing-forms/types/types";
 import logger from "@calcom/lib/logger";
 import type { AttributesQueryValue, dynamicFieldValueOperands } from "@calcom/lib/raqb/types";
 import prisma from "@calcom/prisma";
@@ -42,7 +42,11 @@ type RaqbRuleItem = {
 
 function isQueryValueARuleGroup(
   queryValue: unknown
-): queryValue is { type: "group"; children1?: Record<string, RaqbRuleItem>; properties?: { conjunction?: string } } {
+): queryValue is {
+  type: "group";
+  children1?: Record<string, RaqbRuleItem>;
+  properties?: { conjunction?: string };
+} {
   return (
     typeof queryValue === "object" &&
     queryValue !== null &&
@@ -70,8 +74,7 @@ function parseAttributesQueryValue(queryValue: AttributesQueryValue): ParsedAttr
   }
 
   // Get conjunction from properties, default to AND
-  const conjunction: "AND" | "OR" =
-    queryValue.properties?.conjunction === "OR" ? "OR" : "AND";
+  const conjunction: "AND" | "OR" = queryValue.properties?.conjunction === "OR" ? "OR" : "AND";
 
   const rules: ParsedRule[] = [];
 

--- a/packages/features/routing-forms/lib/findTeamMembersByAttributeValue.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersByAttributeValue.ts
@@ -1,0 +1,394 @@
+import type { Attribute } from "@calcom/app-store/routing-forms/types/types";
+import { resolveQueryValue } from "@calcom/app-store/routing-forms/lib/resolveQueryValue";
+import logger from "@calcom/lib/logger";
+import type { AttributesQueryValue, dynamicFieldValueOperands } from "@calcom/lib/raqb/types";
+import prisma from "@calcom/prisma";
+
+const moduleLogger = logger.getSubLogger({ prefix: ["findTeamMembersByAttributeValue"] });
+
+/**
+ * Represents a parsed rule from the RAQB query value
+ */
+type ParsedRule = {
+  attributeId: string;
+  operator: string;
+  /** Values to match - these are the resolved labels (not IDs) */
+  values: string[];
+};
+
+/**
+ * Result of parsing the attributes query value
+ */
+type ParsedAttributeQuery = {
+  rules: ParsedRule[];
+  /** The conjunction type - 'AND' or 'OR' */
+  conjunction: "AND" | "OR";
+};
+
+/**
+ * Type for RAQB rule item in children1
+ */
+type RaqbRuleItem = {
+  type: string;
+  properties?: {
+    field?: string;
+    operator?: string;
+    value?: unknown[];
+    valueSrc?: string[];
+    valueType?: string[];
+    valueError?: (string | null)[];
+  };
+};
+
+function isQueryValueARuleGroup(
+  queryValue: unknown
+): queryValue is { type: "group"; children1?: Record<string, RaqbRuleItem>; properties?: { conjunction?: string } } {
+  return (
+    typeof queryValue === "object" &&
+    queryValue !== null &&
+    "type" in queryValue &&
+    (queryValue as { type: string }).type === "group"
+  );
+}
+
+function isARule(rule: RaqbRuleItem): boolean {
+  return rule.type === "rule";
+}
+
+/**
+ * Parses the RAQB query value to extract the rules and conjunction type.
+ * The query value should already be resolved (field templates replaced with actual values).
+ */
+function parseAttributesQueryValue(queryValue: AttributesQueryValue): ParsedAttributeQuery | null {
+  if (!isQueryValueARuleGroup(queryValue)) {
+    return null;
+  }
+
+  const children1 = queryValue.children1;
+  if (!children1) {
+    return null;
+  }
+
+  // Get conjunction from properties, default to AND
+  const conjunction: "AND" | "OR" =
+    queryValue.properties?.conjunction === "OR" ? "OR" : "AND";
+
+  const rules: ParsedRule[] = [];
+
+  for (const ruleId of Object.keys(children1)) {
+    const rule = children1[ruleId];
+
+    if (!isARule(rule)) {
+      // Skip nested groups for now - we only support flat rules
+      continue;
+    }
+
+    const properties = rule.properties;
+    if (!properties) {
+      continue;
+    }
+
+    const attributeId = properties.field;
+    const operator = properties.operator;
+    const value = properties.value;
+
+    if (!attributeId || !operator || !value) {
+      continue;
+    }
+
+    // Extract values from the RAQB value format
+    // Value can be: [["value1", "value2"]] for multiselect or ["value1"] for single select
+    const flattenedValues: string[] = [];
+    for (const v of value) {
+      if (v === null || v === undefined) {
+        continue;
+      }
+      if (Array.isArray(v)) {
+        for (const innerV of v) {
+          if (typeof innerV === "string") {
+            flattenedValues.push(innerV);
+          }
+        }
+      } else if (typeof v === "string") {
+        flattenedValues.push(v);
+      }
+    }
+
+    if (flattenedValues.length === 0) {
+      continue;
+    }
+
+    rules.push({
+      attributeId,
+      operator,
+      values: flattenedValues,
+    });
+  }
+
+  if (rules.length === 0) {
+    return null;
+  }
+
+  return { rules, conjunction };
+}
+
+/**
+ * Maps RAQB operators to their matching behavior
+ */
+type OperatorMatchType = "EQUALS" | "ANY_IN" | "NOT_EQUALS" | "NOT_ANY_IN";
+
+function getOperatorMatchType(operator: string): OperatorMatchType {
+  switch (operator) {
+    case "select_equals":
+      return "EQUALS";
+    case "select_not_equals":
+      return "NOT_EQUALS";
+    case "select_any_in":
+    case "multiselect_some_in":
+      return "ANY_IN";
+    case "select_not_any_in":
+    case "multiselect_not_some_in":
+      return "NOT_ANY_IN";
+    default:
+      // Default to ANY_IN for unknown operators
+      moduleLogger.warn(`Unknown operator: ${operator}, defaulting to ANY_IN`);
+      return "ANY_IN";
+  }
+}
+
+/**
+ * Finds team members who have attribute options matching the given values.
+ * This is the "inverted index" approach - instead of fetching all members and evaluating logic,
+ * we query directly for members who have the required attribute values.
+ */
+async function findMembersByAttributeOptionValues({
+  teamId,
+  orgId,
+  attributeId,
+  values,
+  matchType,
+}: {
+  teamId: number;
+  orgId: number;
+  attributeId: string;
+  /** Values to match - these should be the option labels (case-insensitive) */
+  values: string[];
+  matchType: OperatorMatchType;
+}): Promise<number[]> {
+  // First, find the attribute options that match the given values
+  const attributeOptions = await prisma.attributeOption.findMany({
+    where: {
+      attributeId,
+      // Case-insensitive match on the value
+      value: {
+        in: values,
+        mode: "insensitive",
+      },
+    },
+    select: {
+      id: true,
+      value: true,
+      isGroup: true,
+      contains: true,
+    },
+  });
+
+  if (attributeOptions.length === 0 && (matchType === "EQUALS" || matchType === "ANY_IN")) {
+    // No matching options found, so no members can match
+    return [];
+  }
+
+  // Collect all option IDs to search for, including group expansion
+  const optionIdsToSearch: string[] = [];
+  for (const option of attributeOptions) {
+    optionIdsToSearch.push(option.id);
+    // If this is a group option, also include the contained options
+    if (option.isGroup && option.contains.length > 0) {
+      optionIdsToSearch.push(...option.contains);
+    }
+  }
+
+  // Find team members who have these attribute options assigned
+  // We need to join through membership to filter by team
+  const membersWithAttribute = await prisma.attributeToUser.findMany({
+    where: {
+      attributeOptionId: {
+        in: optionIdsToSearch,
+      },
+      member: {
+        // The member must be in the team (sub-team)
+        user: {
+          teams: {
+            some: {
+              teamId,
+            },
+          },
+        },
+        // The membership must be in the org (for attribute assignment)
+        teamId: orgId,
+      },
+    },
+    select: {
+      member: {
+        select: {
+          userId: true,
+        },
+      },
+    },
+  });
+
+  const matchingUserIds = Array.from(new Set(membersWithAttribute.map((m) => m.member.userId)));
+
+  if (matchType === "NOT_EQUALS" || matchType === "NOT_ANY_IN") {
+    // For NOT operators, we need to find all team members and exclude the matching ones
+    const allTeamMembers = await prisma.membership.findMany({
+      where: {
+        teamId,
+      },
+      select: {
+        userId: true,
+      },
+    });
+
+    const allUserIds = allTeamMembers.map((m) => m.userId);
+    const matchingSet = new Set(matchingUserIds);
+    return allUserIds.filter((userId) => !matchingSet.has(userId));
+  }
+
+  return matchingUserIds;
+}
+
+/**
+ * Finds team members matching the attribute logic using direct database queries.
+ * This is an optimized alternative to the JSON logic evaluation approach.
+ *
+ * @param data - The query parameters
+ * @param data.teamId - The team ID to search within
+ * @param data.orgId - The organization ID (for attribute assignments)
+ * @param data.attributesQueryValue - The RAQB query value defining the attribute logic
+ * @param data.attributesOfTheOrg - All attributes defined for the organization
+ * @param data.dynamicFieldValueOperands - Optional field values for resolving field templates
+ *
+ * @returns Array of user IDs matching the attribute logic, or null if no logic is defined
+ */
+export async function findTeamMembersByAttributeValue({
+  teamId,
+  orgId,
+  attributesQueryValue,
+  attributesOfTheOrg,
+  dynamicFieldValueOperands,
+}: {
+  teamId: number;
+  orgId: number;
+  attributesQueryValue: AttributesQueryValue | null;
+  attributesOfTheOrg: Attribute[];
+  dynamicFieldValueOperands?: dynamicFieldValueOperands;
+}): Promise<{
+  userIds: number[] | null;
+  timeTaken: number | null;
+}> {
+  const startTime = performance.now();
+
+  if (!attributesQueryValue) {
+    return { userIds: null, timeTaken: null };
+  }
+
+  // Resolve the query value (replace field templates with actual values)
+  const resolvedQueryValue = resolveQueryValue({
+    queryValue: attributesQueryValue,
+    attributes: attributesOfTheOrg,
+    dynamicFieldValueOperands,
+  });
+
+  // Parse the resolved query value
+  const parsedQuery = parseAttributesQueryValue(resolvedQueryValue);
+
+  if (!parsedQuery) {
+    // No valid rules found - return null to indicate all members match
+    return { userIds: null, timeTaken: performance.now() - startTime };
+  }
+
+  const { rules, conjunction } = parsedQuery;
+
+  // Execute queries for each rule
+  const ruleResults: number[][] = [];
+
+  for (const rule of rules) {
+    const matchType = getOperatorMatchType(rule.operator);
+    const matchingUserIds = await findMembersByAttributeOptionValues({
+      teamId,
+      orgId,
+      attributeId: rule.attributeId,
+      values: rule.values,
+      matchType,
+    });
+    ruleResults.push(matchingUserIds);
+  }
+
+  // Combine results based on conjunction
+  let finalUserIds: number[];
+
+  if (conjunction === "AND") {
+    // Intersection of all rule results
+    if (ruleResults.length === 0) {
+      finalUserIds = [];
+    } else {
+      const firstResult = new Set(ruleResults[0]);
+      finalUserIds = Array.from(firstResult).filter((userId) =>
+        ruleResults.every((result) => result.includes(userId))
+      );
+    }
+  } else {
+    // Union of all rule results
+    const allUserIds = new Set<number>();
+    for (const result of ruleResults) {
+      for (const userId of result) {
+        allUserIds.add(userId);
+      }
+    }
+    finalUserIds = Array.from(allUserIds);
+  }
+
+  const timeTaken = performance.now() - startTime;
+
+  moduleLogger.debug("findTeamMembersByAttributeValue completed", {
+    teamId,
+    orgId,
+    rulesCount: rules.length,
+    conjunction,
+    matchingMembersCount: finalUserIds.length,
+    timeTaken,
+  });
+
+  return { userIds: finalUserIds, timeTaken };
+}
+
+/**
+ * Checks if the attribute query can be optimized using the inverted index approach.
+ * Some complex queries (nested groups, unsupported operators) may not be supported.
+ */
+export function canUseInvertedIndexApproach(attributesQueryValue: AttributesQueryValue | null): boolean {
+  if (!attributesQueryValue) {
+    return false;
+  }
+
+  if (!isQueryValueARuleGroup(attributesQueryValue)) {
+    return false;
+  }
+
+  const children1 = attributesQueryValue.children1;
+  if (!children1) {
+    return false;
+  }
+
+  // Check if all children are simple rules (not nested groups)
+  for (const ruleId of Object.keys(children1)) {
+    const rule = children1[ruleId];
+    if (rule.type !== "rule") {
+      // Nested group found - not supported
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.test.ts
@@ -1,13 +1,11 @@
-import type { BaseWidget } from "react-awesome-query-builder";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { RouteActionType } from "@calcom/app-store/routing-forms/zod";
 import * as getAttributesModule from "@calcom/features/attributes/lib/getAttributes";
 import { RaqbLogicResult } from "@calcom/lib/raqb/evaluateRaqbLogic";
 import type { AttributeType } from "@calcom/prisma/enums";
 import { RoutingFormFieldType } from "@calcom/routing-forms/lib/FieldTypes";
 import type { AttributesQueryValue, FormFieldsQueryValue } from "@calcom/routing-forms/types/types";
-
+import type { BaseWidget } from "react-awesome-query-builder";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   findTeamMembersMatchingAttributeLogic,
   TroubleshooterCase,
@@ -21,6 +19,13 @@ vi.mock("@calcom/features/attributes/lib/getAttributes", () => {
 
 vi.mock("@calcom/app-store/routing-forms/components/react-awesome-query-builder/widgets", () => ({
   default: {},
+}));
+
+// Mock the inverted index module to always return that it can't use the optimized approach
+// This ensures existing tests continue to use the original JSON logic evaluation path
+vi.mock("./findTeamMembersByAttributeValue", () => ({
+  findTeamMembersByAttributeValue: vi.fn(),
+  canUseInvertedIndexApproach: vi.fn().mockReturnValue(false),
 }));
 
 const orgId = 1001;


### PR DESCRIPTION
## What does this PR do?

Adds a new optimized function `findTeamMembersByAttributeValue` that queries team members directly based on attribute criteria instead of fetching all members and evaluating JSON logic for each one, and integrates it into the main routing flow.

**Background:** In headless routing flows, the current approach fetches all team members' attributes and evaluates JSON logic for each member (O(n)). For large teams with many routed members, this is expensive. This PR implements an "inverted index" approach that queries the database directly for members matching specific attribute values.

**Key changes:**
- Parse `attributesQueryValue` to extract attribute IDs, operators, and values
- Build direct Prisma queries to find team members with matching attributes
- Support `select_equals`, `select_any_in`, `multiselect_some_in` operators (and their negations)
- Handle AND/OR conjunction logic between multiple rules
- Support group options that contain other options
- **Integrate into `findTeamMembersMatchingAttributeLogic`** with new `useInvertedIndex` option (defaults to `true`)
- Fall back to original JSON logic evaluation for complex queries (nested groups) or when troubleshooter is enabled

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal optimization, no user-facing changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the unit tests for the new inverted index function:
   ```bash
   TZ=UTC yarn test packages/features/routing-forms/lib/findTeamMembersByAttributeValue.test.ts
   ```
   All 12 tests should pass.

2. Run the existing attribute logic tests (verifies fallback path still works):
   ```bash
   TZ=UTC yarn test packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.test.ts
   ```
   All 21 tests should pass.

3. For integration testing with real routing forms:
   - Test with routing forms that use attribute-based routing
   - Verify the optimized path is used for simple queries (single-level rules)
   - Verify fallback to JSON logic for complex queries (nested groups)

## Human Review Checklist

- [ ] Verify the Prisma query logic correctly filters by team membership AND org membership
- [ ] Confirm the AND conjunction logic (`ruleResults.every((result) => result.includes(userId))`) is acceptable for expected result set sizes
- [ ] Review operator mapping in `getOperatorMatchType` - are there other operators that should be supported?
- [ ] Nested groups are explicitly not supported (falls back to original approach) - is this acceptable?
- [ ] Verify `troubleshooter: undefined` in optimized path doesn't break callers (optimized path is only used when troubleshooter is disabled)
- [ ] Review the type casting `as Record<string, number | null>` for timeTaken field

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized (~900 lines including tests)

---

**Link to Devin run:** https://app.devin.ai/sessions/77d76d3dd41b4ad4b2323dce8fa15344
**Requested by:** @joeauyeung