### PR TITLE
perf: optimize myStats tRPC call to only trigger when Intercom session is created

### DIFF
--- a/apps/web/modules/ee/support/lib/intercom/useIntercom.ts
+++ b/apps/web/modules/ee/support/lib/intercom/useIntercom.ts
@@ -33,11 +33,9 @@ export const useIntercom = () => {
   const { hasPaidPlan, plan } = useHasPaidPlan();
   const { hasTeamPlan } = useHasTeamPlan();
 
-  // Fetch stats on-demand when booting Intercom, not upfront
   const fetchStatsAndBoot = async () => {
     if (!data) return;
 
-    // Fetch stats only when actually creating the Intercom session
     const statsData = await utils.viewer.me.myStats.fetch();
 
     let userHash;
@@ -87,7 +85,6 @@ export const useIntercom = () => {
   const open = async () => {
     if (!data) return;
 
-    // Fetch stats only when actually opening Intercom
     const statsData = await utils.viewer.me.myStats.fetch();
 
     let userHash;
@@ -149,7 +146,6 @@ declare global {
 export const useBootIntercom = () => {
   const { hasPaidPlan } = useHasPaidPlan();
   const flagMap = useFlagMap();
-  // Stats are now fetched on-demand inside boot() when Intercom session is created
   const { boot, open, update } = useIntercom();
 
   const { data: user } = trpc.viewer.me.get.useQuery();

--- a/apps/web/modules/ee/support/lib/intercom/useIntercom.ts
+++ b/apps/web/modules/ee/support/lib/intercom/useIntercom.ts
@@ -35,6 +35,8 @@ export const useIntercom = () => {
         skipBatch: true,
       },
     },
+    // Only fetch stats when Intercom is enabled to avoid unnecessary API calls
+    enabled: isInterComEnabled,
   });
   const { hasPaidPlan, plan } = useHasPaidPlan();
   const { hasTeamPlan } = useHasTeamPlan();
@@ -131,7 +133,7 @@ export const useIntercom = () => {
     });
     hookData.show();
   };
-  return { ...hookData, open, boot };
+  return { ...hookData, open, boot, statsData };
 };
 
 declare global {
@@ -146,17 +148,11 @@ declare global {
 export const useBootIntercom = () => {
   const { hasPaidPlan } = useHasPaidPlan();
   const flagMap = useFlagMap();
-  const { boot, open, update } = useIntercom();
+  // statsData is now returned from useIntercom to avoid duplicate API calls
+  const { boot, open, update, statsData } = useIntercom();
 
   const { data: user } = trpc.viewer.me.get.useQuery();
   const isTieredSupportEnabled = flagMap["tiered-support-chat"];
-  const { data: statsData } = trpc.viewer.me.myStats.useQuery(undefined, {
-    trpc: {
-      context: {
-        skipBatch: true,
-      },
-    },
-  });
   useEffect(() => {
     // not using useMediaQuery as it toggles between true and false
     const showIntercom = localStorage.getItem("showIntercom");

--- a/apps/web/modules/ee/support/lib/intercom/useIntercom.ts
+++ b/apps/web/modules/ee/support/lib/intercom/useIntercom.ts
@@ -29,20 +29,17 @@ export const useIntercom = () => {
   const hookData = useIntercomHook();
   const isMobile = useMediaQuery("(max-width: 768px)");
   const { data } = trpc.viewer.me.get.useQuery();
-  const { data: statsData } = trpc.viewer.me.myStats.useQuery(undefined, {
-    trpc: {
-      context: {
-        skipBatch: true,
-      },
-    },
-    // Only fetch stats when Intercom is enabled to avoid unnecessary API calls
-    enabled: isInterComEnabled,
-  });
+  const utils = trpc.useUtils();
   const { hasPaidPlan, plan } = useHasPaidPlan();
   const { hasTeamPlan } = useHasTeamPlan();
 
-  const boot = async () => {
-    if (!data || !statsData) return;
+  // Fetch stats on-demand when booting Intercom, not upfront
+  const fetchStatsAndBoot = async () => {
+    if (!data) return;
+
+    // Fetch stats only when actually creating the Intercom session
+    const statsData = await utils.viewer.me.myStats.fetch();
+
     let userHash;
     const req = await fetch(`/api/support/hash`);
     const res = await req.json();
@@ -88,8 +85,12 @@ export const useIntercom = () => {
   };
 
   const open = async () => {
-    let userHash;
+    if (!data) return;
 
+    // Fetch stats only when actually opening Intercom
+    const statsData = await utils.viewer.me.myStats.fetch();
+
+    let userHash;
     const req = await fetch(`/api/support/hash`);
     const res = await req.json();
     if (res?.hash) {
@@ -133,7 +134,7 @@ export const useIntercom = () => {
     });
     hookData.show();
   };
-  return { ...hookData, open, boot, statsData };
+  return { ...hookData, open, boot: fetchStatsAndBoot };
 };
 
 declare global {
@@ -148,8 +149,8 @@ declare global {
 export const useBootIntercom = () => {
   const { hasPaidPlan } = useHasPaidPlan();
   const flagMap = useFlagMap();
-  // statsData is now returned from useIntercom to avoid duplicate API calls
-  const { boot, open, update, statsData } = useIntercom();
+  // Stats are now fetched on-demand inside boot() when Intercom session is created
+  const { boot, open, update } = useIntercom();
 
   const { data: user } = trpc.viewer.me.get.useQuery();
   const isTieredSupportEnabled = flagMap["tiered-support-chat"];
@@ -160,7 +161,6 @@ export const useBootIntercom = () => {
       !isInterComEnabled ||
       showIntercom === "false" ||
       !user ||
-      !statsData ||
       (!hasPaidPlan && isTieredSupportEnabled)
     )
       return;
@@ -178,7 +178,7 @@ export const useBootIntercom = () => {
       window.dispatchEvent(new Event("support:ready"));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, statsData, hasPaidPlan, isTieredSupportEnabled]);
+  }, [user, hasPaidPlan, isTieredSupportEnabled]);
 };
 
 export default useIntercom;


### PR DESCRIPTION
## What does this PR do?

Optimizes the `trpc.viewer.me.myStats` endpoint which was being called hundreds of thousands of times per day unnecessarily. The issue was twofold:

1. The `myStats` query was being called unconditionally on every page load, even when Intercom is disabled
2. The query was being called twice - once in `useIntercom` and again in `useBootIntercom`

This PR changes the approach to **fetch stats on-demand** only when the Intercom session is actually being created:
- Removes the upfront `useQuery` calls for `myStats` from both hooks
- Uses `trpc.useUtils()` to fetch stats inside `boot()` and `open()` functions only when needed
- Stats are now fetched right before creating the Intercom session, not on component mount

This means `myStats` will only be called when:
- Intercom is enabled AND
- User meets the criteria (paid plan or tiered support disabled) AND
- The Intercom session is actually being initialized

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **With Intercom disabled** (no `NEXT_PUBLIC_INTERCOM_APP_ID` env var):
   - Verify that `myStats` endpoint is NOT called when navigating the app
   - Check network tab to confirm no requests to the myStats tRPC endpoint

2. **With Intercom enabled** (set `NEXT_PUBLIC_INTERCOM_APP_ID`):
   - Verify Intercom still boots correctly with user stats
   - Verify the Intercom widget shows correct user data (sum_of_bookings, sum_of_calendars, etc.)
   - Confirm `myStats` is only called once when Intercom initializes, not on every page load

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the async `utils.viewer.me.myStats.fetch()` inside `boot()` doesn't cause timing issues with Intercom initialization
- [ ] Confirm error handling is acceptable if the myStats fetch fails (currently uses optional chaining)
- [ ] Verify the useEffect dependencies in `useBootIntercom` correctly trigger boot without statsData dependency
- [ ] Test that Intercom widget displays correct stats after the on-demand fetch

---

Requested by: @keithwillcode
Link to Devin run: https://app.devin.ai/sessions/dd86c920aeaf4921889f08c1bfc43441