### PR TITLE
feat: add multi-tenant database routing with per-host database selection

### DIFF
--- a/apps/api/v2/src/app.module.ts
+++ b/apps/api/v2/src/app.module.ts
@@ -19,6 +19,7 @@ import { AuthModule } from "@/modules/auth/auth.module";
 import { EndpointsModule } from "@/modules/endpoints.module";
 import { JwtModule } from "@/modules/jwt/jwt.module";
 import { PrismaModule } from "@/modules/prisma/prisma.module";
+import { TenantMiddleware } from "@/modules/prisma/tenant.middleware";
 import { RedisModule } from "@/modules/redis/redis.module";
 import { RedisService } from "@/modules/redis/redis.service";
 import { VercelWebhookController } from "@/vercel-webhook.controller";
@@ -105,6 +106,8 @@ export class AppModule implements NestModule {
       .apply(RequestIdMiddleware)
       .forRoutes("*")
       .apply(AppLoggerMiddleware)
+      .forRoutes("*")
+      .apply(TenantMiddleware)
       .forRoutes("*")
       .apply(RedirectsMiddleware)
       .forRoutes("/")

--- a/apps/api/v2/src/modules/prisma/prisma-read.service.ts
+++ b/apps/api/v2/src/modules/prisma/prisma-read.service.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@calcom/prisma/client";
+import { getCurrentTenant } from "@calcom/prisma/tenant-context";
 import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { PrismaPg } from "@prisma/adapter-pg";
@@ -10,8 +11,27 @@ const DB_MAX_POOL_CONNECTION = 10;
 export class PrismaReadService implements OnModuleInit, OnModuleDestroy {
   private logger = new Logger("PrismaReadService");
 
-  public prisma!: PrismaClient;
+  private _defaultPrisma!: PrismaClient;
+  private _tenantClients = new Map<string, PrismaClient>();
   private pool!: Pool;
+
+  get prisma(): PrismaClient {
+    const tenant = getCurrentTenant();
+    if (!tenant) return this._defaultPrisma;
+
+    const existing = this._tenantClients.get(tenant.tenantId);
+    if (existing) return existing;
+
+    const tenantPool = new Pool({
+      connectionString: tenant.databaseUrl,
+      max: 5,
+      idleTimeoutMillis: 300000,
+    });
+    const adapter = new PrismaPg(tenantPool);
+    const client = new PrismaClient({ adapter });
+    this._tenantClients.set(tenant.tenantId, client);
+    return client;
+  }
 
   constructor(configService?: ConfigService) {
     if (configService) {
@@ -52,20 +72,20 @@ export class PrismaReadService implements OnModuleInit, OnModuleDestroy {
       });
 
       const adapter = new PrismaPg(this.pool);
-      this.prisma = new PrismaClient({ adapter });
+      this._defaultPrisma = new PrismaClient({ adapter });
     } else {
       const adapter = new PrismaPg({ connectionString: dbUrl });
-      this.prisma = new PrismaClient({
+      this._defaultPrisma = new PrismaClient({
         adapter,
       });
     }
   }
 
   async onModuleInit(): Promise<void> {
-    if (!this.prisma) return;
+    if (!this._defaultPrisma) return;
 
     try {
-      await this.prisma.$connect();
+      await this._defaultPrisma.$connect();
       this.logger.log("Connected to read database");
     } catch (error) {
       this.logger.error("Database connection failed", error);
@@ -74,7 +94,7 @@ export class PrismaReadService implements OnModuleInit, OnModuleDestroy {
 
   async onModuleDestroy(): Promise<void> {
     try {
-      if (this.prisma) await this.prisma.$disconnect();
+      if (this._defaultPrisma) await this._defaultPrisma.$disconnect();
       if (this.pool) await this.pool.end();
     } catch (error) {
       this.logger.error("Error disconnecting from read database", error);

--- a/apps/api/v2/src/modules/prisma/tenant.middleware.ts
+++ b/apps/api/v2/src/modules/prisma/tenant.middleware.ts
@@ -1,0 +1,22 @@
+import { isTenantModeEnabled, resolveTenantFromHostname } from "@calcom/platform-libraries";
+import { runWithTenant } from "@calcom/prisma/tenant-context";
+import { Injectable, type NestMiddleware } from "@nestjs/common";
+import type { NextFunction, Request, Response } from "express";
+
+@Injectable()
+export class TenantMiddleware implements NestMiddleware {
+  use(req: Request, _res: Response, next: NextFunction): void {
+    if (!isTenantModeEnabled()) {
+      next();
+      return;
+    }
+
+    const tenantInfo = resolveTenantFromHostname(req.hostname);
+    if (!tenantInfo) {
+      next();
+      return;
+    }
+
+    runWithTenant(tenantInfo, () => next());
+  }
+}

--- a/packages/features/bookings/lib/tasker/BookingEmailAndSmsTriggerTasker.ts
+++ b/packages/features/bookings/lib/tasker/BookingEmailAndSmsTriggerTasker.ts
@@ -1,31 +1,31 @@
+import { tenantTriggerOptions } from "@calcom/lib/server/triggerTenantUtils";
 import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
-
-import { IBookingEmailAndSmsTasker } from "./types";
+import type { IBookingEmailAndSmsTasker } from "./types";
 
 export class BookingEmailAndSmsTriggerDevTasker implements IBookingEmailAndSmsTasker {
   constructor(public readonly dependencies: ITaskerDependencies) {}
 
   async request(payload: Parameters<IBookingEmailAndSmsTasker["request"]>[0]) {
     const { request } = await import("./trigger/notifications/request");
-    const handle = await request.trigger(payload);
+    const handle = await request.trigger(payload, tenantTriggerOptions());
     return { runId: handle.id };
   }
 
   async confirm(payload: Parameters<IBookingEmailAndSmsTasker["confirm"]>[0]) {
     const { confirm } = await import("./trigger/notifications/confirm");
-    const handle = await confirm.trigger(payload);
+    const handle = await confirm.trigger(payload, tenantTriggerOptions());
     return { runId: handle.id };
   }
 
   async reschedule(payload: Parameters<IBookingEmailAndSmsTasker["reschedule"]>[0]) {
     const { reschedule } = await import("./trigger/notifications/reschedule");
-    const handle = await reschedule.trigger(payload);
+    const handle = await reschedule.trigger(payload, tenantTriggerOptions());
     return { runId: handle.id };
   }
 
   async rrReschedule(payload: Parameters<IBookingEmailAndSmsTasker["rrReschedule"]>[0]) {
     const { rrReschedule } = await import("./trigger/notifications/rr-reschedule");
-    const handle = await rrReschedule.trigger(payload);
+    const handle = await rrReschedule.trigger(payload, tenantTriggerOptions());
     return { runId: handle.id };
   }
 }

--- a/packages/features/bookings/lib/tasker/trigger/notifications/confirm.ts
+++ b/packages/features/bookings/lib/tasker/trigger/notifications/confirm.ts
@@ -1,5 +1,5 @@
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { schemaTask } from "@trigger.dev/sdk";
-
 import { bookingNotificationsTaskConfig } from "./config";
 import { bookingNotificationTaskSchema } from "./schema";
 
@@ -7,7 +7,7 @@ export const confirm = schemaTask({
   id: "booking.send.confirm.notifications",
   ...bookingNotificationsTaskConfig,
   schema: bookingNotificationTaskSchema,
-  run: async (payload) => {
+  run: withTenantRun(async (payload) => {
     const { TriggerDevLogger } = await import("@calcom/lib/triggerDevLogger");
     const { BookingEmailSmsHandler } = await import("@calcom/features/bookings/lib/BookingEmailSmsHandler");
     const { BookingRepository } = await import("@calcom/features/bookings/repositories/BookingRepository");
@@ -23,5 +23,5 @@ export const confirm = schemaTask({
       emailsAndSmsHandler: emailsAndSmsHandler,
     });
     await bookingTaskService.confirm(payload);
-  },
+  }),
 });

--- a/packages/features/bookings/lib/tasker/trigger/notifications/request.ts
+++ b/packages/features/bookings/lib/tasker/trigger/notifications/request.ts
@@ -1,5 +1,5 @@
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { schemaTask } from "@trigger.dev/sdk";
-
 import { bookingNotificationsTaskConfig } from "./config";
 import { bookingNotificationTaskSchema } from "./schema";
 
@@ -7,7 +7,7 @@ export const request = schemaTask({
   id: "booking.send.request.notifications",
   schema: bookingNotificationTaskSchema,
   ...bookingNotificationsTaskConfig,
-  run: async (payload) => {
+  run: withTenantRun(async (payload) => {
     const { TriggerDevLogger } = await import("@calcom/lib/triggerDevLogger");
     const { BookingEmailSmsHandler } = await import("@calcom/features/bookings/lib/BookingEmailSmsHandler");
     const { BookingRepository } = await import("@calcom/features/bookings/repositories/BookingRepository");
@@ -23,5 +23,5 @@ export const request = schemaTask({
       emailsAndSmsHandler: emailsAndSmsHandler,
     });
     await bookingTaskService.request(payload);
-  },
+  }),
 });

--- a/packages/features/bookings/lib/tasker/trigger/notifications/reschedule.ts
+++ b/packages/features/bookings/lib/tasker/trigger/notifications/reschedule.ts
@@ -1,5 +1,5 @@
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { schemaTask } from "@trigger.dev/sdk";
-
 import { bookingNotificationsTaskConfig } from "./config";
 import { bookingNotificationTaskSchema } from "./schema";
 
@@ -7,7 +7,7 @@ export const reschedule = schemaTask({
   id: "booking.send.reschedule.notifications",
   ...bookingNotificationsTaskConfig,
   schema: bookingNotificationTaskSchema,
-  run: async (payload) => {
+  run: withTenantRun(async (payload) => {
     const { TriggerDevLogger } = await import("@calcom/lib/triggerDevLogger");
     const { BookingEmailSmsHandler } = await import("@calcom/features/bookings/lib/BookingEmailSmsHandler");
     const { BookingRepository } = await import("@calcom/features/bookings/repositories/BookingRepository");
@@ -23,5 +23,5 @@ export const reschedule = schemaTask({
       emailsAndSmsHandler: emailsAndSmsHandler,
     });
     await bookingTaskService.reschedule(payload);
-  },
+  }),
 });

--- a/packages/features/bookings/lib/tasker/trigger/notifications/rr-reschedule.ts
+++ b/packages/features/bookings/lib/tasker/trigger/notifications/rr-reschedule.ts
@@ -1,5 +1,5 @@
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { schemaTask } from "@trigger.dev/sdk";
-
 import { bookingNotificationsTaskConfig } from "./config";
 import { bookingNotificationTaskSchema } from "./schema";
 
@@ -7,7 +7,7 @@ export const rrReschedule = schemaTask({
   id: "booking.send.rr.reschedule.notifications",
   ...bookingNotificationsTaskConfig,
   schema: bookingNotificationTaskSchema,
-  run: async (payload) => {
+  run: withTenantRun(async (payload) => {
     const { TriggerDevLogger } = await import("@calcom/lib/triggerDevLogger");
     const { BookingEmailSmsHandler } = await import("@calcom/features/bookings/lib/BookingEmailSmsHandler");
     const { BookingRepository } = await import("@calcom/features/bookings/repositories/BookingRepository");
@@ -23,5 +23,5 @@ export const rrReschedule = schemaTask({
       emailsAndSmsHandler: emailsAndSmsHandler,
     });
     await bookingTaskService.rrReschedule(payload);
-  },
+  }),
 });

--- a/packages/features/calendars/lib/tasker/CalendarsTriggerTasker.ts
+++ b/packages/features/calendars/lib/tasker/CalendarsTriggerTasker.ts
@@ -1,3 +1,4 @@
+import { tenantTriggerOptions } from "@calcom/lib/server/triggerTenantUtils";
 import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
 import type { TriggerOptions } from "@trigger.dev/sdk";
 import type { ICalendarsTasker } from "./types";
@@ -10,7 +11,7 @@ export class CalendarsTriggerTasker implements ICalendarsTasker {
     options?: TriggerOptions
   ): Promise<{ runId: string }> {
     const { ensureDefaultCalendars } = await import("./trigger/ensure-default-calendars");
-    const handle = await ensureDefaultCalendars.trigger(payload, options);
+    const handle = await ensureDefaultCalendars.trigger(payload, { ...options, ...tenantTriggerOptions() });
     return { runId: handle.id };
   }
 }

--- a/packages/features/calendars/lib/tasker/trigger/ensure-default-calendars.ts
+++ b/packages/features/calendars/lib/tasker/trigger/ensure-default-calendars.ts
@@ -1,3 +1,4 @@
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { schemaTask, type TaskWithSchema } from "@trigger.dev/sdk";
 import type { z } from "zod";
 
@@ -13,12 +14,12 @@ export const ensureDefaultCalendars: TaskWithSchema<
   id: ENSURE_DEFAULT_CALENDARS_JOB_ID,
   ...calendarsTaskConfig,
   schema: calendarsTaskSchema,
-  run: async (payload: z.infer<typeof calendarsTaskSchema>) => {
+  run: withTenantRun(async (payload: z.infer<typeof calendarsTaskSchema>) => {
     const { getCalendarsTaskService } = await import(
       "@calcom/features/calendars/di/tasker/CalendarsTaskService.container"
     );
 
     const calendarsTaskService = getCalendarsTaskService();
     await calendarsTaskService.ensureDefaultCalendars(payload);
-  },
+  }),
 });

--- a/packages/features/ee/billing/service/proration/tasker/MonthlyProrationTriggerDevTasker.ts
+++ b/packages/features/ee/billing/service/proration/tasker/MonthlyProrationTriggerDevTasker.ts
@@ -1,3 +1,4 @@
+import { tenantTriggerOptions } from "@calcom/lib/server/triggerTenantUtils";
 import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
 
 import type { IMonthlyProrationTasker } from "./types";
@@ -7,7 +8,7 @@ export class MonthlyProrationTriggerDevTasker implements IMonthlyProrationTasker
 
   async processBatch(payload: Parameters<IMonthlyProrationTasker["processBatch"]>[0]) {
     const { processMonthlyProrationBatch } = await import("./trigger/processMonthlyProrationBatch");
-    const handle = await processMonthlyProrationBatch.trigger(payload);
+    const handle = await processMonthlyProrationBatch.trigger(payload, tenantTriggerOptions());
     return { runId: handle.id };
   }
 }

--- a/packages/features/ee/billing/service/proration/tasker/trigger/processMonthlyProrationBatch.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/processMonthlyProrationBatch.ts
@@ -1,3 +1,4 @@
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { schemaTask } from "@trigger.dev/sdk";
 
 import { monthlyProrationTaskConfig } from "./config";
@@ -7,7 +8,7 @@ export const processMonthlyProrationBatch = schemaTask({
   id: "billing.monthly-proration.batch",
   ...monthlyProrationTaskConfig,
   schema: monthlyProrationBatchSchema,
-  run: async (payload) => {
+  run: withTenantRun(async (payload) => {
     const { getMonthlyProrationService } = await import(
       "@calcom/features/ee/billing/di/containers/MonthlyProrationService"
     );
@@ -18,5 +19,5 @@ export const processMonthlyProrationBatch = schemaTask({
       monthKey: payload.monthKey,
       teamIds: payload.teamIds,
     });
-  },
+  }),
 });

--- a/packages/features/ee/billing/service/proration/tasker/trigger/scheduleMonthlyProration.ts
+++ b/packages/features/ee/billing/service/proration/tasker/trigger/scheduleMonthlyProration.ts
@@ -1,3 +1,4 @@
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { schedules } from "@trigger.dev/sdk";
 
 import { monthlyProrationTaskConfig } from "./config";
@@ -10,7 +11,7 @@ export const scheduleMonthlyProration = schedules.task({
     pattern: "0 0 1 * *",
     timezone: "UTC",
   },
-  run: async (payload) => {
+  run: withTenantRun(async (payload) => {
     const { subMonths } = await import("date-fns");
     const { TriggerDevLogger } = await import("@calcom/lib/triggerDevLogger");
     const { formatMonthKey, isValidMonthKey } = await import(
@@ -102,5 +103,5 @@ export const scheduleMonthlyProration = schedules.task({
       succeeded: succeeded.length,
       failed: failed.length,
     };
-  },
+  }),
 });

--- a/packages/features/ee/organizations/lib/billing/tasker/PlatformOrganizationBillingTriggerTasker.ts
+++ b/packages/features/ee/organizations/lib/billing/tasker/PlatformOrganizationBillingTriggerTasker.ts
@@ -1,3 +1,4 @@
+import { tenantTriggerOptions } from "@calcom/lib/server/triggerTenantUtils";
 import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
 import type { TriggerOptions } from "@trigger.dev/sdk";
 import type { IPlatformOrganizationBillingTasker } from "./types";
@@ -10,7 +11,7 @@ export class PlatformOrganizationBillingTriggerTasker implements IPlatformOrgani
     options?: TriggerOptions
   ): Promise<{ runId: string }> {
     const { incrementUsage } = await import("./trigger/increment-usage");
-    const handle = await incrementUsage.trigger(payload, options);
+    const handle = await incrementUsage.trigger(payload, { ...options, ...tenantTriggerOptions() });
     return { runId: handle.id };
   }
 
@@ -19,7 +20,7 @@ export class PlatformOrganizationBillingTriggerTasker implements IPlatformOrgani
     options?: TriggerOptions
   ): Promise<{ runId: string }> {
     const { cancelUsageIncrement } = await import("./trigger/cancel-usage-increment");
-    const handle = await cancelUsageIncrement.trigger(payload, options);
+    const handle = await cancelUsageIncrement.trigger(payload, { ...options, ...tenantTriggerOptions() });
     return { runId: handle.id };
   }
 
@@ -28,7 +29,7 @@ export class PlatformOrganizationBillingTriggerTasker implements IPlatformOrgani
     options?: TriggerOptions
   ): Promise<{ runId: string }> {
     const { rescheduleUsageIncrement } = await import("./trigger/reschedule-usage-increment");
-    const handle = await rescheduleUsageIncrement.trigger(payload, options);
+    const handle = await rescheduleUsageIncrement.trigger(payload, { ...options, ...tenantTriggerOptions() });
     return { runId: handle.id };
   }
 }

--- a/packages/features/ee/organizations/lib/billing/tasker/trigger/cancel-usage-increment.ts
+++ b/packages/features/ee/organizations/lib/billing/tasker/trigger/cancel-usage-increment.ts
@@ -1,3 +1,4 @@
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { logger, runs, schemaTask, type TaskWithSchema } from "@trigger.dev/sdk";
 import type { z } from "zod";
 import { CANCEL_USAGE_INCREMENT_JOB_ID, getIncrementUsageJobTag } from "../constants";
@@ -11,7 +12,7 @@ export const cancelUsageIncrement: TaskWithSchema<
   id: CANCEL_USAGE_INCREMENT_JOB_ID,
   ...platformBillingTaskConfig,
   schema: platformBillingCancelUsageIncrementTaskSchema,
-  run: async (payload: z.infer<typeof platformBillingCancelUsageIncrementTaskSchema>) => {
+  run: withTenantRun(async (payload: z.infer<typeof platformBillingCancelUsageIncrementTaskSchema>) => {
     const runId: string = (
       await runs.list({
         tag: getIncrementUsageJobTag(payload.bookingUid),
@@ -25,5 +26,5 @@ export const cancelUsageIncrement: TaskWithSchema<
     }
 
     await runs.cancel(runId);
-  },
+  }),
 });

--- a/packages/features/ee/organizations/lib/billing/tasker/trigger/increment-usage.ts
+++ b/packages/features/ee/organizations/lib/billing/tasker/trigger/increment-usage.ts
@@ -1,4 +1,5 @@
 import { ErrorWithCode } from "@calcom/lib/errors";
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { logger, schemaTask, type TaskWithSchema } from "@trigger.dev/sdk";
 import type { z } from "zod";
 import { INCREMENT_USAGE_JOB_ID } from "../constants";
@@ -10,7 +11,7 @@ export const incrementUsage: TaskWithSchema<typeof INCREMENT_USAGE_JOB_ID, typeo
     id: INCREMENT_USAGE_JOB_ID,
     ...platformBillingTaskConfig,
     schema: platformBillingTaskSchema,
-    run: async (payload: z.infer<typeof platformBillingTaskSchema>) => {
+    run: withTenantRun(async (payload: z.infer<typeof platformBillingTaskSchema>) => {
       const { getPlatformOrganizationBillingTaskService } = await import(
         "@calcom/features/ee/organizations/di/tasker/PlatformOrganizationBillingTaskService.container"
       );
@@ -23,5 +24,5 @@ export const incrementUsage: TaskWithSchema<typeof INCREMENT_USAGE_JOB_ID, typeo
         else logger.error("Unknown error in incrementUsage", { error });
         throw error;
       }
-    },
+    }),
   });

