### PR TITLE
fix(ui): change phone booking display from Organizer Phone Number to Phone Call

### DIFF
--- a/apps/web/components/dialog/__tests__/EditLocationDialog.test.tsx
+++ b/apps/web/components/dialog/__tests__/EditLocationDialog.test.tsx
@@ -47,7 +47,7 @@ vi.mock("@calcom/features/form/components/LocationSelect", () => {
 });
 
 const AttendeePhoneNumberLabel = "Attendee phone number";
-const OrganizerPhoneLabel = "Organizer phone number";
+const OrganizerPhoneLabel = "Phone call";
 const CampfireLabel = "Campfire";
 const ZoomVideoLabel = "Zoom Video";
 const OrganizerDefaultConferencingAppLabel = "Organizer's default app";
@@ -202,7 +202,7 @@ describe("EditLocationDialog", () => {
   });
 
   describe("Team Booking Case", () => {
-    it("should not show Attendee Phone Number but show Organizer Phone Number and dynamic link Conferencing apps", async () => {
+    it("should not show Attendee Phone Number but show Phone Call option and dynamic link Conferencing apps", async () => {
       render(<EditLocationDialog {...mockProps} booking={{ location: "Office" }} teamId={1} />);
 
       expect(screen.queryByText(AttendeePhoneNumberLabel)).not.toBeInTheDocument();

--- a/apps/web/playwright/event-types.e2e.ts
+++ b/apps/web/playwright/event-types.e2e.ts
@@ -365,7 +365,7 @@ test.describe("Event Types tests", () => {
         await page.getByTestId(removeButtomId).nth(0).click();
         await page.getByTestId(removeButtomId).nth(0).click();
 
-        // Add Multiple Organizer Phone Number options
+        // Add Multiple Phone Call location options
         await page.getByTestId("location-select").last().click();
         await page.getByTestId("location-select-item-userPhone").click();
 

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -753,7 +753,6 @@
   "phone_number": "Phone number",
   "attendee_phone_number": "Attendee phone number",
   "organizer_phone_number": "Organizer phone number",
-  "phone_call": "Phone call",
   "enter_phone_number": "Enter phone number",
   "reschedule": "Reschedule",
   "reschedule_this": "Reschedule instead",

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -753,6 +753,7 @@
   "phone_number": "Phone number",
   "attendee_phone_number": "Attendee phone number",
   "organizer_phone_number": "Organizer phone number",
+  "phone_call": "Phone call",
   "enter_phone_number": "Enter phone number",
   "reschedule": "Reschedule",
   "reschedule_this": "Reschedule instead",

--- a/companion/components/event-type-detail/constants.ts
+++ b/companion/components/event-type-detail/constants.ts
@@ -62,7 +62,7 @@ export const defaultLocations = [
   { label: "Organizer Address", type: "inPerson" as const },
   { label: "Link Meeting", type: "link" as const },
   { label: "Attendee Phone Number", type: "phone" as const },
-  { label: "Organizer Phone Number", type: "userPhone" as const },
+  { label: "Phone Call", type: "userPhone" as const },
 ];
 
 export const tabs = [

--- a/companion/utils/defaultLocations.ts
+++ b/companion/utils/defaultLocations.ts
@@ -71,7 +71,7 @@ export const defaultLocations: DefaultLocation[] = [
   },
   {
     type: DefaultLocationType.UserPhone,
-    label: "Organizer Phone Number",
+    label: "Phone Call",
     iconUrl: "https://app.cal.com/phone.svg",
     category: "phone",
     organizerInputType: "phone",

--- a/companion/utils/locationHelpers.ts
+++ b/companion/utils/locationHelpers.ts
@@ -83,7 +83,7 @@ export function mapApiLocationToItem(apiLocation: ApiLocation): LocationItem {
       id,
       type: "phone",
       phone: apiLocation.phone || "",
-      displayName: "Organizer Phone Number",
+      displayName: "Phone Call",
       iconUrl: "https://app.cal.com/phone.svg",
       public: apiLocation.public,
     };
@@ -198,7 +198,7 @@ export function getLocationDisplayName(locationType: string, integration?: strin
     address: "In Person (Organizer Address)",
     attendeeAddress: "In Person (Attendee Address)",
     link: "Link Meeting",
-    phone: "Organizer Phone Number",
+    phone: "Phone Call",
     attendeePhone: "Attendee Phone Number",
     attendeeDefined: "Custom Attendee Location",
   };

--- a/packages/app-store/locations.ts
+++ b/packages/app-store/locations.ts
@@ -192,7 +192,7 @@ export const defaultLocations: DefaultEventLocationType[] = [
   {
     default: true,
     type: DefaultEventLocationTypeEnum.UserPhone,
-    label: "organizer_phone_number",
+    label: "phone_call",
     messageForOrganizer: "Provide your phone number",
     organizerInputType: "phone",
     organizerInputLabel: "phone_number",
@@ -209,7 +209,7 @@ const translateAbleKeys = [
   "in_person",
   "attendee_phone_number",
   "link_meeting",
-  "organizer_phone_number",
+  "phone_call",
   "organizer_default_conferencing_app",
   "somewhere_else",
   "custom_attendee_location",


### PR DESCRIPTION
## Summary

- Replaced the user-facing label "Organizer Phone Number" with "Phone Call" across booking UI, companion app, and i18n keys
- The previous label exposed internal terminology that confused attendees on the booking page
- Added new i18n key phone_call while preserving organizer_phone_number for backward compatibility

## Changes

| File | What changed |
|------|-------------|
| packages/app-store/locations.ts | Label changed from organizer_phone_number to phone_call; updated translateAbleKeys |
| apps/web/public/static/locales/en/common.json | Added phone_call i18n key |
| companion/ files | Updated hardcoded labels and display name mappings |
| EditLocationDialog.test.tsx | Updated test assertions to match new label |
| event-types.e2e.ts | Updated test comment |

## Test plan

- [ ] Verify booking page shows Phone Call instead of Organizer Phone Number
- [ ] Verify event type settings dropdown shows Phone Call for organizer phone location
- [ ] Verify confirmation emails display Phone Call label
- [ ] Run existing unit tests (EditLocationDialog.test.tsx)
- [ ] Run E2E tests for event types

Closes #13010