### PR TITLE
fix: hide cancel/reschedule links in emails when disabled

### DIFF
--- a/packages/features/bookings/lib/payment/getBooking.ts
+++ b/packages/features/bookings/lib/payment/getBooking.ts
@@ -90,6 +90,8 @@ export async function getBooking(bookingId: number) {
           },
           seatsPerTimeSlot: true,
           seatsShowAttendees: true,
+          disableCancelling: true,
+          disableRescheduling: true,
         },
       },
       metadata: true,
@@ -200,6 +202,8 @@ export async function getBooking(bookingId: number) {
     customReplyToEmail: booking.eventType?.customReplyToEmail,
     seatsPerTimeSlot: booking.eventType?.seatsPerTimeSlot,
     seatsShowAttendees: booking.eventType?.seatsShowAttendees,
+    disableCancelling: booking.eventType?.disableCancelling ?? false,
+    disableRescheduling: booking.eventType?.disableRescheduling ?? false,
   };
 
   return {

--- a/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
@@ -150,6 +150,8 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
           hideCalendarNotes: true,
           hideCalendarEventDetails: true,
           disableGuests: true,
+          disableCancelling: true,
+          disableRescheduling: true,
           customReplyToEmail: true,
           seatsPerTimeSlot: true,
           seatsShowAttendees: true,
@@ -326,6 +328,8 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
     customReplyToEmail: booking.eventType?.customReplyToEmail,
     seatsPerTimeSlot: booking.eventType?.seatsPerTimeSlot,
     seatsShowAttendees: booking.eventType?.seatsShowAttendees,
+    disableCancelling: booking.eventType?.disableCancelling ?? false,
+    disableRescheduling: booking.eventType?.disableRescheduling ?? false,
     team: booking.eventType?.team
       ? {
           name: booking.eventType.team.name,


### PR DESCRIPTION
## Summary

Fixes #22906

When `disableCancelling` or `disableRescheduling` is enabled on an event type, confirmation emails still showed non-functional cancel/reschedule links. This was confusing for attendees who clicked links that led to error pages.

**Root cause:** The `ManageLink` email component already had correct conditional logic to hide these links based on `calEvent.disableCancelling` and `calEvent.disableRescheduling`. However, two code paths constructed the `CalendarEvent` object manually without including these flags:

1. **Booking confirmation handler** (`confirm.handler.ts`) — used when organizers confirm pending bookings
2. **Payment booking flow** (`getBooking.ts`) — used when bookings involve payments

Since the flags were `undefined`, `!undefined === true`, so `ManageLink` always rendered the links.

## Changes

- Added `disableCancelling` and `disableRescheduling` to the Prisma `select` for `eventType` in both files
- Mapped these flags into the `CalendarEvent` object with `?? false` fallback

## Test plan

- [ ] Create an event type with "Disable Cancelling" enabled
- [ ] Create a booking that requires confirmation
- [ ] Confirm the booking and verify the confirmation email does NOT show the cancel link
- [ ] Create an event type with "Disable Rescheduling" enabled
- [ ] Repeat and verify the email does NOT show the reschedule link
- [ ] Create an event type with both disabled and verify neither link appears
- [ ] Create a paid event type with cancelling disabled and verify email after payment does NOT show cancel link
- [ ] Verify normal bookings (without disable flags) still show both links