### PR TITLE
feat(companion): upcoming bookings widget android

### DIFF
--- a/companion/app.json
+++ b/companion/app.json
@@ -104,7 +104,6 @@
               "description": "View your upcoming Cal.com bookings",
               "previewImage": "./assets/icon.png",
               "resizeMode": "horizontal|vertical",
-              "widgetFeatures": "reconfigurable",
               "targetCellWidth": 3,
               "targetCellHeight": 2
             }

--- a/companion/bun.lock
+++ b/companion/bun.lock
@@ -46,7 +46,6 @@
         "react-native-reanimated": "4.2.0",
         "react-native-safe-area-context": "5.6.2",
         "react-native-screens": "4.19.0",
-        "react-native-shared-group-preferences": "1.1.24",
         "react-native-svg": "15.12.1",
         "react-native-web": "0.21.2",
         "react-native-worklets": "0.7.1",
@@ -1776,8 +1775,6 @@
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg=="],
 
     "react-native-screens": ["react-native-screens@4.19.0", "", { "dependencies": { "react-freeze": "^1.0.0", "warn-once": "^0.1.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-qSDAO3AL5bti0Ri7KZRSVmWlhDr8MV86N5GruiKVQfEL7Zx2nUi3Dl62lqHUAD/LnDvOPuDDsMHCfIpYSv3hPQ=="],
-
-    "react-native-shared-group-preferences": ["react-native-shared-group-preferences@1.1.24", "", { "peerDependencies": { "react-native": ">=0.41.2" } }, "sha512-lncFBltdqXLp8H87wNZUg/P7KvaCqscQ/8GXvrRl0RIUBVVSzrKdAQyBTcsHb7mkMULmph73u41/6nQ5BvUchw=="],
 
     "react-native-svg": ["react-native-svg@15.12.1", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g=="],
 

--- a/companion/package.json
+++ b/companion/package.json
@@ -92,7 +92,6 @@
     "react-native-reanimated": "4.2.0",
     "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.19.0",
-    "react-native-shared-group-preferences": "1.1.24",
     "react-native-svg": "15.12.1",
     "react-native-web": "0.21.2",
     "react-native-worklets": "0.7.1",

--- a/companion/widgets/UpcomingBookingsWidget.tsx
+++ b/companion/widgets/UpcomingBookingsWidget.tsx
@@ -18,45 +18,19 @@ interface WidgetProps {
   bookings: BookingData[];
 }
 
-// Calculate minutes until meeting starts
-function getMinutesUntilStart(startTimeISO?: string): number | null {
-  if (!startTimeISO) return null;
+// Get accent color based on start time proximity - returns HexColor type
+function getAccentColor(startTimeISO?: string): `#${string}` {
+  if (!startTimeISO) return "#007AFF";
   try {
     const startDate = new Date(startTimeISO);
     const now = new Date();
     const minutes = Math.floor((startDate.getTime() - now.getTime()) / 60000);
-    return Math.max(0, minutes);
+    if (minutes <= 0) return "#007AFF"; // Blue - already started or past
+    if (minutes <= 30) return "#FF9500"; // Orange - starting soon
+    return "#007AFF";
   } catch {
-    return null;
+    return "#007AFF";
   }
-}
-
-// Get countdown text
-function getCountdownText(minutes: number | null): string | null {
-  if (minutes === null) return null;
-  if (minutes <= 0) return "Now";
-  if (minutes < 60) return `In ${minutes}m`;
-  if (minutes < 1440) {
-    const hours = Math.floor(minutes / 60);
-    return `In ${hours}h`;
-  }
-  return null;
-}
-
-// Get accent color based on urgency - returns HexColor type
-function getAccentColor(minutes: number | null): `#${string}` {
-  if (minutes === null) return "#007AFF"; // Blue - default
-  if (minutes <= 0) return "#34C759"; // Green - happening now
-  if (minutes <= 30) return "#FF9500"; // Orange - starting soon
-  return "#007AFF"; // Blue - default
-}
-
-// Get countdown text color - returns HexColor type
-function getCountdownColor(minutes: number | null): `#${string}` {
-  if (minutes === null) return "#8E8E93";
-  if (minutes <= 0) return "#34C759"; // Green
-  if (minutes <= 30) return "#FF9500"; // Orange
-  return "#8E8E93"; // Gray
 }
 
 // Get first initial from name
@@ -66,10 +40,7 @@ function getInitial(name: string | null): string {
 }
 
 function BookingItem({ booking }: { booking: BookingData }) {
-  const minutes = getMinutesUntilStart(booking.startTimeISO);
-  const countdownText = getCountdownText(minutes);
-  const accentColor = getAccentColor(minutes);
-  const countdownColor = getCountdownColor(minutes);
+  const accentColor = getAccentColor(booking.startTimeISO);
 
   return (
     <FlexWidget
@@ -144,16 +115,6 @@ function BookingItem({ booking }: { booking: BookingData }) {
               color: "#8E8E93",
             }}
           />
-          {countdownText && (
-            <TextWidget
-              text={` • ${countdownText}`}
-              style={{
-                fontSize: 11,
-                fontWeight: "500",
-                color: countdownColor,
-              }}
-            />
-          )}
         </FlexWidget>
 
         {/* Attendee info with initial circle */}

--- a/companion/widgets/UpcomingBookingsWidget.tsx
+++ b/companion/widgets/UpcomingBookingsWidget.tsx
@@ -1,61 +1,202 @@
+"use no memo";
 import { FlexWidget, TextWidget } from "react-native-android-widget";
 
 interface BookingData {
   id: string;
   title: string;
+  date: string;
   startTime: string;
+  endTime: string;
+  startTimeISO?: string;
   attendeeName: string | null;
+  hostName?: string | null;
+  location?: string | null;
+  hasVideoCall?: boolean;
 }
 
 interface WidgetProps {
   bookings: BookingData[];
 }
 
+// Calculate minutes until meeting starts
+function getMinutesUntilStart(startTimeISO?: string): number | null {
+  if (!startTimeISO) return null;
+  try {
+    const startDate = new Date(startTimeISO);
+    const now = new Date();
+    const minutes = Math.floor((startDate.getTime() - now.getTime()) / 60000);
+    return Math.max(0, minutes);
+  } catch {
+    return null;
+  }
+}
+
+// Get countdown text
+function getCountdownText(minutes: number | null): string | null {
+  if (minutes === null) return null;
+  if (minutes <= 0) return "Now";
+  if (minutes < 60) return `In ${minutes}m`;
+  if (minutes < 1440) {
+    const hours = Math.floor(minutes / 60);
+    return `In ${hours}h`;
+  }
+  return null;
+}
+
+// Get accent color based on urgency - returns HexColor type
+function getAccentColor(minutes: number | null): `#${string}` {
+  if (minutes === null) return "#007AFF"; // Blue - default
+  if (minutes <= 0) return "#34C759"; // Green - happening now
+  if (minutes <= 30) return "#FF9500"; // Orange - starting soon
+  return "#007AFF"; // Blue - default
+}
+
+// Get countdown text color - returns HexColor type
+function getCountdownColor(minutes: number | null): `#${string}` {
+  if (minutes === null) return "#8E8E93";
+  if (minutes <= 0) return "#34C759"; // Green
+  if (minutes <= 30) return "#FF9500"; // Orange
+  return "#8E8E93"; // Gray
+}
+
+// Get first initial from name
+function getInitial(name: string | null): string {
+  if (!name) return "";
+  return name.charAt(0).toUpperCase();
+}
+
 function BookingItem({ booking }: { booking: BookingData }) {
+  const minutes = getMinutesUntilStart(booking.startTimeISO);
+  const countdownText = getCountdownText(minutes);
+  const accentColor = getAccentColor(minutes);
+  const countdownColor = getCountdownColor(minutes);
+
   return (
     <FlexWidget
       style={{
-        flexDirection: "column",
-        padding: 8,
+        flexDirection: "row",
+        paddingVertical: 8,
+        paddingHorizontal: 12,
         borderBottomWidth: 1,
-        borderBottomColor: "#E5E5E5",
+        borderBottomColor: "#E5E5EA",
+      }}
+      clickAction="OPEN_URI"
+      clickActionData={{
+        uri: `calcom://(tabs)/(bookings)/booking-detail?uid=${booking.id}`,
       }}
     >
-      <TextWidget
-        text={booking.title}
-        style={{
-          fontSize: 14,
-          fontWeight: "600",
-          color: "#000000",
-        }}
-        maxLines={1}
-      />
+      {/* Left accent bar */}
       <FlexWidget
         style={{
-          flexDirection: "row",
-          alignItems: "center",
-          marginTop: 2,
+          width: 3,
+          borderRadius: 2,
+          backgroundColor: accentColor,
+          marginRight: 8,
+        }}
+      />
+
+      {/* Content */}
+      <FlexWidget
+        style={{
+          flex: 1,
+          flexDirection: "column",
         }}
       >
-        <TextWidget
-          text={booking.startTime}
+        {/* Title row with video icon */}
+        <FlexWidget
           style={{
-            fontSize: 12,
-            color: "#666666",
+            flexDirection: "row",
+            alignItems: "center",
           }}
-        />
-      </FlexWidget>
-      {booking.attendeeName && (
-        <TextWidget
-          text={booking.attendeeName}
+        >
+          <TextWidget
+            text={booking.title}
+            style={{
+              fontSize: 13,
+              fontWeight: "600",
+              color: "#000000",
+            }}
+            maxLines={1}
+          />
+          {booking.hasVideoCall && (
+            <TextWidget
+              text=" 📹"
+              style={{
+                fontSize: 10,
+                color: "#007AFF",
+              }}
+            />
+          )}
+        </FlexWidget>
+
+        {/* Date and time with countdown */}
+        <FlexWidget
           style={{
-            fontSize: 11,
-            color: "#888888",
+            flexDirection: "row",
+            alignItems: "center",
             marginTop: 2,
           }}
-          maxLines={1}
-        />
-      )}
+        >
+          <TextWidget
+            text={`${booking.date} • ${booking.startTime}`}
+            style={{
+              fontSize: 11,
+              color: "#8E8E93",
+            }}
+          />
+          {countdownText && (
+            <TextWidget
+              text={` • ${countdownText}`}
+              style={{
+                fontSize: 11,
+                fontWeight: "500",
+                color: countdownColor,
+              }}
+            />
+          )}
+        </FlexWidget>
+
+        {/* Attendee info with initial circle */}
+        {booking.attendeeName && (
+          <FlexWidget
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              marginTop: 4,
+            }}
+          >
+            {/* Initial circle */}
+            <FlexWidget
+              style={{
+                width: 16,
+                height: 16,
+                borderRadius: 8,
+                backgroundColor: "#007AFF20",
+                justifyContent: "center",
+                alignItems: "center",
+                marginRight: 4,
+              }}
+            >
+              <TextWidget
+                text={getInitial(booking.attendeeName)}
+                style={{
+                  fontSize: 9,
+                  fontWeight: "600",
+                  color: "#007AFF",
+                }}
+              />
+            </FlexWidget>
+            <TextWidget
+              text={booking.attendeeName}
+              style={{
+                fontSize: 11,
+                color: "#8E8E93",
+              }}
+              maxLines={1}
+            />
+          </FlexWidget>
+        )}
+      </FlexWidget>
     </FlexWidget>
   );
 }
@@ -70,20 +211,32 @@ export function UpcomingBookingsWidget({ bookings }: WidgetProps) {
         borderRadius: 16,
         flexDirection: "column",
       }}
+      clickAction="OPEN_URI"
+      clickActionData={{
+        uri: "calcom://(tabs)/(bookings)",
+      }}
     >
+      {/* Header with calendar icon */}
       <FlexWidget
         style={{
           flexDirection: "row",
           alignItems: "center",
           padding: 12,
           borderBottomWidth: 1,
-          borderBottomColor: "#E5E5E5",
+          borderBottomColor: "#E5E5EA",
         }}
       >
         <TextWidget
+          text="📅"
+          style={{
+            fontSize: 12,
+            marginRight: 4,
+          }}
+        />
+        <TextWidget
           text="Upcoming"
           style={{
-            fontSize: 14,
+            fontSize: 12,
             fontWeight: "600",
             color: "#000000",
           }}
@@ -100,10 +253,18 @@ export function UpcomingBookingsWidget({ bookings }: WidgetProps) {
           }}
         >
           <TextWidget
+            text="✓"
+            style={{
+              fontSize: 24,
+              color: "#8E8E93",
+            }}
+          />
+          <TextWidget
             text="No upcoming bookings"
             style={{
-              fontSize: 13,
-              color: "#888888",
+              fontSize: 12,
+              color: "#8E8E93",
+              marginTop: 4,
             }}
           />
         </FlexWidget>

--- a/companion/widgets/widgetTaskHandler.tsx
+++ b/companion/widgets/widgetTaskHandler.tsx
@@ -1,3 +1,4 @@
+"use no memo";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { WidgetTaskHandlerProps } from "react-native-android-widget";
 import { UpcomingBookingsWidget } from "./UpcomingBookingsWidget";
@@ -7,8 +8,14 @@ const WIDGET_STORAGE_KEY = "android_widget_bookings";
 interface BookingData {
   id: string;
   title: string;
+  date: string;
   startTime: string;
+  endTime: string;
+  startTimeISO?: string;
   attendeeName: string | null;
+  hostName?: string | null;
+  location?: string | null;
+  hasVideoCall?: boolean;
 }
 
 async function getStoredBookings(): Promise<BookingData[]> {


### PR DESCRIPTION
## What does this PR do?

Redesigns the Android Upcoming Bookings home screen widget with improved UI, deep links, and reliable time display.

- Adds urgency accent bar, attendee initials, and video call indicator
- Adds deep links: tapping the widget opens the bookings tab; tapping an item opens booking detail via `calcom://`
- Uses absolute date/time display instead of relative countdowns (e.g. "In 15m") which become stale due to Android's 30+ min widget refresh interval
- Removes `react-native-shared-group-preferences` dependency and `widgetFeatures: reconfigurable` flag
- Extends `BookingData` with `date`, `endTime`, `startTimeISO`, `hostName`, `location`, `hasVideoCall` fields

> **Devin note:** Addressed two Cubic AI review findings (both confidence 9/10):
> 1. Removed relative countdown text that becomes misleading on Android widgets due to infrequent updates
> 2. Fixed `Math.max(0, minutes)` clamping that caused past/ended meetings to display as "Now" indefinitely

## Visual Demo (For contributors especially)

#### Video Demo:

https://github.com/user-attachments/assets/ca80df18-d281-4f68-bf4d-a2062f576382

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a redesigned Upcoming Bookings widget for Android with deep links and clearer at-a-glance info. Uses absolute date/time with a color accent for urgency.

- **New Features**
  - Title and date/time with urgency accent; shows attendee initial and a video icon when applicable.
  - Tap actions: widget opens the bookings tab; item opens booking detail via calcom://.

- **Refactors**
  - Simplified time display: removed relative countdown; fixed past-time display; accent color uses startTimeISO.
  - Data/config: widget accepts date, endTime, startTimeISO, hostName, location, hasVideoCall; removed react-native-shared-group-preferences and reconfigurable flag.

<sup>Written for commit 852239e57a5d83655c89823a2b31a566d8228121. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Build the companion app for Android
2. Add the "Upcoming Bookings" widget to the home screen
3. Verify bookings display with absolute date/time (no relative "In Xm" countdown)
4. Verify the accent bar shows orange for meetings starting within 30 minutes, blue otherwise
5. Tap the widget header → should open the bookings tab
6. Tap an individual booking → should deep link to booking detail
7. Wait 30+ minutes and verify displayed times are still accurate (absolute format)

## Human Review Checklist

- [ ] Accent color still computes at render time — verify it's acceptable that the orange accent (≤30 min) may become stale between widget refreshes
- [ ] `BookingData` interface is duplicated in `UpcomingBookingsWidget.tsx` and `widgetTaskHandler.tsx` — consider extracting to a shared type
- [ ] No `endTimeISO` field exists, so accent color cannot distinguish "ongoing" vs "ended" meetings (both show blue)
- [ ] No automated tests for widget utility functions (`getAccentColor`, `getInitial`)

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized

---
Link to Devin run: https://app.devin.ai/sessions/f057811ba7c04e7790c00f468db86fab
Requested by: unknown ()