### PR TITLE
fix: ensure default calendars domain

### DIFF
--- a/apps/api/v2/src/modules/organizations/delegation-credentials/organizations-delegation-credential.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/delegation-credentials/organizations-delegation-credential.controller.e2e-spec.ts
@@ -139,7 +139,7 @@ describe("Organizations Delegation Credentials Endpoints", () => {
         data: {
           workspacePlatformId: workspacePlatform.id,
           organizationId: org.id,
-          domain: "@test-domain.com",
+          domain: "test-domain.com",
           serviceAccountKey: encryptedServiceAccountKey,
           enabled: false,
         },
@@ -194,7 +194,7 @@ describe("Organizations Delegation Credentials Endpoints", () => {
       expect(responseBody.status).toEqual(SUCCESS_STATUS);
       expect(responseBody.data.enabled).toEqual(true);
 
-      expect(ensureDefaultCalendarsSpy).toHaveBeenCalledWith(org.id, "@test-domain.com");
+      expect(ensureDefaultCalendarsSpy).toHaveBeenCalledWith(org.id, "test-domain.com");
     });
 
     it("should not call ensureDefaultCalendars when disabling delegation credentials", async () => {

--- a/apps/api/v2/src/modules/organizations/delegation-credentials/organizations-delegation-credential.repository.ts
+++ b/apps/api/v2/src/modules/organizations/delegation-credentials/organizations-delegation-credential.repository.ts
@@ -37,7 +37,7 @@ export class OrganizationsDelegationCredentialRepository {
       },
       where: {
         organizationId: orgId,
-        user: { email: { endsWith: domain } },
+        user: { email: { endsWith: `@${domain}`, mode: "insensitive" } },
       },
     });
   }

--- a/apps/api/v2/src/modules/organizations/delegation-credentials/services/organizations-delegation-credential.service.spec.ts
+++ b/apps/api/v2/src/modules/organizations/delegation-credentials/services/organizations-delegation-credential.service.spec.ts
@@ -172,7 +172,7 @@ describe("OrganizationsDelegationCredentialService", () => {
 
       await service.ensureDefaultCalendarsForUser(orgId, userId, userEmail);
 
-      expect(mockRepository.findEnabledByOrgIdAndDomain).toHaveBeenCalledWith(orgId, "@example.com");
+      expect(mockRepository.findEnabledByOrgIdAndDomain).toHaveBeenCalledWith(orgId, "example.com");
       expect(mockQueue.add).toHaveBeenCalledWith(
         DEFAULT_CALENDARS_JOB,
         { userId },
@@ -198,7 +198,7 @@ describe("OrganizationsDelegationCredentialService", () => {
 
       await service.ensureDefaultCalendarsForUser(orgId, userId, userEmail);
 
-      expect(mockRepository.findEnabledByOrgIdAndDomain).toHaveBeenCalledWith(orgId, "@example.com");
+      expect(mockRepository.findEnabledByOrgIdAndDomain).toHaveBeenCalledWith(orgId, "example.com");
       expect(mockQueue.add).not.toHaveBeenCalled();
     });
 

--- a/apps/api/v2/src/modules/organizations/delegation-credentials/services/organizations-delegation-credential.service.ts
+++ b/apps/api/v2/src/modules/organizations/delegation-credentials/services/organizations-delegation-credential.service.ts
@@ -174,7 +174,7 @@ export class OrganizationsDelegationCredentialService {
         this.logger.warn(`Invalid email format for user ${userId}: missing domain`);
         return;
       }
-      const emailDomain = `@${emailParts[1]}`;
+      const emailDomain = emailParts[1];
 
       const delegationCredential =
         await this.organizationsDelegationCredentialRepository.findEnabledByOrgIdAndDomain(


### PR DESCRIPTION
## What does this PR do?

Fixes domain handling in `ensureDefaultCalendars` for organization delegation credentials. The database stores domains without the leading "@" (e.g., `example.com`), but the code was incorrectly adding "@" when extracting domains from user emails, causing lookups to fail.

**Changes:**
- Service now extracts email domain without "@" prefix (`example.com` instead of `@example.com`)
- Repository query adds "@" when matching emails (`endsWith: @${domain}`) with case-insensitive mode
- Updated tests to use correct domain format

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a delegation credential for an organization with a domain (e.g., `test-domain.com`)
2. Call `updateDelegationCredential` endpoint with `enabled: true` when the credential is currently disabled
3. Verify `ensureDefaultCalendars` is called with the domain without "@" prefix
4. Verify users with matching email domains (case-insensitive) are found correctly

Existing unit and e2e tests cover this behavior.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/2549b19ede8e443fbed861004c7c2e53
Requested by: @ThyMinimalDev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes domain handling when ensuring default calendars for organization delegation credentials. Domains are now compared without the leading "@" and in a case-insensitive way, so default calendars are set up correctly for matching users.

- **Bug Fixes**
  - Extracts email domain as "example.com" (not "@example.com") in the service.
  - Repository filters users by emails ending with "@{domain}" using case-insensitive matching.
  - Updates tests/e2e to use the new domain format and confirm ensureDefaultCalendars runs when enabling credentials.

<sup>Written for commit 79c5c1b0fcac3f56549907ed00042dd6822c214d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->