### PR TITLE
test: add unit tests for /api/geolocation endpoint

### DIFF
--- a/apps/web/app/api/geolocation/__tests__/route.test.ts
+++ b/apps/web/app/api/geolocation/__tests__/route.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("app/api/defaultResponderForAppDir", () => ({
+  defaultResponderForAppDir: (handler: () => Promise<Response>) => handler,
+}));
+
+const mockHeadersGet = vi.fn();
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue({
+    get: (name: string) => mockHeadersGet(name),
+  }),
+}));
+
+import { GET } from "../route";
+
+describe("geolocation route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("caching headers optimization", () => {
+    it("should include public directive for CDN caching", async () => {
+      mockHeadersGet.mockReturnValue("US");
+
+      const response = await GET();
+
+      expect(response.headers.get("Cache-Control")).toContain("public");
+    });
+
+    it("should include s-maxage for CDN edge caching", async () => {
+      mockHeadersGet.mockReturnValue("US");
+
+      const response = await GET();
+
+      expect(response.headers.get("Cache-Control")).toContain("s-maxage=3600");
+    });
+
+    it("should include stale-while-revalidate for better cache hit rates", async () => {
+      mockHeadersGet.mockReturnValue("US");
+
+      const response = await GET();
+
+      expect(response.headers.get("Cache-Control")).toContain("stale-while-revalidate=86400");
+    });
+
+    it("should include max-age for client-side caching", async () => {
+      mockHeadersGet.mockReturnValue("US");
+
+      const response = await GET();
+
+      expect(response.headers.get("Cache-Control")).toContain("max-age=3600");
+    });
+
+    it("should have complete Cache-Control header with all directives", async () => {
+      mockHeadersGet.mockReturnValue("US");
+
+      const response = await GET();
+
+      expect(response.headers.get("Cache-Control")).toBe(
+        "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400"
+      );
+    });
+  });
+
+  describe("country detection", () => {
+    it("should return country from x-vercel-ip-country header", async () => {
+      mockHeadersGet.mockImplementation((name: string) => {
+        if (name === "x-vercel-ip-country") return "US";
+        return null;
+      });
+
+      const response = await GET();
+      const body = await response.json();
+
+      expect(body.country).toBe("US");
+    });
+
+    it("should return Unknown when x-vercel-ip-country header is missing", async () => {
+      mockHeadersGet.mockReturnValue(null);
+
+      const response = await GET();
+      const body = await response.json();
+
+      expect(body.country).toBe("Unknown");
+    });
+
+    it("should handle various country codes", async () => {
+      const countryCodes = ["GB", "DE", "FR", "JP", "AU", "BR", "IN"];
+
+      for (const code of countryCodes) {
+        mockHeadersGet.mockImplementation((name: string) => {
+          if (name === "x-vercel-ip-country") return code;
+          return null;
+        });
+
+        const response = await GET();
+        const body = await response.json();
+
+        expect(body.country).toBe(code);
+      }
+    });
+  });
+
+  describe("response format", () => {
+    it("should return JSON response", async () => {
+      mockHeadersGet.mockReturnValue("US");
+
+      const response = await GET();
+
+      expect(response.headers.get("content-type")).toContain("application/json");
+    });
+
+    it("should return 200 status code", async () => {
+      mockHeadersGet.mockReturnValue("US");
+
+      const response = await GET();
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should return object with country property", async () => {
+      mockHeadersGet.mockReturnValue("CA");
+
+      const response = await GET();
+      const body = await response.json();
+
+      expect(body).toHaveProperty("country");
+      expect(typeof body.country).toBe("string");
+    });
+  });
+});

--- a/apps/web/app/api/geolocation/__tests__/route.test.ts
+++ b/apps/web/app/api/geolocation/__tests__/route.test.ts
@@ -2,18 +2,13 @@ import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("app/api/defaultResponderForAppDir", () => ({
-  defaultResponderForAppDir:
-    (handler: () => Promise<Response>) =>
-    (_req: NextRequest, _context: { params: Promise<Record<string, string>> }) =>
-      handler(),
+  defaultResponderForAppDir: (handler: () => Promise<Response>) => handler,
 }));
 
 const mockHeadersGet = vi.fn();
 
 vi.mock("next/headers", () => ({
-  headers: vi.fn().mockResolvedValue({
-    get: (name: string) => mockHeadersGet(name),
-  }),
+  headers: vi.fn().mockResolvedValue({ get: (name: string) => mockHeadersGet(name) }),
 }));
 
 import { GET } from "../route";
