### PR TITLE
fix: actions menu being hidden by long availability titles

### DIFF
--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -66,7 +66,6 @@ export function ScheduleListItem({
   return (
     <li key={schedule.id}>
       <div className="hover:bg-cal-muted flex items-center justify-between px-3 py-5 transition sm:px-4">
-        <div className="group flex w-full items-center justify-between ">
           <Link href={redirectUrl} className="grow truncate text-sm" title={schedule.name}>
             <div className="space-x-2 rtl:space-x-reverse">
               <span className="text-emphasis truncate font-medium">{schedule.name}</span>
@@ -108,7 +107,6 @@ export function ScheduleListItem({
               )}
             </p>
           </Link>
-        </div>
         <Dropdown>
           <DropdownMenuTrigger asChild>
             <Button


### PR DESCRIPTION
## What does this PR do?

This PR fixes a layout issue where long availability titles could cause the actions (ellipsis) menu to be hidden or misaligned.
The issue was caused by an extra flex container using full width, which prevented proper space allocation for the actions menu. 

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

Before 

https://github.com/user-attachments/assets/534c5abd-4f79-4971-b34c-5b82775ce474

After

https://github.com/user-attachments/assets/ad5cf5ce-8858-4148-9a40-63e4b78eb6f6



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


## How should this be tested?

1. Navigate to the Availability / Schedule list page.
2. Create or edit an availability with a very long title.
3. Verify that:
   - The availability title truncates correctly.
   - The actions (ellipsis) menu remains visible and clickable.
4. Test on both small and large screen sizes to ensure consistent behavior.


- Are there environment variables that should be set?
  - None
- What are the minimal test data to have?
  - A schedule with a long availability title
- What is expected (happy path) to have (input and output)?
  - Input: Availability with a long title
  - Output: Title truncates correctly and the actions (ellipsis) menu remains visible and accessible
- Any other important info that could help to test that PR?
  - Issue was reproducible before the change and no longer occurs after the fix




<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27607">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
