### PR TITLE
fix: cleaned the extra space in description before saving to avoid word break

### DIFF
--- a/apps/web/modules/event-types/components/tabs/setup/EventSetupTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/setup/EventSetupTab.tsx
@@ -143,9 +143,12 @@ export const EventSetupTab = (
                 </Label>
                 <Editor
                   getText={() => md.render(formMethods.getValues("description") || "")}
-                  setText={(value: string) =>
-                    formMethods.setValue("description", turndown(value), { shouldDirty: true })
-                  }
+                  setText={(value: string) => {
+                  // Clean up non-breaking spaces
+                  const cleanedValue = value.replace(/&nbsp;/g, ' ');
+                  const markdownValue = turndown(cleanedValue);
+                  formMethods.setValue("description", markdownValue, { shouldDirty: true });
+                  }}
                   excludedToolbarItems={["blockType"]}
                   placeholder={t("quick_video_meeting")}
                   editable={!descriptionLockedProps.disabled}


### PR DESCRIPTION

- Fixes #27619 
- Fixes [CAL-7170 (Linear issue number - should be visible at the bottom of the GitHub issue description)](https://linear.app/calcom/issue/CAL-7170/event-description-breaks-lines-mid-word-on-desktop)


#### Video Demo (if applicable):

- After change
 
https://github.com/user-attachments/assets/47d98b6d-a5a0-4d7b-bc38-e7251acc251b


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Edit the event type description and notice that the word is not breaking between two lines.

## Checklist
