### PR TITLE
chore: add deprecated comment to FeaturesRepository

### DIFF
--- a/packages/features/flags/features.repository.ts
+++ b/packages/features/flags/features.repository.ts
@@ -14,6 +14,8 @@ interface CacheOptions {
  * Repository class for managing feature flags and feature access control.
  * Implements the IFeaturesRepository interface to provide feature flag functionality
  * for users, teams, and global application features.
+ *
+ * @deprecated
  */
 export class FeaturesRepository implements IFeaturesRepository {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## What does this PR do?

Adds a `@deprecated` JSDoc annotation to the `FeaturesRepository` class in `packages/features/flags/features.repository.ts`.

This will cause IDEs to show deprecation warnings when the class is used, signaling to developers that this class should not be used for new code.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - documentation-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - no functional changes.

## How should this be tested?

No testing required - this is a documentation-only change that adds a `@deprecated` JSDoc tag.

To verify:
1. Open `packages/features/flags/features.repository.ts` in an IDE
2. Confirm the `@deprecated` tag is present in the class JSDoc
3. Import/use `FeaturesRepository` elsewhere and verify the IDE shows a deprecation warning

---

**Requested by:** @eunjae-lee
**Link to Devin run:** https://app.devin.ai/sessions/7628fd1fea3c433cba5bd8271a5f7911