### PR TITLE
fix: show bookings-v3 opt-in banner

### DIFF
--- a/packages/features/feature-opt-in/config.ts
+++ b/packages/features/feature-opt-in/config.ts
@@ -74,7 +74,7 @@ export const OPT_IN_FEATURES: OptInFeatureConfig[] = [
       height: 348,
     },
     policy: "permissive",
-    displayLocations: ["settings"],
+    displayLocations: ["banner", "settings"],
     scope: ["org", "team", "user"], // Optional: defaults to all scopes if not specified
     formbricks: {
       waitAfterDays: 3,


### PR DESCRIPTION
## What does this PR do?

Now we shows the opt-in banner for bookings-v3


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

