### PR TITLE
feat: show routing trace dialog on assignment reason badge click

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -41,7 +41,6 @@ import { Tooltip } from "@calcom/ui/components/tooltip";
 import assignmentReasonBadgeTitleMap from "@lib/booking/assignmentReasonBadgeTitleMap";
 
 import { WrongAssignmentDialog } from "../dialog/WrongAssignmentDialog";
-import { RoutingTraceSheet } from "./RoutingTraceSheet";
 import { buildBookingLink } from "../../modules/bookings/lib/buildBookingLink";
 import { useBookingDetailsSheetStore } from "../../modules/bookings/store/bookingDetailsSheetStore";
 import type { BookingAttendee } from "../../modules/bookings/types";
@@ -281,7 +280,6 @@ function BookingListItem(booking: BookingItemProps) {
   const setIsOpenWrongAssignmentDialog = useBookingActionsStoreContext(
     (state) => state.setIsOpenWrongAssignmentDialog
   );
-  const isOpenRoutingTraceSheet = useBookingActionsStoreContext((state) => state.isOpenRoutingTraceSheet);
   const setIsOpenRoutingTraceSheet = useBookingActionsStoreContext(
     (state) => state.setIsOpenRoutingTraceSheet
   );
@@ -537,13 +535,6 @@ function BookingListItem(booking: BookingItemProps) {
           hostEmail={booking.user?.email ?? ""}
           hostName={booking.user?.name ?? null}
           teamId={booking.eventType?.team?.id ?? null}
-        />
-      )}
-      {booking.assignmentReason.length > 0 && (
-        <RoutingTraceSheet
-          isOpen={isOpenRoutingTraceSheet}
-          setIsOpen={setIsOpenRoutingTraceSheet}
-          bookingUid={booking.uid}
         />
       )}
     </div>

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -41,6 +41,7 @@ import { Tooltip } from "@calcom/ui/components/tooltip";
 import assignmentReasonBadgeTitleMap from "@lib/booking/assignmentReasonBadgeTitleMap";
 
 import { WrongAssignmentDialog } from "../dialog/WrongAssignmentDialog";
+import { RoutingTraceSheet } from "./RoutingTraceSheet";
 import { buildBookingLink } from "../../modules/bookings/lib/buildBookingLink";
 import { useBookingDetailsSheetStore } from "../../modules/bookings/store/bookingDetailsSheetStore";
 import type { BookingAttendee } from "../../modules/bookings/types";
