### PR TITLE
fix: vertically center availability atom

### DIFF
--- a/apps/web/modules/bookings/components/event-meta/Duration.tsx
+++ b/apps/web/modules/bookings/components/event-meta/Duration.tsx
@@ -126,7 +126,7 @@ export const EventDuration = ({
               ref={(el) => (itemRefs.current[duration] = el)}
               className={classNames(
                 selectedDuration === duration ? "bg-emphasis" : "hover:text-emphasis",
-                "text-default cursor-pointer rounded-[4px] px-3 py-1.5 text-sm leading-tight transition"
+                "text-default cursor-pointer rounded-[4px] px-3 py-1.5 text-sm leading-tight transition flex items-center justify-center"
               )}>
               <div className="w-max">{getDurationFormatted(duration, t)}</div>
             </li>


### PR DESCRIPTION
This PR fixes the vertical centering of the availability atom (Duration component) in the booking page. it was identified as a persistent UI issue, even mentioned in https://github.com/calcom/cal.com/issues/22685 manually. Removing the fixed pr-10 and adding flex classes ensures the text is perfectly centered.