### PR TITLE
fix: instant booking location lookup

### DIFF
--- a/apps/web/modules/bookings/hooks/useBookings.ts
+++ b/apps/web/modules/bookings/hooks/useBookings.ts
@@ -158,13 +158,13 @@ const setInstantCooldownNow = (eventTypeId?: number | null) => {
 const storeInLocalStorage = ({
   eventTypeId,
   expiryTime,
-  bookingId,
+  bookingUid,
 }: {
   eventTypeId: number;
   expiryTime: Date;
-  bookingId: number;
+  bookingUid: string;
 }) => {
-  const value = JSON.stringify({ eventTypeId, expiryTime, bookingId });
+  const value = JSON.stringify({ eventTypeId, expiryTime, bookingUid });
   localStorage.setItem(STORAGE_KEY, value);
 };
 
@@ -194,7 +194,7 @@ export const useBookings = ({ event, hashedLink, bookingForm, metadata, isBookin
 
   const isRescheduling = !!rescheduleUid && !!bookingData;
 
-  const bookingId = parseInt(getQueryParam("bookingId") ?? "0");
+  const bookingUid = getQueryParam("bookingUid") ?? "";
 
   useEffect(() => {
     if (!isInstantMeeting) return;
@@ -213,7 +213,7 @@ export const useBookings = ({ event, hashedLink, bookingForm, metadata, isBookin
 
       if (parsedInstantBookingInfo) {
         setExpiryTime(parsedInstantBookingInfo.expiryTime);
-        updateQueryParam("bookingId", parsedInstantBookingInfo.bookingId);
+        updateQueryParam("bookingUid", parsedInstantBookingInfo.bookingUid);
       }
     }
   }, [eventTypeId, isInstantMeeting]);
@@ -222,10 +222,10 @@ export const useBookings = ({ event, hashedLink, bookingForm, metadata, isBookin
 
   const _instantBooking = trpc.viewer.bookings.getInstantBookingLocation.useQuery(
     {
-      bookingId: bookingId,
+      bookingUid: bookingUid,
     },
     {
-      enabled: !!bookingId,
+      enabled: !!bookingUid,
       refetchInterval: 2000,
       refetchIntervalInBackground: true,
     }
@@ -421,12 +421,12 @@ export const useBookings = ({ event, hashedLink, bookingForm, metadata, isBookin
         storeInLocalStorage({
           eventTypeId,
           expiryTime: responseData.expires,
-          bookingId: responseData.bookingId,
+          bookingUid: responseData.bookingUid,
         });
         setInstantCooldownNow(eventTypeId);
       }
 
-      updateQueryParam("bookingId", responseData.bookingId);
+      updateQueryParam("bookingUid", responseData.bookingUid);
       setExpiryTime(responseData.expires);
     },
     onError: (err) => {

--- a/packages/trpc/server/routers/viewer/bookings/getInstantBookingLocation.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/getInstantBookingLocation.handler.ts
@@ -12,11 +12,11 @@ type GetOptions = {
 
 export const getHandler = async ({ ctx, input }: GetOptions) => {
   const { prisma } = ctx;
-  const { bookingId } = input;
+  const { bookingUid } = input;
 
   const booking = await prisma.booking.findUnique({
     where: {
-      id: bookingId,
+      uid: bookingUid,
       status: BookingStatus.ACCEPTED,
     },
     select: {

--- a/packages/trpc/server/routers/viewer/bookings/getInstantBookingLocation.schema.ts
+++ b/packages/trpc/server/routers/viewer/bookings/getInstantBookingLocation.schema.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
 export type TInstantBookingInputSchema = {
-  bookingId: number;
+  bookingUid: string;
 };
 
 export const ZInstantBookingInputSchema: z.ZodType<TInstantBookingInputSchema> = z.object({
-  bookingId: z.number(),
+  bookingUid: z.string(),
 });


### PR DESCRIPTION
## What does this PR do?

Standardizes the instant booking location endpoint to use `bookingUid` instead of numeric `bookingId`, aligning with other booking endpoints in the codebase.

### Changes

| Layer | File(s) | Change |
|-------|---------|--------|
| Zod Schema | `getInstantBookingLocation.schema.ts` | Change input from `bookingId: number` to `bookingUid: string` |
| Handler | `getInstantBookingLocation.handler.ts` | Query by `uid` instead of `id` |
| Frontend | `useBookings.ts` | Update query param and tRPC call to use `bookingUid` |

### Technical Details

The `createInstantBooking` response already includes both `bookingId` and `bookingUid`. This change uses the uid consistently throughout the instant booking flow.

## How should this be tested?

1. Create an instant booking
2. Verify the location is retrieved correctly after booking is accepted
3. Verify URL uses `bookingUid` parameter

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs)
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
- *Manually tested locally. No automated test coverage exists for this endpoint currently. Tests will be added in a follow-up PR.*