### PR TITLE
feat: reusable YouTubePlayerModal component for in-app video playback

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -54,6 +54,7 @@
   "enable_automatic_transcription": "Enable automatic transcription after joining the meeting",
   "enable_automatic_recording": "Enable automatic recording after organizer joins the meeting",
   "video_options": "Video options",
+  "video_player": "Video player",
   "edit_event": "Edit event",
   "view_session_details": "View session details",
   "meeting_session_details": "Meeting session details",

--- a/packages/ui/components/youtube-player-modal/YouTubePlayerModal.test.tsx
+++ b/packages/ui/components/youtube-player-modal/YouTubePlayerModal.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { extractYouTubeVideoId, YouTubePlayerModal } from "./YouTubePlayerModal";
+
+vi.mock("@calcom/lib/hooks/useLocale", () => ({
+  useLocale() {
+    return { t: (key: string) => key };
+  },
+}));
+
+vi.mock("@calcom/lib/hooks/useCompatSearchParams", () => ({
+  useCompatSearchParams() {
+    return new URLSearchParams();
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname() {
+    return "";
+  },
+  useSearchParams() {
+    return new URLSearchParams();
+  },
+  useRouter() {
+    return {
+      push: vi.fn(),
+      beforePopState: vi.fn(() => null),
+      prefetch: vi.fn(() => null),
+    };
+  },
+}));
+
+describe("extractYouTubeVideoId", () => {
+  it("extracts video ID from youtu.be short URLs", () => {
+    expect(extractYouTubeVideoId("https://youtu.be/dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+  });
+
+  it("extracts video ID from youtube.com watch URLs", () => {
+    expect(extractYouTubeVideoId("https://www.youtube.com/watch?v=dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+  });
+
+  it("extracts video ID from youtube.com embed URLs", () => {
+    expect(extractYouTubeVideoId("https://www.youtube.com/embed/dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+  });
+
+  it("extracts video ID from youtube.com shorts URLs", () => {
+    expect(extractYouTubeVideoId("https://www.youtube.com/shorts/dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+  });
+
+  it("extracts video ID from youtube-nocookie.com embed URLs", () => {
+    expect(extractYouTubeVideoId("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+  });
+
+  it("extracts video ID from YouTube thumbnail URLs", () => {
+    expect(extractYouTubeVideoId("https://img.youtube.com/vi/dQw4w9WgXcQ/0.jpg")).toBe("dQw4w9WgXcQ");
+    expect(extractYouTubeVideoId("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")).toBe(
+      "dQw4w9WgXcQ"
+    );
+  });
+
+  it("handles video IDs with hyphens and underscores", () => {
+    expect(extractYouTubeVideoId("https://youtu.be/abc-_def_12")).toBe("abc-_def_12");
+  });
+
+  it("returns null for non-YouTube URLs", () => {
+    expect(extractYouTubeVideoId("https://www.google.com")).toBeNull();
+    expect(extractYouTubeVideoId("https://vimeo.com/123456")).toBeNull();
+  });
+
+  it("returns null for invalid YouTube URLs without a valid video ID", () => {
+    expect(extractYouTubeVideoId("https://www.youtube.com/")).toBeNull();
+    expect(extractYouTubeVideoId("https://www.youtube.com/watch")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractYouTubeVideoId("")).toBeNull();
+  });
+
+  it("extracts video ID from URLs with additional query parameters", () => {
+    expect(extractYouTubeVideoId("https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120")).toBe("dQw4w9WgXcQ");
+  });
+});
+
+describe("YouTubePlayerModal", () => {
+  it("renders nothing when closed", () => {
+    render(<YouTubePlayerModal open={false} onOpenChange={vi.fn()} videoId="dQw4w9WgXcQ" />);
+
+    expect(screen.queryByTitle("video_player")).not.toBeInTheDocument();
+  });
+
+  it("renders iframe with correct src when open with videoId", () => {
+    render(<YouTubePlayerModal open={true} onOpenChange={vi.fn()} videoId="dQw4w9WgXcQ" />);
+
+    const iframe = screen.getByTitle("video_player");
+    expect(iframe).toBeInTheDocument();
+    expect(iframe.getAttribute("src")).toBe(
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0"
+    );
+  });
+
+  it("disables autoplay when autoplay prop is false", () => {
+    render(
+      <YouTubePlayerModal open={true} onOpenChange={vi.fn()} videoId="dQw4w9WgXcQ" autoplay={false} />
+    );
+
+    const iframe = screen.getByTitle("video_player");
+    expect(iframe.getAttribute("src")).toBe(
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=0&rel=0"
+    );
+  });
+
+  it("does not render iframe when videoId is null", () => {
+    render(<YouTubePlayerModal open={true} onOpenChange={vi.fn()} videoId={null} />);
+
+    expect(screen.queryByTitle("video_player")).not.toBeInTheDocument();
+  });
+
+  it("uses youtube-nocookie.com for privacy", () => {
+    render(<YouTubePlayerModal open={true} onOpenChange={vi.fn()} videoId="dQw4w9WgXcQ" />);
+
+    const iframe = screen.getByTitle("video_player");
+    expect(iframe.getAttribute("src")).toContain("youtube-nocookie.com");
+  });
+});

--- a/packages/ui/components/youtube-player-modal/YouTubePlayerModal.tsx
+++ b/packages/ui/components/youtube-player-modal/YouTubePlayerModal.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useCallback } from "react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+
+import { Dialog, DialogContent, DialogClose } from "../dialog";
+import { Icon } from "../icon";
+
+export type YouTubePlayerModalProps = {
+  /** Whether the modal is open */
+  open: boolean;
+  /** Callback when the modal open state changes */
+  onOpenChange: (open: boolean) => void;
+  /** YouTube video ID to play */
+  videoId: string | null;
+  /** Whether to autoplay the video when modal opens (default: true) */
+  autoplay?: boolean;
+};
+
+/**
+ * Extracts a YouTube video ID from various URL formats.
+ * Supports:
+ * - youtu.be short URLs (e.g., https://youtu.be/VIDEO_ID)
+ * - youtube.com watch URLs (e.g., https://youtube.com/watch?v=VIDEO_ID)
+ * - youtube.com embed URLs (e.g., https://youtube.com/embed/VIDEO_ID)
+ * - youtube.com shorts URLs (e.g., https://youtube.com/shorts/VIDEO_ID)
+ * - youtube-nocookie.com embed URLs
+ * - YouTube thumbnail URLs (e.g., https://img.youtube.com/vi/VIDEO_ID/0.jpg)
+ *
+ * @param url - The URL to extract the video ID from
+ * @returns The video ID if found, null otherwise
+ */
+export function extractYouTubeVideoId(url: string): string | null {
+  // Handle youtu.be short URLs
+  const shortUrlMatch = url.match(/youtu\.be\/([a-zA-Z0-9_-]{11})/);
+  if (shortUrlMatch) return shortUrlMatch[1];
+
+  // Handle youtube.com URLs (watch, embed, shorts)
+  const longUrlMatch = url.match(/youtube\.com\/(?:watch\?v=|embed\/|shorts\/)([a-zA-Z0-9_-]{11})/);
+  if (longUrlMatch) return longUrlMatch[1];
+
+  // Handle youtube-nocookie.com URLs
+  const noCookieMatch = url.match(/youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]{11})/);
+  if (noCookieMatch) return noCookieMatch[1];
+
+  // Handle YouTube thumbnail URLs
+  const thumbnailMatch = url.match(/img\.youtube\.com\/vi\/([a-zA-Z0-9_-]{11})/);
+  if (thumbnailMatch) return thumbnailMatch[1];
+
+  return null;
+}
+
+/**
+ * A reusable modal component for playing YouTube videos in an embedded player.
+ * Uses youtube-nocookie.com for privacy-enhanced embedding.
+ *
+ * @example
+ * ```tsx
+ * const [open, setOpen] = useState(false);
+ * const [videoId, setVideoId] = useState<string | null>(null);
+ *
+ * // Open modal with a video
+ * const handleVideoClick = (url: string) => {
+ *   const id = extractYouTubeVideoId(url);
+ *   if (id) {
+ *     setVideoId(id);
+ *     setOpen(true);
+ *   }
+ * };
+ *
+ * return (
+ *   <>
+ *     <button onClick={() => handleVideoClick("https://youtu.be/VIDEO_ID")}>
+ *       Watch Video
+ *     </button>
+ *     <YouTubePlayerModal
+ *       open={open}
+ *       onOpenChange={setOpen}
+ *       videoId={videoId}
+ *     />
+ *   </>
+ * );
+ * ```
+ */
+export function YouTubePlayerModal({
+  open,
+  onOpenChange,
+  videoId,
+  autoplay = true,
+}: YouTubePlayerModalProps) {
+  const { t } = useLocale();
+
+  const handleOpenChange = useCallback(
+    (newOpen: boolean) => {
+      onOpenChange(newOpen);
+    },
+    [onOpenChange]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent size="xl" className="!max-w-4xl !rounded-xl !bg-black !p-0" enableOverflow>
+        <div className="relative">
+          {/* Close button positioned above the video */}
+          <DialogClose
+            className="absolute -top-12 right-0 flex h-10 w-10 items-center justify-center rounded-full bg-black/70 text-white backdrop-blur-sm transition-all duration-200 hover:bg-black/90"
+            color="minimal">
+            <Icon name="x" className="h-5 w-5" />
+          </DialogClose>
+
+          {/* Video container with 16:9 aspect ratio */}
+          {videoId && (
+            <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
+              <iframe
+                className="absolute left-0 top-0 h-full w-full rounded-xl"
+                src={`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=${autoplay ? 1 : 0}&rel=0`}
+                title={t("video_player")}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/components/youtube-player-modal/YouTubePlayerModal.tsx
+++ b/packages/ui/components/youtube-player-modal/YouTubePlayerModal.tsx
@@ -1,88 +1,33 @@
 "use client";
 
-import { useCallback } from "react";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
 import { Dialog, DialogContent, DialogClose } from "../dialog";
 import { Icon } from "../icon";
 
 export type YouTubePlayerModalProps = {
-  /** Whether the modal is open */
   open: boolean;
-  /** Callback when the modal open state changes */
   onOpenChange: (open: boolean) => void;
-  /** YouTube video ID to play */
   videoId: string | null;
-  /** Whether to autoplay the video when modal opens (default: true) */
   autoplay?: boolean;
 };
 
-/**
- * Extracts a YouTube video ID from various URL formats.
- * Supports:
- * - youtu.be short URLs (e.g., https://youtu.be/VIDEO_ID)
- * - youtube.com watch URLs (e.g., https://youtube.com/watch?v=VIDEO_ID)
- * - youtube.com embed URLs (e.g., https://youtube.com/embed/VIDEO_ID)
- * - youtube.com shorts URLs (e.g., https://youtube.com/shorts/VIDEO_ID)
- * - youtube-nocookie.com embed URLs
- * - YouTube thumbnail URLs (e.g., https://img.youtube.com/vi/VIDEO_ID/0.jpg)
- *
- * @param url - The URL to extract the video ID from
- * @returns The video ID if found, null otherwise
- */
 export function extractYouTubeVideoId(url: string): string | null {
-  // Handle youtu.be short URLs
   const shortUrlMatch = url.match(/youtu\.be\/([a-zA-Z0-9_-]{11})/);
   if (shortUrlMatch) return shortUrlMatch[1];
 
-  // Handle youtube.com URLs (watch, embed, shorts)
   const longUrlMatch = url.match(/youtube\.com\/(?:watch\?v=|embed\/|shorts\/)([a-zA-Z0-9_-]{11})/);
   if (longUrlMatch) return longUrlMatch[1];
 
-  // Handle youtube-nocookie.com URLs
   const noCookieMatch = url.match(/youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]{11})/);
   if (noCookieMatch) return noCookieMatch[1];
 
-  // Handle YouTube thumbnail URLs
   const thumbnailMatch = url.match(/img\.youtube\.com\/vi\/([a-zA-Z0-9_-]{11})/);
   if (thumbnailMatch) return thumbnailMatch[1];
 
   return null;
 }
 
-/**
- * A reusable modal component for playing YouTube videos in an embedded player.
- * Uses youtube-nocookie.com for privacy-enhanced embedding.
- *
- * @example
- * ```tsx
- * const [open, setOpen] = useState(false);
- * const [videoId, setVideoId] = useState<string | null>(null);
- *
- * // Open modal with a video
- * const handleVideoClick = (url: string) => {
- *   const id = extractYouTubeVideoId(url);
- *   if (id) {
- *     setVideoId(id);
- *     setOpen(true);
- *   }
- * };
- *
- * return (
- *   <>
- *     <button onClick={() => handleVideoClick("https://youtu.be/VIDEO_ID")}>
- *       Watch Video
- *     </button>
- *     <YouTubePlayerModal
- *       open={open}
- *       onOpenChange={setOpen}
- *       videoId={videoId}
- *     />
- *   </>
- * );
- * ```
- */
 export function YouTubePlayerModal({
   open,
   onOpenChange,
@@ -91,25 +36,16 @@ export function YouTubePlayerModal({
 }: YouTubePlayerModalProps) {
   const { t } = useLocale();
 
-  const handleOpenChange = useCallback(
-    (newOpen: boolean) => {
-      onOpenChange(newOpen);
-    },
-    [onOpenChange]
-  );
-
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size="xl" className="!max-w-4xl !rounded-xl !bg-black !p-0" enableOverflow>
         <div className="relative">
-          {/* Close button positioned above the video */}
           <DialogClose
             className="absolute -top-12 right-0 flex h-10 w-10 items-center justify-center rounded-full bg-black/70 text-white backdrop-blur-sm transition-all duration-200 hover:bg-black/90"
             color="minimal">
             <Icon name="x" className="h-5 w-5" />
           </DialogClose>
 
-          {/* Video container with 16:9 aspect ratio */}
           {videoId && (
             <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
               <iframe

--- a/packages/ui/components/youtube-player-modal/index.ts
+++ b/packages/ui/components/youtube-player-modal/index.ts
@@ -1,0 +1,2 @@
+export { YouTubePlayerModal, extractYouTubeVideoId } from "./YouTubePlayerModal";
+export type { YouTubePlayerModalProps } from "./YouTubePlayerModal";


### PR DESCRIPTION
## What does this PR do?

Introduces a reusable `YouTubePlayerModal` component in `@calcom/ui` that embeds YouTube videos in an in-app modal, preventing users from being redirected to YouTube. This component can be used across the app — in Tips, upgrade paths, and anywhere video content is displayed.

- Fixes #26282
- Fixes [CAL-6992](https://linear.app/calcom/issue/CAL-6992/render-sidebar-help-videos-in-an-embedded-modal-to-improve-in-app)

**Key changes:**

- **New `YouTubePlayerModal` component** (`packages/ui/components/youtube-player-modal/`) — reusable dialog with embedded YouTube iframe using `youtube-nocookie.com` for privacy, `rel=0` to limit recommendations, configurable autoplay, and 16:9 aspect ratio
- **New `extractYouTubeVideoId()` utility** — exported helper that parses video IDs from youtu.be, youtube.com (watch/embed/shorts), youtube-nocookie.com, and thumbnail URLs
- **Refactored `Tips.tsx`** to import and use the shared component instead of inline Dialog/regex logic
- **16 unit tests** covering all URL format parsing and modal rendering behavior
- Preserves gated feature modal behavior for tips with custom onClick handlers (e.g., Roles & Permissions)
- Added `video_player` translation key for iframe accessibility

### Updates since last revision

- Added comprehensive unit tests for both `extractYouTubeVideoId` (11 tests) and `YouTubePlayerModal` (5 tests)
- Cleaned up component: removed redundant `handleOpenChange` wrapper and unnecessary code comments

## Visual Demo (For contributors especially)

This PR recreates the functionality from the closed PR #26454 (branch was deleted).

The feature is behind the `sidebar-tips` feature flag. When enabled:
- Clicking a video thumbnail opens an embedded modal instead of redirecting to YouTube
- Clicking "Learn more" also opens the video in the modal (for tips without custom onClick)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Enable the `sidebar-tips` feature flag in the database
2. Log in and navigate to any page with the sidebar (e.g., Event Types)
3. Click on a video thumbnail in the Tips section
4. **Expected:** Modal opens with embedded YouTube video, autoplay enabled
5. Click "Learn more" on a tip
6. **Expected:** Same modal behavior for tips without custom onClick
7. Test the "Roles & Permissions" tip specifically
8. **Expected:** Should open the gated features modal, NOT the video modal

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Important areas for review

1. **`YouTubePlayerModal` component** (`packages/ui/components/youtube-player-modal/YouTubePlayerModal.tsx`) — verify Dialog styling, iframe attributes, and close button positioning
2. **`extractYouTubeVideoId` regex patterns** (lines 15-29) — assumes YouTube video IDs are always exactly 11 characters; reviewer should verify this assumption holds for all expected inputs
3. **`learnMore.href` set to `undefined`** when `tip.onClick` exists (`Tips.tsx` line 285) — verify the Card component handles undefined href correctly
4. **`event` parameter threading** in `mediaLinkOnClick` and `learnMore.onClick` (`Tips.tsx` lines 275, 288) — verify the Card component passes event objects to these callbacks

---

Link to Devin run: https://app.devin.ai/sessions/02f9d145f9f342e4b390115939b0c599
Requested by: @Amit91848