### PR TITLE
feat: Take into account guest's availability when rescheduling

### DIFF
--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -190,6 +190,96 @@ export class AvailableSlotsService {
     }
   }
 
+  /**
+   * When rescheduling, check if the guest (attendee) is a Cal.com user.
+   * If they are, fetch their availability and return time ranges when they're available.
+   * This allows hosts to only see time slots when both parties are free.
+   */
+  private async _getGuestAvailabilityForReschedule({
+    rescheduleUid,
+    startTime,
+    endTime,
+    timeZone,
+  }: {
+    rescheduleUid: string;
+    startTime: Dayjs;
+    endTime: Dayjs;
+    timeZone: string | undefined;
+  }): Promise<{ start: Dayjs; end: Dayjs }[] | null> {
+    const bookingRepo = this.dependencies.bookingRepo;
+    const userRepo = this.dependencies.userRepo;
+
+    // Fetch the original booking with attendees
+    const booking = await bookingRepo.findByUidIncludeEventType({ bookingUid: rescheduleUid });
+    if (!booking || !booking.attendees || booking.attendees.length === 0) {
+      return null;
+    }
+
+    // Get attendee emails (excluding the host)
+    const hostEmails = new Set<string>();
+    if (booking.user?.email) hostEmails.add(booking.user.email.toLowerCase());
+    if (booking.eventType?.hosts) {
+      booking.eventType.hosts.forEach((h) => {
+        if (h.user?.email) hostEmails.add(h.user.email.toLowerCase());
+      });
+    }
+    if (booking.eventType?.users) {
+      booking.eventType.users.forEach((u) => {
+        if (u.email) hostEmails.add(u.email.toLowerCase());
+      });
+    }
+
+    const guestEmails = booking.attendees
+      .map((a) => a.email.toLowerCase())
+      .filter((email) => !hostEmails.has(email));
+
+    if (guestEmails.length === 0) {
+      return null;
+    }
+
+    // Check if any guest is a Cal.com user
+    let guestUser = null;
+    for (const email of guestEmails) {
+      const user = await userRepo.findByEmail({ email });
+      if (user) {
+        guestUser = user;
+        break; // Use the first Cal.com user found
+      }
+    }
+
+    if (!guestUser) {
+      return null; // Guest is not a Cal.com user, skip availability check
+    }
+
+    // Fetch the guest's availability using the user availability service
+    try {
+      const guestAvailability = await this.dependencies.userAvailabilityService.getUserAvailability({
+        userId: guestUser.id,
+        dateFrom: startTime,
+        dateTo: endTime,
+        returnDateOverrides: false,
+      });
+
+      if (!guestAvailability || !guestAvailability.dateRanges) {
+        return null;
+      }
+
+      // Return the guest's available date ranges
+      return guestAvailability.dateRanges.map((range) => ({
+        start: dayjs(range.start),
+        end: dayjs(range.end),
+      }));
+    } catch (error) {
+      log.warn("Failed to fetch guest availability for reschedule", { error, guestUserId: guestUser.id });
+      return null; // On error, don't block - just skip guest availability check
+    }
+  }
+
+  private getGuestAvailabilityForReschedule = withReporting(
+    this._getGuestAvailabilityForReschedule.bind(this),
+    "getGuestAvailabilityForReschedule"
+  );
+
   private async _getDynamicEventType(
     input: TGetScheduleInputSchema,
     organizationDetails: { currentOrgDomain: string | null; isValidOrgDomain: boolean }
@@ -1208,6 +1298,46 @@ export class AvailableSlotsService {
       });
 
     let aggregatedAvailability = getAggregatedAvailability(allUsersAvailability, eventType.schedulingType);
+
+    // When rescheduling, check if the guest is a Cal.com user and intersect their availability
+    if (input.rescheduleUid) {
+      const guestAvailability = await this.getGuestAvailabilityForReschedule({
+        rescheduleUid: input.rescheduleUid,
+        startTime,
+        endTime,
+        timeZone: input.timeZone,
+      });
+
+      if (guestAvailability && guestAvailability.length > 0) {
+        // Intersect host availability with guest availability
+        // Only keep time ranges where both host and guest are available
+        aggregatedAvailability = aggregatedAvailability.flatMap((hostRange) => {
+          const intersections: typeof aggregatedAvailability = [];
+
+          for (const guestRange of guestAvailability) {
+            // Find overlap between host and guest ranges
+            const overlapStart = hostRange.start.isAfter(guestRange.start) ? hostRange.start : guestRange.start;
+            const overlapEnd = hostRange.end.isBefore(guestRange.end) ? hostRange.end : guestRange.end;
+
+            // If there's a valid overlap, add it
+            if (overlapStart.isBefore(overlapEnd)) {
+              intersections.push({
+                start: overlapStart,
+                end: overlapEnd,
+              });
+            }
+          }
+
+          return intersections;
+        });
+
+        loggerWithEventDetails.info("Intersected host availability with guest Cal.com user availability", {
+          rescheduleUid: input.rescheduleUid,
+          originalRanges: allUsersAvailability.length,
+          intersectedRanges: aggregatedAvailability.length,
+        });
+      }
+    }
 
     // Fairness and Contact Owner have fallbacks because we check for within 2 weeks
     if (hasFallbackRRHosts) {

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1308,34 +1308,46 @@ export class AvailableSlotsService {
         timeZone: input.timeZone,
       });
 
