### PR TITLE
fix: verification code perf

### DIFF
--- a/packages/trpc/server/routers/viewer/workflows/sendVerificationCode.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/sendVerificationCode.handler.ts
@@ -1,5 +1,6 @@
 import { CreditsRepository } from "@calcom/features/credits/repositories/CreditsRepository";
 import { sendVerificationCode } from "@calcom/features/ee/workflows/lib/reminders/verifyPhoneNumber";
+import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import hasKeyInMetadata from "@calcom/lib/hasKeyInMetadata";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
@@ -33,6 +34,11 @@ export const sendVerificationCodeHandler = async ({ ctx, input }: SendVerificati
   if (!isCurrentUsernamePremium && !isTeamsPlan && hasNoAdditionalCredits) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
+
+  await checkRateLimitAndThrowError({
+    identifier: `sendVerificationCode:${user.id}`,
+    rateLimitingType: "core",
+  });
 
   const { phoneNumber } = input;
   return sendVerificationCode(phoneNumber);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added per-user rate limiting to the sendVerificationCode handler to smooth bursts and improve responsiveness. This reduces load and keeps the verification flow stable under heavy usage.

<sup>Written for commit 1f4d301a135a6bd8442f02f43594f00319250bce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

