### PR TITLE
fix: oauth-allow-resubmit-rejected-clients

### DIFF
--- a/packages/trpc/server/routers/viewer/oAuth/updateClient.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/updateClient.handler.test.ts
@@ -487,4 +487,61 @@ describe("updateClientHandler", () => {
       })
     );
   });
+
+  it("sets status to PENDING when an owner edits a rejected client (reapproval flow)", async () => {
+    mocks.findByClientIdIncludeUser.mockResolvedValue({
+      clientId: CLIENT_ID,
+      userId: OWNER_USER_ID,
+      name: CLIENT_NAME,
+      purpose: CLIENT_PURPOSE,
+      redirectUri: REDIRECT_URI,
+      websiteUrl: null,
+      logo: null,
+      status: "REJECTED",
+      rejectionReason: "Original rejection reason",
+      user: null,
+    });
+
+    const prismaUpdate = vi.fn().mockResolvedValue({
+      clientId: CLIENT_ID,
+      name: "Updated Client Name",
+      purpose: CLIENT_PURPOSE,
+      status: "PENDING",
+      redirectUri: REDIRECT_URI,
+      websiteUrl: null,
+      logo: null,
+      rejectionReason: null,
+    });
+
+    const ctx = {
+      user: {
+        id: OWNER_USER_ID,
+        role: UserPermissionRole.USER,
+      },
+      prisma: {
+        oAuthClient: {
+          update: prismaUpdate,
+        },
+      } as unknown as PrismaClient,
+    };
+
+    await updateClientHandler({
+      ctx,
+      input: {
+        clientId: CLIENT_ID,
+        name: "Updated Client Name",
+      },
+    });
+
+    expect(prismaUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clientId: CLIENT_ID },
+        data: {
+          name: "Updated Client Name",
+          status: "PENDING",
+          rejectionReason: null,
+        },
+      })
+    );
+  });
 });


### PR DESCRIPTION
closes: #27324

## What does this PR do?

Allows OAuth client owners to edit previously rejected clients and resubmit them for approval.

When a rejected client is updated:
- The client is moved back to `PENDING`
- The previous `rejectionReason` is cleared
- The client must go through the approval flow again

This aligns rejected-client behavior with the existing reapproval flow for approved clients.

- Fixes #27324 
- Fixes CAL-7142

#### Image Demo (if applicable):

<img width="894" height="240" alt="image" src="https://github.com/user-attachments/assets/d9e25e05-7d85-4068-b5eb-38f1fc0ac4b0" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
