### PR TITLE
fix: handle trusted forwarded hosts in API v2

### DIFF
--- a/apps/api/v2/.env.example
+++ b/apps/api/v2/.env.example
@@ -75,3 +75,11 @@ ENABLE_ASYNC_TASKER="false" # set to "true" to enable
 TRIGGER_SECRET_KEY=
 TRIGGER_API_URL=https://api.trigger.dev
 TRIGGER_DEV_PROJECT_REF=
+
+# Trusted Forwarded Hosts
+# Comma-separated list of trusted hosts that can appear in X-Forwarded-Host header.
+# When a request's X-Forwarded-Host matches one of these hosts, it will be used
+# as the effective host instead of the Host header. This is useful when the API
+# is behind a proxy (like Cloudflare) that needs to override the Host header.
+# Example: API_TRUSTED_FORWARDED_HOSTS="api.cal.com,api.staging.cal.com"
+API_TRUSTED_FORWARDED_HOSTS=

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
@@ -12,6 +12,7 @@ import { EventTypesRepository_2024_06_14 } from "@/ee/event-types/event-types_20
 import { OutputEventTypesService_2024_06_14 } from "@/ee/event-types/event-types_2024_06_14/services/output-event-types.service";
 import { apiToInternalintegrationsMapping } from "@/ee/event-types/event-types_2024_06_14/transformers";
 import { sha256Hash, isApiKey, stripApiKey } from "@/lib/api-key";
+import { getEffectiveHost } from "@/lib/get-effective-host";
 import { defaultBookingResponses } from "@/lib/safe-parse/default-responses-booking";
 import { safeParse } from "@/lib/safe-parse/safe-parse";
 import { ApiKeysRepository } from "@/modules/api-keys/api-keys-repository";
