### PR TITLE
feat: enable username editing during personal onboarding for social sign-in users

### DIFF
--- a/apps/web/modules/onboarding/personal/settings/personal-settings-view.tsx
+++ b/apps/web/modules/onboarding/personal/settings/personal-settings-view.tsx
@@ -1,11 +1,5 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
-import { FormProvider, useForm } from "react-hook-form";
-import { z } from "zod";
-
 import { FULL_NAME_LENGTH_MAX_LIMIT } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
@@ -14,9 +8,12 @@ import { Button } from "@calcom/ui/components/button";
 import { Label, TextArea, TextField } from "@calcom/ui/components/form";
 import { ImageUploader } from "@calcom/ui/components/image-uploader";
 import { showToast } from "@calcom/ui/components/toast";
-
 import { UsernameAvailabilityField } from "@components/ui/UsernameAvailability";
-
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { z } from "zod";
 import { OnboardingCard } from "../../components/OnboardingCard";
 import { OnboardingLayout } from "../../components/OnboardingLayout";
 import { OnboardingBrowserView } from "../../components/onboarding-browser-view";
@@ -190,7 +187,6 @@ export const PersonalSettingsView = ({
               {/* Username */}
               <div className="flex w-full flex-col gap-1.5">
                 <UsernameAvailabilityField
-                  disabled
                   onSuccessMutation={async () => {
                     // Refetch user to get updated username and save to store
                     const updatedUser = await utils.viewer.me.get.fetch();


### PR DESCRIPTION
## What does this PR do?

Enables users who sign up with Google or other social providers to edit their username during the personal onboarding flow. Previously, the username field was disabled during onboarding, forcing users to accept the auto-generated username.

- Fixes #27448

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Sign up with Google (or another social provider)
2. Proceed to the personal onboarding flow (`/onboarding/personal/profile`)
3. Verify the username field is now editable
4. Change the username and verify it saves correctly
5. Verify organization users still have the field disabled (this is expected behavior per the component logic)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small and focused

---

### Link to Devin run
https://app.devin.ai/sessions/699cfec2229c4fc88efb7e3b75ba6e91

### Requested by
@sean-brydon