### PR TITLE
feat: add parent-level visibility toggle for managed events

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -96,11 +96,11 @@ interface InfiniteEventTypeListProps {
   readOnly: boolean;
   bookerUrl: string | null;
   pages:
-    | {
-        nextCursor: number | null | undefined;
-        eventTypes: InfiniteEventType[];
-      }[]
-    | undefined;
+  | {
+    nextCursor: number | null | undefined;
+    eventTypes: InfiniteEventType[];
+  }[]
+  | undefined;
   lockedByOrg?: boolean;
   isPending?: boolean;
   debouncedSearchTerm?: string;
@@ -339,9 +339,19 @@ export const InfiniteEventTypeList = ({
               ...oldData,
               pages: oldData.pages.map((page) => ({
                 ...page,
-                eventTypes: page.eventTypes.map((eventType) =>
-                  eventType.id === data.id ? { ...eventType, hidden: !eventType.hidden } : eventType
-                ),
+                eventTypes: page.eventTypes.map((eventType) => {
+                  if (eventType.id === data.id) {
+                    const hidden = !eventType.hidden;
+                    // Parent-level visibility toggle - when toggling a parent event type,
+                    // also toggle all its children (managed event types) to maintain consistency
+                    return {
+                      ...eventType,
+                      hidden,
+                      children: eventType.children?.map((child) => ({ ...child, hidden })),
+                    };
+                  }
+                  return eventType;
+                }),
               })),
             };
           }
@@ -537,8 +547,42 @@ export const InfiniteEventTypeList = ({
     team: firstItem?.team,
   });
 
+  // Aggregate all event types across pages to determine collective visibility state
+  const allEventTypes = pages.flatMap((page) => page.eventTypes);
+  const allHidden = allEventTypes.every((type) => type.hidden);
+
+  // Parent-level toggle function - shows/hides all event types at once
+  const toggleAll = () => {
+    const newHiddenState = !allHidden;
+    allEventTypes.forEach((type) => {
+      // Only mutate if the state is different to avoid unnecessary calls
+      if (type.hidden !== newHiddenState) {
+        setHiddenMutation.mutate({
+          id: type.id,
+          hidden: newHiddenState,
+        });
+      }
+    });
+    // Show toast notification after all mutations are done
+    showToast(
+      newHiddenState ? t("All event types are hidden") : t("All event types are visible"),
+      "success",
+      5000 // 5 seconds timeout
+    );
+  };
+
   return (
     <div className="bg-default border-subtle flex flex-col overflow-hidden rounded-md border">
+      {/* Parent-level visibility control header */}
+      <div className="flex items-center justify-between border-b border-subtle p-4">
+        <span className="text-sm font-semibold leading-none">{t("events")}</span>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-normal text-default flex items-center">
+            {allHidden ? t("Show All") : t("Hide All")}
+          </span>
+          <Switch checked={!allHidden} onCheckedChange={toggleAll} />
+        </div>
+      </div>
       <ul ref={parent} className="divide-subtle static! w-full divide-y" data-testid="event-types">
         {pages.map((page, pageIdx) => {
           return page?.eventTypes?.map((type, index) => {
@@ -598,29 +642,26 @@ export const InfiniteEventTypeList = ({
                           />
                         )}
                         <div className="flex items-center justify-between space-x-2 rtl:space-x-reverse">
-                          {!isManagedEventType && (
-                            <>
-                              {type.hidden && <span className="text-sm text-gray-400">{t("hidden")}</span>}
-                              <Tooltip
-                                content={
-                                  type.hidden ? t("show_eventtype_on_profile") : t("hide_from_profile")
-                                }>
-                                <div className="self-center rounded-md p-2">
-                                  <Switch
-                                    name="Hidden"
-                                    disabled={lockedByOrg}
-                                    checked={!type.hidden}
-                                    onCheckedChange={() => {
-                                      setHiddenMutation.mutate({
-                                        id: type.id,
-                                        hidden: !type.hidden,
-                                      });
-                                    }}
-                                  />
-                                </div>
-                              </Tooltip>
-                            </>
-                          )}
+                          {/*Removed !isManagedEventType check to allow parent-level visibility toggle on all event types */}
+                          <>
+                            {type.hidden && <span className="text-sm text-gray-400">{t("hidden")}</span>}
+                            <Tooltip
+                              content={type.hidden ? t("show_eventtype_on_profile") : t("hide_from_profile")}>
+                              <div className="self-center rounded-md p-2">
+                                <Switch
+                                  name="Hidden"
+                                  disabled={lockedByOrg}
+                                  checked={!type.hidden}
+                                  onCheckedChange={() => {
+                                    setHiddenMutation.mutate({
+                                      id: type.id,
+                                      hidden: !type.hidden,
+                                    });
+                                  }}
+                                />
+                              </div>
+                            </Tooltip>
+                          </>
 
                           <ButtonGroup combined>
                             {!isManagedEventType && (
@@ -1055,9 +1096,9 @@ export const EventTypesCTA = ({ userEventGroupsData }: Omit<Props, "user">) => {
         const permissions = profile.teamId
           ? userEventGroupsData.teamPermissions[profile.teamId]
           : {
-              // always can create eventType on personal level
-              canCreateEventType: true,
-            };
+            // always can create eventType on personal level
+            canCreateEventType: true,
+          };
 
         return {
           teamId: profile.teamId,


### PR DESCRIPTION
## What does this PR do?

This PR adds a parent-level visibility toggle for managed events, allowing visibility to be controlled centrally instead of toggling each child event individually.

Previously, managed events only supported visibility control at the child level, which made it tedious to manage multiple related events. This change introduces a single toggle at the parent level that propagates visibility changes to all child events while preserving existing child-level behavior.

-  Fixes #27438 

## Visual Demo

### Previous behavior

Managed events did not support a visibility (hidden) toggle at the parent event level.
Visibility could only be controlled for individual child events, which made it difficult and time-consuming to manage visibility across multiple related events.

<img width="1585" height="749" alt="Screenshot 2026-02-02 174919" src="https://github.com/user-attachments/assets/455a99b8-7abb-4a67-8dcc-4057f25f5ae1" />

### New behavior

Managed events now include a parent-level visibility toggle that propagates visibility changes to all child events, enabling centralized control while retaining individual child-level overrides.

https://github.com/user-attachments/assets/1297d916-4c19-4379-958e-3fc4d03ff85f

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change (N/A).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to the managed events page.
2. Identify a parent event with multiple child events.
3. Toggle the parent-level visibility control.
4. Verify that all child events update their visibility accordingly.
5. Toggle individual child events to ensure existing behavior still works as expected.

No additional environment variables are required.