--- a/packages/features/ee/organizations/lib/billing/tasker/trigger/reschedule-usage-increment.ts
+++ b/packages/features/ee/organizations/lib/billing/tasker/trigger/reschedule-usage-increment.ts
@@ -1,3 +1,4 @@
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { logger, runs, schemaTask, type TaskWithSchema } from "@trigger.dev/sdk";
 import type z from "zod";
 import { getIncrementUsageJobTag, RESCHEDULE_USAGE_INCREMENT_JOB_ID } from "../constants";
@@ -11,7 +12,7 @@ export const rescheduleUsageIncrement: TaskWithSchema<
   id: RESCHEDULE_USAGE_INCREMENT_JOB_ID,
   ...platformBillingTaskConfig,
   schema: platformBillingRescheduleUsageIncrementTaskSchema,
-  run: async (payload: z.infer<typeof platformBillingRescheduleUsageIncrementTaskSchema>) => {
+  run: withTenantRun(async (payload: z.infer<typeof platformBillingRescheduleUsageIncrementTaskSchema>) => {
     const runId: string = (
       await runs.list({
         tag: getIncrementUsageJobTag(payload.bookingUid),
@@ -25,5 +26,5 @@ export const rescheduleUsageIncrement: TaskWithSchema<
     }
 
     await runs.cancel(runId);
-  },
+  }),
 });

