### PR TITLE
fix: improve webhook URL display layout for long URLs

### DIFF
--- a/apps/web/modules/webhooks/components/WebhookListItem.tsx
+++ b/apps/web/modules/webhooks/components/WebhookListItem.tsx
@@ -76,63 +76,54 @@ export default function WebhookListItem(props: {
         "flex w-full justify-between p-4",
         props.lastItem ? "" : "border-subtle border-b"
       )}>
-      <div className="w-full truncate">
-        <div className="flex">
-          <Tooltip content={webhook.subscriberUrl}>
-            <p className="text-emphasis max-w-[600px] truncate text-sm font-medium">
-              {webhook.subscriberUrl}
-            </p>
-          </Tooltip>
+      <div className="min-w-0 flex-1">
+        <Tooltip content={webhook.subscriberUrl}>
+          <p className="text-emphasis truncate text-sm font-medium">{webhook.subscriberUrl}</p>
+        </Tooltip>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
           {!props.permissions.canEditWebhook && (
-            <Badge variant="gray" className="ml-2 ">
-              {t("readonly")}
-            </Badge>
+            <Badge variant="gray">{t("readonly")}</Badge>
           )}
           <Tooltip content={t("webhook_version")}>
-            <div className="flex items-center">
-              <Badge variant="blue" className="ml-2">
-                {getWebhookVersionLabel(webhook.version)}
-              </Badge>
+            <div className="flex items-center gap-1">
+              <Badge variant="blue">{getWebhookVersionLabel(webhook.version)}</Badge>
+              <Tooltip
+                content={t("webhook_version_docs", { version: getWebhookVersionLabel(webhook.version) })}>
+                <Link
+                  href={getWebhookVersionDocsUrl(webhook.version)}
+                  target="_blank"
+                  className="text-subtle hover:text-emphasis flex items-center">
+                  <Icon name="external-link" className="h-4 w-4" />
+                </Link>
+              </Tooltip>
             </div>
           </Tooltip>
-          <Tooltip content={t("webhook_version_docs", { version: getWebhookVersionLabel(webhook.version) })}>
-            <Link
-              href={getWebhookVersionDocsUrl(webhook.version)}
-              target="_blank"
-              className="text-subtle hover:text-emphasis ml-1 flex items-center">
-              <Icon name="external-link" className="h-4 w-4" />
-            </Link>
+          <Tooltip content={t("triggers_when")}>
+            <div className="flex flex-wrap gap-2">
+              {webhook.eventTriggers.slice(0, MAX_BADGES_TWO_ROWS).map((trigger) => (
+                <Badge key={trigger} variant="gray" startIcon="zap">
+                  {t(`${trigger.toLowerCase()}`)}
+                </Badge>
+              ))}
+              {webhook.eventTriggers.length > MAX_BADGES_TWO_ROWS && (
+                <Tooltip
+                  content={
+                    <div className="flex flex-col gap-1 p-1">
+                      {webhook.eventTriggers.slice(MAX_BADGES_TWO_ROWS).map((trigger) => (
+                        <span key={trigger} className="text-xs">
+                          {t(`${trigger.toLowerCase()}`)}
+                        </span>
+                      ))}
+                    </div>
+                  }>
+                  <Badge className="cursor-help" variant="gray">
+                    +{webhook.eventTriggers.length - MAX_BADGES_TWO_ROWS} {t("more")}
+                  </Badge>
+                </Tooltip>
+              )}
+            </div>
           </Tooltip>
         </div>
