### PR TITLE
fix: correct LearnMoreLink import path in BillingCredits

### DIFF
--- a/apps/web/modules/settings/billing/components/BillingCredits.tsx
+++ b/apps/web/modules/settings/billing/components/BillingCredits.tsx
@@ -22,7 +22,7 @@ import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 
 import { MemberInvitationModalWithoutMembers } from "~/ee/teams/components/MemberInvitationModal";
-import { LearnMoreLink } from "~/event-types/components/LearnMoreLink";
+import { LearnMoreLink } from "@calcom/features/eventtypes/components/LearnMoreLink";
 
 import { BillingCreditsSkeleton } from "./BillingCreditsSkeleton";
 


### PR DESCRIPTION
### Problem:

- type check failing 

### Root Cause

`import { LearnMoreLink } from "~/event-types/components/LearnMoreLink";` This path doesn't exist

<img width="1057" height="142" alt="Screenshot 2026-02-03 at 3 52 46 PM" src="https://github.com/user-attachments/assets/5796525b-a5bc-41b6-b058-2515b54c03fc" />

The component exists in packages/features/eventtypes/components/.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix type-check failure in BillingCredits by correcting the LearnMoreLink import to @calcom/features/eventtypes/components/LearnMoreLink. This points to the actual component and restores successful builds.

<sup>Written for commit 1d96de06e33cafcacfc6cb5ea7c76b5cbaecfb8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

