### PR TITLE
fix: missing phone numbers on new HubSpot contacts

### DIFF
--- a/packages/app-store/hubspot/lib/CrmService.ts
+++ b/packages/app-store/hubspot/lib/CrmService.ts
@@ -560,12 +560,18 @@ class HubspotCalendarService implements CRM {
 
     const simplePublicObjectInputs = contactsToCreate.map((attendee) => {
       const [firstname, lastname] = attendee.name ? attendee.name.split(" ") : [attendee.email, ""];
+      const properties: Record<string, string> = {
+        firstname,
+        lastname,
+        email: attendee.email,
+      };
+      
+      if (attendee.phone) {
+        properties.phone = attendee.phone;
+      }
+      
       return {
-        properties: {
-          firstname,
-          lastname,
-          email: attendee.email,
-        },
+        properties,
       };
     });
     const createdContacts = await Promise.all(

--- a/packages/features/crmManager/crmManager.ts
+++ b/packages/features/crmManager/crmManager.ts
@@ -40,8 +40,14 @@ export default class CrmManager {
 
     if (skipContactCreation) return;
     const contactSet = new Set(contacts.map((c: { email: string }) => c.email));
-    // Figure out which contacts to create
-    const contactsToCreate = eventAttendees.filter((attendee) => !contactSet.has(attendee.email));
+    // Figure out which contacts to create and map phoneNumber to phone
+    const contactsToCreate: ContactCreateInput[] = eventAttendees
+      .filter((attendee) => !contactSet.has(attendee.email))
+      .map((attendee) => ({
+        email: attendee.email,
+        name: attendee.name,
+        phone: attendee.phoneNumber ?? undefined,
+      }));
     const createdContacts = await this.createContacts(
       contactsToCreate,
       event.organizer?.email,

--- a/packages/types/CrmService.d.ts
+++ b/packages/types/CrmService.d.ts
@@ -11,6 +11,7 @@ export interface CrmData {
 export interface ContactCreateInput {
   email: string;
   name: string;
+  phone?: string | null;
 }
 
 export interface Contact {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Now:-
<img width="424" height="161" alt="Screenshot 2026-02-03 at 1 59 58 PM" src="https://github.com/user-attachments/assets/828deecc-ee11-4ae8-8a1a-be62874dc317" />

Fixes missing phone numbers on new HubSpot contacts by passing attendee phone through the CRM flow and setting the HubSpot "phone" property when present.

- **Bug Fixes**
  - Map attendee.phoneNumber to ContactCreateInput.phone in crmManager and forward it to HubSpot.
  - Update ContactCreateInput type to include optional phone and set properties.phone during contact creation.

<sup>Written for commit aeacf3a044e873baa0989dc8f48dd09c1d583c8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



