### PR TITLE
feat: add hover effect to category tab

### DIFF
--- a/apps/web/modules/apps/components/AllApps.tsx
+++ b/apps/web/modules/apps/components/AllApps.tsx
@@ -89,7 +89,7 @@ function CategoryTab({ selectedCategory, categories, searchText, onCategoryChang
       </h2>
       {leftVisible && (
         <button onClick={handleLeft} className="absolute bottom-0 flex  lg:left-1/2">
-          <div className="bg-default flex h-12 w-5 items-center justify-end">
+          <div className="bg-default hover:bg-subtle rounded-sm flex h-12 w-5 items-center justify-end">
             <Icon name="chevron-left" className="text-subtle h-4 w-4" />
           </div>
           <div className="to-default flex h-12 w-5 bg-linear-to-l from-transparent" />
@@ -130,7 +130,7 @@ function CategoryTab({ selectedCategory, categories, searchText, onCategoryChang
       {rightVisible && (
         <button onClick={handleRight} className="absolute bottom-0 right-0 flex ">
           <div className="to-default flex h-12 w-5 bg-linear-to-r from-transparent" />
-          <div className="bg-default flex h-12 w-5 items-center justify-end">
+          <div className="bg-default hover:bg-subtle rounded-sm flex h-12 w-5 items-center justify-end">
             <Icon name="chevron-right" className="text-subtle h-4 w-4" />
           </div>
         </button>


### PR DESCRIPTION
## What does this PR do?

Adds a hover effect to the category tab to improve visual feedback for users.
Improves UI interactivity and user experience when navigating categories.



## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

Before 

https://github.com/user-attachments/assets/4d0dee21-4855-4841-9065-e031854ffd86

After

https://github.com/user-attachments/assets/25587e1d-2ebe-4bb5-ab70-d34b554eee5e




## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to the category tab on the relevant page.
2. Hover over each category tab.
3. Verify the hover effect appears correctly.
4. Ensure other UI elements are unaffected.




