### PR TITLE
fix: suppress alerts for expected billing errors in increment-usage task

### DIFF
--- a/packages/features/ee/organizations/lib/billing/tasker/trigger/increment-usage.ts
+++ b/packages/features/ee/organizations/lib/billing/tasker/trigger/increment-usage.ts
@@ -5,6 +5,30 @@ import { INCREMENT_USAGE_JOB_ID } from "../constants";
 import { platformBillingTaskConfig } from "./config";
 import { platformBillingTaskSchema } from "./schema";
 
+/**
+ * Checks if an error is expected and should not trigger alerts.
+ * Expected errors include:
+ * - Subscriptions with "temp" or "sandbox" in the ID (test/placeholder subscriptions)
+ * - Subscriptions that are not usage-based (this task only handles usage-based subscriptions)
+ */
+function isExpectedBillingError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const message = error.message.toLowerCase();
+
+  // Check for temp/sandbox subscription IDs in "No such subscription" errors
+  if (message.includes("no such subscription")) {
+    return message.includes("temp") || message.includes("sandbox");
+  }
+
+  // Check for non-usage-based subscription errors
+  if (message.includes("is not usage based")) {
+    return true;
+  }
+
+  return false;
+}
+
 export const incrementUsage: TaskWithSchema<typeof INCREMENT_USAGE_JOB_ID, typeof platformBillingTaskSchema> =
   schemaTask({
     id: INCREMENT_USAGE_JOB_ID,
@@ -19,6 +43,11 @@ export const incrementUsage: TaskWithSchema<typeof INCREMENT_USAGE_JOB_ID, typeo
       try {
         await billingTaskService.incrementUsage(payload);
       } catch (error) {
+        if (isExpectedBillingError(error)) {
+          logger.info("Skipping expected billing error", { error: (error as Error).message });
+          return;
+        }
+
         if (error instanceof Error || error instanceof ErrorWithCode) logger.error(error.message);
         else logger.error("Unknown error in incrementUsage", { error });
         throw error;


### PR DESCRIPTION
## What does this PR do?

Suppresses trigger.dev alerts for expected billing errors in the `increment-usage` task. These errors are expected in certain scenarios and should not trigger alerts:

1. **Temp/sandbox subscriptions**: Errors like `No such subscription: 'sub_temp_scale_but_should_be_per_user'` where the subscription ID contains "temp" or "sandbox"
2. **Non-usage-based subscriptions**: Errors like `Stripe subscription (sub_xxx) is not usage based` - this task only handles usage-based subscriptions

When these expected errors occur, the task now logs at `info` level and returns successfully instead of throwing and triggering alerts.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Trigger the `increment-usage` task with a subscription ID containing "temp" or "sandbox"
2. Trigger the task for a subscription that is not usage-based
3. Verify that in both cases:
   - The task completes successfully (no retry/alert)
   - An info-level log is recorded with the error message
4. Verify that other errors still throw and trigger alerts as expected

## Human Review Checklist

- [ ] Verify the error message patterns (`"no such subscription"`, `"is not usage based"`) match actual Stripe/service error messages
- [ ] Consider if string matching on error messages is robust enough for production
- [ ] Note: No unit tests added for `isExpectedBillingError` function

---

> **Link to Devin run**: https://app.devin.ai/sessions/4d9b334d74e14d929451b173847004e9
> **Requested by**: @ThyMinimalDev