@@ -22,118 +17,25 @@ const mockRequest = {} as NextRequest;
 const mockContext = { params: Promise.resolve({}) };
 
 describe("geolocation route", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns country with proper cache headers", async () => {
+    mockHeadersGet.mockReturnValue("US");
+
+    const res = await GET(mockRequest, mockContext);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.country).toBe("US");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400");
   });
 
-  describe("caching headers optimization", () => {
-    it("should include public directive for CDN caching", async () => {
-      mockHeadersGet.mockReturnValue("US");
+  it("returns Unknown when x-vercel-ip-country header is missing", async () => {
+    mockHeadersGet.mockReturnValue(null);
 
-      const response = await GET(mockRequest, mockContext);
+    const res = await GET(mockRequest, mockContext);
+    const body = await res.json();
 
-      expect(response.headers.get("Cache-Control")).toContain("public");
-    });
-
-    it("should include s-maxage for CDN edge caching", async () => {
-      mockHeadersGet.mockReturnValue("US");
-
-      const response = await GET(mockRequest, mockContext);
-
-      expect(response.headers.get("Cache-Control")).toContain("s-maxage=3600");
-    });
-
-    it("should include stale-while-revalidate for better cache hit rates", async () => {
-      mockHeadersGet.mockReturnValue("US");
-
-      const response = await GET(mockRequest, mockContext);
-
-      expect(response.headers.get("Cache-Control")).toContain("stale-while-revalidate=86400");
-    });
-
-    it("should include max-age for client-side caching", async () => {
-      mockHeadersGet.mockReturnValue("US");
-
-      const response = await GET(mockRequest, mockContext);
-
-      expect(response.headers.get("Cache-Control")).toContain("max-age=3600");
-    });
-
-    it("should have complete Cache-Control header with all directives", async () => {
-      mockHeadersGet.mockReturnValue("US");
-
-      const response = await GET(mockRequest, mockContext);
-
-      expect(response.headers.get("Cache-Control")).toBe(
-        "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400"
-      );
-    });
-  });
-
-  describe("country detection", () => {
-    it("should return country from x-vercel-ip-country header", async () => {
-      mockHeadersGet.mockImplementation((name: string) => {
-        if (name === "x-vercel-ip-country") return "US";
-        return null;
-      });
-
-      const response = await GET(mockRequest, mockContext);
-      const body = await response.json();
-
-      expect(body.country).toBe("US");
-    });
-
-    it("should return Unknown when x-vercel-ip-country header is missing", async () => {
-      mockHeadersGet.mockReturnValue(null);
-
-      const response = await GET(mockRequest, mockContext);
-      const body = await response.json();
-
-      expect(body.country).toBe("Unknown");
-    });
-
-    it("should handle various country codes", async () => {
-      const countryCodes = ["GB", "DE", "FR", "JP", "AU", "BR", "IN"];
-
-      for (const code of countryCodes) {
-        mockHeadersGet.mockImplementation((name: string) => {
-          if (name === "x-vercel-ip-country") return code;
-          return null;
-        });
-
-        const response = await GET(mockRequest, mockContext);
-        const body = await response.json();
-
-        expect(body.country).toBe(code);
-      }
-    });
-  });
-
-  describe("response format", () => {
-    it("should return JSON response", async () => {
-      mockHeadersGet.mockReturnValue("US");
-
-      const response = await GET(mockRequest, mockContext);
-
-      expect(response.headers.get("content-type")).toContain("application/json");
-    });
-
-    it("should return 200 status code", async () => {
-      mockHeadersGet.mockReturnValue("US");
-
-      const response = await GET(mockRequest, mockContext);
-
-      expect(response.status).toBe(200);
-    });
-
-    it("should return object with country property", async () => {
-      mockHeadersGet.mockReturnValue("CA");
-
-      const response = await GET(mockRequest, mockContext);
-      const body = await response.json();
-
-      expect(body).toHaveProperty("country");
-      expect(typeof body.country).toBe("string");
-    });
+    expect(body.country).toBe("Unknown");
   });
 });

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -265,7 +265,8 @@ function enrichRequestWithHeaders({ req }: { req: NextRequest }) {
 }
 
 export const config = {
-  matcher: ["/((?!_next(?:/|$)|static(?:/|$)|public(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap\\.xml$).*)"],
+  matcher: [
+    "/((?!_next(?:/|$)|static(?:/|$)|public(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap\\.xml$|api/geolocation(?:/|$)).*)"],
 };
 
 export default proxy;

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -264,9 +264,21 @@ function enrichRequestWithHeaders({ req }: { req: NextRequest }) {
   return reqWithCSP;
 }
 