@@ -279,6 +280,10 @@ function BookingListItem(booking: BookingItemProps) {
   );
   const setIsOpenWrongAssignmentDialog = useBookingActionsStoreContext(
     (state) => state.setIsOpenWrongAssignmentDialog
+  );
+  const isOpenRoutingTraceSheet = useBookingActionsStoreContext((state) => state.isOpenRoutingTraceSheet);
+  const setIsOpenRoutingTraceSheet = useBookingActionsStoreContext(
+    (state) => state.setIsOpenRoutingTraceSheet
   );
   const reportAction = getReportAction(actionContext);
   const reportActionWithHandler = {
@@ -519,7 +524,7 @@ function BookingListItem(booking: BookingItemProps) {
         userTimeZone={userTimeZone}
         isRescheduled={isRescheduled}
         onAssignmentReasonClick={
-          isBookingFromRoutingForm ? () => setIsOpenWrongAssignmentDialog(true) : undefined
+          booking.assignmentReason.length > 0 ? () => setIsOpenRoutingTraceSheet(true) : undefined
         }
       />
       {isBookingFromRoutingForm && (
@@ -532,6 +537,13 @@ function BookingListItem(booking: BookingItemProps) {
           hostEmail={booking.user?.email ?? ""}
           hostName={booking.user?.name ?? null}
           teamId={booking.eventType?.team?.id ?? null}
+        />
+      )}
+      {booking.assignmentReason.length > 0 && (
+        <RoutingTraceSheet
+          isOpen={isOpenRoutingTraceSheet}
+          setIsOpen={setIsOpenRoutingTraceSheet}
+          bookingUid={booking.uid}
         />
       )}
     </div>

--- a/apps/web/components/booking/actions/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/actions/BookingActionsDropdown.tsx
@@ -455,23 +455,23 @@ export function BookingActionsDropdown({
         status={getBookingStatus()}
       />
       {isBookingFromRoutingForm && (
-        <>
-          <WrongAssignmentDialog
-            isOpenDialog={isOpenWrongAssignmentDialog}
-            setIsOpenDialog={setIsOpenWrongAssignmentDialog}
-            bookingUid={booking.uid}
-            routingReason={booking.assignmentReason[0]?.reasonString ?? null}
-            guestEmail={booking.attendees[0]?.email ?? ""}
-            hostEmail={booking.user?.email ?? ""}
-            hostName={booking.user?.name ?? null}
-            teamId={booking.eventType?.team?.id ?? null}
-          />
-          <RoutingTraceSheet
-            isOpen={isOpenRoutingTraceSheet}
-            setIsOpen={setIsOpenRoutingTraceSheet}
-            bookingUid={booking.uid}
-          />
-        </>
+        <WrongAssignmentDialog
+          isOpenDialog={isOpenWrongAssignmentDialog}
+          setIsOpenDialog={setIsOpenWrongAssignmentDialog}
+          bookingUid={booking.uid}
+          routingReason={booking.assignmentReason[0]?.reasonString ?? null}
+          guestEmail={booking.attendees[0]?.email ?? ""}
+          hostEmail={booking.user?.email ?? ""}
+          hostName={booking.user?.name ?? null}
+          teamId={booking.eventType?.team?.id ?? null}
+        />
+      )}
+      {booking.assignmentReason.length > 0 && (
+        <RoutingTraceSheet
+          isOpen={isOpenRoutingTraceSheet}
+          setIsOpen={setIsOpenRoutingTraceSheet}
+          bookingUid={booking.uid}
+        />
       )}
       {booking.paid && booking.payment[0] && (
         <ChargeCardDialog

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -57,6 +57,7 @@ import { Icon } from "@calcom/ui/components/icon";
 import { showToast } from "@calcom/ui/components/toast";
 import { useCalcomTheme } from "@calcom/ui/styles";
 import CancelBooking from "@calcom/web/components/booking/CancelBooking";
+import { RoutingTraceSheet } from "@calcom/web/components/booking/RoutingTraceSheet";
 import EventReservationSchema from "@calcom/web/components/schemas/EventReservationSchema";
 import { timeZone } from "@calcom/web/lib/clock";
 
@@ -203,6 +204,7 @@ export default function Success(props: PageProps) {
   const defaultRating = validateRating(rating);
   const [rateValue, setRateValue] = useState<number>(defaultRating);
   const [isFeedbackSubmitted, setIsFeedbackSubmitted] = useState(false);
+  const [isRoutingTraceSheetOpen, setIsRoutingTraceSheetOpen] = useState(false);
 
   const mutation = trpc.viewer.public.submitRating.useMutation({
     onSuccess: async () => {
@@ -773,7 +775,10 @@ export default function Success(props: PageProps) {
                             <>
                               <div className="mt-9 font-medium">{t("assignment_reason")}</div>
                               <div className="col-span-2 mb-2 mt-9">
-                                <Badge variant="gray" className="mb-2">
+                                <Badge
+                                  variant="gray"
+                                  className="mb-2 cursor-pointer hover:opacity-80"
+                                  onClick={() => setIsRoutingTraceSheetOpen(true)}>
                                   {t(
                                     assignmentReasonBadgeTitleMap(
                                       bookingInfo.assignmentReason[0].reasonEnum as AssignmentReasonEnum
@@ -785,6 +790,11 @@ export default function Success(props: PageProps) {
                                     {bookingInfo.assignmentReason[0].reasonString}
                                   </p>
                                 )}
+                                <RoutingTraceSheet
+                                  isOpen={isRoutingTraceSheetOpen}
+                                  setIsOpen={setIsRoutingTraceSheetOpen}
+                                  bookingUid={bookingInfo.uid}
+                                />
                               </div>
                             </>
                           )}


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability to view the routing trace dialog when clicking on the assignment reason badge in two places:

1. **BookingListItem** - When a booking has an assignment reason, clicking the badge now opens the RoutingTraceSheet to show the routing trace details
2. **Booking Single View Page** - Added a clickable assignment reason badge that opens the RoutingTraceSheet, only visible to users with permission to view hidden data (hosts and team members)

The existing `RoutingTraceSheet` component is reused in both locations.

### Updates since last revision

- Fixed duplicate RoutingTraceSheet rendering issue: The sheet was being rendered in both `BookingListItem.tsx` and `BookingActionsDropdown.tsx`, causing duplicate sheets and double data fetches when clicking the badge
- Moved RoutingTraceSheet rendering to only `BookingActionsDropdown.tsx` with condition `booking.assignmentReason.length > 0`
- Removed redundant RoutingTraceSheet from `BookingListItem.tsx` (the click handler still works via shared store state)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a booking that was routed through a routing form (so it has an assignment reason)
2. Navigate to the bookings list view
3. Click on the assignment reason badge on a booking item - the routing trace sheet should open
4. **Verify only one sheet opens** (not duplicates)
5. Navigate to the booking single view page (click on a booking to view details)
6. If you are the host or a team member, you should see the assignment reason section
7. Click on the assignment reason badge - the routing trace sheet should open

**Permission check:** The routing trace on the booking single view page should only be visible to users who have `canViewHiddenData` permission (hosts and team members).

## Human Review Checklist

- [ ] Verify clicking assignment reason badge in BookingListItem opens the RoutingTraceSheet correctly (via shared store state with BookingActionsDropdown)
- [ ] Confirm no duplicate sheets appear when clicking the badge
- [ ] Verify the condition `booking.assignmentReason.length > 0` is appropriate for showing the routing trace

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run:** https://app.devin.ai/sessions/a8b6f7773b174705b0e378f642de1e45
**Requested by:** @joeauyeung
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
