### PR TITLE
feat: add PostHog event tracking for feature opt-in banner and dialog

### DIFF
--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
@@ -3,7 +3,8 @@
 import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
 import { getOptInFeatureConfig, shouldDisplayFeatureAt } from "@calcom/features/feature-opt-in/config";
 import { trpc } from "@calcom/trpc/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import posthog from "posthog-js";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   getFeatureOptInTimestamp,
   isFeatureDismissed,
@@ -28,6 +29,12 @@ type FeatureOptInMutations = {
   invalidateQueries: () => void;
 };
 
+type FeatureOptInTrackingData = {
+  enableFor: "user" | "organization" | "teams";
+  teamCount?: number;
+  autoOptIn: boolean;
+};
+
 type UseFeatureOptInBannerResult = {
   shouldShow: boolean;
   isLoading: boolean;
@@ -41,6 +48,7 @@ type UseFeatureOptInBannerResult = {
   dismiss: () => void;
   markOptedIn: () => void;
   mutations: FeatureOptInMutations;
+  trackFeatureEnabled: (data: FeatureOptInTrackingData) => void;
 };
 
 function isFeatureOptedIn(featureId: string): boolean {
@@ -108,7 +116,12 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
     ]
   );
 
+  const hasBannerShownBeenTracked = useRef(false);
+
   const dismiss = useCallback(() => {
+    posthog.capture("feature_opt_in_banner_dismissed", {
+      feature_slug: featureId,
+    });
     setFeatureDismissed(featureId);
     setIsDismissed(true);
   }, [featureId]);
@@ -119,12 +132,27 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
   }, [featureId]);
 
   const openDialog = useCallback(() => {
+    posthog.capture("feature_opt_in_banner_try_it_clicked", {
+      feature_slug: featureId,
+    });
     setIsDialogOpen(true);
-  }, []);
+  }, [featureId]);
 
   const closeDialog = useCallback(() => {
     setIsDialogOpen(false);
   }, []);
+
+  const trackFeatureEnabled = useCallback(
+    (data: FeatureOptInTrackingData) => {
+      posthog.capture("feature_opt_in_enabled", {
+        feature_slug: featureId,
+        enable_for: data.enableFor,
+        team_count: data.teamCount,
+        auto_opt_in: data.autoOptIn,
+      });
+    },
+    [featureId]
+  );
 
   const shouldShow = useMemo(() => {
     if (isDismissed) return false;
@@ -136,6 +164,15 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
     if (!eligibilityQuery.data) return false;
     return eligibilityQuery.data.status === "can_opt_in";
   }, [isDismissed, isOptedIn, featureConfig, eligibilityQuery.isLoading, eligibilityQuery.data]);
+
+  useEffect(() => {
+    if (shouldShow && !hasBannerShownBeenTracked.current) {
+      hasBannerShownBeenTracked.current = true;
+      posthog.capture("feature_opt_in_banner_shown", {
+        feature_slug: featureId,
+      });
+    }
+  }, [shouldShow, featureId]);
 
   return {
     shouldShow,
@@ -150,6 +187,7 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
     dismiss,
     markOptedIn,
     mutations,
+    trackFeatureEnabled,
   };
 }
 

--- a/packages/features/feature-opt-in/components/FeatureOptInBannerWrapper.tsx
+++ b/packages/features/feature-opt-in/components/FeatureOptInBannerWrapper.tsx
@@ -15,6 +15,12 @@ type UserRoleContext = {
   adminTeamNames: { id: number; name: string }[];
 };
 
