### PR TITLE
fix: misalignment in select rows per page select in bookings page

### DIFF
--- a/packages/ui/components/pagination/Pagination.tsx
+++ b/packages/ui/components/pagination/Pagination.tsx
@@ -75,6 +75,7 @@ export const Pagination = ({
           value={pageSizeSelectOptions.find((option) => option.value === internalPageSize)}
           onChange={handlePageSizeChange}
           size="sm"
+          className="min-w-20"
         />
         <span className="text-default text-sm">{t("rows_per_page")}</span>
       </div>
@@ -101,6 +102,7 @@ export const Pagination = ({
             disabled={currentPage >= totalPages}
             color="secondary"
             size="sm"
+            
           />
         </ButtonGroup>
       </div>

--- a/packages/ui/components/pagination/Pagination.tsx
+++ b/packages/ui/components/pagination/Pagination.tsx
@@ -75,7 +75,7 @@ export const Pagination = ({
           value={pageSizeSelectOptions.find((option) => option.value === internalPageSize)}
           onChange={handlePageSizeChange}
           size="sm"
-          className="min-w-14"
+          className="min-w-15"
         />
         <span className="text-default text-sm">{t("rows_per_page")}</span>
       </div>

--- a/packages/ui/components/pagination/Pagination.tsx
+++ b/packages/ui/components/pagination/Pagination.tsx
@@ -75,7 +75,7 @@ export const Pagination = ({
           value={pageSizeSelectOptions.find((option) => option.value === internalPageSize)}
           onChange={handlePageSizeChange}
           size="sm"
-          className="min-w-20"
+          className="min-w-14"
         />
         <span className="text-default text-sm">{t("rows_per_page")}</span>
       </div>
@@ -102,7 +102,6 @@ export const Pagination = ({
             disabled={currentPage >= totalPages}
             color="secondary"
             size="sm"
-            
           />
         </ButtonGroup>
       </div>


### PR DESCRIPTION
Fixed the issue where selecting '100' rows per page would cut off the text on mobile devices/small screens. Added min-w-15 to the Select component to ensure 3 digits fit comfortably.
AFTER FIX::
<img width="689" height="789" alt="Screenshot 2026-02-02 at 8 49 40 PM" src="https://github.com/user-attachments/assets/4c178d0e-fea7-4ed5-9199-ac9413995e53" />


BEFORE::
<img width="660" height="801" alt="Screenshot 2026-02-02 at 8 28 39 PM" src="https://github.com/user-attachments/assets/c7f5c467-df73-4e10-b2f7-b4da68d395f3" />