### PR TITLE
fix: improve API v2 error handling for validation errors

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/errors.service.spec.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/errors.service.spec.ts
@@ -1,0 +1,193 @@
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { ZodError, ZodIssue, ZodIssueCode } from "zod";
+
+import { ErrorsBookingsService_2024_08_13 } from "./errors.service";
+
+describe("ErrorsBookingsService_2024_08_13", () => {
+  let service: ErrorsBookingsService_2024_08_13;
+
+  beforeEach(() => {
+    service = new ErrorsBookingsService_2024_08_13();
+  });
+
+  describe("handleEventTypeToBeBookedNotFound", () => {
+    it("should throw NotFoundException for user event type without org", () => {
+      const body = {
+        username: "testuser",
+        eventTypeSlug: "test-event",
+      };
+
+      expect(() => service.handleEventTypeToBeBookedNotFound(body as any)).toThrow(NotFoundException);
+      expect(() => service.handleEventTypeToBeBookedNotFound(body as any)).toThrow(
+        "Event type with slug test-event belonging to user testuser not found."
+      );
+    });
+
+    it("should throw NotFoundException for user event type with org", () => {
+      const body = {
+        username: "testuser",
+        eventTypeSlug: "test-event",
+        organizationSlug: "test-org",
+      };
+
+      expect(() => service.handleEventTypeToBeBookedNotFound(body as any)).toThrow(NotFoundException);
+      expect(() => service.handleEventTypeToBeBookedNotFound(body as any)).toThrow(
+        "Event type with slug test-event belonging to user testuser within organization test-org not found."
+      );
+    });
+
+    it("should throw NotFoundException for team event type without org", () => {
+      const body = {
+        teamSlug: "test-team",
+        eventTypeSlug: "test-event",
+      };
+
+      expect(() => service.handleEventTypeToBeBookedNotFound(body as any)).toThrow(NotFoundException);
+      expect(() => service.handleEventTypeToBeBookedNotFound(body as any)).toThrow(
+        "Event type with slug test-event belonging to team test-team not found."
+      );
+    });
+
+    it("should throw NotFoundException for team event type with org", () => {
+      const body = {
+        teamSlug: "test-team",
+        eventTypeSlug: "test-event",
+        organizationSlug: "test-org",
+      };
+
+      expect(() => service.handleEventTypeToBeBookedNotFound(body as any)).toThrow(NotFoundException);
+      expect(() => service.handleEventTypeToBeBookedNotFound(body as any)).toThrow(
+        "Event type with slug test-event belonging to team test-team within organization test-org not found."
+      );
+    });
+
+    it("should throw NotFoundException for event type by id", () => {
+      const body = {
+        eventTypeId: 123,
+      };
+
+      expect(() => service.handleEventTypeToBeBookedNotFound(body as any)).toThrow(NotFoundException);
+      expect(() => service.handleEventTypeToBeBookedNotFound(body as any)).toThrow(
+        "Event type with id 123 not found."
+      );
+    });
+  });
+
+  describe("handleBookingError", () => {
+    it("should throw BadRequestException for no_available_users_found_error with team event", () => {
+      const error = new Error("no_available_users_found_error");
+
+      expect(() => service.handleBookingError(error, true)).toThrow(BadRequestException);
+      expect(() => service.handleBookingError(error, true)).toThrow(
+        "One of the hosts either already has booking at this time or is not available"
+      );
+    });
+
+    it("should throw BadRequestException for no_available_users_found_error with non-team event", () => {
+      const error = new Error("no_available_users_found_error");
+
+      expect(() => service.handleBookingError(error, false)).toThrow(BadRequestException);
+      expect(() => service.handleBookingError(error, false)).toThrow(
+        "User either already has booking at this time or is not available"
+      );
+    });
+
+    it("should throw BadRequestException for booking_time_out_of_bounds_error", () => {
+      const error = new Error("booking_time_out_of_bounds_error");
+
+      expect(() => service.handleBookingError(error, false)).toThrow(BadRequestException);
+    });
+
+    it("should throw BadRequestException for past meeting booking", () => {
+      const error = new Error("Attempting to book a meeting in the past.");
+
+      expect(() => service.handleBookingError(error, false)).toThrow(BadRequestException);
+      expect(() => service.handleBookingError(error, false)).toThrow(
+        "Attempting to book a meeting in the past."
+      );
+    });
+
+    it("should throw BadRequestException for hosts_unavailable_for_booking", () => {
+      const error = new Error("hosts_unavailable_for_booking");
+
+      expect(() => service.handleBookingError(error, false)).toThrow(BadRequestException);
+      expect(() => service.handleBookingError(error, false)).toThrow(
+        "One of the hosts either already has booking at this time or is not available"
+      );
+    });
+
+    it("should throw BadRequestException for booker_limit_exceeded_error", () => {
+      const error = new Error("booker_limit_exceeded_error");
+
+      expect(() => service.handleBookingError(error, false)).toThrow(BadRequestException);
+      expect(() => service.handleBookingError(error, false)).toThrow(
+        "Attendee with this email can't book because the maximum number of active bookings has been reached."
+      );
+    });
+
+    it("should throw BadRequestException for booker_limit_exceeded_error_reschedule with rescheduleUid", () => {
+      const error = Object.assign(new Error("booker_limit_exceeded_error_reschedule"), {
+        data: { rescheduleUid: "abc123" },
+      });
+
+      expect(() => service.handleBookingError(error, false)).toThrow(BadRequestException);
+      expect(() => service.handleBookingError(error, false)).toThrow(
+        /You can reschedule your existing booking \(abc123\)/
+      );
+    });
+
+    it("should throw BadRequestException for ZodError with formatted messages", () => {
+      const zodIssues: ZodIssue[] = [
+        {
+          code: ZodIssueCode.invalid_type,
+          expected: "string",
+          received: "number",
+          path: ["email"],
+          message: "Expected string, received number",
+        },
+        {
+          code: ZodIssueCode.too_small,
+          minimum: 1,
+          type: "string",
+          inclusive: true,
+          path: ["name"],
+          message: "Name is required",
+        },
+      ];
+      const zodError = new ZodError(zodIssues);
+
+      expect(() => service.handleBookingError(zodError, false)).toThrow(BadRequestException);
+      expect(() => service.handleBookingError(zodError, false)).toThrow(
+        "Expected string, received number, Name is required"
+      );
+    });
+
+    it("should throw BadRequestException for ZodError with single issue", () => {
+      const zodIssues: ZodIssue[] = [
+        {
+          code: ZodIssueCode.invalid_type,
+          expected: "string",
+          received: "undefined",
+          path: ["start"],
+          message: "Start time is required",
+        },
+      ];
+      const zodError = new ZodError(zodIssues);
+
+      expect(() => service.handleBookingError(zodError, false)).toThrow(BadRequestException);
+      expect(() => service.handleBookingError(zodError, false)).toThrow("Start time is required");
+    });
+
+    it("should rethrow unknown errors", () => {
+      const error = new Error("Unknown error");
+
+      expect(() => service.handleBookingError(error, false)).toThrow("Unknown error");
+    });
+
+    it("should rethrow non-Error objects", () => {
+      const error = { message: "Not an error" };
+
+      expect(() => service.handleBookingError(error, false)).toThrow();
+    });
+  });
+});

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/errors.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/errors.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { Logger } from "@nestjs/common";
+import { ZodError } from "zod";
 
 import { CreateBookingInput } from "@calcom/platform-types";
 
