### PR TITLE
feat: add CI workflow job for yarn test coverage

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -319,6 +319,13 @@ jobs:
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
+  unit-test-coverage:
+    name: Tests
+    needs: [prepare]
+    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    uses: ./.github/workflows/unit-tests-coverage.yml
+    secrets: inherit
+
   api-v2-unit-test:
     name: Tests
     needs: [prepare]

--- a/.github/workflows/unit-tests-coverage.yml
+++ b/.github/workflows/unit-tests-coverage.yml
@@ -1,0 +1,27 @@
+name: Unit Tests Coverage
+on:
+  workflow_call:
+env:
+  LINGO_DOT_DEV_API_KEY: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY }}
+permissions:
+  contents: read
+jobs:
+  test-coverage:
+    name: Unit Tests Coverage
+    timeout-minutes: 30
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+      - uses: ./.github/actions/yarn-install
+      - run: yarn prisma generate
+      - name: Run tests with coverage
+        run: yarn test -- --coverage --no-isolate
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14


### PR DESCRIPTION
## What does this PR do?

Adds a new CI workflow job that generates yarn test coverage for code changes in PRs. This creates a `unit-tests-coverage.yml` reusable workflow and integrates it into the PR workflow.

- Requested by @sean-brydon via Slack

## Changes

1. **New workflow file** (`.github/workflows/unit-tests-coverage.yml`):
   - Runs unit tests with `--coverage` flag
   - Uploads coverage report as artifact (14-day retention)
   - Uses same setup steps as existing unit tests workflow

2. **PR workflow update** (`.github/workflows/pr.yml`):
   - Adds `unit-test-coverage` job that runs alongside other test jobs

## Important Review Notes

- The coverage job is **not** added to the `required` job's failure conditions - it runs as an informational job and won't block PRs if it fails. Please confirm if this is the desired behavior.
- Coverage reports are uploaded as artifacts and can be downloaded from the workflow run. No external coverage service integration (e.g., Codecov) is included.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - this adds test coverage reporting.

## How should this be tested?

1. Merge this PR and observe the CI workflow on subsequent PRs
2. Verify the `unit-test-coverage` job runs successfully
3. Check that coverage artifacts are uploaded and downloadable from the workflow run

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small and focused

---
Link to Devin run: https://app.devin.ai/sessions/71efee4d9d6d4754bb3debd1de05ba3a
Requested by: @sean-brydon