@@ -297,7 +298,7 @@ export class InputBookingsService_2024_08_13 {
     return {
       ...newRequest,
       headers: {
-        hostname: request.headers["host"] || "",
+        hostname: getEffectiveHost(request),
         forcedSlug: request.headers["x-cal-force-slug"] as string | undefined,
       },
     } as unknown as BookingRequest;

--- a/apps/api/v2/src/env.ts
+++ b/apps/api/v2/src/env.ts
@@ -43,6 +43,11 @@ export type Environment = {
   USE_POOL: string;
   VERCEL: string;
   ENABLE_ASYNC_TASKER: string;
+  // Comma-separated list of trusted hosts that can appear in X-Forwarded-Host header.
+  // When a request's X-Forwarded-Host matches one of these hosts, it will be used
+  // as the effective host instead of the Host header. This is useful when the API
+  // is behind a proxy (like Cloudflare) that needs to override the Host header.
+  API_TRUSTED_FORWARDED_HOSTS: string;
 };
 
 export const getEnv = <K extends keyof Environment>(key: K, fallback?: Environment[K]): Environment[K] => {

--- a/apps/api/v2/src/lib/get-effective-host.spec.ts
+++ b/apps/api/v2/src/lib/get-effective-host.spec.ts
@@ -1,0 +1,176 @@
+import type { Request } from "express";
+
+jest.mock("@/env", () => ({
+  getEnv: jest.fn((key: string, fallback?: string) => {
+    const value = process.env[key];
+    if (value === undefined) {
+      if (fallback !== undefined) {
+        return fallback;
+      }
+      throw new Error(`Missing environment variable: ${key}.`);
+    }
+    return value;
+  }),
+}));
+
+import { getEffectiveHost, getTrustedForwardedHosts } from "./get-effective-host";
+
+describe("getTrustedForwardedHosts", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns empty array when API_TRUSTED_FORWARDED_HOSTS is not set", () => {
+    delete process.env.API_TRUSTED_FORWARDED_HOSTS;
+    const result = getTrustedForwardedHosts();
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when API_TRUSTED_FORWARDED_HOSTS is empty string", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "";
+    const result = getTrustedForwardedHosts();
+    expect(result).toEqual([]);
+  });
+
+  it("returns single host when API_TRUSTED_FORWARDED_HOSTS has one value", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "api.cal.com";
+    const result = getTrustedForwardedHosts();
+    expect(result).toEqual(["api.cal.com"]);
+  });
+
+  it("returns multiple hosts when API_TRUSTED_FORWARDED_HOSTS has comma-separated values", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "api.cal.com,api.staging.cal.com";
+    const result = getTrustedForwardedHosts();
+    expect(result).toEqual(["api.cal.com", "api.staging.cal.com"]);
+  });
+
+  it("trims whitespace from hosts", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = " api.cal.com , api.staging.cal.com ";
+    const result = getTrustedForwardedHosts();
+    expect(result).toEqual(["api.cal.com", "api.staging.cal.com"]);
+  });
+
+  it("converts hosts to lowercase", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "API.CAL.COM,Api.Staging.Cal.Com";
+    const result = getTrustedForwardedHosts();
+    expect(result).toEqual(["api.cal.com", "api.staging.cal.com"]);
+  });
+
+  it("filters out empty entries", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "api.cal.com,,api.staging.cal.com,";
+    const result = getTrustedForwardedHosts();
+    expect(result).toEqual(["api.cal.com", "api.staging.cal.com"]);
+  });
+});
+
+describe("getEffectiveHost", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function createMockRequest(headers: Record<string, string | string[] | undefined>): Request {
+    return {
+      headers,
+    } as unknown as Request;
+  }
+
+  it("returns Host header when X-Forwarded-Host is not present", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "api.cal.com";
+    const request = createMockRequest({
+      host: "cal-api-v2.vercel.app",
+    });
+    const result = getEffectiveHost(request);
+    expect(result).toBe("cal-api-v2.vercel.app");
+  });
+
+  it("returns Host header when no trusted hosts are configured", () => {
+    delete process.env.API_TRUSTED_FORWARDED_HOSTS;
+    const request = createMockRequest({
+      host: "cal-api-v2.vercel.app",
+      "x-forwarded-host": "api.cal.com",
+    });
+    const result = getEffectiveHost(request);
+    expect(result).toBe("cal-api-v2.vercel.app");
+  });
+
+  it("returns X-Forwarded-Host when it matches a trusted host", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "api.cal.com";
+    const request = createMockRequest({
+      host: "cal-api-v2.vercel.app",
+      "x-forwarded-host": "api.cal.com",
+    });
+    const result = getEffectiveHost(request);
+    expect(result).toBe("api.cal.com");
+  });
+
+  it("returns Host header when X-Forwarded-Host does not match trusted hosts", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "api.cal.com";
+    const request = createMockRequest({
+      host: "cal-api-v2.vercel.app",
+      "x-forwarded-host": "malicious.com",
+    });
+    const result = getEffectiveHost(request);
+    expect(result).toBe("cal-api-v2.vercel.app");
+  });
+
+  it("handles X-Forwarded-Host with multiple values (comma-separated)", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "api.cal.com";
+    const request = createMockRequest({
+      host: "cal-api-v2.vercel.app",
+      "x-forwarded-host": "api.cal.com, proxy.example.com",
+    });
+    const result = getEffectiveHost(request);
+    expect(result).toBe("api.cal.com");
+  });
+
+  it("handles X-Forwarded-Host as array", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "api.cal.com";
+    const request = createMockRequest({
+      host: "cal-api-v2.vercel.app",
+      "x-forwarded-host": ["api.cal.com", "proxy.example.com"],
+    });
+    const result = getEffectiveHost(request);
+    expect(result).toBe("api.cal.com");
+  });
+
+  it("is case-insensitive when matching trusted hosts", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "api.cal.com";
+    const request = createMockRequest({
+      host: "cal-api-v2.vercel.app",
+      "x-forwarded-host": "API.CAL.COM",
+    });
+    const result = getEffectiveHost(request);
+    expect(result).toBe("api.cal.com");
+  });
+
+  it("returns empty string when no Host header is present", () => {
+    delete process.env.API_TRUSTED_FORWARDED_HOSTS;
+    const request = createMockRequest({});
+    const result = getEffectiveHost(request);
+    expect(result).toBe("");
+  });
+
+  it("works with multiple trusted hosts", () => {
+    process.env.API_TRUSTED_FORWARDED_HOSTS = "api.cal.com,api.staging.cal.com";
+    const request = createMockRequest({
+      host: "cal-api-v2.vercel.app",
+      "x-forwarded-host": "api.staging.cal.com",
+    });
+    const result = getEffectiveHost(request);
+    expect(result).toBe("api.staging.cal.com");
+  });
+});

