### PR TITLE
fix(companion): handle special characters in extension event types

### DIFF
--- a/companion/extension/entrypoints/content.ts
+++ b/companion/extension/entrypoints/content.ts
@@ -1,6 +1,7 @@
 /// <reference types="chrome" />
 import { initGoogleCalendarIntegration } from "../lib/google-calendar";
 import { initLinkedInIntegration } from "../lib/linkedin";
+import { escapeHtml } from "../lib/utils";
 
 /**
  * Development-only logging utility for content scripts.
@@ -964,7 +965,7 @@ export default defineContentScript({
 
                   contentWrapper.innerHTML = `
                     <div style="display: flex; align-items: center; margin-bottom: 6px; overflow: hidden;">
-                      <span style="color: #3c4043; font-weight: 500; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: block;">${title}</span>
+                      <span style="color: #3c4043; font-weight: 500; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: block;">${escapeHtml(title)}</span>
                     </div>
                     <div style="display: flex; align-items: center; gap: 8px; overflow: hidden;">
                       <span style="
@@ -983,7 +984,7 @@ export default defineContentScript({
                       </span>
                       ${
                         description
-                          ? `<span style="color: #5f6368; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0;">${description}</span>`
+                          ? `<span style="color: #5f6368; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0;">${escapeHtml(description)}</span>`
                           : ""
                       }
                     </div>
@@ -1714,7 +1715,7 @@ export default defineContentScript({
 
               contentWrapper.innerHTML = `
                 <div style="display: flex; align-items: center; margin-bottom: 6px; overflow: hidden;">
-                  <span style="color: #3c4043; font-weight: 500; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: block;">${title}</span>
+                  <span style="color: #3c4043; font-weight: 500; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: block;">${escapeHtml(title)}</span>
                 </div>
                 <div style="display: flex; align-items: center; gap: 8px; overflow: hidden;">
                   <span style="
@@ -1733,7 +1734,7 @@ export default defineContentScript({
                   </span>
                   ${
                     description
-                      ? `<span style="color: #5f6368; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0;">${description}</span>`
+                      ? `<span style="color: #5f6368; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0;">${escapeHtml(description)}</span>`
                       : ""
                   }
                 </div>

--- a/companion/extension/lib/linkedin.ts
+++ b/companion/extension/lib/linkedin.ts
@@ -1,4 +1,5 @@
 /// <reference types="chrome" />
+import { escapeHtml } from "./utils";
 
 // LinkedIn integration: inject a Cal.com scheduling button in LinkedIn messaging
 
@@ -951,15 +952,6 @@ export function initLinkedInIntegration() {
   }
 
   // ============================================================================
-  // Utility Functions
-  // ============================================================================
-
-  function escapeHtml(text: string): string {
-    const div = document.createElement("div");
-    div.textContent = text;
-    return div.innerHTML;
-  }
-
   // ============================================================================
   // Initialization
   // ============================================================================

--- a/companion/extension/lib/utils.ts
+++ b/companion/extension/lib/utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Escapes HTML special characters to prevent XSS attacks.
+ * Uses the browser's built-in text encoding via textContent.
+ */
+export function escapeHtml(text: string): string {
+  if (typeof text !== "string") return "";
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
+}


### PR DESCRIPTION
## What does this PR do?

Adds text sanitization to event type rendering in the browser extension's Gmail integration.

### Changes

| Layer | File(s) | Change |
|-------|---------|--------|
| Utility | `extension/lib/utils.ts` | Extract `escapeHtml` to shared utility |
| Gmail | `extension/entrypoints/content.ts` | Sanitize title/description in dropdown |
| LinkedIn | `extension/lib/linkedin.ts` | Use shared utility instead of local function |

### Technical Details

Event type titles and descriptions are now passed through `escapeHtml()` before rendering in the Gmail compose dropdown. The function was extracted from `linkedin.ts` (where it was already used) into a shared utility for reuse.

## How should this be tested?

1. Install extension locally
2. Open Gmail compose, click Cal.com button
3. Verify event types display correctly
4. Create event type with special characters in title (e.g., `<Test> & "Quotes"`)
5. Verify it renders as text, not HTML

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs)
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.