-        <Tooltip content={t("triggers_when")}>
-          <div className="flex w-4/5 flex-wrap">
-            {webhook.eventTriggers.slice(0, MAX_BADGES_TWO_ROWS).map((trigger) => (
-              <Badge
-                key={trigger}
-                className="mt-2.5 basis-1/5 ltr:mr-2 rtl:ml-2"
-                variant="gray"
-                startIcon="zap">
-                {t(`${trigger.toLowerCase()}`)}
-              </Badge>
-            ))}
-            {webhook.eventTriggers.length > MAX_BADGES_TWO_ROWS && (
-              <Tooltip
-                content={
-                  <div className="flex flex-col gap-1 p-1">
-                    {webhook.eventTriggers.slice(MAX_BADGES_TWO_ROWS).map((trigger) => (
-                      <span key={trigger} className="text-xs">
-                        {t(`${trigger.toLowerCase()}`)}
-                      </span>
-                    ))}
-                  </div>
-                }>
-                <Badge className="mt-2.5 cursor-help ltr:mr-2 rtl:ml-2" variant="gray">
-                  +{webhook.eventTriggers.length - MAX_BADGES_TWO_ROWS} {t("more")}
-                </Badge>
-              </Tooltip>
-            )}
-          </div>
-        </Tooltip>
       </div>
       {(props.permissions.canEditWebhook || props.permissions.canDeleteWebhook) && (
         <div className="ml-2 flex items-center space-x-4">


### PR DESCRIPTION
## What does this PR do?

Improves the layout of the webhook list items on `/settings/developer/webhooks` to better handle long URLs. The previous design had the URL constrained to `max-w-[600px]` and crammed together with the version badge on the same line, causing long URLs to be truncated awkwardly.

Changes:
- Removed the `max-w-[600px]` constraint so URLs can use the full available width
- Restructured layout: URL now gets its own dedicated line, with version badge and trigger badges on a second line
- Replaced margin-based spacing (`ml-2`, `mr-2`) with `gap-2` flex layout for cleaner, more consistent spacing
- Grouped the external link icon with the version badge for better visual association

The full URL is still visible on hover via the existing tooltip.

## Visual Demo (For contributors especially)

#### Video Demo:

![Webhook URL layout demo](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2NzZmMmQzNDMyMWE5NmU4OGU1MmM2ZmQiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi81OTRlM2NmYi05ZDNlLTRiMjAtODdmMS02YTc1OTRhZDQxM2UiLCJpYXQiOjE3NzAwNDE4MTUsImV4cCI6MTc3MDY0NjYxNX0.J-ASX3OgxvwmWxKqDQUANJ4g9CysUlsJLb51pOUrKdM)

[View original video (rec-5bdfba7539474998b0b563d5d93140c8-edited.mp4)](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2NzZmMmQzNDMyMWE5NmU4OGU1MmM2ZmQiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi9iNjFkYmQ3Mi00MmVjLTQ2NGItOTVmYi1mZmFhODEyNjJlMWIiLCJpYXQiOjE3NzAwNDE4MTUsImV4cCI6MTc3MDY0NjYxNX0.0KBmt9N5MOzO-v26hEM50UgYEHQFTnAleC_AIOabfwg)

#### Image Demo:

**After (new layout):**
![New webhook layout](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2NzZmMmQzNDMyMWE5NmU4OGU1MmM2ZmQiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi9jN2I4ZDE1MC02Y2U3LTQ5NjItYWQyMS0xODAxMTZkZDZkY2UiLCJpYXQiOjE3NzAwNDE4MTYsImV4cCI6MTc3MDY0NjYxNn0.ZisSaRdVHtG9EaJUJ-iqRNPv31LikKi7RexiuOKhCsw)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - UI-only change.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to `/settings/developer/webhooks`
2. Create or view webhooks with long URLs (e.g., `https://webhook.site/62d903d8-9c2d-41e3-a61e-935b1...`)
3. Verify the URL displays cleanly with truncation only when necessary
4. Verify the version badge and trigger badges appear on a second line
5. Hover over the URL to confirm the tooltip shows the full URL
6. Check the layout on different screen widths

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is not too large

---

> [!NOTE]
> **Reviewer:** Please verify the visual appearance of the webhook list items, particularly with long URLs. Also confirm RTL language support still works correctly (the old code used `ltr:mr-2 rtl:ml-2` which was replaced with `gap-2`).

### Link to Devin run
https://app.devin.ai/sessions/9443487914aa492396abe8a67a7b67bb

### Requested by
@sean-brydon