### PR TITLE
feat: redesign team creation flow and fix org slug validation

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/teams/new/invite/email/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/teams/new/invite/email/page.tsx
@@ -3,19 +3,21 @@ import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { CreateNewTeamView, LayoutWrapper } from "~/settings/teams/new/create-new-team-view";
+import { TeamInviteEmailView } from "~/settings/teams/new/invite/email/team-invite-email-view";
 
-export const generateMetadata = async () =>
-  await _generateMetadata(
-    (t) => t("create_new_team"),
-    (t) => t("create_new_team_description"),
+export const generateMetadata = async () => {
+  return await _generateMetadata(
+    (t) => `${APP_NAME} - ${t("invite")}`,
+    () => "",
+    true,
     undefined,
-    undefined,
-    "/settings/teams/new"
+    "/settings/teams/new/invite/email"
   );
+};
 
 const ServerPage = async () => {
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
@@ -26,11 +28,7 @@ const ServerPage = async () => {
 
   const userEmail = session.user.email || "";
 
-  return (
-    <LayoutWrapper>
-      <CreateNewTeamView userEmail={userEmail} />
-    </LayoutWrapper>
-  );
+  return <TeamInviteEmailView userEmail={userEmail} />;
 };
 
 export default ServerPage;

--- a/apps/web/app/(use-page-wrapper)/settings/teams/new/invite/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/teams/new/invite/page.tsx
@@ -3,19 +3,21 @@ import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { CreateNewTeamView, LayoutWrapper } from "~/settings/teams/new/create-new-team-view";
+import { TeamInviteView } from "~/settings/teams/new/invite/team-invite-view";
 
-export const generateMetadata = async () =>
-  await _generateMetadata(
-    (t) => t("create_new_team"),
-    (t) => t("create_new_team_description"),
+export const generateMetadata = async () => {
+  return await _generateMetadata(
+    (t) => `${APP_NAME} - ${t("invite")}`,
+    () => "",
+    true,
     undefined,
-    undefined,
-    "/settings/teams/new"
+    "/settings/teams/new/invite"
   );
+};
 
 const ServerPage = async () => {
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
@@ -26,11 +28,7 @@ const ServerPage = async () => {
 
   const userEmail = session.user.email || "";
 
-  return (
-    <LayoutWrapper>
-      <CreateNewTeamView userEmail={userEmail} />
-    </LayoutWrapper>
-  );
+  return <TeamInviteView userEmail={userEmail} />;
 };
 
 export default ServerPage;

--- a/apps/web/modules/onboarding/components/onboarding-browser-view.tsx
+++ b/apps/web/modules/onboarding/components/onboarding-browser-view.tsx
@@ -134,12 +134,14 @@ export const OnboardingBrowserView = ({
             {/* Profile Header */}
             <div className="border-subtle flex flex-col gap-4 border-b p-4">
               <div className="flex flex-col items-start gap-4">
-                <Avatar
-                  size="lg"
-                  imageSrc={avatar || undefined}
-                  alt={name || ""}
-                  className="border-2 border-white"
-                />
+                {avatar && (
+                  <Avatar
+                    size="lg"
+                    imageSrc={avatar}
+                    alt={name || ""}
+                    className="border-2 border-white"
+                  />
+                )}
                 <div className="flex w-full flex-col gap-2">
                   <h2 className="text-emphasis w-full truncate text-xl font-semibold leading-tight">
                     {name || t("your_name")}

--- a/apps/web/modules/onboarding/hooks/useCreateTeam.ts
+++ b/apps/web/modules/onboarding/hooks/useCreateTeam.ts
@@ -9,7 +9,12 @@ import { trpc } from "@calcom/trpc/react";
 import type { OnboardingState } from "../store/onboarding-store";
 import { useOnboardingStore } from "../store/onboarding-store";
 
-export function useCreateTeam() {
+type UseCreateTeamOptions = {
+  redirectBasePath?: string;
+};
+
+export function useCreateTeam(options: UseCreateTeamOptions = {}) {
+  const { redirectBasePath = "/onboarding/teams" } = options;
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const flags = useFlagMap();
@@ -28,7 +33,7 @@ export function useCreateTeam() {
 
       // Validate team details - if empty, redirect back to team details step
       if (!teamDetails.name || !teamDetails.name.trim() || !teamDetails.slug || !teamDetails.slug.trim()) {
-        router.push("/onboarding/teams/details");
+        router.push(`${redirectBasePath}/details`);
         setIsSubmitting(false);
         return;
       }
@@ -51,7 +56,7 @@ export function useCreateTeam() {
       if (result.team) {
         // Store the teamId and redirect to invite flow after team creation
         setTeamId(result.team.id);
-        router.push(`/onboarding/teams/invite?teamId=${result.team.id}`);
+        router.push(`${redirectBasePath}/invite/email?teamId=${result.team.id}`);
       }
     } catch (error) {
       console.error("Failed to create team:", error);

--- a/apps/web/modules/onboarding/teams/details/action/check-team-slug-availability.test.ts
+++ b/apps/web/modules/onboarding/teams/details/action/check-team-slug-availability.test.ts
@@ -1,0 +1,395 @@
+import prismock from "@calcom/testing/lib/__mocks__/prisma";
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
+import { MembershipRole } from "@calcom/prisma/enums";
+import type { Session } from "next-auth";
+import { beforeEach, describe, expect, it, type MockedFunction, vi } from "vitest";
+import { checkTeamSlugAvailability } from "./check-team-slug-availability";
+
+// Mock the dependencies
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() => Promise.resolve({})),
+  headers: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock("@calcom/features/auth/lib/getServerSession", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@lib/buildLegacyCtx", () => ({
+  buildLegacyRequest: vi.fn(() => ({})),
+}));
+
+vi.mock("@calcom/features/profile/repositories/ProfileRepository", () => ({
+  ProfileRepository: {
+    findByOrgIdAndUsername: vi.fn(),
+  },
+}));
+
+const mockedGetServerSession = getServerSession as MockedFunction<typeof getServerSession>;
+const mockedFindByOrgIdAndUsername = ProfileRepository.findByOrgIdAndUsername as MockedFunction<
+  typeof ProfileRepository.findByOrgIdAndUsername
+>;
+
+describe("checkTeamSlugAvailability", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // @ts-expect-error reset is a method on Prismock
+    await prismock.reset();
+  });
+
+  const createMockSession = (overrides: Partial<Session> = {}): Session => ({
+    expires: "2025-01-01",
+    hasValidLicense: true,
+    user: {
+      id: 123,
+      uuid: "test-uuid-123",
+      email: "test@example.com",
+      name: "Test User",
+      profile: {
+        id: 789,
+        upId: "usr-123",
+        username: "testuser",
+        organizationId: null,
+        organization: null,
+      },
+    },
+    profileId: 789,
+    upId: "usr-123",
+    ...overrides,
+  });
+
+  const createOrgMockSession = (organizationId: number): Session =>
+    createMockSession({
+      user: {
+        id: 123,
+        uuid: "test-uuid-123",
+        email: "test@example.com",
+        name: "Test User",
+        org: {
+          id: organizationId,
+          name: "Test Org",
+          slug: "test-org",
+          logoUrl: null,
+          fullDomain: "test-org.cal.com",
+          domainSuffix: "cal.com",
+          role: MembershipRole.ADMIN,
+        },
+        profile: {
+          id: 789,
+          upId: "usr-123",
+          username: "testuser",
+          organizationId: organizationId,
+          organization: {
+            id: organizationId,
+            name: "Test Org",
+            slug: "test-org",
+            calVideoLogo: null,
+            bannerUrl: null,
+            requestedSlug: null,
+          },
+        },
+      },
+    });
+
+  describe("input validation", () => {
+    it("should return unavailable for empty slug", async () => {
+      const result = await checkTeamSlugAvailability("");
+
+      expect(result).toEqual({
+        available: false,
+        message: "Slug is required",
+      });
+    });
+
+    it("should return unavailable for whitespace-only slug", async () => {
+      const result = await checkTeamSlugAvailability("   ");
+
+      expect(result).toEqual({
+        available: false,
+        message: "Slug is required",
+      });
+    });
+  });
+
+  describe("authentication", () => {
+    it("should return unauthorized when session is null", async () => {
+      mockedGetServerSession.mockResolvedValue(null);
+
+      const result = await checkTeamSlugAvailability("my-team");
+
+      expect(result).toEqual({
+        available: false,
+        message: "Unauthorized",
+      });
+    });
+
+    it("should return unauthorized when user has no id", async () => {
+      const mockSession = createMockSession({
+        user: {
+          id: undefined as unknown as number,
+          uuid: "test-uuid",
+          email: "test@example.com",
+          name: "Test",
+        },
+      });
+      mockedGetServerSession.mockResolvedValue(mockSession);
+
+      const result = await checkTeamSlugAvailability("my-team");
+
+      expect(result).toEqual({
+        available: false,
+        message: "Unauthorized",
+      });
+    });
+  });
+
+  describe("non-organization users (parentId = null)", () => {
+    it("should return available when slug does not exist at top level", async () => {
+      const mockSession = createMockSession();
+      mockedGetServerSession.mockResolvedValue(mockSession);
+
+      const result = await checkTeamSlugAvailability("new-team");
+
+      expect(result).toEqual({ available: true });
+    });
+
+    it("should return unavailable when slug exists at top level", async () => {
+      const mockSession = createMockSession();
+      mockedGetServerSession.mockResolvedValue(mockSession);
+
+      // Create a top-level team with the same slug
+      await prismock.team.create({
+        data: {
+          name: "Existing Team",
+          slug: "existing-team",
+          parentId: null,
+        },
+      });
+
+      const result = await checkTeamSlugAvailability("existing-team");
+
+      expect(result).toEqual({
+        available: false,
+        message: "This slug is already taken",
+      });
+    });
+
+    it("should return available when slug exists in an organization but not at top level", async () => {
+      const mockSession = createMockSession();
+      mockedGetServerSession.mockResolvedValue(mockSession);
+
+      // Create an organization
+      const org = await prismock.team.create({
+        data: {
+          name: "Some Org",
+          slug: "some-org",
+          parentId: null,
+          isOrganization: true,
+        },
+      });
+
+      // Create a team inside the organization with the slug
+      await prismock.team.create({
+        data: {
+          name: "Team In Org",
+          slug: "team-slug",
+          parentId: org.id,
+        },
+      });
+
+      // Non-org user should be able to use the same slug at top level
+      const result = await checkTeamSlugAvailability("team-slug");
+
+      expect(result).toEqual({ available: true });
+    });
+  });
+
+  describe("organization users (parentId = organizationId)", () => {
+    it("should return available when slug does not exist within the organization", async () => {
+      const organizationId = 456;
+      const mockSession = createOrgMockSession(organizationId);
+      mockedGetServerSession.mockResolvedValue(mockSession);
+      mockedFindByOrgIdAndUsername.mockResolvedValue(null);
+
+      // Create the organization
+      await prismock.team.create({
+        data: {
+          id: organizationId,
+          name: "Test Org",
+          slug: "test-org",
+          parentId: null,
+          isOrganization: true,
+        },
+      });
+
+      const result = await checkTeamSlugAvailability("new-team");
+
+      expect(result).toEqual({ available: true });
+    });
+
+    it("should return unavailable when slug exists within the same organization", async () => {
+      const organizationId = 456;
+      const mockSession = createOrgMockSession(organizationId);
+      mockedGetServerSession.mockResolvedValue(mockSession);
+
+      // Create the organization
+      await prismock.team.create({
+        data: {
+          id: organizationId,
+          name: "Test Org",
+          slug: "test-org",
+          parentId: null,
+          isOrganization: true,
+        },
+      });
+
+      // Create a team inside this organization with the same slug
+      await prismock.team.create({
+        data: {
+          name: "Existing Team",
+          slug: "existing-team",
+          parentId: organizationId,
+        },
+      });
+
+      const result = await checkTeamSlugAvailability("existing-team");
+
+      expect(result).toEqual({
+        available: false,
+        message: "This slug is already taken",
+      });
+    });
+
+    it("should return available when slug exists in a DIFFERENT organization", async () => {
+      const myOrgId = 456;
+      const otherOrgId = 789;
+      const mockSession = createOrgMockSession(myOrgId);
+      mockedGetServerSession.mockResolvedValue(mockSession);
+      mockedFindByOrgIdAndUsername.mockResolvedValue(null);
+
+      // Create my organization
+      await prismock.team.create({
+        data: {
+          id: myOrgId,
+          name: "My Org",
+          slug: "my-org",
+          parentId: null,
+          isOrganization: true,
+        },
+      });
+
+      // Create another organization
+      await prismock.team.create({
+        data: {
+          id: otherOrgId,
+          name: "Other Org",
+          slug: "other-org",
+          parentId: null,
+          isOrganization: true,
+        },
+      });
+
+      // Create a team in the OTHER organization with the slug
+      await prismock.team.create({
+        data: {
+          name: "Team In Other Org",
+          slug: "shared-slug",
+          parentId: otherOrgId,
+        },
+      });
+
+      // Should be available because slug doesn't exist in MY organization
+      const result = await checkTeamSlugAvailability("shared-slug");
+
+      expect(result).toEqual({ available: true });
+    });
+
+    it("should return unavailable when slug conflicts with a username in the organization", async () => {
+      const organizationId = 456;
+      const mockSession = createOrgMockSession(organizationId);
+      mockedGetServerSession.mockResolvedValue(mockSession);
+
+      // Create the organization
+      await prismock.team.create({
+        data: {
+          id: organizationId,
+          name: "Test Org",
+          slug: "test-org",
+          parentId: null,
+          isOrganization: true,
+        },
+      });
+
+      // Mock that the slug matches a user's profile username in the org
+      mockedFindByOrgIdAndUsername.mockResolvedValue({
+        id: 999,
+        uid: "uid-999",
+        userId: 111,
+        username: "john",
+        organizationId: organizationId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        movedFromUserId: null,
+        organization: null,
+        user: null,
+      } as Awaited<ReturnType<typeof ProfileRepository.findByOrgIdAndUsername>>);
+
+      const result = await checkTeamSlugAvailability("john");
+
+      expect(mockedFindByOrgIdAndUsername).toHaveBeenCalledWith({
+        organizationId: organizationId,
+        username: "john",
+      });
+      expect(result).toEqual({
+        available: false,
+        message: "This slug is already taken by a user",
+      });
+    });
+
+    it("should NOT check for username conflicts for non-org users", async () => {
+      const mockSession = createMockSession(); // Non-org user
+      mockedGetServerSession.mockResolvedValue(mockSession);
+
+      const result = await checkTeamSlugAvailability("some-slug");
+
+      // ProfileRepository should NOT be called for non-org users
+      expect(mockedFindByOrgIdAndUsername).not.toHaveBeenCalled();
+      expect(result).toEqual({ available: true });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle slug that exists at top level but user is in an org", async () => {
+      const organizationId = 456;
+      const mockSession = createOrgMockSession(organizationId);
+      mockedGetServerSession.mockResolvedValue(mockSession);
+      mockedFindByOrgIdAndUsername.mockResolvedValue(null);
+
+      // Create the organization
+      await prismock.team.create({
+        data: {
+          id: organizationId,
+          name: "Test Org",
+          slug: "test-org",
+          parentId: null,
+          isOrganization: true,
+        },
+      });
+
+      // Create a top-level team with the slug
+      await prismock.team.create({
+        data: {
+          name: "Top Level Team",
+          slug: "top-level-slug",
+          parentId: null,
+        },
+      });
+
+      // Org user should be able to use this slug within their org
+      const result = await checkTeamSlugAvailability("top-level-slug");
+
+      expect(result).toEqual({ available: true });
+    });
+  });
+});

--- a/apps/web/modules/onboarding/teams/details/action/check-team-slug-availability.ts
+++ b/apps/web/modules/onboarding/teams/details/action/check-team-slug-availability.ts
@@ -1,12 +1,11 @@
 "use server";
 
-import { cookies, headers } from "next/headers";
-
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { RESERVED_SUBDOMAINS } from "@calcom/lib/constants";
 import { prisma } from "@calcom/prisma";
-
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
+import { cookies, headers } from "next/headers";
 
 export async function checkTeamSlugAvailability(slug: string): Promise<{
   available: boolean;
@@ -26,11 +25,16 @@ export async function checkTeamSlugAvailability(slug: string): Promise<{
     return { available: false, message: "Unauthorized" };
   }
 
-  // Check if slug already exists (teams have parentId, organizations don't)
+  // Get the user's organization context from their profile
+  const organizationId = session.user.profile?.organizationId ?? null;
+
+  // Check if slug already exists within the same organization context
+  // For org users: check within the organization (parentId = organizationId)
+  // For non-org users: check at the top level (parentId = null)
   const existingTeam = await prisma.team.findFirst({
     where: {
       slug,
-      parentId: null,
+      parentId: organizationId,
     },
     select: {
       id: true,
@@ -39,6 +43,18 @@ export async function checkTeamSlugAvailability(slug: string): Promise<{
 
   if (existingTeam) {
     return { available: false, message: "This slug is already taken" };
+  }
+
+  // For org users, also check if the slug conflicts with a user's username in the organization
+  if (organizationId) {
+    const usernameConflict = await ProfileRepository.findByOrgIdAndUsername({
+      organizationId,
+      username: slug,
+    });
+
+    if (usernameConflict) {
+      return { available: false, message: "This slug is already taken by a user" };
+    }
   }
 
   return { available: true };

--- a/apps/web/modules/settings/teams/new/create-new-team-view.tsx
+++ b/apps/web/modules/settings/teams/new/create-new-team-view.tsx
@@ -1,58 +1,210 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import React from "react";
-import { z } from "zod";
+import posthog from "posthog-js";
+import React, { useEffect, useRef, useState, type FormEvent } from "react";
 
-import { HOSTED_CAL_FEATURES } from "@calcom/lib/constants";
-import { getSafeRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
-import { useParamsWithFallback } from "@calcom/lib/hooks/useParamsWithFallback";
-import type { RouterOutputs } from "@calcom/trpc/react";
-import { WizardLayout } from "@calcom/ui/components/layout";
-import { CreateANewTeamForm } from "@calcom/web/modules/ee/teams/components/CreateANewTeamForm";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import slugify from "@calcom/lib/slugify";
+import { Avatar } from "@calcom/ui/components/avatar";
+import { Button } from "@calcom/ui/components/button";
+import { Label, TextField, TextArea } from "@calcom/ui/components/form";
+import { ImageUploader } from "@calcom/ui/components/image-uploader";
+import { showToast } from "@calcom/ui/components/toast";
 
-const querySchema = z.object({
-  returnTo: z.string().optional(),
-  slug: z.string().optional(),
-});
+import { OnboardingCard } from "~/onboarding/components/OnboardingCard";
+import { OnboardingLayout } from "~/onboarding/components/OnboardingLayout";
+import { OnboardingBrowserView } from "~/onboarding/components/onboarding-browser-view";
+import { useCreateTeam } from "~/onboarding/hooks/useCreateTeam";
+import { useOnboardingStore } from "~/onboarding/store/onboarding-store";
+import { ValidatedTeamSlug } from "~/onboarding/teams/details/validated-team-slug";
 
-const CreateNewTeamPage = () => {
-  const params = useParamsWithFallback();
-  const parsedQuery = querySchema.safeParse(params);
+type CreateNewTeamViewProps = {
+  userEmail: string;
+};
+
+export const CreateNewTeamView = ({ userEmail }: CreateNewTeamViewProps) => {
   const router = useRouter();
+  const { t } = useLocale();
+  const store = useOnboardingStore();
+  const { teamDetails, teamBrand, setTeamDetails, setTeamBrand, resetOnboardingPreservingPlan } = store;
+  const { createTeam, isSubmitting } = useCreateTeam({ redirectBasePath: "/settings/teams/new" });
 
-  const isTeamBillingEnabledClient = !!process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY && HOSTED_CAL_FEATURES;
-  const flag = isTeamBillingEnabledClient
-    ? {
-        submitLabel: "checkout",
-      }
-    : {
-        submitLabel: "continue",
-      };
+  const logoRef = useRef<HTMLInputElement>(null);
+  const [teamName, setTeamName] = useState("");
+  const [teamSlug, setTeamSlug] = useState("");
+  const [teamBio, setTeamBio] = useState("");
+  const [teamLogo, setTeamLogo] = useState<string>("");
+  const [isSlugValid, setIsSlugValid] = useState(false);
+  const [isSlugManuallyEdited, setIsSlugManuallyEdited] = useState(false);
 
-  const returnToParam =
-    (parsedQuery.success ? getSafeRedirectUrl(parsedQuery.data.returnTo) : "/teams") || "/teams";
+  // Reset onboarding store when entering the team creation flow from settings
+  useEffect(() => {
+    resetOnboardingPreservingPlan();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  const onSuccess = (data: RouterOutputs["viewer"]["teams"]["create"]) => {
-    // telemetry.event(flag.telemetryEvent);
-    router.push(data.url);
+  useEffect(() => {
+    setTeamName(teamDetails.name);
+    setTeamSlug(teamDetails.slug);
+    setTeamBio(teamDetails.bio);
+    setTeamLogo(teamBrand.logo || "");
+    if (teamDetails.slug) {
+      setIsSlugManuallyEdited(true);
+    }
+  }, [teamDetails, teamBrand]);
+
+  useEffect(() => {
+    if (!isSlugManuallyEdited && teamName) {
+      const slugifiedName = slugify(teamName);
+      setTeamSlug(slugifiedName);
+    }
+  }, [teamName, isSlugManuallyEdited]);
+
+  const handleSlugChange = (value: string) => {
+    setTeamSlug(value);
+    setIsSlugManuallyEdited(true);
+  };
+
+  const handleLogoChange = (newLogo: string) => {
+    if (logoRef.current) {
+      logoRef.current.value = newLogo;
+    }
+    setTeamLogo(newLogo);
+  };
+
+  const handleContinue = async (e?: FormEvent) => {
+    e?.preventDefault();
+
+    if (!isSlugValid) {
+      return;
+    }
+
+    posthog.capture("settings_team_details_continue_clicked", {
+      has_logo: !!teamLogo,
+      has_bio: !!teamBio,
+    });
+
+    setTeamDetails({
+      name: teamName,
+      slug: teamSlug,
+      bio: teamBio,
+    });
+
+    setTeamBrand({
+      logo: teamLogo || null,
+    });
+
+    try {
+      await createTeam();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t("something_went_wrong");
+      showToast(message, "error");
+    }
+  };
+
+  const handleCancel = () => {
+    posthog.capture("settings_team_details_cancel_clicked");
+    resetOnboardingPreservingPlan();
+    router.push("/teams");
   };
 
   return (
-    <CreateANewTeamForm
-      slug={parsedQuery.success ? parsedQuery.data.slug : ""}
-      onCancel={() => router.push(returnToParam)}
-      submitLabel={flag.submitLabel}
-      onSuccess={onSuccess}
-    />
-  );
-};
-export const LayoutWrapper = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <WizardLayout currentStep={1} maxSteps={3}>
-      {children}
-    </WizardLayout>
+    <OnboardingLayout userEmail={userEmail} currentStep={1} totalSteps={3}>
+      {/* Left column - Main content */}
+      <div className="flex h-full w-full flex-col gap-4">
+        <form onSubmit={handleContinue} className="flex h-full w-full flex-col gap-4">
+          <OnboardingCard
+            title={t("create_your_team")}
+            subtitle={t("team_onboarding_details_subtitle")}
+            footer={
+              <div className="flex w-full items-center justify-end gap-4">
+                <Button
+                  type="button"
+                  color="minimal"
+                  className="rounded-[10px]"
+                  onClick={handleCancel}
+                  disabled={isSubmitting}>
+                  {t("cancel")}
+                </Button>
+                <Button
+                  type="submit"
+                  color="primary"
+                  className="rounded-[10px]"
+                  disabled={!isSlugValid || !teamName || !teamSlug || isSubmitting}>
+                  {t("continue")}
+                </Button>
+              </div>
+            }>
+            <div className="flex h-full w-full flex-col gap-4">
+              {/* Team Profile Picture */}
+              <div className="flex w-full flex-col gap-2">
+                <Label className="text-emphasis text-sm font-medium leading-4">{t("team_logo")}</Label>
+                <div className="flex flex-row items-center justify-start gap-2 rtl:justify-end">
+                  <div className="relative shrink-0">
+                    <Avatar
+                      size="lg"
+                      imageSrc={teamLogo || undefined}
+                      alt={teamName || "Team"}
+                      className="border-2 border-white"
+                    />
+                  </div>
+                  <input ref={logoRef} type="hidden" name="logo" id="logo" defaultValue={teamLogo} />
+                  <ImageUploader
+                    target="avatar"
+                    id="team-logo-upload"
+                    buttonMsg={t("upload")}
+                    handleAvatarChange={handleLogoChange}
+                    imageSrc={teamLogo}
+                  />
+                </div>
+                <p className="text-subtle text-xs font-normal leading-3">{t("onboarding_logo_size_hint")}</p>
+              </div>
+
+              {/* Team Name */}
+              <div className="flex w-full flex-col gap-1.5">
+                <Label className="text-emphasis mb-0 text-sm font-medium leading-4">{t("team_name")}</Label>
+                <TextField
+                  name="name"
+                  data-testid="team-name-input"
+                  value={teamName}
+                  onChange={(e) => setTeamName(e.target.value)}
+                  placeholder="Acme Inc."
+                  className="border-default h-7 rounded-[10px] border px-2 py-1.5 text-sm"
+                />
+              </div>
+
+              {/* Team Slug */}
+              <ValidatedTeamSlug
+                value={teamSlug}
+                onChange={handleSlugChange}
+                onValidationChange={setIsSlugValid}
+              />
+
+              {/* Team Bio */}
+              <div className="flex w-full flex-col gap-1.5">
+                <Label className="text-emphasis mb-0 text-sm font-medium leading-4">{t("team_bio")}</Label>
+                <TextArea
+                  value={teamBio}
+                  onChange={(e) => setTeamBio(e.target.value)}
+                  placeholder={t("team_bio_placeholder")}
+                  className="border-default max-h-[150px] min-h-[80px] rounded-[10px] border px-2 py-1.5 text-sm"
+                  rows={3}
+                />
+              </div>
+            </div>
+          </OnboardingCard>
+        </form>
+      </div>
+
+      {/* Right column - Browser view */}
+      <OnboardingBrowserView teamSlug={teamSlug} name={teamName} bio={teamBio} avatar={teamLogo || null} />
+    </OnboardingLayout>
   );
 };
 
-export default CreateNewTeamPage;
+export const LayoutWrapper = ({ children }: { children: React.ReactNode }) => {
+  return <>{children}</>;
+};
+
+export default CreateNewTeamView;

--- a/apps/web/modules/settings/teams/new/invite/csv-upload-modal.tsx
+++ b/apps/web/modules/settings/teams/new/invite/csv-upload-modal.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import React, { useRef, useState } from "react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button } from "@calcom/ui/components/button";
+import { Dialog, DialogContent } from "@calcom/ui/components/dialog";
+import { Icon } from "@calcom/ui/components/icon";
+import { Logo } from "@calcom/ui/components/logo";
+import { showToast } from "@calcom/ui/components/toast";
+
+import { useOnboardingStore, type Invite } from "~/onboarding/store/onboarding-store";
+
+/**
+ * Parse a CSV line handling quoted fields that may contain commas.
+ * Example: '"Name, Inc",admin' -> ['Name, Inc', 'admin']
+ */
+function parseCSVLine(line: string): string[] {
+  const result: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    } else if (char === "," && !inQuotes) {
+      result.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current.trim());
+  return result;
+}
+
+type CSVUploadModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const CSVUploadModal = ({ isOpen, onClose }: CSVUploadModalProps) => {
+  const { t } = useLocale();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const store = useOnboardingStore();
+  const { setTeamInvites, teamDetails, teamId } = store;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      if (!file.name.endsWith(".csv")) {
+        showToast(t("please_upload_csv_file"), "error");
+        return;
+      }
+      setSelectedFile(file);
+    }
+  };
+
+  const handleDownloadTemplate = () => {
+    const headers = ["email", "role"];
+    const exampleRow = ["example@email.com", "MEMBER"];
+    const csvContent = [headers.join(","), exampleRow.join(",")].join("\n");
+
+    const blob = new Blob([csvContent], { type: "text/csv" });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "team_invite_template.csv";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+
+    showToast(t("template_downloaded"), "success");
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFile) {
+      showToast(t("please_select_file"), "error");
+      return;
+    }
+
+    setIsUploading(true);
+
+    try {
+      const text = await selectedFile.text();
+      const lines = text.split("\n").filter((line) => line.trim());
+
+      if (lines.length < 2) {
+        showToast(t("csv_file_empty"), "error");
+        setIsUploading(false);
+        return;
+      }
+
+      const headers = parseCSVLine(lines[0]).map((h) => h.toLowerCase());
+      const emailIndex = headers.indexOf("email");
+      const roleIndex = headers.indexOf("role");
+
+      if (emailIndex === -1) {
+        showToast(t("csv_missing_email_column"), "error");
+        setIsUploading(false);
+        return;
+      }
+
+      const parsedInvites = lines
+        .slice(1)
+        .map((line) => {
+          const values = parseCSVLine(line);
+          return {
+            email: values[emailIndex]?.trim(),
+            role: (roleIndex !== -1 ? values[roleIndex]?.trim().toUpperCase() : "MEMBER") as
+              | "MEMBER"
+              | "ADMIN",
+          };
+        })
+        .filter((invite) => invite.email && invite.email.length > 0);
+
+      if (parsedInvites.length === 0) {
+        showToast(t("csv_file_empty"), "error");
+        setIsUploading(false);
+        return;
+      }
+
+      const invites: Invite[] = parsedInvites.map((invite) => ({
+        email: invite.email,
+        team: teamDetails.name,
+        role: invite.role === "ADMIN" ? "ADMIN" : "MEMBER",
+      }));
+
+      setTeamInvites(invites);
+
+      showToast(t("csv_uploaded_successfully", { count: invites.length }), "success");
+      onClose();
+
+      // Navigate to email page to display the invites - use settings path
+      const teamIdParam = searchParams?.get("teamId") || teamId;
+      router.push(`/settings/teams/new/invite/email?teamId=${teamIdParam}`);
+    } catch (error) {
+      console.error("Error uploading CSV:", error);
+      showToast(t("error_uploading_csv"), "error");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleClose = () => {
+    setSelectedFile(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent size="default" className="!p-0">
+        <div className="flex flex-col gap-4 p-6">
+          <div className="flex flex-col items-center gap-1">
+            <Logo className="h-10 w-auto" />
+          </div>
+
+          <div
+            className="relative mx-auto flex items-center justify-center"
+            style={{ width: 320, height: 180 }}>
+            <div
+              className="from-default to-muted border-subtle flex items-center justify-center rounded-2xl border bg-gradient-to-br p-8 shadow-sm"
+              style={{ width: 200, height: 150 }}>
+              {selectedFile ? (
+                <div className="flex flex-col items-center gap-3">
+                  <div className="from-default to-muted border-subtle flex items-center justify-center rounded-full border bg-gradient-to-b p-4 shadow-sm">
+                    <Icon name="file-text" className="text-emphasis" style={{ width: 32, height: 32 }} />
+                  </div>
+                  <div className="flex flex-col items-center gap-1">
+                    <p className="text-emphasis text-sm font-medium">{selectedFile.name}</p>
+                    <p className="text-subtle text-xs">{(selectedFile.size / 1024).toFixed(2)} KB</p>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center gap-3">
+                  <div className="from-default to-muted border-subtle flex items-center justify-center rounded-full border bg-gradient-to-b p-4 shadow-sm">
+                    <Icon
+                      name="upload"
+                      className="text-emphasis opacity-70"
+                      style={{ width: 32, height: 32 }}
+                    />
+                  </div>
+                  <p className="text-subtle text-center text-sm">{t("upload_csv_subtitle")}</p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="mb-2 flex flex-col gap-2 text-center">
+            <h2 className="font-heading text-emphasis text-2xl leading-none">{t("upload_csv_file")}</h2>
+            <p className="text-default text-sm leading-normal">{t("upload_csv_description")}</p>
+          </div>
+
+          <div className="mb-2 flex flex-col gap-3">
+            <div className="bg-cal-muted border-subtle flex items-center gap-3 rounded-lg border p-4">
+              <div className="from-default to-muted border-subtle flex items-center justify-center rounded-full border bg-gradient-to-b p-2 shadow-sm">
+                <Icon name="download" className="text-emphasis" style={{ width: 16, height: 16 }} />
+              </div>
+              <div className="flex-1">
+                <p className="text-emphasis text-sm font-medium">{t("need_template")}</p>
+                <p className="text-subtle text-xs">{t("download_csv_template_description")}</p>
+              </div>
+              <Button color="secondary" StartIcon="download" size="sm" onClick={handleDownloadTemplate}>
+                {t("download_template")}
+              </Button>
+            </div>
+
+            <div className="bg-cal-muted border-subtle flex items-center gap-3 rounded-lg border p-4">
+              <div className="from-default to-muted border-subtle flex items-center justify-center rounded-full border bg-gradient-to-b p-2 shadow-sm">
+                <Icon name="upload" className="text-emphasis" style={{ width: 16, height: 16 }} />
+              </div>
+              <div className="flex-1">
+                <p className="text-emphasis text-sm font-medium">{t("upload_your_file")}</p>
+                <p className="text-subtle text-xs">
+                  {selectedFile ? selectedFile.name : t("upload_csv_description")}
+                </p>
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".csv"
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+              <Button
+                color="secondary"
+                StartIcon={selectedFile ? "file-text" : "upload"}
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}>
+                {t("choose_file")}
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-cal-muted border-subtle mt-6 flex items-center justify-between rounded-b-2xl border-t px-8 py-6">
+          <Button color="minimal" onClick={handleClose} disabled={isUploading}>
+            {t("cancel")}
+          </Button>
+          <Button
+            color="primary"
+            onClick={handleUpload}
+            disabled={!selectedFile || isUploading}
+            loading={isUploading}>
+            {t("upload")}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/web/modules/settings/teams/new/invite/email/team-invite-email-view.tsx
+++ b/apps/web/modules/settings/teams/new/invite/email/team-invite-email-view.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter, useSearchParams } from "next/navigation";
+import React, { useEffect } from "react";
+import { useForm, useFieldArray } from "react-hook-form";
+import { z } from "zod";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { trpc } from "@calcom/trpc/react";
+import { Button } from "@calcom/ui/components/button";
+import { Form } from "@calcom/ui/components/form";
+import { showToast } from "@calcom/ui/components/toast";
+
+import { revalidateTeamsList } from "@calcom/web/app/(use-page-wrapper)/(main-nav)/teams/actions";
+import { EmailInviteForm } from "~/onboarding/components/EmailInviteForm";
+import { OnboardingCard } from "~/onboarding/components/OnboardingCard";
+import { OnboardingLayout } from "~/onboarding/components/OnboardingLayout";
+import { RoleSelector } from "~/onboarding/components/RoleSelector";
+import { OnboardingInviteBrowserView } from "~/onboarding/components/onboarding-invite-browser-view";
+import { useCreateTeam } from "~/onboarding/hooks/useCreateTeam";
+import { useOnboardingStore, type InviteRole } from "~/onboarding/store/onboarding-store";
+
+type TeamInviteEmailViewProps = {
+  userEmail: string;
+};
+
+type FormValues = {
+  invites: {
+    email: string;
+    role: InviteRole;
+  }[];
+};
+
+export const TeamInviteEmailView = ({ userEmail }: TeamInviteEmailViewProps) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { t, i18n } = useLocale();
+  const utils = trpc.useUtils();
+
+  const store = useOnboardingStore();
+  const { teamInvites, setTeamInvites, teamDetails, setTeamId, teamId, resetOnboardingPreservingPlan } = store;
+  const [inviteRole, setInviteRole] = React.useState<InviteRole>("MEMBER");
+  const { inviteMembers, isSubmitting } = useCreateTeam({ redirectBasePath: "/settings/teams/new" });
+
+  // Read teamId from query params and store it (from payment callback or redirect)
+  useEffect(() => {
+    const teamIdParam = searchParams?.get("teamId");
+    if (teamIdParam && !teamId) {
+      const parsedTeamId = parseInt(teamIdParam, 10);
+      if (!isNaN(parsedTeamId)) {
+        setTeamId(parsedTeamId);
+      }
+    }
+  }, [searchParams, setTeamId, teamId]);
+
+  const formSchema = z.object({
+    invites: z.array(
+      z.object({
+        email: z.union([z.literal(""), z.string().email(t("invalid_email_address"))]),
+        role: z.enum(["MEMBER", "ADMIN"]),
+      })
+    ),
+  });
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      invites:
+        teamInvites.length > 0
+          ? teamInvites.map((inv) => ({ email: inv.email, role: inv.role }))
+          : [{ email: "", role: inviteRole }],
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "invites",
+  });
+
+  const handleContinue = async (data: FormValues) => {
+    const teamIdParam = searchParams?.get("teamId");
+    const parsedTeamId = !teamId ? parseInt(teamIdParam || "", 10) : teamId;
+    if (!parsedTeamId) {
+      console.log("Team ID is missing. Please go back and create your team first.");
+      showToast(
+        t("team_id_missing") || "Team ID is missing. Please go back and create your team first.",
+        "error"
+      );
+      return;
+    }
+
+    const invitesWithTeam = data.invites.map((invite) => ({
+      email: invite.email,
+      role: invite.role,
+      team: teamDetails.name,
+    }));
+
+    setTeamInvites(invitesWithTeam);
+
+    // Filter out empty emails and invite members
+    const validInvites = data.invites.filter((invite) => invite.email && invite.email.trim().length > 0);
+
+    if (validInvites.length > 0) {
+      try {
+        await inviteMembers(
+          validInvites.map((invite) => ({
+            email: invite.email,
+            role: invite.role,
+          })),
+          i18n.language
+        );
+        // Invalidate both server-side cache and client-side tRPC cache
+        await revalidateTeamsList();
+        await utils.viewer.teams.list.invalidate();
+        resetOnboardingPreservingPlan();
+        router.replace("/teams");
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : t("something_went_wrong") || "Something went wrong";
+        showToast(errorMessage, "error");
+      }
+    } else {
+      // No invites, skip to teams page
+      await revalidateTeamsList();
+      await utils.viewer.teams.list.invalidate();
+      resetOnboardingPreservingPlan();
+      router.replace("/teams");
+    }
+  };
+
+  const handleSkip = async () => {
+    setTeamInvites([]);
+    await revalidateTeamsList();
+    await utils.viewer.teams.list.invalidate();
+    resetOnboardingPreservingPlan();
+    router.replace("/teams");
+  };
+
+  // Watch form values to pass to browser view for real-time updates
+  const watchedInvites = form.watch("invites");
+
+  const hasValidInvites = watchedInvites.some((invite) => {
+    return invite.email && invite.email.trim().length > 0;
+  });
+
+  return (
+    <OnboardingLayout userEmail={userEmail} currentStep={3} totalSteps={3}>
+      {/* Left column - Main content */}
+      <div className="flex h-full w-full flex-col gap-4">
+        <Form form={form} handleSubmit={handleContinue} className="flex h-full w-full flex-col gap-4">
+          <OnboardingCard
+            title={t("invite")}
+            subtitle={t("team_invite_subtitle")}
+            footer={
+              <div className="flex w-full items-center justify-end gap-4">
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    color="minimal"
+                    className="rounded-[10px]"
+                    onClick={handleSkip}
+                    disabled={isSubmitting}
+                    data-testid="skip-invite-button">
+                    {t("onboarding_skip_for_now")}
+                  </Button>
+                  <Button
+                    type="submit"
+                    color="primary"
+                    className="rounded-[10px]"
+                    disabled={!hasValidInvites || isSubmitting}
+                    loading={isSubmitting}>
+                    {t("continue")}
+                  </Button>
+                </div>
+              </div>
+            }>
+            <div className="flex w-full flex-col gap-4 px-1">
+              <div className="flex w-full flex-col gap-4">
+                <EmailInviteForm
+                  fields={fields}
+                  append={append}
+                  remove={remove}
+                  defaultRole={inviteRole}
+                  emailPlaceholder="rick@cal.com"
+                />
+
+                <RoleSelector
+                  value={inviteRole}
+                  onValueChange={(value) => {
+                    setInviteRole(value);
+                    fields.forEach((_, index) => {
+                      form.setValue(`invites.${index}.role`, value);
+                    });
+                  }}
+                  showInfoBadge
+                />
+              </div>
+            </div>
+          </OnboardingCard>
+        </Form>
+      </div>
+
+      {/* Right column - Browser view */}
+      <OnboardingInviteBrowserView teamName={teamDetails.name} watchedInvites={watchedInvites} />
+    </OnboardingLayout>
+  );
+};

--- a/apps/web/modules/settings/teams/new/invite/team-invite-view.tsx
+++ b/apps/web/modules/settings/teams/new/invite/team-invite-view.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import posthog from "posthog-js";
+import React, { useEffect } from "react";
+
+import { useFlags } from "@calcom/features/flags/hooks";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button } from "@calcom/ui/components/button";
+
+import { InviteOptions } from "~/onboarding/components/InviteOptions";
+import { OnboardingCard } from "~/onboarding/components/OnboardingCard";
+import { OnboardingLayout } from "~/onboarding/components/OnboardingLayout";
+import { OnboardingInviteBrowserView } from "~/onboarding/components/onboarding-invite-browser-view";
+import { useCreateTeam } from "~/onboarding/hooks/useCreateTeam";
+import { useOnboardingStore } from "~/onboarding/store/onboarding-store";
+
+import { CSVUploadModal } from "./csv-upload-modal";
+
+type TeamInviteViewProps = {
+  userEmail: string;
+};
+
+export const TeamInviteView = ({ userEmail }: TeamInviteViewProps) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { t } = useLocale();
+  const flags = useFlags();
+
+  const store = useOnboardingStore();
+  const { setTeamInvites, teamDetails, setTeamId, teamId, resetOnboardingPreservingPlan } = store;
+  const { isSubmitting } = useCreateTeam({ redirectBasePath: "/settings/teams/new" });
+  const [isCSVModalOpen, setIsCSVModalOpen] = React.useState(false);
+
+  // Read teamId from query params and store it (from payment callback)
+  useEffect(() => {
+    const teamIdParam = searchParams?.get("teamId");
+    if (teamIdParam) {
+      const parsedTeamId = parseInt(teamIdParam, 10);
+      if (!isNaN(parsedTeamId)) {
+        setTeamId(parsedTeamId);
+      }
+    }
+  }, [searchParams, setTeamId]);
+
+  const googleWorkspaceEnabled = flags["google-workspace-directory"];
+
+  const handleGoogleWorkspaceConnect = () => {
+    // TODO: Implement Google Workspace connection
+    console.log("Connect Google Workspace");
+  };
+
+  const handleInviteViaEmail = () => {
+    router.push(`/settings/teams/new/invite/email?teamId=${teamId}`);
+  };
+
+  const handleUploadCSV = () => {
+    setIsCSVModalOpen(true);
+  };
+
+  const handleCopyInviteLink = () => {
+    // Disabled for now as per requirements
+    console.log("Copy invite link - disabled");
+  };
+
+  const handleSkip = async () => {
+    posthog.capture("settings_team_invite_skip_clicked");
+    setTeamInvites([]);
+    resetOnboardingPreservingPlan();
+    // Redirect to teams page after skipping
+    router.push("/teams");
+  };
+
+  const handleBack = () => {
+    posthog.capture("settings_team_invite_back_clicked");
+    router.push("/settings/teams/new");
+  };
+
+  return (
+    <>
+      <OnboardingLayout userEmail={userEmail} currentStep={2} totalSteps={3}>
+        {/* Left column - Main content */}
+        <div className="flex w-full flex-col gap-4">
+          <OnboardingCard
+            title={t("invite")}
+            subtitle={t("onboarding_invite_subtitle")}
+            footer={
+              <div className="flex w-full items-center justify-between gap-4">
+                <Button
+                  color="minimal"
+                  className="rounded-[10px]"
+                  onClick={handleBack}
+                  disabled={isSubmitting}>
+                  {t("back")}
+                </Button>
+                <div className="flex items-center gap-2">
+                  <Button
+                    color="minimal"
+                    className="rounded-[10px]"
+                    onClick={handleSkip}
+                    disabled={isSubmitting}>
+                    {t("onboarding_skip_for_now")}
+                  </Button>
+                </div>
+              </div>
+            }>
+            <InviteOptions
+              onInviteViaEmail={handleInviteViaEmail}
+              onUploadCSV={handleUploadCSV}
+              onCopyInviteLink={handleCopyInviteLink}
+              onConnectGoogleWorkspace={googleWorkspaceEnabled ? handleGoogleWorkspaceConnect : undefined}
+              isSubmitting={isSubmitting}
+            />
+          </OnboardingCard>
+        </div>
+
+        {/* Right column - Browser view */}
+        <OnboardingInviteBrowserView teamName={teamDetails.name} />
+      </OnboardingLayout>
+
+      {/* CSV Upload Modal */}
+      <CSVUploadModal isOpen={isCSVModalOpen} onClose={() => setIsCSVModalOpen(false)} />
+    </>
+  );
+};

--- a/apps/web/playwright/auth/auth-index.e2e.ts
+++ b/apps/web/playwright/auth/auth-index.e2e.ts
@@ -26,16 +26,18 @@ test.describe("Can signup from a team invite", async () => {
     await page.goto("/settings/teams/new");
     await page.waitForLoadState("networkidle");
 
-    // Create a new team
-    await page.locator('input[name="name"]').fill(teamName);
-    await page.locator('input[name="slug"]').fill(teamName);
+    // Create a new team (new onboarding-v3 style flow)
+    await page.locator('[data-testid="team-name-input"]').fill(teamName);
     await page.locator('button[type="submit"]').click();
 
-    // Add new member to team
-    await page.click('[data-testid="new-member-button"]');
-    await page.fill('input[id="inviteUser"]', testUser.email);
+    // Wait for the invite email page
+    await page.waitForURL(/\/settings\/teams\/new\/invite\/email.*$/i);
+    await page.waitForLoadState("networkidle");
+
+    // Add new member to team via email invite form
+    await page.locator('input[type="email"]').first().fill(testUser.email);
     const submitPromise = page.waitForResponse("/api/trpc/teams/inviteMember?batch=1");
-    await page.getByTestId("invite-new-member-button").click();
+    await page.locator('button[type="submit"]').click();
     const response = await submitPromise;
     expect(response.status()).toBe(200);
 

--- a/apps/web/playwright/organization/team-management.e2e.ts
+++ b/apps/web/playwright/organization/team-management.e2e.ts
@@ -29,51 +29,30 @@ test.describe("Teams", () => {
       // Click text=Create Team
       await page.locator("text=Create a new Team").click();
       await page.waitForLoadState("networkidle");
-      // Fill input[name="name"]
-      await page.locator('input[name="name"]').fill(`${user.username}'s Team`);
+      // Fill team name input (new onboarding-v3 style flow)
+      await page.locator('[data-testid="team-name-input"]').fill(`${user.username}'s Team`);
       // Click text=Continue
       await page.click("[type=submit]");
       // TODO: Figure out a way to make this more reliable
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (IS_TEAM_BILLING_ENABLED) await fillStripeTestCheckout(page);
-      await expect(page).toHaveURL(/\/settings\/teams\/(\d+)\/onboard-members.*$/i);
-      await page.waitForSelector('[data-testid="pending-member-list"]');
-      await expect(page.getByTestId("pending-member-item")).toHaveCount(1);
+      // Wait for the invite email page (new flow)
+      await expect(page).toHaveURL(/\/settings\/teams\/new\/invite\/email.*$/i);
+      await page.waitForLoadState("networkidle");
     });
 
-    await test.step("Can add members", async () => {
-      await page.getByTestId("new-member-button").click();
-      await page.locator('[placeholder="email\\@example\\.com"]').fill(inviteeEmail);
-      await page.getByTestId("invite-new-member-button").click();
-      await expect(page.getByTestId("pending-member-item").filter({ hasText: inviteeEmail })).toBeVisible();
-
-      // locator.count() does not await for the expected number of elements
-      // https://github.com/microsoft/playwright/issues/14278
-      // using toHaveCount() is more reliable
-      await expect(page.getByTestId("pending-member-item")).toHaveCount(2);
+    await test.step("Can add members via email invite", async () => {
+      // Add member via email invite form
+      await page.locator('input[type="email"]').first().fill(inviteeEmail);
+      await page.click("[type=submit]");
+      await page.waitForLoadState("networkidle");
+      // Wait for redirect to teams page
+      await expect(page).toHaveURL(/\/teams$/i);
     });
 
-    await test.step("Can remove members", async () => {
-      await expect(page.getByTestId("pending-member-item")).toHaveCount(2);
-      const lastRemoveMemberButton = page.getByTestId("remove-member-button").last();
-      await lastRemoveMemberButton.click();
-      await expect(page.getByTestId("pending-member-item")).toHaveCount(1);
-
-      // Cleanup here since this user is created without our fixtures.
-      await prisma.user.delete({ where: { email: inviteeEmail } });
-    });
-
-    await test.step("Can finish team invitation", async () => {
-      await page.getByTestId("publish-button").click();
-      await expect(page).toHaveURL(/\/settings\/teams\/(\d+)\/event-type$/i);
-    });
-
-    await test.step("Can finish team creation", async () => {
-      const locator = page.locator('div:has(input[value="ROUND_ROBIN"]) > button');
-      await expect(locator).toBeVisible();
-      await locator.click();
-      await page.fill("[name=title]", "roundRobin");
-      await page.getByTestId("finish-button").click();
+    await test.step("Can navigate to team settings", async () => {
+      // Click on the team to go to settings
+      await page.locator(`text=${user.username}'s Team`).click();
       await page.waitForURL(/\/settings\/teams\/(\d+)\/profile$/i);
     });
 
@@ -82,6 +61,13 @@ test.describe("Teams", () => {
       await page.getByTestId("dialog-confirmation").click();
       await page.waitForURL("/teams");
       expect(await page.locator(`text=${user.username}'s Team`).count()).toEqual(0);
+
+      // Cleanup the invited user since they were created without our fixtures
+      const invitedUser = await prisma.user.findUnique({ where: { email: inviteeEmail } });
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      if (invitedUser) {
+        await prisma.user.delete({ where: { email: inviteeEmail } });
+      }
     });
   });
 });

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -139,11 +139,11 @@ test.describe("Teams - NonOrg", () => {
 
       const uniqueName = "test-unique-team-name";
 
-      // Go directly to the create team page
+      // Go directly to the create team page (new onboarding-v3 style flow)
       await page.goto("/settings/teams/new");
       await page.waitForLoadState("networkidle");
-      // Fill input[name="name"]
-      await page.locator('input[name="name"]').fill(uniqueName);
+      // Fill team name input
+      await page.locator('[data-testid="team-name-input"]').fill(uniqueName);
       await page.click("[type=submit]");
 
       // cleanup
@@ -163,22 +163,22 @@ test.describe("Teams - NonOrg", () => {
       // Click text=Create Team
       await page.locator("text=Create Team").click();
       await page.waitForLoadState("networkidle");
-      // Fill input[name="name"]
-      await page.locator('input[name="name"]').fill(uniqueName);
-      // Click text=Continue
+      // Fill team name input (new onboarding-v3 style flow)
+      await page.locator('[data-testid="team-name-input"]').fill(uniqueName);
+      // Click Continue
       await page.click("[type=submit]");
       // TODO: Figure out a way to make this more reliable
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (IS_TEAM_BILLING_ENABLED) await fillStripeTestCheckout(page);
-      await page.waitForURL(/\/settings\/teams\/(\d+)\/onboard-members.*$/i);
-      // Wait for the page to fully load and the publish button to be visible
+      // Wait for the invite email page
+      await page.waitForURL(/\/settings\/teams\/new\/invite\/email.*$/i);
       await page.waitForLoadState("networkidle");
-      const publishButton = page.locator("[data-testid=publish-button]");
-      await publishButton.waitFor({ state: "visible", timeout: 10000 });
-      await publishButton.click();
-      await page.waitForURL(/\/settings\/teams\/(\d+)\/event-type*$/i);
-      await page.locator("[data-testid=handle-later-button]").click();
-      await page.waitForURL(/\/settings\/teams\/(\d+)\/profile$/i);
+      // Skip the invite step
+      const skipButton = page.locator("[data-testid=skip-invite-button]");
+      await skipButton.waitFor({ state: "visible", timeout: 10000 });
+      await skipButton.click();
+      // Wait for redirect to teams page
+      await page.waitForURL(/\/teams$/i);
     });
 
     await test.step("Can access user and team with same slug", async () => {


### PR DESCRIPTION
## Summary

Re-applies the team creation flow redesign from #26733 with a fix for the org slug validation issue that caused the original to be reverted.

**The bug:** `checkTeamSlugAvailability` was always checking for slugs with `parentId=null` (top-level teams), but org child teams have `parentId=orgId`. This caused org admins to be blocked from creating teams with slugs that existed in other orgs but not their own.

**The fix:** Now uses the user's `organizationId` from their profile to scope the slug uniqueness check within their organization context, matching the behavior in the team creation handler (`create.handler.ts`).

## Key changes

- Redesigned team creation at `/settings/teams/new` using onboarding-v3 components
- Added team logo upload and bio fields  
- Added new invite flow routes: `/settings/teams/new/invite` and `/invite/email`
- **Fixed slug validation to check within organization context instead of globally**
- Added username conflict check within organization (same as creation handler)

## How the fix works

```typescript
// Before (incorrect - always checking top-level)
const existingTeam = await prisma.team.findFirst({
  where: {
    slug,
    parentId: null,  // Always top-level
  },
});

// After (correct - scoped to organization)
const organizationId = session.user.profile?.organizationId ?? null;
const existingTeam = await prisma.team.findFirst({
  where: {
    slug,
    parentId: organizationId,  // Scoped to user's org
  },
});

// Also added username conflict check for org users
if (organizationId) {
  const usernameConflict = await ProfileRepository.findByOrgIdAndUsername({
    organizationId,
    username: slug,
  });
  // ...
}
```

## Test plan

- [ ] Create a team in an organization where the slug already exists in a different organization - should work
- [ ] Create a team in an organization where the slug already exists within the same organization - should fail
- [ ] Create a team where the slug matches a user's username in the organization - should fail
- [ ] Non-org users can still create teams normally
- [ ] New team creation flow works with logo upload and bio

🤖 Generated with [Claude Code](https://claude.com/claude-code)