### PR TITLE
feat: add devin-finish-pr label as trigger for PR completion workflow

### DIFF
--- a/.github/workflows/stale-pr-devin-completion.yml
+++ b/.github/workflows/stale-pr-devin-completion.yml
@@ -17,11 +17,12 @@ permissions:
 jobs:
   complete-stale-pr:
     name: Trigger Devin to Complete Stale Community PR
-    # For labeled events: only run if 'Stale' label was added
+    # For labeled events: only run if 'Stale' or 'devin-finish-pr' label was added
     # For workflow_dispatch: always run (we'll validate the PR in the steps)
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.label.name == 'Stale'
+      github.event.label.name == 'Stale' ||
+      github.event.label.name == 'devin-finish-pr'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Get PR details
@@ -201,7 +202,7 @@ jobs:
           6. Run the appropriate checks (lint, type-check, tests) to ensure the PR is ready for review.
           7. Commit your changes with clear commit messages.
           8. Push your changes to the PR branch.
-          9. After successfully pushing, remove the 'Stale' label from the PR.
+          9. After successfully pushing, remove the 'Stale' or 'devin-finish-pr' label from the PR (whichever was used to trigger this workflow).
           10. Post a summary comment on the PR explaining what you completed.
           11. Mark the PR as ready for review if applicable.
 


### PR DESCRIPTION
## What does this PR do?

Adds `devin-finish-pr` as an additional label trigger for the Devin PR completion workflow, alongside the existing `Stale` label trigger.

This allows maintainers to trigger Devin to finish PRs using a dedicated label rather than repurposing the `Stale` label, which has a different semantic meaning.

## Changes

- Added `devin-finish-pr` label to the workflow trigger condition
- Updated the Devin prompt to instruct removal of whichever label was used to trigger the workflow

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub workflow configuration change.

## How should this be tested?

1. Add the `devin-finish-pr` label to a PR
2. Verify the workflow triggers and creates/messages a Devin session
3. Verify the `Stale` label still works as before

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> **Devin Session**: https://app.devin.ai/sessions/e0382bfd89a94ffe852a78fdc4229984
> **Requested by**: @keithwillcode