+type FeatureOptInTrackingData = {
+  enableFor: "user" | "organization" | "teams";
+  teamCount?: number;
+  autoOptIn: boolean;
+};
+
 type FeatureOptInBannerState = {
   shouldShow: boolean;
   isLoading: boolean;
@@ -28,6 +34,7 @@ type FeatureOptInBannerState = {
   dismiss: () => void;
   markOptedIn: () => void;
   mutations: FeatureOptInMutations;
+  trackFeatureEnabled: (data: FeatureOptInTrackingData) => void;
 };
 
 interface FeatureOptInBannerWrapperProps {
@@ -60,6 +67,7 @@ function FeatureOptInBannerWrapper({ state }: FeatureOptInBannerWrapperProps): R
           featureConfig={state.featureConfig}
           userRoleContext={state.userRoleContext}
           mutations={state.mutations}
+          onTrackFeatureEnabled={state.trackFeatureEnabled}
         />
       )}
     </>

--- a/packages/features/feature-opt-in/components/FeatureOptInConfirmDialog.tsx
+++ b/packages/features/feature-opt-in/components/FeatureOptInConfirmDialog.tsx
@@ -41,6 +41,12 @@ export type FeatureOptInMutations = {
   invalidateQueries: () => void;
 };
 
+type FeatureOptInTrackingData = {
+  enableFor: "user" | "organization" | "teams";
+  teamCount?: number;
+  autoOptIn: boolean;
+};
+
 interface FeatureOptInConfirmDialogProps {
   isOpen: boolean;
   onClose: () => void;
@@ -49,6 +55,7 @@ interface FeatureOptInConfirmDialogProps {
   featureConfig: OptInFeatureConfig;
   userRoleContext: UserRoleContext;
   mutations: FeatureOptInMutations;
+  onTrackFeatureEnabled?: (data: FeatureOptInTrackingData) => void;
 }
 
 export function FeatureOptInConfirmDialog({
@@ -59,6 +66,7 @@ export function FeatureOptInConfirmDialog({
   featureConfig,
   userRoleContext,
   mutations,
+  onTrackFeatureEnabled,
 }: FeatureOptInConfirmDialogProps): ReactElement {
   const { t } = useLocale();
   const router = useRouter();
@@ -158,6 +166,13 @@ export function FeatureOptInConfirmDialog({
       }
 
       await Promise.all(promises);
+
+      const enableFor = enableForOrg ? "organization" : hasTeamsSelected ? "teams" : "user";
+      onTrackFeatureEnabled?.({
+        enableFor,
+        teamCount: hasTeamsSelected ? selectedTeamIds.length : undefined,
+        autoOptIn,
+      });
 
       setIsSuccess(true);
       setShouldInvalidate(true);


### PR DESCRIPTION
## What does this PR do?

Adds PostHog event tracking to the feature opt-in banner and confirmation dialog components. This enables analytics for understanding user engagement with feature opt-in flows.

**Events tracked:**
- `feature_opt_in_banner_shown` - fired when the banner is displayed to the user
- `feature_opt_in_banner_dismissed` - fired when user dismisses the banner
- `feature_opt_in_banner_try_it_clicked` - fired when user clicks the "Try it" button
- `feature_opt_in_enabled` - fired when user successfully enables a feature, includes:
  - `feature_slug` - the feature being enabled
  - `enable_for` - "user", "organization", or "teams"
  - `team_count` - number of teams selected (if applicable)
  - `auto_opt_in` - whether auto opt-in was enabled

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to a page that shows the feature opt-in banner (e.g., Bookings page with bookings-v3 feature)
2. Open browser dev tools and check PostHog events are being captured:
   - Banner shown event should fire when banner appears
   - Clicking "Try it" should fire the try_it_clicked event
   - Dismissing the banner should fire the dismissed event
   - Completing the opt-in flow should fire the enabled event with correct properties

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized

## Human Review Checklist

- [ ] Verify event names and properties are appropriate for analytics needs
- [ ] The `FeatureOptInTrackingData` type is duplicated in 3 files - confirm this is acceptable or should be extracted to a shared location
- [ ] Confirm tracking fires at the correct times (especially the banner_shown event with the ref guard)

---

Link to Devin run: https://app.devin.ai/sessions/0511e329460447718c237b265395918b
Requested by: @eunjae-lee