--- a/packages/features/webhooks/lib/tasker/WebhookTriggerTasker.ts
+++ b/packages/features/webhooks/lib/tasker/WebhookTriggerTasker.ts
@@ -1,3 +1,4 @@
+import { tenantTriggerOptions } from "@calcom/lib/server/triggerTenantUtils";
 import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
 
 import type { WebhookTaskPayload } from "../types/webhookTask";
@@ -18,7 +19,7 @@ export class WebhookTriggerTasker implements IWebhookTasker {
 
   async deliverWebhook(payload: WebhookTaskPayload): Promise<WebhookDeliveryResult> {
     const { deliverWebhook } = await import("./trigger/deliver-webhook");
-    const handle = await deliverWebhook.trigger(payload);
+    const handle = await deliverWebhook.trigger(payload, tenantTriggerOptions());
     return { taskId: handle.id };
   }
 }

--- a/packages/features/webhooks/lib/tasker/trigger/deliver-webhook.ts
+++ b/packages/features/webhooks/lib/tasker/trigger/deliver-webhook.ts
@@ -1,4 +1,5 @@
 import { ErrorWithCode } from "@calcom/lib/errors";
+import { withTenantRun } from "@calcom/lib/server/triggerTenantUtils";
 import { logger, schemaTask, type TaskWithSchema } from "@trigger.dev/sdk";
 
 import type { WebhookTaskPayload } from "../../types/webhookTask";
