### PR TITLE
Fix/27299 Optional email field verification

### DIFF
--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -236,6 +236,75 @@ describe("getBookingResponsesSchema", () => {
         expect(parsedResponses.success).toBe(true);
       });
 
+      test(`optional email field with invalid value should be validated and fail`, async () => {
+        const schema = getBookingResponsesSchema({
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              required: true,
+            },
+            {
+              name: "email",
+              type: "email",
+              required: true,
+            },
+            {
+              name: "optionalEmail",
+              type: "email",
+              required: false,
+            },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+          view: "ALL_VIEWS",
+        });
+        const parsedResponses = await schema.safeParseAsync({
+          name: "John",
+          email: "john@example.com",
+          optionalEmail: "invalid-email",
+        });
+        expect(parsedResponses.success).toBe(false);
+        if (parsedResponses.success) {
+          throw new Error("Should have failed");
+        }
+        expect(parsedResponses.error.issues[0]).toEqual(
+          expect.objectContaining({
+            message: `{optionalEmail}${CUSTOM_EMAIL_VALIDATION_ERROR_MSG}`,
+            code: "custom",
+          })
+        );
+      });
+
+      test(`optional email field with valid value should pass`, async () => {
+        const schema = getBookingResponsesSchema({
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              required: true,
+            },
+            {
+              name: "email",
+              type: "email",
+              required: true,
+            },
+            {
+              name: "optionalEmail",
+              type: "email",
+              required: false,
+            },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+          view: "ALL_VIEWS",
+        });
+        const parsedResponses = await schema.safeParseAsync({
+          name: "John",
+          email: "john@example.com",
+          optionalEmail: "optional@example.com",
+        });
+        expect(parsedResponses.success).toBe(true);
+        if (!parsedResponses.success) throw new Error("Should be success");
+        expect((parsedResponses.data as Record<string, unknown>).optionalEmail).toBe("optional@example.com");
+      });
+
       test(`firstName is required and lastName is optional by default`, async () => {
         const schema = getBookingResponsesSchema({
           bookingFields: [

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -185,8 +185,8 @@ function preprocess<T extends z.ZodType>({
         const phoneSchema = isPartialSchema
           ? z.string()
           : z.string().refine(async (val) => {
-              return isValidPhoneNumber(val);
-            });
+            return isValidPhoneNumber(val);
+          });
         // Tag the message with the input name so that the message can be shown at appropriate place
         const m = (message: string, options?: Record<string, unknown>) => {
           const translatedMessage = translateFn ? translateFn(message, options) : message;
@@ -216,7 +216,10 @@ function preprocess<T extends z.ZodType>({
         }
 
         if (bookingField.type === "email") {
-          if (!bookingField.hidden && (checkOptional || bookingField.required)) {
+          if (
+            !bookingField.hidden &&
+            (checkOptional || bookingField.required || (value && value !== ""))
+          ) {
             // Email RegExp to validate if the input is a valid email
             if (!emailSchema.safeParse(value).success) {
               ctx.addIssue({


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where optional email fields were not being validated when a user filled them out with an invalid email address.

The validation logic in `getBookingResponsesSchema.ts` has been updated. Previously, it only validated the field if it was marked as `required`. Now, it ensures that if a value is provided (i.e., the user types something into the field), the email validation rules are applied, even if the field is optional.

- Fixes #27299 
- Fixes CAL-7141 (Please replace with the actual Linear issue number if applicable)

## Visual Demo (For contributors especially)

**(N/A - Backend Validation Logic Change)**

_The fix is verified by the new unit tests which confirm that invalid inputs in optional fields now correctly trigger a validation error._

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Unit Tests
Run the updated test suite for the booking response schema:
```bash
yarn test packages/features/bookings/lib/getBookingResponsesSchema.test.ts
```
**Verify:**
1.  The new test case `optional email field with invalid value should be validated and fail` passes.
2.  The new test case `optional email field with valid value should pass` passes.

### Manual Verification
1.  Configure an Event Type to have a custom field of type **Email** that is **Optional** (not required).
2.  Go to the public booking page for this event.
3.  Enter an invalid string (e.g., `not-an-email`) into the optional email field.
4.  Attempt to book.
    *   **Expected:** The form should display a validation error.
5.  Enter a valid email (e.g., `test@example.com`).
    *   **Expected:** The booking should succeed.
6.  Leave the field empty.
    *   **Expected:** The booking should succeed (since it is optional).

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings
