### PR TITLE
fix: upload onboarding images immediately to prevent body size limit exceeded error

### DIFF
--- a/packages/trpc/server/routers/viewer/organizations/_router.tsx
+++ b/packages/trpc/server/routers/viewer/organizations/_router.tsx
@@ -38,6 +38,7 @@ import { ZOrgPasswordResetSchema } from "./sendPasswordReset.schema";
 import { ZSetPasswordSchema } from "./setPassword.schema";
 import { ZUpdateInputSchema } from "./update.schema";
 import { ZUpdateUserInputSchema } from "./updateUser.schema";
+import { ZUploadOnboardingImageInputSchema } from "./uploadOnboardingImage.schema";
 
 export const viewerOrganizationsRouter = router({
   getOrganizationOnboarding: authedProcedure.query(async (opts) => {
@@ -218,6 +219,10 @@ export const viewerOrganizationsRouter = router({
     }),
   pendingReportsCount: authedOrgAdminProcedure.query(async (opts) => {
     const { default: handler } = await import("./pendingReportsCount.handler");
+    return handler(opts);
+  }),
+  uploadOnboardingImage: authedProcedure.input(ZUploadOnboardingImageInputSchema).mutation(async (opts) => {
+    const { default: handler } = await import("./uploadOnboardingImage.handler");
     return handler(opts);
   }),
 });

--- a/packages/trpc/server/routers/viewer/organizations/uploadOnboardingImage.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/uploadOnboardingImage.handler.ts
@@ -1,0 +1,64 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { resizeBase64Image } from "@calcom/lib/server/resizeBase64Image";
+import { prisma } from "@calcom/prisma";
+
+import type { TrpcSessionUser } from "../../../types";
+import type { TUploadOnboardingImageInputSchema } from "./uploadOnboardingImage.schema";
+
+type UploadOnboardingImageOptions = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+  };
+  input: TUploadOnboardingImageInputSchema;
+};
+
+/**
+ * Uploads an onboarding image (logo or banner) temporarily using the user's ID.
+ * This allows images to be uploaded before the organization is created,
+ * avoiding the "Body exceeded" error from large base64 payloads.
+ *
+ * The image is stored in the Avatar table with:
+ * - teamId: 0 (no team yet)
+ * - userId: current user's ID
+ * - isBanner: true for banners, false for logos
+ *
+ * After the organization is created, the backend will re-upload the images
+ * with the proper organization ID via uploadOrganizationBrandAssets.
+ */
+export const uploadOnboardingImageHandler = async ({ ctx, input }: UploadOnboardingImageOptions) => {
+  const { user } = ctx;
+  const { image, isBanner } = input;
+
+  const maxSize = isBanner ? 1500 : 512;
+  const resizedImage = await resizeBase64Image(image, { maxSize });
+
+  const objectKey = uuidv4();
+
+  await prisma.avatar.upsert({
+    where: {
+      teamId_userId_isBanner: {
+        teamId: 0,
+        userId: user.id,
+        isBanner,
+      },
+    },
+    create: {
+      teamId: 0,
+      userId: user.id,
+      data: resizedImage,
+      objectKey,
+      isBanner,
+    },
+    update: {
+      data: resizedImage,
+      objectKey,
+    },
+  });
+
+  return {
+    url: `/api/avatar/${objectKey}.png`,
+  };
+};
+
+export default uploadOnboardingImageHandler;

--- a/packages/trpc/server/routers/viewer/organizations/uploadOnboardingImage.schema.ts
+++ b/packages/trpc/server/routers/viewer/organizations/uploadOnboardingImage.schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const ZUploadOnboardingImageInputSchema = z.object({
+  image: z.string().min(1, "Image data is required"),
+  isBanner: z.boolean().default(false),
+});
+
+export type TUploadOnboardingImageInputSchema = z.infer<typeof ZUploadOnboardingImageInputSchema>;


### PR DESCRIPTION
## What does this PR do?

Fixes the "Body exceeded" error that occurs during platform onboarding when users upload logo/banner images.

**Root cause:** During organization onboarding, logo/banner images were stored as base64 strings in the client-side store and sent in the final `intentToCreateOrg` mutation request. When the combined image data exceeded the server's body size limit (~1MB), the server returned "Body exceeded limit" as plain text, which the frontend failed to parse as JSON.

**Solution:** Upload images immediately when selected (before final submission) and store URLs instead of base64 data. This mirrors the approach already used in organization settings.

### Changes:
- Adds new `uploadOnboardingImage` tRPC mutation that stores images in the Avatar table with `teamId: 0` and the current user's ID
- Modifies the brand step to call this mutation when images are selected
- Adds loading state to the continue button while uploads are in progress
- The existing `uploadOrganizationBrandAssets` flow will re-upload with proper org ID after the organization is created

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go through the organization onboarding flow
2. On the brand step, upload a large logo image (>500KB)
3. Upload a large banner image (>500KB)
4. Verify the images upload successfully (continue button shows loading state during upload)
5. Complete the onboarding flow
6. Verify the organization is created with the correct logo and banner

**Expected behavior:** Images should upload immediately when selected, and the final submission should succeed without "Body exceeded" errors.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small (<500 lines and <10 files)

## Important Review Notes

- The handler uses `teamId: 0` as a placeholder since the organization doesn't exist yet - please verify this doesn't conflict with existing data
- Empty catch blocks revert the preview but don't surface detailed errors to users beyond the toast
- No automated tests included - manual testing recommended

---

Link to Devin run: https://app.devin.ai/sessions/02d856191007413b825f4c505d6af7e0
Requested by: @sean-brydon