### PR TITLE
fix: trpc build

### DIFF
--- a/packages/trpc/server/routers/viewer/calendars/connectedCalendars.handler.ts
+++ b/packages/trpc/server/routers/viewer/calendars/connectedCalendars.handler.ts
@@ -1,6 +1,6 @@
 import { getConnectedDestinationCalendarsAndEnsureDefaultsInDb } from "@calcom/features/calendars/lib/getConnectedDestinationCalendars";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
-import type { PrismaClient } from "@prisma/client";
+import type { PrismaClient } from "@calcom/prisma";
 import type { TConnectedCalendarsInputSchema } from "./connectedCalendars.schema";
 
 type ConnectedCalendarsOptions = {


### PR DESCRIPTION
When building trpc package or running api v2 locally we had error:
```
server/routers/viewer/calendars/_router.tsx:11:40 - error TS2322: Type '{ user: { avatar: string; organization: { id: number | null; isOrgAdmin: boolean; metadata: { subscriptionId?: string | null | undefined; billingPeriod?: BillingPeriod | undefined; ... 6 more ...; orgPricePerSeat?: number | ... 1 more ... | undefined; } | null; ... 11 more ...; isPlatform?: boolean | undefined; }; ....' is not assignable to type '{ user: NonNullable<{ avatar: string; organization: { id: number | null; isOrgAdmin: boolean; metadata: { subscriptionId?: string | null | undefined; billingPeriod?: BillingPeriod | undefined; ... 6 more ...; orgPricePerSeat?: number | ... 1 more ... | undefined; } | null; ... 11 more ...; isPlatform?: boolean | und...'.
  Type '{ user: { avatar: string; organization: { id: number | null; isOrgAdmin: boolean; metadata: { subscriptionId?: string | null | undefined; billingPeriod?: BillingPeriod | undefined; ... 6 more ...; orgPricePerSeat?: number | ... 1 more ... | undefined; } | null; ... 11 more ...; isPlatform?: boolean | undefined; }; ....' is not assignable to type '{ user: NonNullable<{ avatar: string; organization: { id: number | null; isOrgAdmin: boolean; metadata: { subscriptionId?: string | null | undefined; billingPeriod?: BillingPeriod | undefined; ... 6 more ...; orgPricePerSeat?: number | ... 1 more ... | undefined; } | null; ... 11 more ...; isPlatform?: boolean | und...'.
    The types of 'prisma.$transaction' are incompatible between these types.
      Type '{ <P extends Prisma.PrismaPromise<any>[]>(arg: [...P], options?: { isolationLevel?: TransactionIsolationLevel | undefined; } | undefined): Promise<UnwrapTuple<P>>; <R>(fn: (prisma: Omit<...>) => Promise<...>, options?: { ...; } | undefined): Promise<...>; }' is not assignable to type '{ <P extends Prisma.PrismaPromise<any>[]>(arg: [...P], options?: { isolationLevel?: "Serializable" | undefined; } | undefined): Promise<UnwrapTuple<P>>; <R>(fn: (prisma: Omit<...>) => Promise<...>, options?: { ...; } | undefined): Promise<...>; }'.
        Types of parameters 'arg' and 'fn' are incompatible.
          Type '(prisma: Omit<PrismaClient<PrismaClientOptions, never, DefaultArgs>, "$extends" | "$transaction" | "$disconnect" | "$connect" | "$on">) => Promise<...>' is not assignable to type 'any[]'.

11     return connectedCalendarsHandler({ ctx, input });
                                          ~~~

  server/routers/viewer/calendars/connectedCalendars.handler.ts:7:3
    7   ctx: {
        ~~~
    The expected type comes from property 'ctx' which is declared here on type 'ConnectedCalendarsOptions'

server/routers/viewer/calendars/connectedCalendars.handler.ts:37:7 - error TS2740: Type 'PrismaClient<PrismaClientOptions, never, DefaultArgs>' is missing the following properties from type 'PrismaClient<never, GlobalOmitConfig | undefined, DefaultArgs>': host, hostGroup, hostLocation, calVideoSettings, and 115 more.

37       prisma,
         ~~~~~~

  ../features/calendars/lib/getConnectedDestinationCalendars.ts:285:3
    285   prisma: PrismaClient;
          ~~~~~~
    The expected type comes from property 'prisma' which is declared here on type '{ user: UserWithCalendars; onboarding: boolean; eventTypeId?: number | null | undefined; prisma: PrismaClient; skipSync?: boolean | undefined; }'


Found 2 errors in 2 files.

Errors  Files
     1  server/routers/viewer/calendars/_router.tsx:11
     1  server/routers/viewer/calendars/connectedCalendars.handler.ts:37
```

Because we imported type from client and not from prisma as in other places.