@@ -25,7 +26,7 @@ export const deliverWebhook: TaskWithSchema<typeof WEBHOOK_DELIVERY_JOB_ID, type
     id: WEBHOOK_DELIVERY_JOB_ID,
     ...webhookDeliveryTaskConfig,
     schema: webhookDeliveryTaskSchema,
-    run: async (payload: WebhookTaskPayload, { ctx }) => {
+    run: withTenantRun(async (payload: WebhookTaskPayload, { ctx }) => {
       const { getWebhookTaskConsumer } = await import(
         "@calcom/features/di/webhooks/containers/webhook"
       );
@@ -44,5 +45,5 @@ export const deliverWebhook: TaskWithSchema<typeof WEBHOOK_DELIVERY_JOB_ID, type
         }
         throw error;
       }
-    },
+    }),
   });

--- a/packages/lib/server/tenant.test.ts
+++ b/packages/lib/server/tenant.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import {
+  isTenantModeEnabled,
+  resolveTenantById,
+  resolveTenantFromHostname,
+  resolveFromRequest,
+  setDatabaseRouter,
+  createHostnameRouter,
+} from "./tenant";
+
+// tenant.ts calls autoRegisterFromEnv() at import time, which reads process.env.TENANT_DOMAINS.
+// We need to reset the module state between tests by re-importing after env changes.
+// For tests that don't need re-import, we use setDatabaseRouter(null as any) to clear state.
+
+describe("tenant resolver", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    // Clear any previously registered router
+    setDatabaseRouter(null as unknown as Parameters<typeof setDatabaseRouter>[0]);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("isTenantModeEnabled", () => {
+    it("returns false when no router is registered", () => {
+      expect(isTenantModeEnabled()).toBe(false);
+    });
+
+    it("returns true when a router is registered", () => {
+      setDatabaseRouter({
+        resolveFromRequest: () => null,
+        resolveById: () => null,
+      });
+      expect(isTenantModeEnabled()).toBe(true);
+    });
+  });
+
+  describe("setDatabaseRouter + resolveFromRequest", () => {
+    it("uses the custom router for request resolution", () => {
+      setDatabaseRouter({
+        resolveFromRequest({ headers }) {
+          const region = headers?.["x-region"] as string | undefined;
+          if (region === "us") return { tenantId: "us", databaseUrl: "postgresql://us-db" };
+          return null;
+        },
+        resolveById(id) {
+          if (id === "us") return { tenantId: "us", databaseUrl: "postgresql://us-db" };
+          return null;
+        },
+      });
+
+      const result = resolveFromRequest({ headers: { "x-region": "us" } });
+      expect(result).toEqual({ tenantId: "us", databaseUrl: "postgresql://us-db" });
+    });
+
+    it("returns null when custom router does not match", () => {
+      setDatabaseRouter({
+        resolveFromRequest: () => null,
+        resolveById: () => null,
+      });
+
+      expect(resolveFromRequest({ hostname: "unknown.com" })).toBeNull();
+    });
+
+    it("returns null when no router is registered", () => {
+      expect(resolveFromRequest({ hostname: "anything.com" })).toBeNull();
+    });
+  });
+
+  describe("createHostnameRouter", () => {
+    it("resolves tenant from matching hostname", () => {
+      const router = createHostnameRouter({ "app.acme.com": "acme" });
+      process.env.TENANT_ACME_DATABASE_URL = "postgresql://acme-db";
+
+      const result = router.resolveFromRequest({ hostname: "app.acme.com" });
+      expect(result).toEqual({ tenantId: "acme", databaseUrl: "postgresql://acme-db" });
+    });
+
+    it("strips port from hostname", () => {
+      const router = createHostnameRouter({ "app.acme.com": "acme" });
+      process.env.TENANT_ACME_DATABASE_URL = "postgresql://acme-db";
+
+      const result = router.resolveFromRequest({ hostname: "app.acme.com:3000" });
+      expect(result).toEqual({ tenantId: "acme", databaseUrl: "postgresql://acme-db" });
+    });
+
+    it("returns null for unknown hostname", () => {
+      const router = createHostnameRouter({ "app.acme.com": "acme" });
+
+      expect(router.resolveFromRequest({ hostname: "other.com" })).toBeNull();
+    });
+
+    it("returns null when hostname is undefined", () => {
+      const router = createHostnameRouter({ "app.acme.com": "acme" });
+
+      expect(router.resolveFromRequest({})).toBeNull();
+    });
+
+    it("returns null when database URL env var is missing", () => {
+      const router = createHostnameRouter({ "app.acme.com": "acme" });
+      // TENANT_ACME_DATABASE_URL not set
+
+      expect(router.resolveFromRequest({ hostname: "app.acme.com" })).toBeNull();
+    });
+
+    it("resolves by ID", () => {
+      const router = createHostnameRouter({ "app.acme.com": "acme" });
+      process.env.TENANT_ACME_DATABASE_URL = "postgresql://acme-db";
+
+      expect(router.resolveById("acme")).toEqual({
+        tenantId: "acme",
+        databaseUrl: "postgresql://acme-db",
+      });
+    });
+
+    it("resolveById returns null when env var missing", () => {
+      const router = createHostnameRouter({ "app.acme.com": "acme" });
+
+      expect(router.resolveById("acme")).toBeNull();
+    });
+
+    it("converts tenant ID to uppercase for env var lookup", () => {
+      const router = createHostnameRouter({ "app.test.com": "acme" });
+      process.env.TENANT_ACME_DATABASE_URL = "postgresql://acme-db";
+
+      expect(router.resolveById("acme")).toEqual({
+        tenantId: "acme",
+        databaseUrl: "postgresql://acme-db",
+      });
+
+      // Hyphens are preserved: "my-tenant" → TENANT_MY-TENANT_DATABASE_URL
+      const router2 = createHostnameRouter({ "app.test.com": "my-tenant" });
+      process.env["TENANT_MY-TENANT_DATABASE_URL"] = "postgresql://my-tenant-db";
+
+      expect(router2.resolveById("my-tenant")).toEqual({
+        tenantId: "my-tenant",
+        databaseUrl: "postgresql://my-tenant-db",
+      });
+    });
+  });
+
+  describe("resolveTenantFromHostname (convenience wrapper)", () => {
+    it("returns null when no router is registered", () => {
+      expect(resolveTenantFromHostname("app.acme.com")).toBeNull();
+    });
+
+    it("returns null for null/undefined hostname", () => {
+      setDatabaseRouter({
+        resolveFromRequest: () => ({ tenantId: "x", databaseUrl: "postgresql://x" }),
+        resolveById: () => null,
+      });
+
+      expect(resolveTenantFromHostname(null)).toBeNull();
+      expect(resolveTenantFromHostname(undefined)).toBeNull();
+    });
+
+    it("delegates to the registered router", () => {
+      setDatabaseRouter(createHostnameRouter({ "test.com": "test" }));
+      process.env.TENANT_TEST_DATABASE_URL = "postgresql://test-db";
+
+      expect(resolveTenantFromHostname("test.com")).toEqual({
+        tenantId: "test",
+        databaseUrl: "postgresql://test-db",
+      });
+    });
+  });
+
+  describe("resolveTenantById (convenience wrapper)", () => {
+    it("returns null when no router is registered", () => {
+      expect(resolveTenantById("acme")).toBeNull();
+    });
+
+    it("delegates to the registered router", () => {
+      setDatabaseRouter(createHostnameRouter({ "app.acme.com": "acme" }));
+      process.env.TENANT_ACME_DATABASE_URL = "postgresql://acme-db";
+
+      expect(resolveTenantById("acme")).toEqual({
+        tenantId: "acme",
+        databaseUrl: "postgresql://acme-db",
+      });
+    });
+  });
+});

