### PR TITLE
perf: Optmize DB queries around attribute routing

### DIFF
--- a/packages/features/attributes/lib/getAttributes.ts
+++ b/packages/features/attributes/lib/getAttributes.ts
@@ -7,10 +7,53 @@ import type {
 import { PrismaAttributeRepository } from "@calcom/features/attributes/repositories/PrismaAttributeRepository";
 import { PrismaAttributeToUserRepository } from "@calcom/features/attributes/repositories/PrismaAttributeToUserRepository";
 import logger from "@calcom/lib/logger";
+import type { AttributesQueryValue } from "@calcom/lib/raqb/types";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import prisma from "@calcom/prisma";
 import type { AttributeToUser } from "@calcom/prisma/client";
 import type { AttributeType } from "@calcom/prisma/enums";
+
+/**
+ * Extracts attribute IDs referenced in a routing rule's attributesQueryValue.
+ * This allows us to only fetch the attributes that are actually needed for evaluation.
+ */
+export function extractAttributeIdsFromQueryValue(
+  queryValue: AttributesQueryValue | null,
+  fallbackQueryValue?: AttributesQueryValue | null
+): string[] {
+  const attributeIds = new Set<string>();
+
+  function walkRules(obj: unknown) {
+    if (!obj || typeof obj !== "object") return;
+
+    const record = obj as Record<string, unknown>;
+
+    // Check if this is a rule with a field property (the attribute ID)
+    if (record.type === "rule" && record.properties) {
+      const properties = record.properties as Record<string, unknown>;
+      if (typeof properties.field === "string") {
+        attributeIds.add(properties.field);
+      }
+    }
+
+    // Recursively walk children1 (the RAQB structure for nested rules)
+    if (record.children1 && typeof record.children1 === "object") {
+      for (const child of Object.values(record.children1 as Record<string, unknown>)) {
+        walkRules(child);
+      }
+    }
+  }
+
+  if (queryValue) {
+    walkRules(queryValue);
+  }
+
+  if (fallbackQueryValue) {
+    walkRules(fallbackQueryValue);
+  }
+
+  return Array.from(attributeIds);
+}
 
 type UserId = number;
 type OrgMembershipId = number;
@@ -294,9 +337,12 @@ async function _getOrgMembershipToUserIdForTeam({
 async function _queryAllData({
   orgId,
   teamId,
+  attributeIds,
 }: {
   orgId: number;
   teamId: number;
+  /** If provided, only fetch attribute assignments for these attribute IDs */
+  attributeIds?: string[];
 }) {
   const attributeRepo = new PrismaAttributeRepository(prisma);
   const attributeToUserRepo = new PrismaAttributeToUserRepository(prisma);
@@ -311,10 +357,12 @@ async function _queryAllData({
     orgMembershipToUserIdForTeamMembers.keys()
   );
 
-  // Get all the attributes assigned to the members of the team
+  // Get the attributes assigned to the members of the team
+  // If attributeIds is provided, only fetch assignments for those specific attributes
   const attributesToUsersForTeam =
     await attributeToUserRepo.findManyByOrgMembershipIds({
       orgMembershipIds,
+      attributeIds,
     });
 
   return {
@@ -440,9 +488,13 @@ function _buildAssignmentsForTeam({
 export async function getAttributesAssignmentData({
   orgId,
   teamId,
+  attributeIds,
 }: {
   orgId: number;
   teamId: number;
+  /** If provided, only fetch attribute assignments for these attribute IDs.
+   * This significantly improves performance when only a few attributes are needed. */
+  attributeIds?: string[];
 }) {
   const {
     attributesOfTheOrg,
@@ -451,6 +503,7 @@ export async function getAttributesAssignmentData({
   } = await _queryAllData({
     orgId,
     teamId,
+    attributeIds,
   });
 
   const assignmentsForTheTeam = _buildAssignmentsForTeam({

--- a/packages/features/attributes/lib/getAttributes.ts
+++ b/packages/features/attributes/lib/getAttributes.ts
@@ -350,7 +350,7 @@ async function _queryAllData({
   const [orgMembershipToUserIdForTeamMembers, attributesOfTheOrg] =
     await Promise.all([
       _getOrgMembershipToUserIdForTeam({ orgId, teamId }),
-      attributeRepo.findManyByOrgId({ orgId }),
+      attributeRepo.findManyByOrgId({ orgId, attributeIds }),
     ]);
 
   const orgMembershipIds = Array.from(

--- a/packages/features/attributes/lib/getAttributes.ts
+++ b/packages/features/attributes/lib/getAttributes.ts
@@ -90,6 +90,17 @@ function _prepareAssignmentData({
   assignmentsForTheTeam: AssignmentForTheTeam[];
   attributesOfTheOrg: Attribute[];
 }) {
+  // Build lookup maps for O(1) access instead of O(n) linear scans
+  const attributeIdToOptions = new Map<string, Attribute["options"]>();
+  const optionIdToOption = new Map<string, Attribute["options"][number]>();
+
+  for (const attribute of attributesOfTheOrg) {
+    attributeIdToOptions.set(attribute.id, attribute.options);
+    for (const option of attribute.options) {
+      optionIdToOption.set(option.id, option);
+    }
+  }
+
   const teamMembersThatHaveOptionAssigned = assignmentsForTheTeam.reduce(
     (acc, attributeToUser) => {
       const userId = attributeToUser.userId;
@@ -169,11 +180,9 @@ function _prepareAssignmentData({
   }) {
     return contains
       .map((optionId) => {
-        const allOptions = attributesOfTheOrg.find(
-          (_attribute) => _attribute.id === attribute.id
-        )?.options;
-        const option = allOptions?.find((option) => option.id === optionId);
+        const option = optionIdToOption.get(optionId);
         if (!option) {
+          const allOptions = attributeIdToOptions.get(attribute.id);
           console.error(
             `Enriching "contains" for attribute ${
               attribute.name
@@ -195,33 +204,44 @@ function _prepareAssignmentData({
   }
 }
 
+/**
+ * Builds lookup maps for O(1) attribute and option lookups by option ID.
+ * This replaces O(n×m) linear scans with O(1) Map lookups.
+ */
+function _buildAttributeLookupMaps(attributesOfTheOrg: FullAttribute[]) {
+  const optionIdToAttribute = new Map<AttributeOptionId, FullAttribute>();
+  const optionIdToOption = new Map<AttributeOptionId, FullAttribute["options"][number]>();
+
+  for (const attribute of attributesOfTheOrg) {
+    for (const option of attribute.options) {
+      optionIdToAttribute.set(option.id, attribute);
+      optionIdToOption.set(option.id, option);
+    }
+  }
+
+  return { optionIdToAttribute, optionIdToOption };
+}
+
+type AttributeLookupMaps = ReturnType<typeof _buildAttributeLookupMaps>;
+
 function _getAttributeFromAttributeOption({
-  allAttributesOfTheOrg,
+  lookupMaps,
   attributeOptionId,
 }: {
-  allAttributesOfTheOrg: Attribute[];
+  lookupMaps: AttributeLookupMaps;
   attributeOptionId: AttributeOptionId;
 }) {
-  return allAttributesOfTheOrg.find((attribute) =>
-    attribute.options.some((option) => option.id === attributeOptionId)
-  );
+  return lookupMaps.optionIdToAttribute.get(attributeOptionId);
 }
 
 function _getAttributeOptionFromAttributeOption({
-  allAttributesOfTheOrg,
+  lookupMaps,
   attributeOptionId,
 }: {
-  allAttributesOfTheOrg: FullAttribute[];
+  lookupMaps: AttributeLookupMaps;
   attributeOptionId: AttributeOptionId;
 }) {
-  const matchingOption = allAttributesOfTheOrg.reduce((found, attribute) => {
-    if (found) return found;
-    return (
-      attribute.options.find((option) => option.id === attributeOptionId) ||
-      null
-    );
-  }, null as null | (typeof allAttributesOfTheOrg)[number]["options"][number]);
-  return matchingOption;
+  return lookupMaps.optionIdToOption.get(attributeOptionId);
 }
 
 async function _getOrgMembershipToUserIdForTeam({
@@ -375,6 +395,8 @@ function _buildAssignmentsForTeam({
   orgMembershipToUserIdForTeamMembers: Map<OrgMembershipId, UserId>;
   attributesOfTheOrg: FullAttribute[];
 }) {
+  const lookupMaps = _buildAttributeLookupMaps(attributesOfTheOrg);
+
   return attributesToUsersForTeam
     .map((attributeToUser) => {
       const orgMembershipId = attributeToUser.memberId;
@@ -386,12 +408,12 @@ function _buildAssignmentsForTeam({
         return null;
       }
       const attribute = _getAttributeFromAttributeOption({
-        allAttributesOfTheOrg: attributesOfTheOrg,
+        lookupMaps,
         attributeOptionId: attributeToUser.attributeOptionId,
       });
 
       const attributeOption = _getAttributeOptionFromAttributeOption({
-        allAttributesOfTheOrg: attributesOfTheOrg,
+        lookupMaps,
         attributeOptionId: attributeToUser.attributeOptionId,
       });
 

--- a/packages/features/attributes/lib/getAttributes.ts
+++ b/packages/features/attributes/lib/getAttributes.ts
@@ -133,17 +133,6 @@ function _prepareAssignmentData({
   assignmentsForTheTeam: AssignmentForTheTeam[];
   attributesOfTheOrg: Attribute[];
 }) {
-  // Build lookup maps for O(1) access instead of O(n) linear scans
-  const attributeIdToOptions = new Map<string, Attribute["options"]>();
-  const optionIdToOption = new Map<string, Attribute["options"][number]>();
-
-  for (const attribute of attributesOfTheOrg) {
-    attributeIdToOptions.set(attribute.id, attribute.options);
-    for (const option of attribute.options) {
-      optionIdToOption.set(option.id, option);
-    }
-  }
-
   const teamMembersThatHaveOptionAssigned = assignmentsForTheTeam.reduce(
     (acc, attributeToUser) => {
       const userId = attributeToUser.userId;
@@ -223,9 +212,11 @@ function _prepareAssignmentData({
   }) {
     return contains
       .map((optionId) => {
-        const option = optionIdToOption.get(optionId);
+        const allOptions = attributesOfTheOrg.find(
+          (_attribute) => _attribute.id === attribute.id
+        )?.options;
+        const option = allOptions?.find((option) => option.id === optionId);
         if (!option) {
-          const allOptions = attributeIdToOptions.get(attribute.id);
           console.error(
             `Enriching "contains" for attribute ${
               attribute.name
@@ -247,44 +238,33 @@ function _prepareAssignmentData({
   }
 }
 
-/**
- * Builds lookup maps for O(1) attribute and option lookups by option ID.
- * This replaces O(n×m) linear scans with O(1) Map lookups.
- */
-function _buildAttributeLookupMaps(attributesOfTheOrg: FullAttribute[]) {
-  const optionIdToAttribute = new Map<AttributeOptionId, FullAttribute>();
-  const optionIdToOption = new Map<AttributeOptionId, FullAttribute["options"][number]>();
-
-  for (const attribute of attributesOfTheOrg) {
-    for (const option of attribute.options) {
-      optionIdToAttribute.set(option.id, attribute);
-      optionIdToOption.set(option.id, option);
-    }
-  }
-
-  return { optionIdToAttribute, optionIdToOption };
-}
-
-type AttributeLookupMaps = ReturnType<typeof _buildAttributeLookupMaps>;
-
 function _getAttributeFromAttributeOption({
-  lookupMaps,
+  allAttributesOfTheOrg,
   attributeOptionId,
 }: {
-  lookupMaps: AttributeLookupMaps;
+  allAttributesOfTheOrg: Attribute[];
   attributeOptionId: AttributeOptionId;
 }) {
-  return lookupMaps.optionIdToAttribute.get(attributeOptionId);
+  return allAttributesOfTheOrg.find((attribute) =>
+    attribute.options.some((option) => option.id === attributeOptionId)
+  );
 }
 
 function _getAttributeOptionFromAttributeOption({
-  lookupMaps,
+  allAttributesOfTheOrg,
   attributeOptionId,
 }: {
-  lookupMaps: AttributeLookupMaps;
+  allAttributesOfTheOrg: FullAttribute[];
   attributeOptionId: AttributeOptionId;
 }) {
-  return lookupMaps.optionIdToOption.get(attributeOptionId);
+  const matchingOption = allAttributesOfTheOrg.reduce((found, attribute) => {
+    if (found) return found;
+    return (
+      attribute.options.find((option) => option.id === attributeOptionId) ||
+      null
+    );
+  }, null as null | (typeof allAttributesOfTheOrg)[number]["options"][number]);
+  return matchingOption;
 }
 
 async function _getOrgMembershipToUserIdForTeam({
@@ -443,8 +423,6 @@ function _buildAssignmentsForTeam({
   orgMembershipToUserIdForTeamMembers: Map<OrgMembershipId, UserId>;
   attributesOfTheOrg: FullAttribute[];
 }) {
-  const lookupMaps = _buildAttributeLookupMaps(attributesOfTheOrg);
-
   return attributesToUsersForTeam
     .map((attributeToUser) => {
       const orgMembershipId = attributeToUser.memberId;
@@ -456,12 +434,12 @@ function _buildAssignmentsForTeam({
         return null;
       }
       const attribute = _getAttributeFromAttributeOption({
-        lookupMaps,
+        allAttributesOfTheOrg: attributesOfTheOrg,
         attributeOptionId: attributeToUser.attributeOptionId,
       });
 
       const attributeOption = _getAttributeOptionFromAttributeOption({
-        lookupMaps,
+        allAttributesOfTheOrg: attributesOfTheOrg,
         attributeOptionId: attributeToUser.attributeOptionId,
       });
 

--- a/packages/features/attributes/repositories/PrismaAttributeRepository.ts
+++ b/packages/features/attributes/repositories/PrismaAttributeRepository.ts
@@ -27,11 +27,17 @@ export class PrismaAttributeRepository {
     });
   }
 
-  async findManyByOrgId({ orgId }: { orgId: number }) {
+  async findManyByOrgId({ orgId, attributeIds }: { orgId: number; attributeIds?: string[] }) {
     // It should be a faster query because of lesser number of attributes record and index on teamId
     const result = await this.prismaClient.attribute.findMany({
       where: {
         teamId: orgId,
+        // Only filter by attribute IDs if provided
+        ...(attributeIds?.length && {
+          id: {
+            in: attributeIds,
+          },
+        }),
       },
       select: {
         id: true,

--- a/packages/features/attributes/repositories/PrismaAttributeToUserRepository.ts
+++ b/packages/features/attributes/repositories/PrismaAttributeToUserRepository.ts
@@ -30,7 +30,13 @@ export class PrismaAttributeToUserRepository {
     });
   }
 
-  async findManyByOrgMembershipIds({ orgMembershipIds }: { orgMembershipIds: number[] }) {
+  async findManyByOrgMembershipIds({
+    orgMembershipIds,
+    attributeIds,
+  }: {
+    orgMembershipIds: number[];
+    attributeIds?: string[];
+  }) {
     if (!orgMembershipIds.length) {
       return [];
     }
@@ -40,6 +46,14 @@ export class PrismaAttributeToUserRepository {
         memberId: {
           in: orgMembershipIds,
         },
+        // Only filter by attribute IDs if provided
+        ...(attributeIds?.length && {
+          attributeOption: {
+            attributeId: {
+              in: attributeIds,
+            },
+          },
+        }),
       },
     });
 

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.test.ts
@@ -266,6 +266,8 @@ function buildScenarioWhereMainAttributeLogicFails() {
 describe("findTeamMembersMatchingAttributeLogic", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    // Re-establish the mock for extractAttributeIdsFromQueryValue after resetAllMocks
+    vi.mocked(getAttributesModule.extractAttributeIdsFromQueryValue).mockReturnValue([]);
   });
 
   it("should return null if the route does not have an attributesQueryValue set", async () => {

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.test.ts
@@ -16,6 +16,7 @@ import {
 vi.mock("@calcom/features/attributes/lib/getAttributes", () => {
   return {
     getAttributesAssignmentData: vi.fn(),
+    extractAttributeIdsFromQueryValue: vi.fn().mockReturnValue([]),
   };
 });
 


### PR DESCRIPTION
## What does this PR do?

This PR optimizes attribute routing queries by only fetching the attributes that are actually referenced in routing rules, rather than fetching all attributes for an organization.

**Key changes:**

1. **New `extractAttributeIdsFromQueryValue()` function** - Walks the RAQB (React Awesome Query Builder) query structure to extract attribute IDs referenced in routing rules

2. **Filtered database queries** - Both `PrismaAttributeRepository.findManyByOrgId()` and `PrismaAttributeToUserRepository.findManyByOrgMembershipIds()` now accept an optional `attributeIds` parameter to filter results

3. **Comprehensive test coverage** - Added 18 new test cases covering the `extractAttributeIdsFromQueryValue` function and `attributeIds` filtering behavior

## Updates since last revision

- Fixed test mock in `findTeamMembersMatchingAttributeLogic.test.ts` - The `extractAttributeIdsFromQueryValue` mock was being reset by `vi.resetAllMocks()` in `beforeEach`, causing 21 tests to fail. Added re-establishment of the mock after reset.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal optimization only
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the unit tests: `TZ=UTC yarn test packages/features/attributes/lib/getAttributes.test.ts`
2. Run the routing forms tests: `TZ=UTC yarn test packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.test.ts`
3. All tests should pass

**Key test scenarios covered:**
- Filtering to specific attributeIds returns only those attributes
- Undefined attributeIds returns all attributes (default behavior)
- Empty array attributeIds returns all attributes (backwards compatible)
- Extracting attribute IDs from nested RAQB query structures
- Deduplication of attribute IDs across queryValue and fallbackQueryValue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is not too large

## Human Review Checklist

- [ ] Verify the RAQB query structure assumptions (children1, properties.field) match actual production queries
- [ ] Confirm backwards compatibility: empty `attributeIds` array intentionally fetches all attributes
- [ ] Verify the `extractAttributeIdsFromQueryValue` function handles all edge cases in production routing rules
- [ ] Confirm the mock fix in `findTeamMembersMatchingAttributeLogic.test.ts` is the correct approach (re-establishing mock after `resetAllMocks`)

---

Link to Devin run: https://app.devin.ai/sessions/3c36d43382fa4bfe8b2069ffcc045c9b
Requested by: @joeauyeung
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
