### PR TITLE
chore: refactor payments.ts to use service classes

### DIFF
--- a/apps/api/v1/pages/api/teams/[teamId]/_patch.ts
+++ b/apps/api/v1/pages/api/teams/[teamId]/_patch.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest } from "next";
 
-import { purchaseTeamOrOrgSubscription } from "@calcom/features/ee/teams/lib/payments";
+import { getTeamBillingServiceFactory } from "@calcom/features/ee/billing/di/containers/Billing";
 import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { IS_TEAM_BILLING_ENABLED } from "@calcom/lib/constants";
 import { HttpError } from "@calcom/lib/http-error";
@@ -107,11 +107,11 @@ export async function patchHandler(req: NextApiRequest) {
     };
     delete data.slug;
     if (IS_TEAM_BILLING_ENABLED) {
-      const checkoutSession = await purchaseTeamOrOrgSubscription({
+      const teamBilling = getTeamBillingServiceFactory().init(team);
+      const checkoutSession = await teamBilling.createTeamCheckoutSession({
         teamId: team.id,
-        seatsUsed: team.members.length,
+        seats: team.members.length,
         userId,
-        pricePerSeat: null,
       });
       if (!checkoutSession.url)
         throw new TRPCError({

--- a/packages/features/ee/billing/organizations/internal-organization-billing.ts
+++ b/packages/features/ee/billing/organizations/internal-organization-billing.ts
@@ -1,7 +1,20 @@
+import { getStripeCustomerIdFromUserId } from "@calcom/app-store/stripepayment/lib/customer";
+import { checkIfTeamPaymentRequired } from "@calcom/features/ee/teams/lib/payments";
 import { stripe } from "@calcom/features/ee/payments/server/stripe";
+import {
+  IS_PRODUCTION,
+  ORGANIZATION_SELF_SERVE_PRICE,
+  WEBAPP_URL,
+  ORG_TRIAL_DAYS,
+} from "@calcom/lib/constants";
+import logger from "@calcom/lib/logger";
+import { safeStringify } from "@calcom/lib/safeStringify";
+import { BillingPeriod } from "@calcom/prisma/zod-utils";
 
-import { OrganizationBilling } from "./organization-billing";
+import { OrganizationBilling, type OrgCheckoutSessionInput } from "./organization-billing";
 import { OrganizationBillingRepository } from "./organization-billing.repository";
+
+const log = logger.getSubLogger({ prefix: ["InternalOrganizationBilling"] });
 
 export class InternalOrganizationBilling extends OrganizationBilling {
   constructor(
@@ -52,5 +65,97 @@ export class InternalOrganizationBilling extends OrganizationBilling {
         pricePerSeat,
       },
     });
+  }
+
+  async createCheckoutSession(input: OrgCheckoutSessionInput): Promise<{ url: string | null }> {
+    const {
+      userId,
+      seatsUsed,
+      seatsToChargeFor,
+      pricePerSeat,
+      billingPeriod = BillingPeriod.MONTHLY,
+      tracking,
+    } = input;
+    const teamId = this.organization.id;
+
+    const { url } = await checkIfTeamPaymentRequired({ teamId });
+    if (url) return { url };
+
+    const quantity = seatsToChargeFor ?? seatsUsed;
+    const customer = await getStripeCustomerIdFromUserId(userId);
+    const priceId = await this.resolveOrgPriceId({ pricePerSeat, billingPeriod });
+
+    const session = await stripe.checkout.sessions.create({
+      customer,
+      mode: "subscription",
+      allow_promotion_codes: true,
+      success_url: `${WEBAPP_URL}/api/teams/${teamId}/upgrade?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${WEBAPP_URL}/settings/my-account/profile`,
+      line_items: [{ price: priceId, quantity }],
+      customer_update: { address: "auto" },
+      automatic_tax: { enabled: IS_PRODUCTION },
+      metadata: {
+        teamId,
+        ...(tracking?.googleAds?.gclid && {
+          gclid: tracking.googleAds.gclid,
+          campaignId: tracking.googleAds.campaignId,
+        }),
+        ...(tracking?.linkedInAds?.liFatId && {
+          liFatId: tracking.linkedInAds.liFatId,
+          linkedInCampaignId: tracking.linkedInAds?.campaignId,
+        }),
+      },
+      subscription_data: {
+        metadata: { teamId, dubCustomerId: userId },
+        ...(ORG_TRIAL_DAYS && { trial_period_days: ORG_TRIAL_DAYS }),
+      },
+    });
+
+    return { url: session.url };
+  }
+
+  private async resolveOrgPriceId({
+    pricePerSeat,
+    billingPeriod,
+  }: {
+    pricePerSeat: number | null;
+    billingPeriod: BillingPeriod;
+  }): Promise<string> {
+    const fixedPriceId = process.env.STRIPE_ORG_MONTHLY_PRICE_ID;
+    if (!fixedPriceId) {
+      throw new Error("STRIPE_ORG_MONTHLY_PRICE_ID env variable is not set");
+    }
+
+    if (!pricePerSeat) {
+      return fixedPriceId;
+    }
+
+    if (pricePerSeat === ORGANIZATION_SELF_SERVE_PRICE) {
+      return fixedPriceId;
+    }
+
+    // Custom price per seat: create a new Stripe price
+    const fixedPriceObj = await stripe.prices.retrieve(fixedPriceId);
+    if (!fixedPriceObj) throw new Error(`No price found for ID ${fixedPriceId}`);
+
+    const teamId = this.organization.id;
+    try {
+      const pricePerSeatInCents = pricePerSeat * 100;
+      const occurrence = billingPeriod === BillingPeriod.MONTHLY ? 1 : 12;
+      const unitAmount = pricePerSeatInCents * occurrence;
+
+      const customPrice = await stripe.prices.create({
+        nickname: `Custom price for Organization ID: ${teamId}`,
+        unit_amount: unitAmount,
+        currency: fixedPriceObj.currency,
+        recurring: { interval: billingPeriod === BillingPeriod.MONTHLY ? "month" : "year" },
+        product: fixedPriceObj.product as string,
+        tax_behavior: "exclusive",
+      });
+      return customPrice.id;
+    } catch (e) {
+      log.error(`Error creating custom price for Organization ID: ${teamId}`, safeStringify(e));
+      throw new Error("Error in creation of custom price");
+    }
   }
 }

--- a/packages/features/ee/billing/organizations/organization-billing.ts
+++ b/packages/features/ee/billing/organizations/organization-billing.ts
@@ -1,6 +1,17 @@
 import type { Team } from "@calcom/prisma/client";
+import type { BillingPeriod } from "@calcom/prisma/zod-utils";
+import type { TrackingData } from "@calcom/lib/tracking";
 
 import type { OrganizationBillingRepository } from "./organization-billing.repository";
+
+export type OrgCheckoutSessionInput = {
+  userId: number;
+  seatsUsed: number;
+  seatsToChargeFor?: number | null;
+  pricePerSeat: number | null;
+  billingPeriod?: BillingPeriod;
+  tracking?: TrackingData;
+};
 
 export abstract class OrganizationBilling {
   protected organization: Pick<Team, "id" | "slug" | "name" | "billingPeriod">;
@@ -13,4 +24,5 @@ export abstract class OrganizationBilling {
   abstract getStripeCustomerId(): Promise<string | null>;
   abstract getSubscriptionId(): Promise<string | null>;
   abstract getSubscriptionItems(): Promise<{ id: string; quantity: number }[]>;
+  abstract createCheckoutSession(input: OrgCheckoutSessionInput): Promise<{ url: string | null }>;
 }

--- a/packages/features/ee/billing/organizations/stub-organization-billing.ts
+++ b/packages/features/ee/billing/organizations/stub-organization-billing.ts
@@ -29,4 +29,8 @@ export class StubOrganizationBilling extends OrganizationBilling {
       status: "requires_payment_method",
     };
   }
+
+  async createCheckoutSession() {
+    return { url: "https://stub-checkout.example.com/session" };
+  }
 }

--- a/packages/features/ee/billing/service/teams/ITeamBillingService.ts
+++ b/packages/features/ee/billing/service/teams/ITeamBillingService.ts
@@ -25,4 +25,9 @@ export interface ITeamBillingService {
   getSubscriptionStatus(): Promise<SubscriptionStatus | null>;
   endTrial(): Promise<boolean>;
   saveTeamBilling(args: IBillingRepositoryCreateArgs): Promise<void>;
+  createTeamCheckoutSession(input: {
+    teamId: number;
+    seats: number;
+    userId: number;
+  }): Promise<{ url: string | null }>;
 }

--- a/packages/features/ee/billing/service/teams/StubTeamBillingService.ts
+++ b/packages/features/ee/billing/service/teams/StubTeamBillingService.ts
@@ -36,4 +36,8 @@ export class StubTeamBillingService implements ITeamBillingService {
   }
 
   async saveTeamBilling() {}
+
+  async createTeamCheckoutSession() {
+    return { url: null };
+  }
 }

--- a/packages/features/ee/billing/service/teams/TeamBillingService.test.ts
+++ b/packages/features/ee/billing/service/teams/TeamBillingService.test.ts
@@ -1,4 +1,4 @@
-import { purchaseTeamOrOrgSubscription } from "@calcom/features/ee/teams/lib/payments";
+import { getStripeCustomerIdFromUserId } from "@calcom/app-store/stripepayment/lib/customer";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -14,11 +14,12 @@ vi.mock("@calcom/lib/constants", async () => {
   return {
     ...actual,
     WEBAPP_URL: "http://localhost:3000",
+    IS_PRODUCTION: false,
   };
 });
 
-vi.mock("@calcom/features/ee/teams/lib/payments", () => ({
-  purchaseTeamOrOrgSubscription: vi.fn(),
+vi.mock("@calcom/app-store/stripepayment/lib/customer", () => ({
+  getStripeCustomerIdFromUserId: vi.fn(),
 }));
 
 const shouldApplyMonthlyProration = vi.fn().mockResolvedValue(false);
@@ -116,6 +117,8 @@ describe("TeamBillingService", () => {
 
   describe("publish", () => {
     it("should create a checkout session and update the team", async () => {
+      process.env.STRIPE_TEAM_MONTHLY_PRICE_ID = "price_team_123";
+
       const teamBillingService = new TeamBillingService({
         team: mockTeam,
         billingProviderService: mockBillingProviderService,
@@ -124,8 +127,10 @@ describe("TeamBillingService", () => {
       });
 
       vi.mocked(mockBillingProviderService.checkoutSessionIsPaid).mockResolvedValue(false);
-      vi.mocked(purchaseTeamOrOrgSubscription).mockResolvedValue({
-        url: "http://checkout.url",
+      vi.mocked(getStripeCustomerIdFromUserId).mockResolvedValue("cus_stripe_123");
+      vi.mocked(mockBillingProviderService.createSubscriptionCheckout).mockResolvedValue({
+        checkoutUrl: "http://checkout.url",
+        sessionId: "cs_session_123",
       });
       prismaMock.membership.count.mockResolvedValue(5);
       prismaMock.membership.findFirstOrThrow.mockResolvedValue({ userId: 123 });
@@ -140,6 +145,21 @@ describe("TeamBillingService", () => {
       expect(prismaMock.membership.findFirstOrThrow).toHaveBeenCalledWith({
         where: { teamId: 1, role: "OWNER" },
         select: { userId: true },
+      });
+      expect(getStripeCustomerIdFromUserId).toHaveBeenCalledWith(123);
+      expect(mockBillingProviderService.createSubscriptionCheckout).toHaveBeenCalledWith({
+        customerId: "cus_stripe_123",
+        successUrl: `${WEBAPP_URL}/api/teams/1/upgrade?session_id={CHECKOUT_SESSION_ID}`,
+        cancelUrl: `${WEBAPP_URL}/settings/my-account/profile`,
+        priceId: "price_team_123",
+        quantity: 5,
+        allowPromotionCodes: true,
+        customerUpdate: { address: "auto" },
+        automaticTax: { enabled: false },
+        metadata: { teamId: 1 },
+        subscriptionData: {
+          metadata: { teamId: 1, dubCustomerId: 123 },
+        },
       });
     });
     it("should return upgrade url if upgrade is required", async () => {

--- a/packages/features/ee/billing/service/teams/TeamBillingService.ts
+++ b/packages/features/ee/billing/service/teams/TeamBillingService.ts
@@ -1,6 +1,6 @@
 import { getRequestedSlugError } from "@calcom/app-store/stripepayment/lib/team-billing";
-import { purchaseTeamOrOrgSubscription } from "@calcom/features/ee/teams/lib/payments";
-import { WEBAPP_URL } from "@calcom/lib/constants";
+import { getStripeCustomerIdFromUserId } from "@calcom/app-store/stripepayment/lib/customer";
+import { IS_PRODUCTION, WEBAPP_URL } from "@calcom/lib/constants";
 import { getMetadataHelpers } from "@calcom/lib/getMetadataHelpers";
 import logger from "@calcom/lib/logger";
 import { Redirect } from "@calcom/lib/redirect";
@@ -100,12 +100,10 @@ export class TeamBillingService implements ITeamBillingService {
     });
 
     try {
-      // TODO: extract this to new billing service
-      const checkoutSession = await purchaseTeamOrOrgSubscription({
+      const checkoutSession = await this.createTeamCheckoutSession({
         teamId,
-        seatsUsed: membershipCount,
+        seats: membershipCount,
         userId: owner.userId,
-        pricePerSeat: null,
       });
 
       if (checkoutSession.url) {
@@ -194,6 +192,43 @@ export class TeamBillingService implements ITeamBillingService {
       this.logErrorFromUnknown(error);
     }
   }
+  /**
+   * Creates a Stripe checkout session for a team subscription.
+   * Handles only team (non-org) subscriptions using the fixed team price.
+   */
+  async createTeamCheckoutSession({
+    teamId,
+    seats,
+    userId,
+  }: {
+    teamId: number;
+    seats: number;
+    userId: number;
+  }): Promise<{ url: string | null }> {
+    const customerId = await getStripeCustomerIdFromUserId(userId);
+    const priceId = process.env.STRIPE_TEAM_MONTHLY_PRICE_ID;
+    if (!priceId) {
+      throw new Error("STRIPE_TEAM_MONTHLY_PRICE_ID env variable is not set");
+    }
+
+    const { checkoutUrl } = await this.billingProviderService.createSubscriptionCheckout({
+      customerId,
+      successUrl: `${WEBAPP_URL}/api/teams/${teamId}/upgrade?session_id={CHECKOUT_SESSION_ID}`,
+      cancelUrl: `${WEBAPP_URL}/settings/my-account/profile`,
+      priceId,
+      quantity: seats,
+      allowPromotionCodes: true,
+      customerUpdate: { address: "auto" },
+      automaticTax: { enabled: IS_PRODUCTION },
+      metadata: { teamId },
+      subscriptionData: {
+        metadata: { teamId, dubCustomerId: userId },
+      },
+    });
+
+    return { url: checkoutUrl };
+  }
+
   /** Used to prevent double charges for the same team */
   async checkIfTeamPaymentRequired() {
     const { paymentId } = this.team.metadata || {};

--- a/packages/features/ee/billing/teams/internal-team-billing.test.ts
+++ b/packages/features/ee/billing/teams/internal-team-billing.test.ts
@@ -1,4 +1,4 @@
-import { purchaseTeamOrOrgSubscription } from "@calcom/features/ee/teams/lib/payments";
+import { getStripeCustomerIdFromUserId } from "@calcom/app-store/stripepayment/lib/customer";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -14,11 +14,12 @@ vi.mock("@calcom/lib/constants", async () => {
   return {
     ...actual,
     WEBAPP_URL: "http://localhost:3000",
+    IS_PRODUCTION: false,
   };
 });
 
-vi.mock("@calcom/features/ee/teams/lib/payments", () => ({
-  purchaseTeamOrOrgSubscription: vi.fn(),
+vi.mock("@calcom/app-store/stripepayment/lib/customer", () => ({
+  getStripeCustomerIdFromUserId: vi.fn(),
 }));
 
 const shouldApplyMonthlyProration = vi.fn().mockResolvedValue(false);
@@ -113,9 +114,13 @@ describe("TeamBillingService", () => {
 
   describe("publish", () => {
     it("should create a checkout session and update the team", async () => {
+      process.env.STRIPE_TEAM_MONTHLY_PRICE_ID = "price_team_123";
+
       vi.mocked(mockBillingProviderService.checkoutSessionIsPaid).mockResolvedValue(false);
-      vi.mocked(purchaseTeamOrOrgSubscription).mockResolvedValue({
-        url: "http://checkout.url",
+      vi.mocked(getStripeCustomerIdFromUserId).mockResolvedValue("cus_stripe_123");
+      vi.mocked(mockBillingProviderService.createSubscriptionCheckout).mockResolvedValue({
+        checkoutUrl: "http://checkout.url",
+        sessionId: "cs_session_123",
       });
       prismaMock.membership.count.mockResolvedValue(5);
       prismaMock.membership.findFirstOrThrow.mockResolvedValue({ userId: 123 });
@@ -130,6 +135,21 @@ describe("TeamBillingService", () => {
       expect(prismaMock.membership.findFirstOrThrow).toHaveBeenCalledWith({
         where: { teamId: 1, role: "OWNER" },
         select: { userId: true },
+      });
+      expect(getStripeCustomerIdFromUserId).toHaveBeenCalledWith(123);
+      expect(mockBillingProviderService.createSubscriptionCheckout).toHaveBeenCalledWith({
+        customerId: "cus_stripe_123",
+        successUrl: `${WEBAPP_URL}/api/teams/1/upgrade?session_id={CHECKOUT_SESSION_ID}`,
+        cancelUrl: `${WEBAPP_URL}/settings/my-account/profile`,
+        priceId: "price_team_123",
+        quantity: 5,
+        allowPromotionCodes: true,
+        customerUpdate: { address: "auto" },
+        automaticTax: { enabled: false },
+        metadata: { teamId: 1 },
+        subscriptionData: {
+          metadata: { teamId: 1, dubCustomerId: 123 },
+        },
       });
     });
     it("should return upgrade url if upgrade is required", async () => {

--- a/packages/features/ee/teams/lib/payments.test.ts
+++ b/packages/features/ee/teams/lib/payments.test.ts
@@ -3,17 +3,10 @@ import prismock from "@calcom/testing/lib/__mocks__/prisma";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 import stripe from "@calcom/features/ee/payments/server/stripe";
-import { BillingPeriod } from "@calcom/prisma/zod-utils";
 
-import {
-  getTeamWithPaymentMetadata,
-  purchaseTeamOrOrgSubscription,
-  updateQuantitySubscriptionFromStripe,
-} from "./payments";
+import { getTeamWithPaymentMetadata, updateQuantitySubscriptionFromStripe } from "./payments";
 
 beforeEach(async () => {
-  vi.stubEnv("STRIPE_ORG_MONTHLY_PRICE_ID", "STRIPE_ORG_MONTHLY_PRICE_ID");
-  vi.stubEnv("STRIPE_TEAM_MONTHLY_PRICE_ID", "STRIPE_TEAM_MONTHLY_PRICE_ID");
   vi.resetAllMocks();
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -41,291 +34,15 @@ vi.mock("@calcom/features/ee/payments/server/stripe", () => {
     default: {
       checkout: {
         sessions: {
-          create: vi.fn(),
           retrieve: vi.fn(),
         },
-      },
-      prices: {
-        retrieve: vi.fn(),
-        create: vi.fn(),
       },
       subscriptions: {
         retrieve: vi.fn(),
         update: vi.fn(),
-        create: vi.fn(),
       },
     },
   };
-});
-
-describe("purchaseTeamOrOrgSubscription", () => {
-  it("should use `seatsToChargeFor` to create price", async () => {
-    const FAKE_PAYMENT_ID = "FAKE_PAYMENT_ID";
-    const user = await prismock.user.create({
-      data: {
-        name: "test",
-        email: "test@email.com",
-      },
-    });
-
-    const checkoutSessionsCreate = mockStripeCheckoutSessionsCreate({
-      url: "SESSION_URL",
-    });
-
-    mockStripeCheckoutSessionRetrieve(
-      {
-        currency: "USD",
-        product: {
-          id: "PRODUCT_ID",
-        },
-      },
-      [FAKE_PAYMENT_ID]
-    );
-
-    mockStripeCheckoutPricesRetrieve({
-      id: "PRICE_ID",
-      product: {
-        id: "PRODUCT_ID",
-      },
-    });
-
-    mockStripePricesCreate({
-      id: "PRICE_ID",
-    });
-
-    const team = await prismock.team.create({
-      data: {
-        name: "test",
-        metadata: {
-          paymentId: FAKE_PAYMENT_ID,
-        },
-      },
-    });
-
-    const seatsToChargeFor = 1000;
-    expect(
-      await purchaseTeamOrOrgSubscription({
-        teamId: team.id,
-        seatsUsed: 10,
-        seatsToChargeFor,
-        userId: user.id,
-        isOrg: true,
-        pricePerSeat: 100,
-      })
-    ).toEqual({ url: "SESSION_URL" });
-
-    expect(checkoutSessionsCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        line_items: [
-          {
-            price: "PRICE_ID",
-            quantity: seatsToChargeFor,
-          },
-        ],
-      })
-    );
-  });
-  it("Should create a monthly subscription if billing period is set to monthly", async () => {
-    const FAKE_PAYMENT_ID = "FAKE_PAYMENT_ID";
-    const user = await prismock.user.create({
-      data: {
-        name: "test",
-        email: "test@email.com",
-      },
-    });
-
-    const checkoutSessionsCreate = mockStripeCheckoutSessionsCreate({
-      url: "SESSION_URL",
-    });
-
-    mockStripeCheckoutSessionRetrieve(
-      {
-        currency: "USD",
-        product: {
-          id: "PRODUCT_ID",
-        },
-      },
-      [FAKE_PAYMENT_ID]
-    );
-
-    mockStripeCheckoutPricesRetrieve({
-      id: "PRICE_ID",
-      product: {
-        id: "PRODUCT_ID",
-      },
-    });
-
-    const checkoutPricesCreate = mockStripePricesCreate({
-      id: "PRICE_ID",
-    });
-
-    const team = await prismock.team.create({
-      data: {
-        name: "test",
-        metadata: {
-          paymentId: FAKE_PAYMENT_ID,
-        },
-      },
-    });
-
-    const seatsToChargeFor = 1000;
-    expect(
-      await purchaseTeamOrOrgSubscription({
-        teamId: team.id,
-        seatsUsed: 10,
-        seatsToChargeFor,
-        userId: user.id,
-        isOrg: true,
-        pricePerSeat: 100,
-        billingPeriod: BillingPeriod.MONTHLY,
-      })
-    ).toEqual({ url: "SESSION_URL" });
-
-    expect(checkoutPricesCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ recurring: { interval: "month" } })
-    );
-
-    expect(checkoutSessionsCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        line_items: [
-          {
-            price: "PRICE_ID",
-            quantity: seatsToChargeFor,
-          },
-        ],
-      })
-    );
-  });
-  it("Should create a annual subscription if billing period is set to annual", async () => {
-    const FAKE_PAYMENT_ID = "FAKE_PAYMENT_ID";
-    const user = await prismock.user.create({
-      data: {
-        name: "test",
-        email: "test@email.com",
-      },
-    });
-
-    const checkoutSessionsCreate = mockStripeCheckoutSessionsCreate({
-      url: "SESSION_URL",
-    });
-
-    mockStripeCheckoutSessionRetrieve(
-      {
-        currency: "USD",
-        product: {
-          id: "PRODUCT_ID",
-        },
-      },
-      [FAKE_PAYMENT_ID]
-    );
-
-    mockStripeCheckoutPricesRetrieve({
-      id: "PRICE_ID",
-      product: {
-        id: "PRODUCT_ID",
-      },
-    });
-
-    const checkoutPricesCreate = mockStripePricesCreate({
-      id: "PRICE_ID",
-    });
-
-    const team = await prismock.team.create({
-      data: {
-        name: "test",
-        metadata: {
-          paymentId: FAKE_PAYMENT_ID,
-        },
-      },
-    });
-
-    const seatsToChargeFor = 1000;
-    expect(
-      await purchaseTeamOrOrgSubscription({
-        teamId: team.id,
-        seatsUsed: 10,
-        seatsToChargeFor,
-        userId: user.id,
-        isOrg: true,
-        pricePerSeat: 100,
-        billingPeriod: BillingPeriod.ANNUALLY,
-      })
-    ).toEqual({ url: "SESSION_URL" });
-
-    expect(checkoutPricesCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ recurring: { interval: "year" } })
-    );
-
-    expect(checkoutSessionsCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        line_items: [
-          {
-            price: "PRICE_ID",
-            quantity: seatsToChargeFor,
-          },
-        ],
-      })
-    );
-  });
-
-  it("It should not create a custom price if price_per_seat is not set", async () => {
-    const FAKE_PAYMENT_ID = "FAKE_PAYMENT_ID";
-    const user = await prismock.user.create({
-      data: {
-        name: "test",
-        email: "test@email.com",
-      },
-    });
-
-    mockStripeCheckoutSessionsCreate({
-      url: "SESSION_URL",
-    });
-
-    mockStripeCheckoutSessionRetrieve(
-      {
-        currency: "USD",
-        product: {
-          id: "PRODUCT_ID",
-        },
-      },
-      [FAKE_PAYMENT_ID]
-    );
-
-    mockStripeCheckoutPricesRetrieve({
-      id: "PRICE_ID",
-      product: {
-        id: "PRODUCT_ID",
-      },
-    });
-
-    const checkoutPricesCreate = mockStripePricesCreate({
-      id: "PRICE_ID",
-    });
-
-    const team = await prismock.team.create({
-      data: {
-        name: "test",
-        metadata: {
-          paymentId: FAKE_PAYMENT_ID,
-        },
-      },
-    });
-
-    const seatsToChargeFor = 1000;
-    expect(
-      await purchaseTeamOrOrgSubscription({
-        teamId: team.id,
-        seatsUsed: 10,
-        seatsToChargeFor,
-        userId: user.id,
-        isOrg: true,
-        billingPeriod: BillingPeriod.ANNUALLY,
-        pricePerSeat: null,
-      })
-    ).toEqual({ url: "SESSION_URL" });
-
-    expect(checkoutPricesCreate).not.toHaveBeenCalled();
-  });
 });
 
 describe("updateQuantitySubscriptionFromStripe", () => {
@@ -658,23 +375,6 @@ async function createOrgWithMembersAndPaymentData({
   return organization;
 }
 
-function mockStripePricesCreate(data) {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
-  return vi.mocked(stripe.prices.create).mockImplementation(() => new Promise((resolve) => resolve(data)));
-}
-
-function mockStripeCheckoutPricesRetrieve(data) {
-  return vi.mocked(stripe.prices.retrieve).mockImplementation(
-    async () =>
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
-      new Promise((resolve) => {
-        resolve(data);
-      })
-  );
-}
-
 function mockStripeCheckoutSessionRetrieve(data, expectedArgs) {
   return vi.mocked(stripe.checkout.sessions.retrieve).mockImplementation(async (sessionId) =>
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -683,14 +383,6 @@ function mockStripeCheckoutSessionRetrieve(data, expectedArgs) {
       const conditionMatched = expectedArgs[0] === sessionId;
       return new Promise((resolve) => resolve(conditionMatched ? data : null));
     }
-  );
-}
-
-function mockStripeCheckoutSessionsCreate(data) {
-  return vi.mocked(stripe.checkout.sessions.create).mockImplementation(
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
-    async () => new Promise((resolve) => resolve(data))
   );
 }
 

--- a/packages/features/ee/teams/lib/payments.ts
+++ b/packages/features/ee/teams/lib/payments.ts
@@ -1,24 +1,14 @@
-import type Stripe from "stripe";
 import { z } from "zod";
 
 import { getStripeCustomerIdFromUserId } from "@calcom/app-store/stripepayment/lib/customer";
 import { getDubCustomer } from "@calcom/features/auth/lib/dub";
 import stripe from "@calcom/features/ee/payments/server/stripe";
 import { CHECKOUT_SESSION_TYPES } from "@calcom/features/ee/billing/constants";
-import {
-  IS_PRODUCTION,
-  ORGANIZATION_SELF_SERVE_PRICE,
-  WEBAPP_URL,
-  ORG_TRIAL_DAYS,
-} from "@calcom/lib/constants";
-import logger from "@calcom/lib/logger";
-import { safeStringify } from "@calcom/lib/safeStringify";
+import { IS_PRODUCTION, WEBAPP_URL } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";
-import { BillingPeriod } from "@calcom/prisma/zod-utils";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
-import { TrackingData } from "@calcom/lib/tracking";
+import type { TrackingData } from "@calcom/lib/tracking";
 
-const log = logger.getSubLogger({ prefix: ["teams/lib/payments"] });
 const teamPaymentMetadataSchema = z.object({
   // Redefine paymentId, subscriptionId and subscriptionItemId to ensure that they are present and nonNullable
   paymentId: z.string(),
@@ -114,174 +104,6 @@ export const generateTeamCheckoutSession = async ({
   });
   return session;
 };
-
-/**
- * @deprecated Move over to internal-team-billing
- * Used to generate a checkout session when creating a new org (parent team) or backwards compatibility for old teams
- */
-export const purchaseTeamOrOrgSubscription = async (input: {
-  teamId: number;
-  /**
-   * The actual number of seats in the team.
-   * For a team it would be the same as this value
-   */
-  seatsUsed: number;
-  /**
-   * If provided, this is the exact number we would charge for.
-   */
-  seatsToChargeFor?: number | null;
-  userId: number;
-  isOrg?: boolean;
-  pricePerSeat: number | null;
-  billingPeriod?: BillingPeriod;
-  tracking?: TrackingData;
-}) => {
-  const {
-    teamId,
-    seatsToChargeFor,
-    seatsUsed,
-    userId,
-    isOrg,
-    pricePerSeat,
-    billingPeriod = BillingPeriod.MONTHLY,
-    tracking,
-  } = input;
-  const { url } = await checkIfTeamPaymentRequired({ teamId });
-  if (url) return { url };
-
-  // Use seatsUsed directly without enforcing minimum
-  const seats = seatsUsed;
-  const quantity = seatsToChargeFor ? seatsToChargeFor : seats;
-
-  const customer = await getStripeCustomerIdFromUserId(userId);
-
-  const fixedPrice = await getFixedPrice();
-
-  let priceId: string | undefined;
-
-  if (pricePerSeat) {
-    if (
-      isOrg &&
-      pricePerSeat === ORGANIZATION_SELF_SERVE_PRICE
-    ) {
-      priceId = fixedPrice as string;
-    } else {
-      const customPriceObj = await getPriceObject(fixedPrice);
-      priceId = await createPrice({
-        isOrg: !!isOrg,
-        teamId,
-        pricePerSeat,
-        billingPeriod,
-        product: customPriceObj.product as string, // We don't expand the object from stripe so just use the product as ID
-        currency: customPriceObj.currency,
-      });
-    }
-  } else {
-    priceId = fixedPrice as string;
-  }
-
-  const session = await stripe.checkout.sessions.create({
-    customer,
-    mode: "subscription",
-    allow_promotion_codes: true,
-    success_url: `${WEBAPP_URL}/api/teams/${teamId}/upgrade?session_id={CHECKOUT_SESSION_ID}`,
-    cancel_url: `${WEBAPP_URL}/settings/my-account/profile`,
-    line_items: [
-      {
-        price: priceId,
-        quantity: quantity,
-      },
-    ],
-    customer_update: {
-      address: "auto",
-    },
-    // Disabled when testing locally as usually developer doesn't setup Tax in Stripe Test mode
-    automatic_tax: {
-      enabled: IS_PRODUCTION,
-    },
-    metadata: {
-      teamId,
-      ...(tracking?.googleAds?.gclid && { gclid: tracking.googleAds.gclid, campaignId: tracking.googleAds.campaignId }),
-      ...(tracking?.linkedInAds?.liFatId && { liFatId: tracking.linkedInAds.liFatId, linkedInCampaignId: tracking.linkedInAds?.campaignId }),
-    },
-    subscription_data: {
-      metadata: {
-        teamId,
-        dubCustomerId: userId,
-      },
-      ...(isOrg && ORG_TRIAL_DAYS && { trial_period_days: ORG_TRIAL_DAYS }),
-    },
-  });
-  return { url: session.url };
-
-  async function createPrice({
-    isOrg,
-    teamId,
-    pricePerSeat,
-    billingPeriod,
-    product,
-    currency,
-  }: {
-    isOrg: boolean;
-    teamId: number;
-    pricePerSeat: number;
-    billingPeriod: BillingPeriod;
-    product: Stripe.Product | string;
-    currency: string;
-  }) {
-    try {
-      const pricePerSeatInCents = pricePerSeat * 100;
-      // Price comes in monthly so we need to convert it to a monthly/yearly price
-      const occurrence = billingPeriod === "MONTHLY" ? 1 : 12;
-      const yearlyPrice = pricePerSeatInCents * occurrence;
-
-      const customPriceObj = await stripe.prices.create({
-        nickname: `Custom price for ${isOrg ? "Organization" : "Team"} ID: ${teamId}`,
-        unit_amount: yearlyPrice, // Stripe expects the amount in cents
-        // Use the same currency as in the fixed price to avoid hardcoding it.
-        currency: currency,
-        recurring: { interval: billingPeriod === "MONTHLY" ? "month" : "year" }, // Define your subscription interval
-        product: typeof product === "string" ? product : product.id,
-        tax_behavior: "exclusive",
-      });
-      return customPriceObj.id;
-    } catch (e) {
-      log.error(
-        `Error creating custom price for ${isOrg ? "Organization" : "Team"} ID: ${teamId}`,
-        safeStringify(e)
-      );
-
-      throw new Error("Error in creation of custom price");
-    }
-  }
-
-  /**
-   * Determines the priceId depending on if a custom price is required or not.
-   * If the organization has a custom price per seat, it will create a new price in stripe and return its ID.
-   */
-  async function getFixedPrice() {
-    const fixedPriceId = isOrg
-      ? process.env.STRIPE_ORG_MONTHLY_PRICE_ID
-      : process.env.STRIPE_TEAM_MONTHLY_PRICE_ID;
-
-    if (!fixedPriceId) {
-      throw new Error(
-        "You need to have STRIPE_ORG_MONTHLY_PRICE_ID and STRIPE_TEAM_MONTHLY_PRICE_ID env variables set"
-      );
-    }
-
-    log.debug("Getting price ID", safeStringify({ fixedPriceId, isOrg, teamId, pricePerSeat }));
-
-    return fixedPriceId;
-  }
-};
-
-async function getPriceObject(priceId: string) {
-  const priceObj = await stripe.prices.retrieve(priceId);
-  if (!priceObj) throw new Error(`No price found for ID ${priceId}`);
-
-  return priceObj;
-}
 
 export const getTeamWithPaymentMetadata = async (teamId: number) => {
   const team = await prisma.team.findUniqueOrThrow({

--- a/packages/trpc/server/routers/viewer/organizations/publish.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/publish.handler.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest } from "next";
 
 import { getRequestedSlugError } from "@calcom/app-store/stripepayment/lib/team-billing";
-import { purchaseTeamOrOrgSubscription } from "@calcom/features/ee/teams/lib/payments";
+import { OrganizationBilling } from "@calcom/features/ee/billing/organizations";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { IS_TEAM_BILLING_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
 import { getTrackingFromCookies } from "@calcom/lib/tracking";
@@ -53,18 +53,17 @@ export const publishHandler = async ({ ctx }: PublishOptions) => {
   const metadata = teamMetadataStrictSchema.safeParse(prevTeam.metadata);
   if (!metadata.success) throw new TRPCError({ code: "BAD_REQUEST", message: "Invalid team metadata" });
 
-  // Since this is an ORG we need to make sure ORG members are scyned with the team. Every time a user is added to the TEAM, we need to add them to the ORG
+  // Since this is an ORG we need to make sure ORG members are synced with the team. Every time a user is added to the TEAM, we need to add them to the ORG
   if (IS_TEAM_BILLING_ENABLED) {
     const tracking = getTrackingFromCookies(ctx.req?.cookies);
 
-    const checkoutSession = await purchaseTeamOrOrgSubscription({
-      teamId: prevTeam.id,
+    const orgBilling = new OrganizationBilling(prevTeam);
+    const checkoutSession = await orgBilling.createCheckoutSession({
+      userId: ctx.user.id,
       seatsUsed: prevTeam.members.length,
       seatsToChargeFor: metadata.data?.orgSeats
         ? Math.max(prevTeam.members.length, metadata.data?.orgSeats ?? 0)
         : null,
-      userId: ctx.user.id,
-      isOrg: true,
       pricePerSeat: metadata.data?.orgPricePerSeat ?? null,
       billingPeriod: metadata.data?.billingPeriod ?? undefined,
       tracking,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored team and org checkout session creation into billing service classes, replacing legacy payments.ts logic. Updates API handlers and tests to use the new services for clearer responsibilities and easier maintenance.

- **Refactors**
  - Removed purchaseTeamOrOrgSubscription and migrated logic into TeamBillingService.createTeamCheckoutSession and InternalOrganizationBilling.createCheckoutSession.
  - Added createTeamCheckoutSession to ITeamBillingService and implemented in TeamBillingService and StubTeamBillingService.
  - Implemented OrganizationBilling.createCheckoutSession with custom org price handling, trial support, and tracking metadata.
  - Switched API routes to use getTeamBillingServiceFactory and OrganizationBilling for checkout flows.
  - Simplified and updated tests to cover new service methods and Stripe interactions.

<sup>Written for commit b534a534e7c6702d3cdee6bca40b080902bc758f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

