### PR TITLE
fix: invalidate Redis cache when OAuth access tokens are deleted

### DIFF
--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.ts
@@ -31,6 +31,7 @@ import { TOKENS_DOCS } from "@/modules/oauth-clients/controllers/oauth-flow/oaut
 import { KeysResponseDto } from "@/modules/oauth-clients/controllers/oauth-flow/responses/KeysResponse.dto";
 import { OAuthClientGuard } from "@/modules/oauth-clients/guards/oauth-client-guard";
 import { OAuthClientRepository } from "@/modules/oauth-clients/oauth-client.repository";
+import { OAuthFlowService } from "@/modules/oauth-clients/services/oauth-flow.service";
 import { OAuthClientUsersService } from "@/modules/oauth-clients/services/oauth-clients-users.service";
 import { OAuthClientUsersOutputService } from "@/modules/oauth-clients/services/oauth-clients-users-output.service";
 import { TokensRepository } from "@/modules/tokens/tokens.repository";
@@ -57,7 +58,8 @@ export class OAuthClientUsersController {
     private readonly oAuthClientUsersService: OAuthClientUsersService,
     private readonly oauthRepository: OAuthClientRepository,
     private readonly tokensRepository: TokensRepository,
-    private readonly oAuthClientUsersOutputService: OAuthClientUsersOutputService
+    private readonly oAuthClientUsersOutputService: OAuthClientUsersOutputService,
+    private readonly oAuthFlowService: OAuthFlowService
   ) {}
 
   @Get("/")
@@ -194,8 +196,17 @@ export class OAuthClientUsersController {
 
     const { id } = await this.validateManagedUserOwnership(oAuthClientId, userId);
 
+    const oldTokenSecrets = await this.tokensRepository.getAccessTokenSecretsByClientAndUser(
+      oAuthClientId,
+      id
+    );
+
     const { accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt } =
       await this.tokensRepository.forceRefreshOAuthTokens(oAuthClientId, id);
+
+    for (const oldToken of oldTokenSecrets) {
+      void this.oAuthFlowService.invalidateAccessTokenCache(oldToken);
+    }
 
     return {
       status: SUCCESS_STATUS,

--- a/apps/api/v2/src/modules/tokens/tokens.repository.ts
+++ b/apps/api/v2/src/modules/tokens/tokens.repository.ts
@@ -92,6 +92,14 @@ export class TokensRepository {
     };
   }
 
+  async getAccessTokenSecretsByClientAndUser(clientId: string, userId: number): Promise<string[]> {
+    const tokens = await this.dbRead.prisma.accessToken.findMany({
+      where: { client: { id: clientId }, userId },
+      select: { secret: true },
+    });
+    return tokens.map((t) => t.secret);
+  }
+
   async forceRefreshOAuthTokens(clientId: string, ownerId: number) {
     const accessExpiry = DateTime.now().plus({ minute: 60 }).startOf("minute").toJSDate();
     const refreshExpiry = DateTime.now().plus({ year: 1 }).startOf("day").toJSDate();


### PR DESCRIPTION
## What does this PR do?

Fixes an intermittent error where platform customers receive "OAuth client not found given the access token" when using managed user access tokens, particularly after token refresh operations.

**Root Cause**: When access tokens are deleted via `forceRefreshOAuthTokens` or `refreshOAuthTokens`, the Redis cache was not being invalidated. This caused a race condition:

1. Token A is validated and cached in Redis (with `expiresAt`)
2. Token A is deleted from DB (via refresh)
3. New request with Token A passes `validateAccessToken` (Redis cache hit - doesn't check DB)
4. `getAccessTokenClient` queries DB, finds nothing, returns null
5. Error: "OAuth client not found given the access token"

**Fix**: Before deleting tokens, fetch their secrets and invalidate the corresponding Redis cache entries after deletion.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - internal API v2 fix.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create an OAuth client and managed user
2. Use the managed user's access token to make API requests
3. Call the force-refresh endpoint (`POST /oauth-clients/:clientId/users/:userId/force-refresh`)
4. Immediately use the OLD access token - should now properly return "Invalid Access Token" instead of "OAuth client not found"

Alternatively, test the standard token refresh flow via `POST /oauth/:clientId/refresh`.

## Human Review Checklist

- [ ] Verify cache key generation (`act_${token}` and `owner_${token}`) matches what's used in `validateAccessToken`
- [ ] Confirm the `void` pattern for cache invalidation is acceptable (non-blocking, errors are logged but don't fail the request)
- [ ] Consider if unit tests should be added for `invalidateAccessTokenCache`
- [ ] Verify NestJS DI properly injects `OAuthFlowService` into `OAuthClientUsersController`

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small (<500 lines and <10 files)

---

Link to Devin run: https://app.devin.ai/sessions/0773f309da454dbfb69f02ace3cfd692
Requested by: @ThyMinimalDev