@@ -62,6 +63,10 @@ export class ErrorsBookingsService_2024_08_13 {
         }
         throw new BadRequestException(message);
       }
+    }
+    if (error instanceof ZodError) {
+      const messages = error.issues.map((issue) => issue.message).join(", ");
+      throw new BadRequestException(messages);
     }
     throw error;
   }

--- a/apps/api/v2/src/ee/calendars/services/gcal.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/gcal.service.ts
@@ -6,7 +6,7 @@ import { CredentialsRepository } from "@/modules/credentials/credentials.reposit
 import { SelectedCalendarsRepository } from "@/modules/selected-calendars/selected-calendars.repository";
 import { TokensService } from "@/modules/tokens/tokens.service";
 import { calendar_v3 } from "@googleapis/calendar";
-import { Logger, NotFoundException, ForbiddenException } from "@nestjs/common";
+import { Logger, NotFoundException } from "@nestjs/common";
 import { BadRequestException, UnauthorizedException } from "@nestjs/common";
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
@@ -162,17 +162,7 @@ export class GoogleCalendarService implements OAuthCalendarApp {
       auth: oAuth2Client,
     });
 
-    let cals;
-    try {
-      cals = await calendar.calendarList.list({ fields: "items(id,summary,primary,accessRole)" });
-    } catch (error) {
-      if (error instanceof Error && error.message === "Insufficient Permission") {
-        throw new ForbiddenException(
-          "Insufficient permissions to access Google Calendar. Please ensure you have granted the required calendar permissions."
-        );
-      }
-      throw error;
-    }
+    const cals = await calendar.calendarList.list({ fields: "items(id,summary,primary,accessRole)" });
 
     const primaryCal = cals.data.items?.find((cal) => cal.primary);
 

