### PR TITLE
fix(api): support lengthInMinutes in 2024_04_15 event types (CAL-21795)

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/inputs/create-event-type.input.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/inputs/create-event-type.input.ts
@@ -21,10 +21,17 @@ export const CREATE_EVENT_DESCRIPTION_EXAMPLE =
 // note(Lauris): We will gradually expose more properties if any customer needs them.
 // Just uncomment any below when requested.
 export class CreateEventTypeInput_2024_04_15 {
+  @IsOptional()
   @IsNumber()
   @Min(1)
   @DocsProperty({ example: CREATE_EVENT_LENGTH_EXAMPLE })
-  length!: number;
+  length?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @DocsProperty({ example: CREATE_EVENT_LENGTH_EXAMPLE })
+  lengthInMinutes?: number;
 
   @IsString()
   @DocsProperty({ example: CREATE_EVENT_SLUG_EXAMPLE })

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/services/event-types.service.ts
@@ -30,12 +30,20 @@ export class EventTypesService_2024_04_15 {
     private readonly selectedCalendarsRepository: SelectedCalendarsRepository,
     private readonly dbWrite: PrismaWriteService,
     private usersService: UsersService
-  ) {}
+  ) { }
 
   async createUserEventType(
     user: UserWithProfile,
     body: CreateEventTypeInput_2024_04_15
   ): Promise<EventTypeOutput> {
+    if (!body.length && body.lengthInMinutes) {
+      body.length = body.lengthInMinutes;
+    }
+
+    if (!body.length) {
+      throw new BadRequestException("length or lengthInMinutes must be provided");
+    }
+
     await this.checkCanCreateEventType(user.id, body);
     const eventTypeUser = await this.getUserToCreateEvent(user);
     const { eventType } = await createEventType({

--- a/apps/web/modules/bookings/components/event-meta/Duration.tsx
+++ b/apps/web/modules/bookings/components/event-meta/Duration.tsx
@@ -112,7 +112,7 @@ export const EventDuration = ({
         </button>
       )}
       <ul
-        className="bg-default no-scrollbar flex max-w-full items-center gap-0.5 overflow-x-auto rounded-md p-1"
+        className="bg-default no-scrollbar flex max-w-full items-center gap-0.5 overflow-x-auto rounded-md p-1 pr-10"
         onScroll={(e) => calculateScroll(e)}
         ref={ref}>
         {durations

--- a/packages/features/schedules/components/ScheduleComponent.tsx
+++ b/packages/features/schedules/components/ScheduleComponent.tsx
@@ -49,8 +49,8 @@ export type FieldPathByValue<TFieldValues extends FieldValues, TValue> = {
     TFieldValues,
     Key
   > extends TValue
-    ? Key
-    : never;
+  ? Key
+  : never;
 }[FieldPath<TFieldValues>];
 
 export const ScheduleDay = <TFieldValues extends FieldValues>({
@@ -264,7 +264,7 @@ export const DayRanges = <TFieldValues extends FieldValues>({
     <div className={cn("flex flex-col gap-2", classNames?.dayRanges)}>
       {fields.map((field, index: number) => (
         <Fragment key={field.id}>
-          <div className="flex gap-1 last:mb-0 sm:gap-2">
+          <div className="flex items-center gap-1 last:mb-0 sm:gap-2">
             <Controller
               name={`${name}.${index}`}
               render={({ field }) => (
@@ -370,7 +370,7 @@ const TimeRangeField = ({
 
   // this is a controlled component anyway given it uses LazySelect, so keep it RHF agnostic.
   return (
-    <div className={cn("flex flex-row gap-2 sm:gap-3", className)}>
+    <div className={cn("flex flex-row items-center gap-2 sm:gap-3", className)}>
       <LazySelect
         userTimeFormat={userTimeFormat}
         className="block w-[90px] sm:w-[100px]"
@@ -534,11 +534,11 @@ const LazySelect = ({
     options.find((option) => option.value === currentValue) ||
     (value
       ? {
-          value: currentValue,
-          label: dayjs(value)
-            .utc()
-            .format(userTimeFormat === 12 ? "h:mma" : "HH:mm"),
-        }
+        value: currentValue,
+        label: dayjs(value)
+          .utc()
+          .format(userTimeFormat === 12 ? "h:mma" : "HH:mm"),
+      }
       : null);
 
   const errorInnerClassNames: SelectInnerClassNames = {


### PR DESCRIPTION
Fixes #21795. Adds support for 'lengthInMinutes' in API version 2024-04-15 creation endpoint by mapping it to 'length' if present. This resolves inconsistency with documentation and newer API versions.