### PR TITLE
fix: toggle chevron icon direction in filter segment dropdown

### DIFF
--- a/apps/web/modules/data-table/components/segment/FilterSegmentSelect.tsx
+++ b/apps/web/modules/data-table/components/segment/FilterSegmentSelect.tsx
@@ -46,6 +46,9 @@ export function FilterSegmentSelect({ shortLabel }: Props = {}) {
   const [segmentToDuplicate, setSegmentToDuplicate] = useState<CombinedFilterSegment | undefined>();
   const [segmentToDelete, setSegmentToDelete] = useState<FilterSegmentOutput | undefined>();
 
+  const [open, setOpen] = useState(false);
+
+
   const submenuItems: SubmenuItem[] = [
     {
       iconName: "square-pen",
@@ -141,21 +144,20 @@ export function FilterSegmentSelect({ shortLabel }: Props = {}) {
   }, [segments, t]);
 
   if (!isSegmentEnabled) {
-    return (
+
       <Button color="secondary" StartIcon="list-filter" EndIcon="chevron-down" disabled>
         {t("segment")}
       </Button>
-    );
   }
 
   return (
     <>
-      <Dropdown>
+      <Dropdown open={open} onOpenChange={setOpen}>
         <DropdownMenuTrigger asChild>
           <Button
             color="secondary"
             StartIcon="list-filter"
-            EndIcon="chevron-down"
+            EndIcon={open ? "chevron-up" : "chevron-down"}
             data-testid="filter-segment-select">
             {selectedSegment?.name || (shortLabel ? t("saved") : t("saved_filters"))}
           </Button>

--- a/apps/web/modules/data-table/components/segment/FilterSegmentSelect.tsx
+++ b/apps/web/modules/data-table/components/segment/FilterSegmentSelect.tsx
@@ -145,9 +145,11 @@ export function FilterSegmentSelect({ shortLabel }: Props = {}) {
 
   if (!isSegmentEnabled) {
 
-      <Button color="secondary" StartIcon="list-filter" EndIcon="chevron-down" disabled>
+     return(
+       <Button color="secondary" StartIcon="list-filter" EndIcon="chevron-down" disabled>
         {t("segment")}
       </Button>
+     )
   }
 
   return (


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the chevron icon in the filter segment dropdown did not reflect the dropdown open/close state. Previously, the icon remained as a downward chevron regardless of whether the dropdown was expanded or collapsed, which caused inconsistent UX feedback.

The fix connects the chevron icon to the dropdown open state so that:

- Chevron-down is shown when the dropdown is closed.
- Chevron-up is shown when the dropdown is open.


## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

Before 

https://github.com/user-attachments/assets/6a6d240c-5476-47f7-a193-267fda022e99

After

https://github.com/user-attachments/assets/953aa28c-ac7e-4add-8904-bf54637222a6



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A – No developer documentation updates required.
- [x] Existing dropdown behavior covered; change is UI-state-based and verified manually.

## How should this be tested?

- Are there environment variables that should be set?
  - None.

- What are the minimal test data to have?
  - Access to the bookings page with filter segments enabled.

- What is expected (happy path) to have (input and output)?
  - Click the "Saved filters" button.
  - Dropdown opens → chevron changes to up.
  - Close dropdown → chevron changes back to down.

- Any other important info that could help to test that PR
  - Verify behavior with different segments selected.
  - Ensure disabled state (when segments are not enabled) still shows correct icon behavior.


## Checklist

- Code follows project style guidelines
- No new warnings introduced
- PR is small and focused
