### PR TITLE
fix: icon on button

### DIFF
--- a/packages/ui/components/button/Button.tsx
+++ b/packages/ui/components/button/Button.tsx
@@ -306,7 +306,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
         <>
           {variant === "fab" ? (
             <>
-              <Icon name={EndIcon} className="-mr-1 me-2 ms-2 hidden h-5 w-5 shrink-0 md:inline" />
+              <Icon name={EndIcon} className="hidden h-4 w-4 shrink-0 stroke-[1.5px] md:inline-flex" />
               <Icon name="plus" data-testid="plus" className="inline h-6 w-6 shrink-0 md:hidden" />
             </>
           ) : (


### PR DESCRIPTION
## What does this PR do?
Before (/event-types): 
<img width="113" height="64" alt="Screenshot 2026-02-02 at 11 11 30 AM" src="https://github.com/user-attachments/assets/21d62ddc-6e0e-4688-a9da-c911635bb421" />

After: 
<img width="107" height="58" alt="Screenshot 2026-02-02 at 11 12 06 AM" src="https://github.com/user-attachments/assets/8c51f6a4-6573-40af-957a-9659655d2fb4" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the end icon in fab buttons to match design and align correctly with the label. The icon is now 16px with a 1.5px stroke, shown only on md+ with inline-flex, no extra margins; the plus icon remains on small screens.

<sup>Written for commit f1886e216bb083089de6acd9d956c4673ff80892. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