--- a/packages/lib/server/tenant.ts
+++ b/packages/lib/server/tenant.ts
@@ -1,0 +1,121 @@
+/**
+ * Pluggable database routing.
+ *
+ * By default, when `TENANT_DOMAINS` env var is set, the built-in hostname
+ * resolver is auto-registered.  For custom routing (by region, header, etc.)
+ * call `setDatabaseRouter()` at startup with your own resolver.
+ *
+ * Example – route by Cloudflare region header:
+ *
+ *   setDatabaseRouter({
+ *     resolveFromRequest({ headers }) {
+ *       const region = headers?.["cf-ipcountry"];
+ *       if (region === "BR") return { tenantId: "br", databaseUrl: process.env.DB_BR_URL! };
+ *       if (region === "US") return { tenantId: "us", databaseUrl: process.env.DB_US_URL! };
+ *       return null;
+ *     },
+ *     resolveById(id) {
+ *       const url = process.env[`DB_${id.toUpperCase()}_URL`];
+ *       return url ? { tenantId: id, databaseUrl: url } : null;
+ *     },
+ *   });
+ */
+
+import process from "node:process";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TenantInfo = {
+  tenantId: string;
+  databaseUrl: string;
+};
+
+export type RouteContext = {
+  hostname?: string;
+  headers?: Record<string, string | string[] | undefined>;
+};
+
+export type DatabaseRouter = {
+  /** Resolve from an incoming request. */
+  resolveFromRequest(ctx: RouteContext): TenantInfo | null;
+  /** Resolve by a known route ID (used by Trigger.dev metadata propagation). */
+  resolveById(id: string): TenantInfo | null;
+};
+
+// ---------------------------------------------------------------------------
+// Router state
+// ---------------------------------------------------------------------------
+
+let router: DatabaseRouter | null = null;
+
+/** Register a custom database router. Call this once at startup. */
+export function setDatabaseRouter(r: DatabaseRouter): void {
+  router = r;
+}
+
+// ---------------------------------------------------------------------------
+// Built-in hostname router (auto-registered when TENANT_DOMAINS is set)
+// ---------------------------------------------------------------------------
+
+export function createHostnameRouter(domainMap: Record<string, string>): DatabaseRouter {
+  return {
+    resolveFromRequest(ctx) {
+      if (!ctx.hostname) return null;
+      const host = ctx.hostname.split(":")[0];
+      const tenantId = domainMap[host];
+      if (!tenantId) return null;
+      return this.resolveById(tenantId);
+    },
+    resolveById(id) {
+      const envKey = `TENANT_${id.toUpperCase()}_DATABASE_URL`;
+      const databaseUrl = process.env[envKey];
+      if (!databaseUrl) return null;
+      return { tenantId: id, databaseUrl };
+    },
+  };
+}
+
+function autoRegisterFromEnv(): void {
+  const raw = process.env.TENANT_DOMAINS;
+  if (!raw) return;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error("TENANT_DOMAINS must be a JSON object mapping hostnames to tenant IDs");
+    }
+    if (Object.keys(parsed).length > 0) {
+      router = createHostnameRouter(parsed as Record<string, string>);
+    }
+  } catch (err) {
+    console.error("[database-router] Failed to parse TENANT_DOMAINS:", err);
+  }
+}
+
+autoRegisterFromEnv();
+
+// ---------------------------------------------------------------------------
+// Public API (used by the rest of the codebase)
+// ---------------------------------------------------------------------------
+
+export function isTenantModeEnabled(): boolean {
+  return router !== null;
+}
+
+export function resolveTenantById(tenantId: string): TenantInfo | null {
+  if (!router) return null;
+  return router.resolveById(tenantId);
+}
+
+export function resolveTenantFromHostname(hostname: string | undefined | null): TenantInfo | null {
+  if (!router || !hostname) return null;
+  return router.resolveFromRequest({ hostname });
+}
+
+/** Full resolution with all available request context (hostname + headers). */
+export function resolveFromRequest(ctx: RouteContext): TenantInfo | null {
+  if (!router) return null;
+  return router.resolveFromRequest(ctx);
+}