+/**
+ * API routes that should be completely excluded from middleware processing.
+ * These routes bypass all middleware logic including rate limiting, CSP, etc.
+ */
+const MIDDLEWARE_EXCLUDED_API_ROUTES: string[] = ["/api/geolocation"];
+
+const excludedRoutes: string = MIDDLEWARE_EXCLUDED_API_ROUTES.map((route) =>
+  route.replace(/\//g, "\\/").replace(/\./g, "\\.")
+).join("|");
+
+const baseExclusions: string =
+  "_next(?:/|$)|static(?:/|$)|public(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap\\.xml$";
+const apiExclusions: string = excludedRoutes.length > 0 ? `|${excludedRoutes}(?:/|$|\\?)` : "";
 export const config = {
-  matcher: [
-    "/((?!_next(?:/|$)|static(?:/|$)|public(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap\\.xml$|api/geolocation(?:/|$)).*)"],
+  matcher: [`/((?!${baseExclusions}${apiExclusions}).*)`],
 };
 
 export default proxy;

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -264,21 +264,13 @@ function enrichRequestWithHeaders({ req }: { req: NextRequest }) {
   return reqWithCSP;
 }
 
-/**
- * API routes that should be completely excluded from middleware processing.
- * These routes bypass all middleware logic including rate limiting, CSP, etc.
- */
-const MIDDLEWARE_EXCLUDED_API_ROUTES: string[] = ["/api/geolocation"];
-
-const excludedRoutes: string = MIDDLEWARE_EXCLUDED_API_ROUTES.map((route) =>
-  route.replace(/\//g, "\\/").replace(/\./g, "\\.")
-).join("|");
-
-const baseExclusions: string =
-  "_next(?:/|$)|static(?:/|$)|public(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap\\.xml$";
-const apiExclusions: string = excludedRoutes.length > 0 ? `|${excludedRoutes}(?:/|$|\\?)` : "";
+// NOTE: Next.js requires config.matcher to be static string literals (no template literals or variables)
+// because Turbopack analyzes the config at build time.
+// Excluded routes: _next, static, public, favicon.ico, robots.txt, sitemap.xml, /api/geolocation
 export const config = {
-  matcher: [`/((?!${baseExclusions}${apiExclusions}).*)`],
+  matcher: [
+    "/((?!_next(?:/|$)|static(?:/|$)|public(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap\\.xml$|api/geolocation(?:/|$|\\?)).*)",
+  ],
 };
 
 export default proxy;

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -264,13 +264,8 @@ function enrichRequestWithHeaders({ req }: { req: NextRequest }) {
   return reqWithCSP;
 }
 
-// NOTE: Next.js requires config.matcher to be static string literals (no template literals or variables)
-// because Turbopack analyzes the config at build time.
-// Excluded routes: _next, static, public, favicon.ico, robots.txt, sitemap.xml, /api/geolocation
 export const config = {
-  matcher: [
-    "/((?!_next(?:/|$)|static(?:/|$)|public(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap\\.xml$|api/geolocation(?:/|$|\\?)).*)",
-  ],
+  matcher: ["/((?!_next(?:/|$)|static(?:/|$)|public(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap\\.xml$).*)"],
 };
 
 export default proxy;


### PR DESCRIPTION
## What does this PR do?

Adds unit tests for the `/api/geolocation` endpoint to ensure proper caching behavior and response format.

The endpoint already has good caching headers (`public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400`) which help reduce Vercel fast data transfer costs by improving CDN cache hit rates.

### Changes

- Adds 2 focused unit tests covering:
  - Country detection with proper cache headers verification
  - Fallback to "Unknown" when `x-vercel-ip-country` header is missing

### Updates since last revision

- Removed middleware exclusion changes - the performance impact of skipping middleware was determined to be minimal, so focusing only on test coverage for this endpoint
- Simplified test file to focus on core functionality

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Unit tests**: Run `TZ=UTC yarn test apps/web/app/api/geolocation` - all tests should pass
2. **Manual verification**: Visit `/api/geolocation` and verify response includes `Cache-Control: public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the middleware exclusion changes in `proxy.ts` have been reverted (should match main branch)
- [ ] Confirm tests accurately reflect the current endpoint behavior
- [ ] Run tests locally to verify they pass

---

Link to Devin run: https://app.devin.ai/sessions/a65c411c5ab945e38d78eb3420eb0682
Requested by: @hbjORbj