-      if (guestAvailability && guestAvailability.length > 0) {
-        // Intersect host availability with guest availability
-        // Only keep time ranges where both host and guest are available
-        aggregatedAvailability = aggregatedAvailability.flatMap((hostRange) => {
-          const intersections: typeof aggregatedAvailability = [];
+      // guestAvailability is:
+      // - null: Guest is not a Cal.com user, show host-only availability
+      // - []: Guest IS a Cal.com user with NO availability, return no slots
+      // - [...]: Guest has availability, intersect with host
+      if (guestAvailability !== null) {
+        if (guestAvailability.length > 0) {
+          // Intersect host availability with guest availability
+          // Only keep time ranges where both host and guest are available
+          aggregatedAvailability = aggregatedAvailability.flatMap((hostRange) => {
+            const intersections: typeof aggregatedAvailability = [];
 
-          for (const guestRange of guestAvailability) {
-            // Find overlap between host and guest ranges
-            const overlapStart = hostRange.start.isAfter(guestRange.start) ? hostRange.start : guestRange.start;
-            const overlapEnd = hostRange.end.isBefore(guestRange.end) ? hostRange.end : guestRange.end;
+            for (const guestRange of guestAvailability) {
+              // Find overlap between host and guest ranges
+              const overlapStart = hostRange.start.isAfter(guestRange.start) ? hostRange.start : guestRange.start;
+              const overlapEnd = hostRange.end.isBefore(guestRange.end) ? hostRange.end : guestRange.end;
 
-            // If there's a valid overlap, add it
-            if (overlapStart.isBefore(overlapEnd)) {
-              intersections.push({
-                start: overlapStart,
-                end: overlapEnd,
-              });
+              // If there's a valid overlap, add it
+              if (overlapStart.isBefore(overlapEnd)) {
+                intersections.push({
+                  start: overlapStart,
+                  end: overlapEnd,
+                });
+              }
             }
-          }
 
-          return intersections;
-        });
+            return intersections;
+          });
 
-        loggerWithEventDetails.info("Intersected host availability with guest Cal.com user availability", {
-          rescheduleUid: input.rescheduleUid,
-          originalRanges: allUsersAvailability.length,
-          intersectedRanges: aggregatedAvailability.length,
-        });
+          loggerWithEventDetails.info("Intersected host availability with guest Cal.com user availability", {
+            rescheduleUid: input.rescheduleUid,
+            originalRanges: allUsersAvailability.length,
+            intersectedRanges: aggregatedAvailability.length,
+          });
+        } else {
+          // Guest is a Cal.com user with NO availability - no reschedule slots available
+          aggregatedAvailability = [];
+          loggerWithEventDetails.info("Guest Cal.com user has no availability - no reschedule slots available", {
+            rescheduleUid: input.rescheduleUid,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
When a host reschedules a booking, this now checks if the guest (attendee) is a Cal.com user. If they are, the system fetches their availability and only shows time slots when BOTH the host AND the guest are available.

## Problem
As described in #16378, when a host reschedules a booking, the current system doesn't consider the guest's availability - it just shows the host's available slots. This can lead to hosts choosing times when the guest is actually busy.

## Solution
1. When rescheduleUid is present in the slot calculation:
   - Fetch the original booking with attendees
   - Check if any attendee is a Cal.com user (by email lookup)
   - If yes, fetch their availability for the date range
   - Intersect host availability with guest availability
   - Only return time slots where both parties are free

2. Graceful degradation:
   - If guest is not a Cal.com user: show all host's available slots (current behavior)
   - If availability fetch fails: fall back to host-only availability
   - Logged for debugging without blocking the flow

## Changes
- Added _getGuestAvailabilityForReschedule helper method in AvailableSlotsService
- Integrated availability intersection in _getAvailableSlots after aggregated availability is calculated

## Testing
- [x] Host reschedules with non-Cal.com guest: shows all host slots (unchanged)
- [x] Host reschedules with Cal.com guest: shows only mutual availability
- [x] Error handling: graceful fallback on failures

Closes #16378
/claim #16378

---
*Found this helpful? [Buy me a coffee](https://ko-fi.com/jarvisdev)*