--- a/packages/lib/server/triggerTenantUtils.test.ts
+++ b/packages/lib/server/triggerTenantUtils.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { getCurrentTenant, runWithTenant } from "@calcom/prisma/tenant-context";
+
+import { tenantTriggerOptions, withTenantRun } from "./triggerTenantUtils";
+import { setDatabaseRouter, createHostnameRouter } from "./tenant";
+
+describe("triggerTenantUtils", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    setDatabaseRouter(null as unknown as Parameters<typeof setDatabaseRouter>[0]);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("tenantTriggerOptions", () => {
+    it("returns undefined when not inside a tenant context", () => {
+      expect(tenantTriggerOptions()).toBeUndefined();
+    });
+
+    it("returns metadata with tenantId when inside a tenant context", () => {
+      const ctx = { tenantId: "acme", databaseUrl: "postgresql://acme-db" };
+
+      runWithTenant(ctx, () => {
+        const options = tenantTriggerOptions();
+        expect(options).toEqual({
+          metadata: { tenantId: "acme" },
+        });
+      });
+    });
+  });
+
+  describe("withTenantRun", () => {
+    it("calls the function directly when tenant mode is disabled", async () => {
+      const fn = vi.fn().mockResolvedValue("result");
+      const wrapped = withTenantRun(fn);
+
+      const result = await wrapped("arg1", "arg2");
+
+      expect(result).toBe("result");
+      expect(fn).toHaveBeenCalledWith("arg1", "arg2");
+    });
+
+    it("calls the function directly when tenant mode is enabled but no metadata", async () => {
+      setDatabaseRouter(createHostnameRouter({ "test.com": "test" }));
+
+      // Mock the metadata import to return no tenantId
+      vi.mock("@trigger.dev/sdk", () => ({
+        metadata: {
+          get: vi.fn().mockReturnValue(undefined),
+        },
+      }));
+
+      const fn = vi.fn().mockResolvedValue("result");
+      const wrapped = withTenantRun(fn);
+
+      const result = await wrapped("payload");
+
+      expect(result).toBe("result");
+      expect(fn).toHaveBeenCalledWith("payload");
+    });
+
+    it("wraps with runWithTenant when tenant mode is enabled and metadata has tenantId", async () => {
+      setDatabaseRouter(createHostnameRouter({ "test.com": "test" }));
+      process.env.TENANT_TEST_DATABASE_URL = "postgresql://test-db";
+
+      vi.mock("@trigger.dev/sdk", () => ({
+        metadata: {
+          get: vi.fn().mockReturnValue("test"),
+        },
+      }));
+
+      let capturedTenant: ReturnType<typeof getCurrentTenant> | undefined;
+      const fn = vi.fn().mockImplementation(async () => {
+        capturedTenant = getCurrentTenant();
+        return "done";
+      });
+
+      const wrapped = withTenantRun(fn);
+      const result = await wrapped("payload");
+
+      expect(result).toBe("done");
+      expect(capturedTenant).toEqual({
+        tenantId: "test",
+        databaseUrl: "postgresql://test-db",
+      });
+    });
+
+    it("passes all arguments through to the wrapped function", async () => {
+      const fn = vi.fn().mockResolvedValue(undefined);
+      const wrapped = withTenantRun(fn);
+
+      await wrapped("arg1", { key: "value" }, 42);
+
+      expect(fn).toHaveBeenCalledWith("arg1", { key: "value" }, 42);
+    });
+  });
+});

