### PR TITLE
Fix/27324 redirect rejected client request as pending

### DIFF
--- a/packages/trpc/server/routers/viewer/oAuth/updateClient.handler.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/updateClient.handler.ts
@@ -83,12 +83,14 @@ const updateClientHandler = async ({
       logo: clientWithUser.logo,
       websiteUrl: clientWithUser.websiteUrl,
       redirectUri: clientWithUser.redirectUri,
+      purpose: clientWithUser.purpose,
     },
     proposedUpdates: {
       name,
       logo,
       websiteUrl,
       redirectUri,
+      purpose,
     },
   });
 
@@ -160,7 +162,9 @@ type ClientFieldsForReapprovalCheck = {
   name: string;
   logo: string | null;
   websiteUrl: string | null;
+
   redirectUri: string;
+  purpose: string | null;
 };
 
 function triggersReapprovalForOwnerEdit(params: {
@@ -172,6 +176,7 @@ function triggersReapprovalForOwnerEdit(params: {
     logo: string | null;
     websiteUrl: string | null;
     redirectUri: string;
+    purpose: string | null;
   }>;
 }) {
   const { isAdmin, isOwner, currentClient, proposedUpdates } = params;
@@ -188,7 +193,7 @@ function triggersReapprovalForOwnerEdit(params: {
   ) {
     return true;
   }
-  
+
   if (
     proposedUpdates.websiteUrl !== undefined &&
     toNullableString(proposedUpdates.websiteUrl) !== toNullableString(currentClient.websiteUrl)
@@ -197,6 +202,13 @@ function triggersReapprovalForOwnerEdit(params: {
   }
 
   if (proposedUpdates.redirectUri !== undefined && proposedUpdates.redirectUri !== currentClient.redirectUri) {
+    return true;
+  }
+
+  if (
+    proposedUpdates.purpose !== undefined &&
+    toNullableString(proposedUpdates.purpose) !== toNullableString(currentClient.purpose)
+  ) {
     return true;
   }
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where submitting changes to a rejected OAuth client (specifically updating the 'purpose') would not revert the status to `PENDING` for re-approval. The client would remain in `REJECTED` status despite the update.

I have updated the [updateClientHandler](cci:1://file:///c:/Users/YASHVI%20SAINI/Desktop/opensource/cal.com/packages/trpc/server/routers/viewer/oAuth/updateClient.handler.ts:33:0-150:2) to ensure that modifications to the `purpose` field now correctly trigger the re-approval flow, resetting the status to `PENDING`. I've also added a comprehensive test case to verify this behavior.

- Fixes #27324
- Fixes CAL-7142

## Visual Demo (For contributors especially)

#### Image Demo (Verification):

I verified the fix by adding a new test case to [updateClient.handler.test.ts](cci:7://file:///c:/Users/YASHVI%20SAINI/Desktop/opensource/cal.com/packages/trpc/server/routers/viewer/oAuth/updateClient.handler.test.ts:0:0-0:0) that specifically checks if editing a rejected client's purpose resets the status to pending.

![Test Verification](<[
<img width="1171" height="277" alt="Screenshot 2026-02-03 195104" src="https://github.com/user-attachments/assets/a2e2d932-5ee2-4749-89b4-1b632337403b" />
]>)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1.  **Run the automated test**:
    Run the following command in your terminal to execute the newly added test case:
    ```bash
    yarn vitest run packages/trpc/server/routers/viewer/oAuth/updateClient.handler.test.ts -t "sets status to PENDING when an owner edits"
    ```
    This should pass and confirm the fix.

2.  **Manual Verification (Optional)**:
    - Log in as an Admin and reject an arbitrary OAuth client.
    - Log in as the Owner of that OAuth client.
    - Go to the client settings and update the "Description/Purpose".
    - Save the changes.
    - Verify that the status of the client has changed from `Rejected` (Red) to `Pending` (Yellow/Orange).

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is not too large (>500 lines or >10 files)