--- a/apps/api/v2/src/modules/auth/guards/organizations/is-org.guard.spec.ts
+++ b/apps/api/v2/src/modules/auth/guards/organizations/is-org.guard.spec.ts
@@ -1,0 +1,165 @@
+import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { OrganizationsRepository } from "@/modules/organizations/index/organizations.repository";
+import { RedisService } from "@/modules/redis/redis.service";
+import { createMock } from "@golevelup/ts-jest";
+import { BadRequestException, ForbiddenException } from "@nestjs/common";
+import { ExecutionContext } from "@nestjs/common";
+
+describe("IsOrgGuard", () => {
+  let guard: IsOrgGuard;
+  let organizationsRepository: OrganizationsRepository;
+  let redisService: RedisService;
+
+  beforeEach(() => {
+    organizationsRepository = createMock<OrganizationsRepository>();
+    redisService = createMock<RedisService>({
+      redis: {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn().mockResolvedValue(null),
+      },
+    });
+    guard = new IsOrgGuard(organizationsRepository, redisService);
+  });
+
+  function createMockExecutionContext(orgId: string | undefined): ExecutionContext {
+    return createMock<ExecutionContext>({
+      switchToHttp: () => ({
+        getRequest: () => ({
+          params: { orgId },
+          organization: undefined,
+        }),
+      }),
+    });
+  }
+
+  it("should be defined", () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe("orgId validation", () => {
+    it("should throw ForbiddenException when orgId is missing", async () => {
+      const mockContext = createMockExecutionContext(undefined);
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(
+        "IsOrgGuard - No organization id found in request params."
+      );
+    });
+
+    it("should throw BadRequestException for non-numeric orgId", async () => {
+      const mockContext = createMockExecutionContext("abc");
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(BadRequestException);
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(
+        "IsOrgGuard - Invalid organization id 'abc'. Organization id must be a positive integer."
+      );
+    });
+
+    it("should throw BadRequestException for floating point orgId", async () => {
+      const mockContext = createMockExecutionContext("1.5");
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(BadRequestException);
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(
+        "IsOrgGuard - Invalid organization id '1.5'. Organization id must be a positive integer."
+      );
+    });
+
+    it("should throw BadRequestException for negative orgId", async () => {
+      const mockContext = createMockExecutionContext("-1");
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(BadRequestException);
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(
+        "IsOrgGuard - Invalid organization id '-1'. Organization id must be a positive integer."
+      );
+    });
+
+    it("should throw BadRequestException for zero orgId", async () => {
+      const mockContext = createMockExecutionContext("0");
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(BadRequestException);
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(
+        "IsOrgGuard - Invalid organization id '0'. Organization id must be a positive integer."
+      );
+    });
+
+    it("should throw BadRequestException for empty string orgId", async () => {
+      const mockContext = createMockExecutionContext("");
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
+    });
+
+    it("should throw BadRequestException for special characters in orgId", async () => {
+      const mockContext = createMockExecutionContext("1; DROP TABLE;");
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(BadRequestException);
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(
+        /Organization id must be a positive integer/
+      );
+    });
+
+    it("should throw BadRequestException for NaN-producing orgId", async () => {
+      const mockContext = createMockExecutionContext("NaN");
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(BadRequestException);
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(
+        "IsOrgGuard - Invalid organization id 'NaN'. Organization id must be a positive integer."
+      );
+    });
+
+    it("should throw BadRequestException for Infinity orgId", async () => {
+      const mockContext = createMockExecutionContext("Infinity");
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(BadRequestException);
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(
+        /Organization id must be a positive integer/
+      );
+    });
+  });
+
+  describe("valid orgId handling", () => {
+    it("should return true for valid organization", async () => {
+      const mockContext = createMockExecutionContext("123");
+
+      jest.spyOn(organizationsRepository, "findById").mockResolvedValue({
+        id: 123,
+        isOrganization: true,
+      } as any);
+
+      await expect(guard.canActivate(mockContext)).resolves.toBe(true);
+    });
+
+    it("should throw ForbiddenException for non-existent organization", async () => {
+      const mockContext = createMockExecutionContext("999");
+
+      jest.spyOn(organizationsRepository, "findById").mockResolvedValue(null);
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(
+        "does not represent any existing organization"
+      );
+    });
+
+    it("should throw ForbiddenException when team is not an organization", async () => {
+      const mockContext = createMockExecutionContext("456");
+
+      jest.spyOn(organizationsRepository, "findById").mockResolvedValue({
+        id: 456,
+        isOrganization: false,
+      } as any);
+
+      await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
+    });
+
+    it("should use cached value from Redis when available", async () => {
+      const mockContext = createMockExecutionContext("789");
+      const cachedOrg = { id: 789, isOrganization: true };
+
+      jest.spyOn(redisService.redis, "get").mockResolvedValue(
+        JSON.stringify({ org: cachedOrg, canAccess: true })
+      );
+
+      await expect(guard.canActivate(mockContext)).resolves.toBe(true);
+      expect(organizationsRepository.findById).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/v2/src/modules/auth/guards/organizations/is-org.guard.ts
+++ b/apps/api/v2/src/modules/auth/guards/organizations/is-org.guard.ts
@@ -1,6 +1,6 @@
 import { OrganizationsRepository } from "@/modules/organizations/index/organizations.repository";
 import { RedisService } from "@/modules/redis/redis.service";
-import { Injectable, CanActivate, ExecutionContext, ForbiddenException, BadRequestException } from "@nestjs/common";
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from "@nestjs/common";
 import { Request } from "express";
 
 import type { Team } from "@calcom/prisma/client";
@@ -23,13 +23,6 @@ export class IsOrgGuard implements CanActivate {
 
     if (!organizationId) {
       throw new ForbiddenException("IsOrgGuard - No organization id found in request params.");
-    }
-
-    const orgIdNumber = Number(organizationId);
-    if (Number.isNaN(orgIdNumber) || !Number.isInteger(orgIdNumber) || orgIdNumber <= 0) {
-      throw new BadRequestException(
-        `IsOrgGuard - Invalid organization id '${organizationId}'. Organization id must be a positive integer.`
-      );
     }
 
     const { canAccess, org } = await this.checkOrgAccess(organizationId);

--- a/apps/api/v2/src/modules/auth/guards/organizations/is-org.guard.ts
+++ b/apps/api/v2/src/modules/auth/guards/organizations/is-org.guard.ts
@@ -1,6 +1,6 @@
 import { OrganizationsRepository } from "@/modules/organizations/index/organizations.repository";
 import { RedisService } from "@/modules/redis/redis.service";
-import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from "@nestjs/common";
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException, BadRequestException } from "@nestjs/common";
 import { Request } from "express";
 
 import type { Team } from "@calcom/prisma/client";
@@ -23,6 +23,13 @@ export class IsOrgGuard implements CanActivate {
 
     if (!organizationId) {
       throw new ForbiddenException("IsOrgGuard - No organization id found in request params.");
+    }
+
+    const orgIdNumber = Number(organizationId);
+    if (Number.isNaN(orgIdNumber) || !Number.isInteger(orgIdNumber) || orgIdNumber <= 0) {
+      throw new BadRequestException(
+        `IsOrgGuard - Invalid organization id '${organizationId}'. Organization id must be a positive integer.`
+      );
     }
 
     const { canAccess, org } = await this.checkOrgAccess(organizationId);

--- a/packages/platform/types/bookings/2024-08-13/inputs/cancel-booking-input.pipe.spec.ts
+++ b/packages/platform/types/bookings/2024-08-13/inputs/cancel-booking-input.pipe.spec.ts
@@ -1,0 +1,117 @@
+import { BadRequestException } from "@nestjs/common";
+
+import { CancelBookingInputPipe } from "./cancel-booking-input.pipe";
+
+describe("CancelBookingInputPipe", () => {
+  let pipe: CancelBookingInputPipe;
+
+  beforeEach(() => {
+    pipe = new CancelBookingInputPipe();
+  });
+
+  it("should be defined", () => {
+    expect(pipe).toBeDefined();
+  });
+
+  describe("transform", () => {
+    it("should throw BadRequestException when body is null", () => {
+      expect(() => pipe.transform(null as any)).toThrow(BadRequestException);
+      expect(() => pipe.transform(null as any)).toThrow("Body is required");
+    });
+
+    it("should throw BadRequestException when body is undefined", () => {
+      expect(() => pipe.transform(undefined as any)).toThrow(BadRequestException);
+      expect(() => pipe.transform(undefined as any)).toThrow("Body is required");
+    });
+
+    it("should throw BadRequestException when body is not an object", () => {
+      expect(() => pipe.transform("string" as any)).toThrow(BadRequestException);
+      expect(() => pipe.transform("string" as any)).toThrow("Body should be an object");
+    });
+
+    it("should handle regular objects with seatUid property", () => {
+      const input = {
+        seatUid: "seat-123",
+        cancellationReason: "Test reason",
+      };
+
+      const result = pipe.transform(input as any);
+      expect(result).toHaveProperty("seatUid", "seat-123");
+    });
+
+    it("should handle regular objects without seatUid property", () => {
+      const input = {
+        cancellationReason: "Test reason",
+      };
+
+      const result = pipe.transform(input as any);
+      expect(result).not.toHaveProperty("seatUid");
+    });
+
+    it("should handle objects created with Object.create(null)", () => {
+      // Create an object without Object prototype
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.cancellationReason = "Test reason";
+
+      // This should NOT throw "hasOwnProperty is not a function"
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle null prototype objects with seatUid", () => {
+      // Create an object without Object prototype
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.seatUid = "seat-456";
+      nullPrototypeObj.cancellationReason = "Test reason";
+
+      // This should correctly identify it as a seated booking input
+      const result = pipe.transform(nullPrototypeObj as any);
+      expect(result).toHaveProperty("seatUid", "seat-456");
+    });
+
+    it("should handle objects from JSON.parse correctly", () => {
+      const jsonInput = JSON.parse('{"cancellationReason": "From JSON"}');
+
+      expect(() => pipe.transform(jsonInput as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle objects with custom prototype correctly", () => {
+      const customProto = { customMethod: () => "test" };
+      const customObj = Object.create(customProto);
+      customObj.cancellationReason = "Test";
+
+      expect(() => pipe.transform(customObj as any)).not.toThrow(TypeError);
+    });
+  });
+
+  describe("isCancelSeatedBookingInput detection", () => {
+    it("should detect seated booking when seatUid is present", () => {
+      const input = {
+        seatUid: "test-seat",
+        cancellationReason: "Test",
+      };
+
+      const result = pipe.transform(input as any);
+      expect(result).toHaveProperty("seatUid");
+    });
+
+    it("should detect regular booking when seatUid is absent", () => {
+      const input = {
+        cancellationReason: "Test",
+      };
+
+      const result = pipe.transform(input as any);
+      expect(result).not.toHaveProperty("seatUid");
+    });
+
+    it("should detect regular booking when seatUid is explicitly undefined", () => {
+      const input = {
+        seatUid: undefined,
+        cancellationReason: "Test",
+      };
+
+      // hasOwnProperty returns true even for undefined values
+      const result = pipe.transform(input as any);
+      expect(result).toHaveProperty("seatUid");
+    });
+  });
+});

--- a/packages/platform/types/bookings/2024-08-13/inputs/create-booking-input.pipe.spec.ts
+++ b/packages/platform/types/bookings/2024-08-13/inputs/create-booking-input.pipe.spec.ts
@@ -1,0 +1,157 @@
+import { BadRequestException } from "@nestjs/common";
+
+import { CreateBookingInputPipe } from "./create-booking-input.pipe";
+
+describe("CreateBookingInputPipe", () => {
+  let pipe: CreateBookingInputPipe;
+
+  beforeEach(() => {
+    pipe = new CreateBookingInputPipe();
+  });
+
+  it("should be defined", () => {
+    expect(pipe).toBeDefined();
+  });
+
+  describe("transform", () => {
+    it("should throw BadRequestException when body is null", () => {
+      expect(() => pipe.transform(null as any)).toThrow(BadRequestException);
+      expect(() => pipe.transform(null as any)).toThrow("Body is required");
+    });
+
+    it("should throw BadRequestException when body is undefined", () => {
+      expect(() => pipe.transform(undefined as any)).toThrow(BadRequestException);
+      expect(() => pipe.transform(undefined as any)).toThrow("Body is required");
+    });
+
+    it("should throw BadRequestException when body is not an object", () => {
+      expect(() => pipe.transform(123 as any)).toThrow(BadRequestException);
+      expect(() => pipe.transform(123 as any)).toThrow("Body should be an object");
+    });
+  });
+
+  describe("null prototype object handling", () => {
+    it("should handle objects created with Object.create(null)", () => {
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.start = "2024-01-01T10:00:00Z";
+      nullPrototypeObj.eventTypeId = 1;
+      nullPrototypeObj.attendee = { name: "Test", email: "test@example.com", timeZone: "UTC" };
+
+      // Should NOT throw "hasOwnProperty is not a function"
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle null prototype objects with recurrenceCount", () => {
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.start = "2024-01-01T10:00:00Z";
+      nullPrototypeObj.eventTypeId = 1;
+      nullPrototypeObj.attendee = { name: "Test", email: "test@example.com", timeZone: "UTC" };
+      nullPrototypeObj.recurrenceCount = 5;
+
+      // Should correctly identify as recurring booking
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle null prototype objects with instant flag", () => {
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.start = "2024-01-01T10:00:00Z";
+      nullPrototypeObj.eventTypeId = 1;
+      nullPrototypeObj.attendee = { name: "Test", email: "test@example.com", timeZone: "UTC" };
+      nullPrototypeObj.instant = true;
+
+      // Should correctly identify as instant booking
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle JSON.parse output correctly", () => {
+      const jsonInput = JSON.parse(
+        '{"start": "2024-01-01T10:00:00Z", "eventTypeId": 1, "attendee": {"name": "Test", "email": "test@example.com", "timeZone": "UTC"}}'
+      );
+
+      expect(() => pipe.transform(jsonInput as any)).not.toThrow(TypeError);
+    });
+  });
+
+  describe("isRecurringBookingInput detection", () => {
+    it("should detect recurring booking when recurrenceCount is present", () => {
+      const input = {
+        start: "2024-01-01T10:00:00Z",
+        eventTypeId: 1,
+        attendee: { name: "Test", email: "test@example.com", timeZone: "UTC" },
+        recurrenceCount: 3,
+      };
+
+      // If recurrenceCount is present, it should be validated as recurring booking
+      expect(() => pipe.transform(input as any)).not.toThrow(TypeError);
+    });
+
+    it("should not detect recurring booking when recurrenceCount is absent", () => {
+      const input = {
+        start: "2024-01-01T10:00:00Z",
+        eventTypeId: 1,
+        attendee: { name: "Test", email: "test@example.com", timeZone: "UTC" },
+      };
+
+      expect(() => pipe.transform(input as any)).not.toThrow(TypeError);
+    });
+  });
+
+  describe("isInstantBookingInput detection", () => {
+    it("should detect instant booking when instant is true", () => {
+      const input = {
+        start: "2024-01-01T10:00:00Z",
+        eventTypeId: 1,
+        attendee: { name: "Test", email: "test@example.com", timeZone: "UTC" },
+        instant: true,
+      };
+
+      expect(() => pipe.transform(input as any)).not.toThrow(TypeError);
+    });
+
+    it("should not detect instant booking when instant is false", () => {
+      const input = {
+        start: "2024-01-01T10:00:00Z",
+        eventTypeId: 1,
+        attendee: { name: "Test", email: "test@example.com", timeZone: "UTC" },
+        instant: false,
+      };
+
+      // instant: false should not be treated as instant booking
+      expect(() => pipe.transform(input as any)).not.toThrow(TypeError);
+    });
+
+    it("should not detect instant booking when instant is absent", () => {
+      const input = {
+        start: "2024-01-01T10:00:00Z",
+        eventTypeId: 1,
+        attendee: { name: "Test", email: "test@example.com", timeZone: "UTC" },
+      };
+
+      expect(() => pipe.transform(input as any)).not.toThrow(TypeError);
+    });
+  });
+
+  describe("custom prototype handling", () => {
+    it("should handle objects with custom prototype", () => {
+      const customProto = { customMethod: () => "test" };
+      const customObj = Object.create(customProto);
+      customObj.start = "2024-01-01T10:00:00Z";
+      customObj.eventTypeId = 1;
+      customObj.attendee = { name: "Test", email: "test@example.com", timeZone: "UTC" };
+
+      expect(() => pipe.transform(customObj as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle objects with shadowed hasOwnProperty", () => {
+      const input = {
+        start: "2024-01-01T10:00:00Z",
+        eventTypeId: 1,
+        attendee: { name: "Test", email: "test@example.com", timeZone: "UTC" },
+        hasOwnProperty: "shadowed", // This would break direct hasOwnProperty calls
+      };
+
+      // The safe hasOwnProperty call should still work
+      expect(() => pipe.transform(input as any)).not.toThrow(TypeError);
+    });
+  });
+});

--- a/packages/platform/types/slots/slots-2024-09-04/inputs/get-slots-input.pipe.spec.ts
+++ b/packages/platform/types/slots/slots-2024-09-04/inputs/get-slots-input.pipe.spec.ts
@@ -1,0 +1,182 @@
+import { BadRequestException } from "@nestjs/common";
+
+import { GetSlotsInputPipe } from "./get-slots-input.pipe";
+
+describe("GetSlotsInputPipe", () => {
+  let pipe: GetSlotsInputPipe;
+
+  beforeEach(() => {
+    pipe = new GetSlotsInputPipe();
+  });
+
+  it("should be defined", () => {
+    expect(pipe).toBeDefined();
+  });
+
+  describe("transform", () => {
+    it("should throw BadRequestException when body is null", () => {
+      expect(() => pipe.transform(null as any)).toThrow(BadRequestException);
+      expect(() => pipe.transform(null as any)).toThrow("Body is required");
+    });
+
+    it("should throw BadRequestException when body is undefined", () => {
+      expect(() => pipe.transform(undefined as any)).toThrow(BadRequestException);
+      expect(() => pipe.transform(undefined as any)).toThrow("Body is required");
+    });
+
+    it("should throw BadRequestException when body is not an object", () => {
+      expect(() => pipe.transform("string" as any)).toThrow(BadRequestException);
+      expect(() => pipe.transform("string" as any)).toThrow("Body should be an object");
+    });
+  });
+
+  describe("null prototype object handling", () => {
+    it("should handle objects created with Object.create(null) for eventTypeId", () => {
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.eventTypeId = 123;
+      nullPrototypeObj.startTime = "2024-01-01";
+      nullPrototypeObj.endTime = "2024-01-07";
+
+      // Should NOT throw "hasOwnProperty is not a function"
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle objects created with Object.create(null) for username and eventTypeSlug", () => {
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.username = "testuser";
+      nullPrototypeObj.eventTypeSlug = "test-event";
+      nullPrototypeObj.startTime = "2024-01-01";
+      nullPrototypeObj.endTime = "2024-01-07";
+
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle objects created with Object.create(null) for teamSlug and eventTypeSlug", () => {
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.teamSlug = "test-team";
+      nullPrototypeObj.eventTypeSlug = "test-event";
+      nullPrototypeObj.startTime = "2024-01-01";
+      nullPrototypeObj.endTime = "2024-01-07";
+
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle JSON.parse output correctly", () => {
+      const jsonInput = JSON.parse(
+        '{"eventTypeId": 123, "startTime": "2024-01-01", "endTime": "2024-01-07"}'
+      );
+
+      expect(() => pipe.transform(jsonInput as any)).not.toThrow(TypeError);
+    });
+  });
+
+  describe("isById detection", () => {
+    it("should detect by ID when eventTypeId is present", () => {
+      const input = {
+        eventTypeId: 123,
+        startTime: "2024-01-01",
+        endTime: "2024-01-07",
+      };
+
+      expect(() => pipe.transform(input as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle null prototype object with eventTypeId", () => {
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.eventTypeId = 456;
+      nullPrototypeObj.startTime = "2024-01-01";
+      nullPrototypeObj.endTime = "2024-01-07";
+
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+  });
+
+  describe("isByUsernameAndEventTypeSlug detection", () => {
+    it("should detect by username and event type slug", () => {
+      const input = {
+        username: "testuser",
+        eventTypeSlug: "test-event",
+        startTime: "2024-01-01",
+        endTime: "2024-01-07",
+      };
+
+      expect(() => pipe.transform(input as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle null prototype object with username and eventTypeSlug", () => {
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.username = "user123";
+      nullPrototypeObj.eventTypeSlug = "my-event";
+      nullPrototypeObj.startTime = "2024-01-01";
+      nullPrototypeObj.endTime = "2024-01-07";
+
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+  });
+
+  describe("isByTeamSlugAndEventTypeSlug detection", () => {
+    it("should detect by team slug and event type slug", () => {
+      const input = {
+        teamSlug: "test-team",
+        eventTypeSlug: "team-event",
+        startTime: "2024-01-01",
+        endTime: "2024-01-07",
+      };
+
+      expect(() => pipe.transform(input as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle null prototype object with teamSlug and eventTypeSlug", () => {
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.teamSlug = "engineering";
+      nullPrototypeObj.eventTypeSlug = "standup";
+      nullPrototypeObj.startTime = "2024-01-01";
+      nullPrototypeObj.endTime = "2024-01-07";
+
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+  });
+
+  describe("custom prototype handling", () => {
+    it("should handle objects with custom prototype", () => {
+      const customProto = { customMethod: () => "test" };
+      const customObj = Object.create(customProto);
+      customObj.eventTypeId = 789;
+      customObj.startTime = "2024-01-01";
+      customObj.endTime = "2024-01-07";
+
+      expect(() => pipe.transform(customObj as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle objects with shadowed hasOwnProperty", () => {
+      const input = {
+        eventTypeId: 123,
+        startTime: "2024-01-01",
+        endTime: "2024-01-07",
+        hasOwnProperty: "shadowed", // This would break direct hasOwnProperty calls
+      };
+
+      // The safe hasOwnProperty call should still work
+      expect(() => pipe.transform(input as any)).not.toThrow(TypeError);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty object", () => {
+      const nullPrototypeObj = Object.create(null);
+
+      // Empty object should fall through to validateByUsernames which will fail validation
+      // but should NOT throw TypeError
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+
+    it("should handle object with only startTime and endTime", () => {
+      const nullPrototypeObj = Object.create(null);
+      nullPrototypeObj.startTime = "2024-01-01";
+      nullPrototypeObj.endTime = "2024-01-07";
+
+      // Should fall through to validateByUsernames
+      expect(() => pipe.transform(nullPrototypeObj as any)).not.toThrow(TypeError);
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Improves error handling across multiple API v2 endpoints to return appropriate HTTP status codes instead of 500 InternalServerError.

### Changes:

1. **Booking validation errors (POST `/v2/bookings`)**: Zod validation errors (e.g., invalid phone numbers, missing required fields) now return 400 BadRequest instead of 500.

2. **Invalid organization ID (GET `/v2/organizations/:orgId/*`)**: Non-numeric or invalid orgId values (e.g., `{orgId}` literal) now return 400 BadRequest instead of causing a Prisma validation error (500).

## Updates since last revision

- Removed Google Calendar permission error handling from this PR (moved to separate PR #27663)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### 1. Booking validation errors
```bash
# Should return 400 BadRequest
curl -X POST /v2/bookings -d '{"eventTypeId": 123, "responses": {"attendeePhoneNumber": "invalid-phone"}}'
```

### 2. Invalid organization ID
```bash
# Should return 400 BadRequest (not 500 Prisma error)
curl /v2/organizations/%7BorgId%7D/routing-forms
curl /v2/organizations/abc/routing-forms
```

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small and focused

## Human Review Checklist

- [ ] Verify the ZodError message format (comma-separated) is acceptable for API consumers
- [ ] Consider if unit tests should be added for these error handling paths
- [ ] Check if other API versions (2024-04-15, etc.) need similar fixes for booking validation

---

Link to Devin run: https://app.devin.ai/sessions/d57afd9bb7834868b5e90963dd39e64c
Requested by: @ThyMinimalDev