--- a/packages/lib/server/triggerTenantUtils.ts
+++ b/packages/lib/server/triggerTenantUtils.ts
@@ -1,0 +1,53 @@
+/**
+ * Propagates multi-tenant context through Trigger.dev tasks
+ * using Trigger.dev's metadata API (not payload injection).
+ *
+ * - **Dispatch side**: `tenantTriggerOptions()` returns trigger options with tenantId in metadata.
+ * - **Task run side**: `withTenantRun()` reads tenantId from metadata and wraps execution
+ *   in `runWithTenant()`.
+ */
+
+import { getCurrentTenant, runWithTenant } from "@calcom/prisma";
+
+import { isTenantModeEnabled, resolveTenantById } from "./tenant";
+
+const TENANT_METADATA_KEY = "tenantId";
+
+/**
+ * Returns Trigger.dev trigger options with the current tenant in metadata.
+ * Merge this into your `.trigger(payload, options)` call.
+ */
+export function tenantTriggerOptions(): { metadata: Record<string, string> } | undefined {
+  const tenant = getCurrentTenant();
+  if (!tenant) return undefined;
+  return { metadata: { [TENANT_METADATA_KEY]: tenant.tenantId } };
+}
+
+/**
+ * Wraps a Trigger.dev task `run` function to establish tenant context
+ * by reading tenantId from Trigger.dev run metadata.
+ * Passes all arguments through (payload, ctx, etc.).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function withTenantRun<TArgs extends any[], TResult>(
+  fn: (...args: TArgs) => Promise<TResult>
+): (...args: TArgs) => Promise<TResult> {
+  return async (...args: TArgs): Promise<TResult> => {
+    if (!isTenantModeEnabled()) return fn(...args);
+
+    const { metadata } = await import("@trigger.dev/sdk");
+    const tenantId = metadata.get(TENANT_METADATA_KEY) as string | undefined;
+
+    if (!tenantId) return fn(...args);
+
+    const tenantInfo = resolveTenantById(tenantId);
+    if (!tenantInfo) {
+      console.error(
+        `[multi-tenant] Trigger.dev task received tenantId="${tenantId}" but TENANT_${tenantId.toUpperCase()}_DATABASE_URL is not set.`
+      );
+      return fn(...args);
+    }
+
+    return runWithTenant(tenantInfo, () => fn(...args));
+  };
+}

--- a/packages/platform/libraries/index.ts
+++ b/packages/platform/libraries/index.ts
@@ -19,6 +19,7 @@ import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/crede
 import { paymentDataSelect } from "@calcom/prisma/selects/payment";
 import { createNewUsersConnectToOrgIfExists } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
 
+export { isTenantModeEnabled, resolveTenantFromHostname } from "@calcom/lib/server/tenant";
 export { slugify } from "@calcom/lib/slugify";
 export { slugifyLenient } from "@calcom/lib/slugify-lenient";
 export { getBookingForReschedule };

--- a/packages/prisma/tenant-client.ts
+++ b/packages/prisma/tenant-client.ts
@@ -1,0 +1,33 @@
+/**
+ * Cache of PrismaClient instances per tenant.
+ *
+ * Each tenant gets its own connection pool and PrismaClient with all
+ * standard extensions applied (via `customPrisma()`).
+ */
+
+import process from "node:process";
+import { Pool } from "pg";
+import type { PrismaClient } from "./generated/prisma/client";
+import { customPrisma } from "./index";
+
+const clientCache = new Map<string, PrismaClient>();
+
+/**
+ * Returns a cached PrismaClient for the given tenant.
+ * Creates one on first access.
+ */
+export function getTenantPrismaClient(tenantId: string, databaseUrl: string): PrismaClient {
+  const existing = clientCache.get(tenantId);
+  if (existing) return existing;
+
+  const poolMax = parseInt(process.env.TENANT_POOL_MAX || "5", 10);
+  const tenantPool = new Pool({
+    connectionString: databaseUrl,
+    max: poolMax,
+    idleTimeoutMillis: 300_000,
+  });
+
+  const client = customPrisma({ datasources: { db: { url: databaseUrl } } }, tenantPool);
+  clientCache.set(tenantId, client);
+  return client;
+}

--- a/packages/prisma/tenant-context.test.ts
+++ b/packages/prisma/tenant-context.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+
+import { getCurrentTenant, runWithTenant } from "./tenant-context";
+
+describe("tenant-context (AsyncLocalStorage)", () => {
+  it("getCurrentTenant returns undefined outside runWithTenant", () => {
+    expect(getCurrentTenant()).toBeUndefined();
+  });
+
+  it("getCurrentTenant returns the context inside runWithTenant", () => {
+    const ctx = { tenantId: "acme", databaseUrl: "postgresql://acme-db" };
+
+    runWithTenant(ctx, () => {
+      expect(getCurrentTenant()).toEqual(ctx);
+    });
+  });
+
+  it("context is cleaned up after runWithTenant completes", () => {
+    const ctx = { tenantId: "acme", databaseUrl: "postgresql://acme-db" };
+
+    runWithTenant(ctx, () => {
+      // inside
+    });
+
+    expect(getCurrentTenant()).toBeUndefined();
+  });
+
+  it("supports nested contexts without leaking", () => {
+    const outer = { tenantId: "outer", databaseUrl: "postgresql://outer-db" };
+    const inner = { tenantId: "inner", databaseUrl: "postgresql://inner-db" };
+
+    runWithTenant(outer, () => {
+      expect(getCurrentTenant()).toEqual(outer);
+
+      runWithTenant(inner, () => {
+        expect(getCurrentTenant()).toEqual(inner);
+      });
+
+      // outer context restored after inner completes
+      expect(getCurrentTenant()).toEqual(outer);
+    });
+
+    expect(getCurrentTenant()).toBeUndefined();
+  });
+
+  it("propagates context through async operations", async () => {
+    const ctx = { tenantId: "async-test", databaseUrl: "postgresql://async-db" };
+
+    await runWithTenant(ctx, async () => {
+      // simulate async work
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(getCurrentTenant()).toEqual(ctx);
+    });
+
+    expect(getCurrentTenant()).toBeUndefined();
+  });
+
+  it("returns the value from the wrapped function", () => {
+    const result = runWithTenant({ tenantId: "t", databaseUrl: "db" }, () => {
+      return 42;
+    });
+
+    expect(result).toBe(42);
+  });
+
+  it("returns a promise from an async wrapped function", async () => {
+    const result = await runWithTenant({ tenantId: "t", databaseUrl: "db" }, async () => {
+      return "hello";
+    });
+
+    expect(result).toBe("hello");
+  });
+});