--- a/apps/api/v2/src/lib/get-effective-host.ts
+++ b/apps/api/v2/src/lib/get-effective-host.ts
@@ -1,0 +1,72 @@
+import type { Request } from "express";
+
+import { getEnv } from "@/env";
+
+/**
+ * Gets the list of trusted forwarded hosts from the environment variable.
+ * These are hosts that are allowed to appear in the X-Forwarded-Host header
+ * and will be used as the effective host instead of the Host header.
+ *
+ * @returns Array of trusted host strings, or empty array if not configured
+ */
+export function getTrustedForwardedHosts(): string[] {
+  try {
+    const hostsEnv = getEnv("API_TRUSTED_FORWARDED_HOSTS", "");
+    if (!hostsEnv) {
+      return [];
+    }
+    return hostsEnv
+      .split(",")
+      .map((host) => host.trim().toLowerCase())
+      .filter((host) => host.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Gets the effective host for a request, preferring X-Forwarded-Host when it
+ * comes from a trusted proxy.
+ *
+ * When requests are proxied through services like Cloudflare, the original Host
+ * header may be overwritten to match the backend server. The X-Forwarded-Host
+ * header preserves the original host that the client used.
+ *
+ * This function checks if the X-Forwarded-Host is in the list of trusted hosts
+ * and returns it if so. Otherwise, it falls back to the Host header.
+ *
+ * @param request - The Express request object
+ * @returns The effective host string to use for this request
+ *
+ * @example
+ * // With API_TRUSTED_FORWARDED_HOSTS="api.cal.com"
+ * // Request with Host: cal-api-v2.vercel.app, X-Forwarded-Host: api.cal.com
+ * getEffectiveHost(request) // Returns "api.cal.com"
+ *
+ * // Request with Host: cal-api-v2.vercel.app, X-Forwarded-Host: malicious.com
+ * getEffectiveHost(request) // Returns "cal-api-v2.vercel.app"
+ */
+export function getEffectiveHost(request: Request): string {
+  const forwardedHost = request.headers["x-forwarded-host"];
+  const host = request.headers["host"] || "";
+
+  if (!forwardedHost) {
+    return host;
+  }
+
+  // X-Forwarded-Host can be a comma-separated list if there are multiple proxies
+  const primaryForwardedHost =
+    typeof forwardedHost === "string" ? forwardedHost.split(",")[0].trim().toLowerCase() : forwardedHost[0].toLowerCase();
+
+  const trustedHosts = getTrustedForwardedHosts();
+
+  if (trustedHosts.length === 0) {
+    return host;
+  }
+
+  if (trustedHosts.includes(primaryForwardedHost)) {
+    return primaryForwardedHost;
+  }
+
+  return host;
+}


### PR DESCRIPTION
## What does this PR do?

When API v2 is behind a reverse proxy (like Cloudflare), the proxy may need to override the `Host` header to match the backend server (e.g., Vercel). This causes issues when the application needs to know the original host that the client used.

This PR adds support for using the `X-Forwarded-Host` header when it comes from a trusted proxy, configured via the `API_TRUSTED_FORWARDED_HOSTS` environment variable.

**Changes:**
- Add `getEffectiveHost()` utility that returns `X-Forwarded-Host` if it matches a trusted host, otherwise falls back to the `Host` header
- Add `API_TRUSTED_FORWARDED_HOSTS` environment variable (comma-separated list of trusted hosts)
- Update `input.service.ts` to use the new utility instead of direct header access
- Add comprehensive unit tests (16 test cases)

**Security:** The implementation only trusts hosts explicitly configured in the environment variable, preventing spoofing attacks from untrusted sources.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - this is an internal configuration option.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Set `API_TRUSTED_FORWARDED_HOSTS=api.cal.com` in the API v2 environment
2. Send a request with:
   - `Host: cal-api-v2.vercel.app`
   - `X-Forwarded-Host: api.cal.com`
3. The application should use `api.cal.com` as the effective host

**Unit tests:** Run `cd apps/api/v2 && TZ=UTC yarn test src/lib/get-effective-host.spec.ts`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized (5 files, ~250 lines including tests)

## Human Review Checklist

- [ ] Verify the security model is correct (only trusting explicitly configured hosts)
- [ ] Check if there are other places in API v2 that access `request.headers["host"]` directly and should also use `getEffectiveHost()`
- [ ] Confirm the environment variable naming convention is appropriate

---

### Link to Devin run
https://app.devin.ai/sessions/0c5cba8bf5c24d13bc09eb6d929d9fcd

### Requested by
@keithwillcode