### PR TITLE
test: add integration test for FeatureRepository with @Memoize decorator

### DIFF
--- a/packages/features/di/containers/FeatureRepository.integration-test.ts
+++ b/packages/features/di/containers/FeatureRepository.integration-test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { prisma } from "@calcom/prisma";
+
+import { getFeatureRepository } from "./FeatureRepository";
+
+const uniqueId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+
+const cleanupFunctions: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanupFunctions) {
+    await cleanup();
+  }
+  cleanupFunctions.length = 0;
+});
+
+interface TestEntities {
+  testFeatureSlug: string;
+}
+
+async function setup(): Promise<TestEntities> {
+  const id = uniqueId();
+  const testFeatureSlug = `test-memoize-feature-${id}`;
+
+  const cleanup = async () => {
+    await prisma.feature.deleteMany({
+      where: { slug: testFeatureSlug },
+    });
+  };
+
+  cleanupFunctions.push(cleanup);
+
+  return {
+    testFeatureSlug,
+  };
+}
+
+describe("FeatureRepository DI Container Integration Tests", () => {
+  describe("getFeatureRepository with @Memoize decorator", () => {
+    it("should return the cached feature repository instance", () => {
+      const repo1 = getFeatureRepository();
+      const repo2 = getFeatureRepository();
+
+      expect(repo1).toBeDefined();
+      expect(repo2).toBeDefined();
+      expect(repo1).toBe(repo2);
+    });
+
+    it("should find a feature by slug using the cached repository", async () => {
+      const { testFeatureSlug } = await setup();
+
+      await prisma.feature.create({
+        data: {
+          slug: testFeatureSlug,
+          enabled: true,
+          type: "OPERATIONAL",
+          description: "Test feature for memoize integration test",
+        },
+      });
+
+      const repo = getFeatureRepository();
+      const feature = await repo.findBySlug(testFeatureSlug);
+
+      expect(feature).not.toBeNull();
+      expect(feature?.slug).toBe(testFeatureSlug);
+      expect(feature?.enabled).toBe(true);
+    });
+
+    it("should return null for non-existent feature", async () => {
+      const { testFeatureSlug } = await setup();
+
+      const repo = getFeatureRepository();
+      const feature = await repo.findBySlug(testFeatureSlug);
+
+      expect(feature).toBeNull();
+    });
+
+    it("should check if feature is enabled globally", async () => {
+      const { testFeatureSlug } = await setup();
+
+      await prisma.feature.create({
+        data: {
+          slug: testFeatureSlug,
+          enabled: true,
+          type: "OPERATIONAL",
+          description: "Test feature for memoize integration test",
+        },
+      });
+
+      const repo = getFeatureRepository();
+      const isEnabled = await repo.checkIfFeatureIsEnabledGlobally(testFeatureSlug);
+
+      expect(isEnabled).toBe(true);
+    });
+
+    it("should return false for disabled feature", async () => {
+      const { testFeatureSlug } = await setup();
+
+      await prisma.feature.create({
+        data: {
+          slug: testFeatureSlug,
+          enabled: false,
+          type: "OPERATIONAL",
+          description: "Test feature for memoize integration test",
+        },
+      });
+
+      const repo = getFeatureRepository();
+      const isEnabled = await repo.checkIfFeatureIsEnabledGlobally(testFeatureSlug);
+
+      expect(isEnabled).toBe(false);
+    });
+
+    it("should find all features", async () => {
+      const { testFeatureSlug } = await setup();
+
+      await prisma.feature.create({
+        data: {
+          slug: testFeatureSlug,
+          enabled: true,
+          type: "OPERATIONAL",
+          description: "Test feature for memoize integration test",
+        },
+      });
+
+      const repo = getFeatureRepository();
+      const features = await repo.findAll();
+
+      expect(Array.isArray(features)).toBe(true);
+      const testFeature = features.find((f) => f.slug === testFeatureSlug);
+      expect(testFeature).toBeDefined();
+    });
+
+    it("should update a feature and invalidate cache via @Unmemoize", async () => {
+      const { testFeatureSlug } = await setup();
+
+      await prisma.feature.create({
+        data: {
+          slug: testFeatureSlug,
+          enabled: false,
+          type: "OPERATIONAL",
+          description: "Test feature for memoize integration test",
+        },
+      });
+
+      const repo = getFeatureRepository();
+
+      const beforeUpdate = await repo.findBySlug(testFeatureSlug);
+      expect(beforeUpdate?.enabled).toBe(false);
+
+      await repo.update({
+        featureId: testFeatureSlug as Parameters<typeof repo.update>[0]["featureId"],
+        enabled: true,
+      });
+
+      const afterUpdate = await repo.findBySlug(testFeatureSlug);
+      expect(afterUpdate?.enabled).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds integration tests for the `FeatureRepository` DI container to verify the `@Memoize` decorator behavior in `CachedFeatureRepository`.

The test exercises the `getFeatureRepository()` function from `packages/features/di/containers/FeatureRepository.ts` which returns a `CachedFeatureRepository` instance that uses `@Memoize` and `@Unmemoize` decorators for Redis caching.

**Test coverage includes:**
- Repository instance caching via DI container
- `findBySlug` with memoization
- `findAll` with memoization
- `update` with `@Unmemoize` cache invalidation
- `checkIfFeatureIsEnabledGlobally`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - test only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the integration test locally:
```bash
VITEST_MODE=integration TZ=UTC yarn test packages/features/di/containers/FeatureRepository.integration-test.ts
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/f702705bd61f4b98a2abc0c3cb26a7e3
Requested by: @eunjae-lee