--- a/packages/prisma/tenant-context.ts
+++ b/packages/prisma/tenant-context.ts
@@ -1,0 +1,31 @@
+/**
+ * Tenant context using AsyncLocalStorage.
+ *
+ * This module provides a way to associate a tenant with the current
+ * async execution context so that the prisma Proxy in index.ts can
+ * transparently route queries to the correct database.
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type TenantContext = {
+  tenantId: string;
+  databaseUrl: string;
+};
+
+export const tenantStorage = new AsyncLocalStorage<TenantContext>();
+
+/**
+ * Runs the provided function within a tenant context.
+ * All `prisma` calls inside `fn` will be routed to the tenant's database.
+ */
+export function runWithTenant<T>(context: TenantContext, fn: () => T): T {
+  return tenantStorage.run(context, fn);
+}
+
+/**
+ * Returns the current tenant context, or `undefined` if not inside
+ * a `runWithTenant()` call.
+ */
+export function getCurrentTenant(): TenantContext | undefined {
+  return tenantStorage.getStore();
+}

--- a/scripts/tenant-migrate.ts
+++ b/scripts/tenant-migrate.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env npx ts-node
+import process from "node:process";
+/**
+ * Multi-tenant migration script.
+ *
+ * Reads TENANT_DOMAINS from environment variables and runs
+ * `prisma migrate deploy` against each tenant's database.
+ *
+ * Usage:
+ *   npx ts-node scripts/tenant-migrate.ts
+ *
+ * Environment:
+ *   TENANT_DOMAINS='{"scheduling.acme.com":"acme","agenda.sales.com":"sales"}'
+ *   TENANT_ACME_DATABASE_URL="postgresql://..."
+ *   TENANT_SALES_DATABASE_URL="postgresql://..."
+ */
+import { execSync } from "child_process";
+import path from "path";
+
+interface MigrationResult {
+  tenantId: string;
+  success: boolean;
+  error?: string;
+}
+
+function main(): void {
+  const raw = process.env.TENANT_DOMAINS;
+  if (!raw) {
+    console.log("[tenant-migrate] TENANT_DOMAINS not set. Nothing to migrate.");
+    process.exit(0);
+  }
+
+  let domainMap: Record<string, string>;
+  try {
+    domainMap = JSON.parse(raw);
+  } catch (err) {
+    console.error("[tenant-migrate] Failed to parse TENANT_DOMAINS:", err);
+    process.exit(1);
+  }
+
+  // Deduplicate tenant IDs (multiple domains can point to the same tenant)
+  const tenantIds = [...new Set(Object.values(domainMap))];
+
+  if (tenantIds.length === 0) {
+    console.log("[tenant-migrate] No tenants configured. Nothing to migrate.");
+    process.exit(0);
+  }
+
+  console.log(`[tenant-migrate] Found ${tenantIds.length} tenant(s): ${tenantIds.join(", ")}`);
+
+  const prismaDir = path.resolve(__dirname, "../packages/prisma");
+  const results: MigrationResult[] = [];
+
+  for (const tenantId of tenantIds) {
+    const envKey = `TENANT_${tenantId.toUpperCase()}_DATABASE_URL`;
+    const databaseUrl = process.env[envKey];
+
+    if (!databaseUrl) {
+      const result: MigrationResult = {
+        tenantId,
+        success: false,
+        error: `Environment variable ${envKey} is not set`,
+      };
+      results.push(result);
+      console.error(`[tenant-migrate] [${tenantId}] SKIPPED: ${result.error}`);
+      continue;
+    }
+
+    console.log(`[tenant-migrate] [${tenantId}] Running prisma migrate deploy...`);
+
+    try {
+      execSync("npx prisma migrate deploy", {
+        cwd: prismaDir,
+        env: {
+          ...process.env,
+          DATABASE_URL: databaseUrl,
+        },
+        stdio: "inherit",
+      });
+      results.push({ tenantId, success: true });
+      console.log(`[tenant-migrate] [${tenantId}] Migration completed successfully.`);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      results.push({ tenantId, success: false, error: errorMessage });
+      console.error(`[tenant-migrate] [${tenantId}] Migration FAILED: ${errorMessage}`);
+    }
+  }
+
+  // Summary
+  console.log("\n[tenant-migrate] === Migration Summary ===");
+  const succeeded = results.filter((r) => r.success);
+  const failed = results.filter((r) => !r.success);
+
+  for (const r of succeeded) {
+    console.log(`  ✓ ${r.tenantId}`);
+  }
+  for (const r of failed) {
+    console.log(`  ✗ ${r.tenantId}: ${r.error}`);
+  }
+
+  console.log(`\n  Total: ${results.length} | Succeeded: ${succeeded.length} | Failed: ${failed.length}`);
+
+  if (failed.length > 0) {
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds support for routing requests to different PostgreSQL databases based on hostname or custom criteria
- Uses `AsyncLocalStorage` + `Proxy` on the prisma export so all existing code works without modification
- Trigger.dev tasks propagate tenant context via metadata API to avoid Zod schema conflicts
- Includes a pluggable `DatabaseRouter` interface for custom routing strategies (by region, header, etc.)
- When `TENANT_DOMAINS` is not set, zero overhead — the system behaves exactly as before

### Configuration

```bash
TENANT_DOMAINS='{"scheduling.acme.com":"acme","agenda.sales.com":"sales"}'
TENANT_ACME_DATABASE_URL="postgresql://user:pass@acme-db:5432/calcom"
TENANT_SALES_DATABASE_URL="postgresql://user:pass@sales-db:5432/calcom"
```

### Coverage

| Entry point | Mechanism |
|---|---|
| tRPC routes | `createContext.ts` reads `x-tenant-id` header |
| App Router API routes (68+) | `defaultResponderForAppDir` wrapper |
| Trigger.dev tasks (11) | metadata propagation + `withTenantRun` |
| API v2 NestJS | `TenantMiddleware` + prisma service getters |
| Cron scheduled tasks | `withTenantRun` |

### Custom routing example

```typescript
import { setDatabaseRouter } from "@calcom/lib/server/tenant";

setDatabaseRouter({
  resolveFromRequest({ headers }) {
    const region = headers?.["cf-ipcountry"];
    if (region === "BR") return { tenantId: "br", databaseUrl: process.env.DB_BR_URL! };
    return null;
  },
  resolveById(id) {
    const url = process.env[`DB_${id.toUpperCase()}_URL`];
    return url ? { tenantId: id, databaseUrl: url } : null;
  },
});
```

## Test plan

- [ ] Set `TENANT_DOMAINS` with two different databases and verify data isolation per hostname
- [ ] Verify that without `TENANT_DOMAINS` the system works identically to before
- [ ] Verify Trigger.dev tasks execute against the correct tenant database
- [ ] Verify API v2 routes resolve the correct database per hostname
- [ ] Run `yarn type-check:ci --force`