### PR TITLE
feat: add comprehensive booking audit logs seed script

### DIFF
--- a/scripts/seed-booking-audit.ts
+++ b/scripts/seed-booking-audit.ts
@@ -386,54 +386,75 @@ async function seedAuditLogsForBooking({
 export default async function seedBookingAuditLogs() {
   console.log("🔍 Seeding booking audit logs...");
 
-  const targetUsers = await prisma.user.findMany({
-    where: {
-      username: { in: ["pro", "owner1-acme"] },
-    },
+  // Audit logs is an org-only feature, so we only seed for owner1-acme
+  const user = await prisma.user.findFirst({
+    where: { username: "owner1-acme" },
     select: { id: true, uuid: true, username: true, email: true },
   });
 
-  if (targetUsers.length === 0) {
-    console.log("❌ No seed users found. Run the main seed first.");
+  if (!user) {
+    console.log("❌ User owner1-acme not found. Run the main seed first.");
     return;
   }
 
-  let totalCreated = 0;
+  // Find an event type for this user to create a booking
+  const eventType = await prisma.eventType.findFirst({
+    where: { userId: user.id },
+    select: { id: true, title: true, length: true },
+  });
 
-  for (const user of targetUsers) {
-    const booking = await prisma.booking.findFirst({
-      where: { userId: user.id },
-      select: {
-        uid: true,
-        attendees: { select: { id: true, email: true }, take: 1 },
-      },
-      orderBy: { createdAt: "desc" },
-    });
-
-    if (!booking) {
-      console.log(`  ⚠️ No booking found for ${user.username}, skipping.`);
-      continue;
-    }
-
-    console.log(`📋 Seeding audit logs for ${user.username} — booking ${booking.uid}`);
-
-    const count = await seedAuditLogsForBooking({
-      bookingUid: booking.uid,
-      userUuid: user.uuid,
-      attendeeId: booking.attendees[0]?.id,
-      attendeeEmail: booking.attendees[0]?.email ?? "attendee@example.com",
-    });
-
-    if (count > 0) {
-      console.log(`  ✅ Created ${count} audit log entries`);
-      console.log(`  View logs at: /booking/${booking.uid}/logs`);
-    }
-
-    totalCreated += count;
+  if (!eventType) {
+    console.log("❌ No event type found for owner1-acme. Run the main seed first.");
+    return;
   }
 
+  // Create a new upcoming booking specifically for audit logs
+  const bookingUid = uuidv4();
+  const startTime = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days from now
+  const endTime = new Date(startTime.getTime() + eventType.length * 60 * 1000);
+
+  console.log(`📋 Creating new booking for audit logs...`);
+
+  const booking = await prisma.booking.create({
+    data: {
+      uid: bookingUid,
+      title: `Audit Log Test Booking - ${eventType.title}`,
+      startTime,
+      endTime,
+      status: BookingStatus.ACCEPTED,
+      userId: user.id,
+      eventTypeId: eventType.id,
+      attendees: {
+        create: {
+          email: "audit-test-attendee@example.com",
+          name: "Audit Test Attendee",
+          timeZone: "UTC",
+        },
+      },
+    },
+    select: {
+      uid: true,
+      attendees: { select: { id: true, email: true }, take: 1 },
+    },
+  });
+
+  console.log(`  ✅ Created booking: ${booking.uid}`);
+
+  console.log(`📋 Seeding audit logs for ${user.username} — booking ${booking.uid}`);
+
+  const count = await seedAuditLogsForBooking({
+    bookingUid: booking.uid,
+    userUuid: user.uuid,
+    attendeeId: booking.attendees[0]?.id,
+    attendeeEmail: booking.attendees[0]?.email ?? "attendee@example.com",
+  });
+
+  console.log(`  ✅ Created ${count} audit log entries`);
+  console.log(`  View logs at: /booking/${booking.uid}/logs`);
+
   console.log(`\n📊 Summary:`);
-  console.log(`  Total audit log entries created: ${totalCreated}`);
+  console.log(`  Booking UID: ${booking.uid}`);
+  console.log(`  Total audit log entries created: ${count}`);
   console.log("  Actions covered: CREATED, ACCEPTED, RESCHEDULE_REQUESTED, RESCHEDULED,");
   console.log("    LOCATION_CHANGED, ATTENDEE_ADDED, ATTENDEE_REMOVED, REASSIGNMENT (x2),");
   console.log("    NO_SHOW_UPDATED (x2), CANCELLED, REJECTED, SEAT_BOOKED, SEAT_RESCHEDULED");

--- a/scripts/seed-booking-audit.ts
+++ b/scripts/seed-booking-audit.ts
@@ -389,12 +389,46 @@ export default async function seedBookingAuditLogs() {
   // Audit logs is an org-only feature, so we only seed for owner1-acme
   const user = await prisma.user.findFirst({
     where: { username: "owner1-acme" },
-    select: { id: true, uuid: true, username: true, email: true },
+    select: { id: true, uuid: true, username: true, email: true, organizationId: true },
   });
 
   if (!user) {
     console.log("❌ User owner1-acme not found. Run the main seed first.");
     return;
+  }
+
+  // Enable bookings-v3 globally
+  await prisma.feature.upsert({
+    where: { slug: "bookings-v3" },
+    create: { slug: "bookings-v3", enabled: true, description: "Enable bookings redesign v3 for all users", type: "EXPERIMENT" },
+    update: { enabled: true },
+  });
+  console.log("  ✅ Enabled bookings-v3 globally");
+
+  // Enable booking-audit at team level for owner1-acme's organization
+  if (user.organizationId) {
+    await prisma.feature.upsert({
+      where: { slug: "booking-audit" },
+      create: {
+        slug: "booking-audit",
+        enabled: false,
+        description: "Enable booking audit trails - Track all booking actions and changes for organizations",
+        type: "OPERATIONAL",
+      },
+      update: {},
+    });
+
+    await prisma.teamFeatures.upsert({
+      where: { teamId_featureId: { teamId: user.organizationId, featureId: "booking-audit" } },
+      create: {
+        teamId: user.organizationId,
+        featureId: "booking-audit",
+        enabled: true,
+        assignedBy: "seed-script",
+      },
+      update: { enabled: true },
+    });
+    console.log(`  ✅ Enabled booking-audit for organization ${user.organizationId}`);
   }
 
   // Find an event type for this user to create a booking

--- a/scripts/seed-booking-audit.ts
+++ b/scripts/seed-booking-audit.ts
@@ -1,7 +1,7 @@
-import { v4 as uuidv4 } from "uuid";
-
+import process from "node:process";
 import { prisma } from "@calcom/prisma";
 import { BookingStatus } from "@calcom/prisma/enums";
+import { v4 as uuidv4 } from "uuid";
 
 async function createUserActor(userUuid: string) {
   return prisma.auditActor.upsert({
@@ -389,7 +389,13 @@ export default async function seedBookingAuditLogs() {
   // Audit logs is an org-only feature, so we only seed for owner1-acme
   const user = await prisma.user.findFirst({
     where: { username: "owner1-acme" },
-    select: { id: true, uuid: true, username: true, email: true, organizationId: true },
+    select: {
+      id: true,
+      uuid: true,
+      username: true,
+      email: true,
+      profiles: { select: { organizationId: true } },
+    },
   });
 
   if (!user) {
@@ -397,16 +403,23 @@ export default async function seedBookingAuditLogs() {
     return;
   }
 
+  const organizationId = user.profiles[0].organizationId;
+
   // Enable bookings-v3 globally
   await prisma.feature.upsert({
     where: { slug: "bookings-v3" },
-    create: { slug: "bookings-v3", enabled: true, description: "Enable bookings redesign v3 for all users", type: "EXPERIMENT" },
+    create: {
+      slug: "bookings-v3",
+      enabled: true,
+      description: "Enable bookings redesign v3 for all users",
+      type: "EXPERIMENT",
+    },
     update: { enabled: true },
   });
   console.log("  ✅ Enabled bookings-v3 globally");
 
   // Enable booking-audit at team level for owner1-acme's organization
-  if (user.organizationId) {
+  if (organizationId) {
     await prisma.feature.upsert({
       where: { slug: "booking-audit" },
       create: {
@@ -419,16 +432,16 @@ export default async function seedBookingAuditLogs() {
     });
 
     await prisma.teamFeatures.upsert({
-      where: { teamId_featureId: { teamId: user.organizationId, featureId: "booking-audit" } },
+      where: { teamId_featureId: { teamId: organizationId, featureId: "booking-audit" } },
       create: {
-        teamId: user.organizationId,
+        teamId: organizationId,
         featureId: "booking-audit",
         enabled: true,
         assignedBy: "seed-script",
       },
       update: { enabled: true },
     });
-    console.log(`  ✅ Enabled booking-audit for organization ${user.organizationId}`);
+    console.log(`  ✅ Enabled booking-audit for organization ${organizationId}`);
   }
 
   // Find an event type for this user to create a booking

--- a/scripts/seed-booking-audit.ts
+++ b/scripts/seed-booking-audit.ts
@@ -54,10 +54,6 @@ async function createAppActor(appSlug: string, appName: string) {
   });
 }
 
-function minutesFromNow(minutes: number): number {
-  return Date.now() + minutes * 60 * 1000;
-}
-
 function hoursFromNow(hours: number): number {
   return Date.now() + hours * 60 * 60 * 1000;
 }
@@ -320,7 +316,7 @@ export default async function seedBookingAuditLogs() {
         },
       },
     },
-    context: { impersonatedBy: "admin-user-uuid-placeholder" },
+    context: { impersonatedBy: proUser.uuid },
   });
 
   auditLogs.push({

--- a/scripts/seed-booking-audit.ts
+++ b/scripts/seed-booking-audit.ts
@@ -1,0 +1,446 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { prisma } from "@calcom/prisma";
+import { BookingStatus } from "@calcom/prisma/enums";
+
+async function createUserActor(userUuid: string) {
+  return prisma.auditActor.upsert({
+    where: { userUuid },
+    create: { type: "USER", userUuid },
+    update: {},
+    select: { id: true },
+  });
+}
+
+async function createAttendeeActor(attendeeId: number) {
+  return prisma.auditActor.upsert({
+    where: { attendeeId },
+    create: { type: "ATTENDEE", attendeeId },
+    update: {},
+    select: { id: true },
+  });
+}
+
+async function createSystemActor() {
+  const systemEmail = "system@system.internal";
+  return prisma.auditActor.upsert({
+    where: { email: systemEmail },
+    create: { type: "SYSTEM", email: systemEmail, name: "System" },
+    update: {},
+    select: { id: true },
+  });
+}
+
+async function createGuestActor(email: string, name: string) {
+  const existing = await prisma.auditActor.findUnique({
+    where: { email },
+    select: { id: true },
+  });
+  if (existing) return existing;
+
+  return prisma.auditActor.create({
+    data: { type: "GUEST", email, name },
+    select: { id: true },
+  });
+}
+
+async function createAppActor(appSlug: string, appName: string) {
+  const email = `${appSlug}@app.internal`;
+  return prisma.auditActor.upsert({
+    where: { email },
+    create: { type: "APP", email, name: appName },
+    update: {},
+    select: { id: true },
+  });
+}
+
+function minutesFromNow(minutes: number): number {
+  return Date.now() + minutes * 60 * 1000;
+}
+
+function hoursFromNow(hours: number): number {
+  return Date.now() + hours * 60 * 60 * 1000;
+}
+
+export default async function seedBookingAuditLogs() {
+  console.log("🔍 Seeding booking audit logs...");
+
+  const proUser = await prisma.user.findFirst({
+    where: { username: "pro" },
+    select: { id: true, uuid: true, email: true },
+  });
+
+  if (!proUser) {
+    console.log("❌ Pro user not found. Run the main seed first.");
+    return;
+  }
+
+  const booking = await prisma.booking.findFirst({
+    where: { userId: proUser.id },
+    select: {
+      uid: true,
+      attendees: { select: { id: true, email: true }, take: 1 },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (!booking) {
+    console.log("❌ No booking found for pro user. Run the main seed first.");
+    return;
+  }
+
+  const bookingUid = booking.uid;
+  console.log(`📋 Using booking UID: ${bookingUid}`);
+
+  const existingLogs = await prisma.bookingAudit.findFirst({
+    where: { bookingUid },
+    select: { id: true },
+  });
+
+  if (existingLogs) {
+    console.log("⏭️ Audit logs already seeded for this booking, skipping.");
+    return;
+  }
+
+  const userActor = await createUserActor(proUser.uuid);
+  const systemActor = await createSystemActor();
+  const guestActor = await createGuestActor("guest-attendee@example.com", "Guest Attendee");
+  const appActor = await createAppActor("stripe", "Stripe");
+
+  const attendeeId = booking.attendees[0]?.id;
+  let attendeeActor: { id: string } | null = null;
+  if (attendeeId) {
+    attendeeActor = await createAttendeeActor(attendeeId);
+  }
+
+  const rescheduledToUid = uuidv4();
+
+  const now = Date.now();
+  let timestampOffset = 0;
+  function nextTimestamp(): Date {
+    timestampOffset += 1;
+    return new Date(now - (20 - timestampOffset) * 60 * 1000);
+  }
+
+  const auditLogs: Parameters<typeof prisma.bookingAudit.create>[0]["data"][] = [];
+
+  auditLogs.push({
+    bookingUid,
+    actorId: userActor.id,
+    action: "CREATED",
+    type: "RECORD_CREATED",
+    timestamp: nextTimestamp(),
+    source: "WEBAPP",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        startTime: hoursFromNow(24),
+        endTime: hoursFromNow(24.5),
+        status: BookingStatus.PENDING,
+        hostUserUuid: proUser.uuid,
+        seatReferenceUid: null,
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: userActor.id,
+    action: "ACCEPTED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "WEBAPP",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        status: { old: BookingStatus.PENDING, new: BookingStatus.ACCEPTED },
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: (attendeeActor ?? guestActor).id,
+    action: "RESCHEDULE_REQUESTED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "WEBAPP",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        rescheduleReason: "Conflict with another meeting",
+        rescheduledRequestedBy: booking.attendees[0]?.email ?? "guest@example.com",
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: userActor.id,
+    action: "RESCHEDULED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "WEBAPP",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        startTime: { old: hoursFromNow(24), new: hoursFromNow(48) },
+        endTime: { old: hoursFromNow(24.5), new: hoursFromNow(48.5) },
+        rescheduledToUid: { old: null, new: rescheduledToUid },
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: userActor.id,
+    action: "LOCATION_CHANGED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "WEBAPP",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        location: { old: "integrations:google:meet", new: "integrations:zoom" },
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: guestActor.id,
+    action: "ATTENDEE_ADDED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "MAGIC_LINK",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        added: ["new-attendee@example.com"],
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: userActor.id,
+    action: "ATTENDEE_REMOVED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "WEBAPP",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        attendees: {
+          old: [booking.attendees[0]?.email ?? "attendee@example.com", "new-attendee@example.com"],
+          new: [booking.attendees[0]?.email ?? "attendee@example.com"],
+        },
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: systemActor.id,
+    action: "REASSIGNMENT",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "SYSTEM",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        organizerUuid: { old: null, new: proUser.uuid },
+        reassignmentReason: "Round-robin auto-reassignment",
+        reassignmentType: "roundRobin",
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: userActor.id,
+    action: "REASSIGNMENT",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "WEBAPP",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        organizerUuid: { old: proUser.uuid, new: proUser.uuid },
+        reassignmentReason: "Manual reassignment by admin",
+        reassignmentType: "manual",
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: userActor.id,
+    action: "NO_SHOW_UPDATED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "WEBAPP",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        attendeesNoShow: [
+          {
+            attendeeEmail: booking.attendees[0]?.email ?? "attendee@example.com",
+            noShow: { old: false, new: true },
+          },
+        ],
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: userActor.id,
+    action: "NO_SHOW_UPDATED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "WEBAPP",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        host: {
+          userUuid: proUser.uuid,
+          noShow: { old: null, new: true },
+        },
+      },
+    },
+    context: { impersonatedBy: "admin-user-uuid-placeholder" },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: appActor.id,
+    action: "CANCELLED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "WEBHOOK",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        cancellationReason: "Payment failed - automatic cancellation",
+        cancelledBy: "stripe@app.internal",
+        status: { old: BookingStatus.ACCEPTED, new: BookingStatus.CANCELLED },
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: userActor.id,
+    action: "REJECTED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "API_V2",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        rejectionReason: "Time slot no longer available",
+        status: { old: BookingStatus.PENDING, new: BookingStatus.REJECTED },
+      },
+    },
+  });
+
+  const seatRefUid = uuidv4();
+
+  auditLogs.push({
+    bookingUid,
+    actorId: guestActor.id,
+    action: "SEAT_BOOKED",
+    type: "RECORD_CREATED",
+    timestamp: nextTimestamp(),
+    source: "WEBAPP",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        seatReferenceUid: seatRefUid,
+        attendeeEmail: "seat-guest@example.com",
+        attendeeName: "Seat Guest",
+        startTime: hoursFromNow(48),
+        endTime: hoursFromNow(48.5),
+      },
+    },
+  });
+
+  auditLogs.push({
+    bookingUid,
+    actorId: (attendeeActor ?? guestActor).id,
+    action: "SEAT_RESCHEDULED",
+    type: "RECORD_UPDATED",
+    timestamp: nextTimestamp(),
+    source: "API_V1",
+    operationId: uuidv4(),
+    data: {
+      version: 1,
+      fields: {
+        seatReferenceUid: seatRefUid,
+        attendeeEmail: "seat-guest@example.com",
+        startTime: { old: hoursFromNow(48), new: hoursFromNow(72) },
+        endTime: { old: hoursFromNow(48.5), new: hoursFromNow(72.5) },
+        rescheduledToBookingUid: { old: null, new: rescheduledToUid },
+      },
+    },
+  });
+
+  for (const logData of auditLogs) {
+    await prisma.bookingAudit.create({ data: logData });
+  }
+
+  console.log(`✅ Created ${auditLogs.length} audit log entries for booking ${bookingUid}`);
+  console.log("\n📊 Summary of seeded audit actions:");
+  console.log("  Actions covered:");
+
+  const actionSummary = [
+    "CREATED          - User actor, WEBAPP source",
+    "ACCEPTED         - User actor, WEBAPP source",
+    "RESCHEDULE_REQUESTED - Attendee actor, WEBAPP source",
+    "RESCHEDULED      - User actor, WEBAPP source",
+    "LOCATION_CHANGED - User actor, WEBAPP source",
+    "ATTENDEE_ADDED   - Guest actor, MAGIC_LINK source",
+    "ATTENDEE_REMOVED - User actor, WEBAPP source",
+    "REASSIGNMENT (roundRobin) - System actor, SYSTEM source",
+    "REASSIGNMENT (manual) - User actor, WEBAPP source",
+    "NO_SHOW_UPDATED (attendees) - User actor, WEBAPP source",
+    "NO_SHOW_UPDATED (host, impersonated) - User actor, WEBAPP source",
+    "CANCELLED        - App actor, WEBHOOK source",
+    "REJECTED         - User actor, API_V2 source",
+    "SEAT_BOOKED      - Guest actor, WEBAPP source",
+    "SEAT_RESCHEDULED - Attendee actor, API_V1 source",
+  ];
+
+  for (const line of actionSummary) {
+    console.log(`    - ${line}`);
+  }
+
+  console.log("\n  Actor types covered: USER, ATTENDEE, GUEST, SYSTEM, APP");
+  console.log("  Sources covered: WEBAPP, API_V1, API_V2, WEBHOOK, MAGIC_LINK, SYSTEM");
+  console.log(`\n  View logs at: /booking/${bookingUid}/logs`);
+}
+
+seedBookingAuditLogs()
+  .then(() => {
+    console.log("\n🎉 Booking audit seed complete!");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("❌ Seed failed:", err);
+    process.exit(1);
+  });

--- a/scripts/seed-booking-audit.ts
+++ b/scripts/seed-booking-audit.ts
@@ -81,7 +81,7 @@ async function seedAuditLogsForBooking({
 
   const userActor = await createUserActor(userUuid);
   const systemActor = await createSystemActor();
-  const guestActor = await createGuestActor("guest-attendee@example.com", "Guest Attendee");
+  const guestActor = await createGuestActor("priya.sharma@acmecorp.io", "Priya Sharma");
   const appActor = await createAppActor("stripe", "Stripe");
 
   let attendeeActor: { id: string } | null = null;
@@ -198,7 +198,7 @@ async function seedAuditLogsForBooking({
     data: {
       version: 1,
       fields: {
-        added: ["new-attendee@example.com"],
+        added: ["rachel.nguyen@designhub.co"],
       },
     },
   });
@@ -215,7 +215,7 @@ async function seedAuditLogsForBooking({
       version: 1,
       fields: {
         attendees: {
-          old: [attendeeEmail, "new-attendee@example.com"],
+          old: [attendeeEmail, "rachel.nguyen@designhub.co"],
           new: [attendeeEmail],
         },
       },
@@ -348,8 +348,8 @@ async function seedAuditLogsForBooking({
       version: 1,
       fields: {
         seatReferenceUid: seatRefUid,
-        attendeeEmail: "seat-guest@example.com",
-        attendeeName: "Seat Guest",
+        attendeeEmail: "marcus.johnson@consulting.io",
+        attendeeName: "Marcus Johnson",
         startTime: hoursFromNow(48),
         endTime: hoursFromNow(48.5),
       },
@@ -368,7 +368,7 @@ async function seedAuditLogsForBooking({
       version: 1,
       fields: {
         seatReferenceUid: seatRefUid,
-        attendeeEmail: "seat-guest@example.com",
+        attendeeEmail: "marcus.johnson@consulting.io",
         startTime: { old: hoursFromNow(48), new: hoursFromNow(72) },
         endTime: { old: hoursFromNow(48.5), new: hoursFromNow(72.5) },
         rescheduledToBookingUid: { old: null, new: rescheduledToUid },
@@ -426,8 +426,8 @@ export default async function seedBookingAuditLogs() {
       eventTypeId: eventType.id,
       attendees: {
         create: {
-          email: "audit-test-attendee@example.com",
-          name: "Audit Test Attendee",
+          email: "james.wilson@techstart.dev",
+          name: "James Wilson",
           timeZone: "UTC",
         },
       },
@@ -446,7 +446,7 @@ export default async function seedBookingAuditLogs() {
     bookingUid: booking.uid,
     userUuid: user.uuid,
     attendeeId: booking.attendees[0]?.id,
-    attendeeEmail: booking.attendees[0]?.email ?? "attendee@example.com",
+    attendeeEmail: booking.attendees[0]?.email ?? "james.wilson@techstart.dev",
   });
 
   console.log(`  ✅ Created ${count} audit log entries`);

--- a/scripts/seed-booking-audit.ts
+++ b/scripts/seed-booking-audit.ts
@@ -403,6 +403,11 @@ export default async function seedBookingAuditLogs() {
     return;
   }
 
+  if (!user.profiles.length) {
+    console.log("❌ User owner1-acme has no organization profile. Run the main seed first.");
+    return;
+  }
+
   const organizationId = user.profiles[0].organizationId;
 
   // Enable bookings-v3 globally

--- a/scripts/seed-booking-audit.ts
+++ b/scripts/seed-booking-audit.ts
@@ -58,52 +58,32 @@ function hoursFromNow(hours: number): number {
   return Date.now() + hours * 60 * 60 * 1000;
 }
 
-export default async function seedBookingAuditLogs() {
-  console.log("🔍 Seeding booking audit logs...");
-
-  const proUser = await prisma.user.findFirst({
-    where: { username: "pro" },
-    select: { id: true, uuid: true, email: true },
-  });
-
-  if (!proUser) {
-    console.log("❌ Pro user not found. Run the main seed first.");
-    return;
-  }
-
-  const booking = await prisma.booking.findFirst({
-    where: { userId: proUser.id },
-    select: {
-      uid: true,
-      attendees: { select: { id: true, email: true }, take: 1 },
-    },
-    orderBy: { createdAt: "desc" },
-  });
-
-  if (!booking) {
-    console.log("❌ No booking found for pro user. Run the main seed first.");
-    return;
-  }
-
-  const bookingUid = booking.uid;
-  console.log(`📋 Using booking UID: ${bookingUid}`);
-
+async function seedAuditLogsForBooking({
+  bookingUid,
+  userUuid,
+  attendeeId,
+  attendeeEmail,
+}: {
+  bookingUid: string;
+  userUuid: string;
+  attendeeId: number | undefined;
+  attendeeEmail: string;
+}): Promise<number> {
   const existingLogs = await prisma.bookingAudit.findFirst({
     where: { bookingUid },
     select: { id: true },
   });
 
   if (existingLogs) {
-    console.log("⏭️ Audit logs already seeded for this booking, skipping.");
-    return;
+    console.log(`  ⏭️ Audit logs already exist for ${bookingUid}, skipping.`);
+    return 0;
   }
 
-  const userActor = await createUserActor(proUser.uuid);
+  const userActor = await createUserActor(userUuid);
   const systemActor = await createSystemActor();
   const guestActor = await createGuestActor("guest-attendee@example.com", "Guest Attendee");
   const appActor = await createAppActor("stripe", "Stripe");
 
-  const attendeeId = booking.attendees[0]?.id;
   let attendeeActor: { id: string } | null = null;
   if (attendeeId) {
     attendeeActor = await createAttendeeActor(attendeeId);
@@ -134,7 +114,7 @@ export default async function seedBookingAuditLogs() {
         startTime: hoursFromNow(24),
         endTime: hoursFromNow(24.5),
         status: BookingStatus.PENDING,
-        hostUserUuid: proUser.uuid,
+        hostUserUuid: userUuid,
         seatReferenceUid: null,
       },
     },
@@ -168,7 +148,7 @@ export default async function seedBookingAuditLogs() {
       version: 1,
       fields: {
         rescheduleReason: "Conflict with another meeting",
-        rescheduledRequestedBy: booking.attendees[0]?.email ?? "guest@example.com",
+        rescheduledRequestedBy: attendeeEmail,
       },
     },
   });
@@ -235,8 +215,8 @@ export default async function seedBookingAuditLogs() {
       version: 1,
       fields: {
         attendees: {
-          old: [booking.attendees[0]?.email ?? "attendee@example.com", "new-attendee@example.com"],
-          new: [booking.attendees[0]?.email ?? "attendee@example.com"],
+          old: [attendeeEmail, "new-attendee@example.com"],
+          new: [attendeeEmail],
         },
       },
     },
@@ -253,7 +233,7 @@ export default async function seedBookingAuditLogs() {
     data: {
       version: 1,
       fields: {
-        organizerUuid: { old: null, new: proUser.uuid },
+        organizerUuid: { old: null, new: userUuid },
         reassignmentReason: "Round-robin auto-reassignment",
         reassignmentType: "roundRobin",
       },
@@ -271,7 +251,7 @@ export default async function seedBookingAuditLogs() {
     data: {
       version: 1,
       fields: {
-        organizerUuid: { old: proUser.uuid, new: proUser.uuid },
+        organizerUuid: { old: userUuid, new: userUuid },
         reassignmentReason: "Manual reassignment by admin",
         reassignmentType: "manual",
       },
@@ -291,7 +271,7 @@ export default async function seedBookingAuditLogs() {
       fields: {
         attendeesNoShow: [
           {
-            attendeeEmail: booking.attendees[0]?.email ?? "attendee@example.com",
+            attendeeEmail,
             noShow: { old: false, new: true },
           },
         ],
@@ -311,12 +291,12 @@ export default async function seedBookingAuditLogs() {
       version: 1,
       fields: {
         host: {
-          userUuid: proUser.uuid,
+          userUuid,
           noShow: { old: null, new: true },
         },
       },
     },
-    context: { impersonatedBy: proUser.uuid },
+    context: { impersonatedBy: userUuid },
   });
 
   auditLogs.push({
@@ -400,35 +380,65 @@ export default async function seedBookingAuditLogs() {
     await prisma.bookingAudit.create({ data: logData });
   }
 
-  console.log(`✅ Created ${auditLogs.length} audit log entries for booking ${bookingUid}`);
-  console.log("\n📊 Summary of seeded audit actions:");
-  console.log("  Actions covered:");
+  return auditLogs.length;
+}
 
-  const actionSummary = [
-    "CREATED          - User actor, WEBAPP source",
-    "ACCEPTED         - User actor, WEBAPP source",
-    "RESCHEDULE_REQUESTED - Attendee actor, WEBAPP source",
-    "RESCHEDULED      - User actor, WEBAPP source",
-    "LOCATION_CHANGED - User actor, WEBAPP source",
-    "ATTENDEE_ADDED   - Guest actor, MAGIC_LINK source",
-    "ATTENDEE_REMOVED - User actor, WEBAPP source",
-    "REASSIGNMENT (roundRobin) - System actor, SYSTEM source",
-    "REASSIGNMENT (manual) - User actor, WEBAPP source",
-    "NO_SHOW_UPDATED (attendees) - User actor, WEBAPP source",
-    "NO_SHOW_UPDATED (host, impersonated) - User actor, WEBAPP source",
-    "CANCELLED        - App actor, WEBHOOK source",
-    "REJECTED         - User actor, API_V2 source",
-    "SEAT_BOOKED      - Guest actor, WEBAPP source",
-    "SEAT_RESCHEDULED - Attendee actor, API_V1 source",
-  ];
+export default async function seedBookingAuditLogs() {
+  console.log("🔍 Seeding booking audit logs...");
 
-  for (const line of actionSummary) {
-    console.log(`    - ${line}`);
+  const targetUsers = await prisma.user.findMany({
+    where: {
+      username: { in: ["pro", "owner1-acme"] },
+    },
+    select: { id: true, uuid: true, username: true, email: true },
+  });
+
+  if (targetUsers.length === 0) {
+    console.log("❌ No seed users found. Run the main seed first.");
+    return;
   }
 
-  console.log("\n  Actor types covered: USER, ATTENDEE, GUEST, SYSTEM, APP");
-  console.log("  Sources covered: WEBAPP, API_V1, API_V2, WEBHOOK, MAGIC_LINK, SYSTEM");
-  console.log(`\n  View logs at: /booking/${bookingUid}/logs`);
+  let totalCreated = 0;
+
+  for (const user of targetUsers) {
+    const booking = await prisma.booking.findFirst({
+      where: { userId: user.id },
+      select: {
+        uid: true,
+        attendees: { select: { id: true, email: true }, take: 1 },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    if (!booking) {
+      console.log(`  ⚠️ No booking found for ${user.username}, skipping.`);
+      continue;
+    }
+
+    console.log(`📋 Seeding audit logs for ${user.username} — booking ${booking.uid}`);
+
+    const count = await seedAuditLogsForBooking({
+      bookingUid: booking.uid,
+      userUuid: user.uuid,
+      attendeeId: booking.attendees[0]?.id,
+      attendeeEmail: booking.attendees[0]?.email ?? "attendee@example.com",
+    });
+
+    if (count > 0) {
+      console.log(`  ✅ Created ${count} audit log entries`);
+      console.log(`  View logs at: /booking/${booking.uid}/logs`);
+    }
+
+    totalCreated += count;
+  }
+
+  console.log(`\n📊 Summary:`);
+  console.log(`  Total audit log entries created: ${totalCreated}`);
+  console.log("  Actions covered: CREATED, ACCEPTED, RESCHEDULE_REQUESTED, RESCHEDULED,");
+  console.log("    LOCATION_CHANGED, ATTENDEE_ADDED, ATTENDEE_REMOVED, REASSIGNMENT (x2),");
+  console.log("    NO_SHOW_UPDATED (x2), CANCELLED, REJECTED, SEAT_BOOKED, SEAT_RESCHEDULED");
+  console.log("  Actor types: USER, ATTENDEE, GUEST, SYSTEM, APP");
+  console.log("  Sources: WEBAPP, API_V1, API_V2, WEBHOOK, MAGIC_LINK, SYSTEM");
 }
 
 seedBookingAuditLogs()


### PR DESCRIPTION
## What does this PR do?

Adds a new seed script (`scripts/seed-booking-audit.ts`) that enables the required feature flags, creates a dedicated upcoming booking for the `owner1-acme` org user, and populates `BookingAudit` / `AuditActor` tables with representative data. This is useful for developing and testing the booking audit log viewer UI at `/booking/{bookingUid}/logs`.

### What the script does

1. **Enables feature flags**
   - `bookings-v3` — set to `enabled: true` globally
   - `booking-audit` — enabled at the team level for `owner1-acme`'s organization (via `TeamFeatures`)

2. **Creates a new upcoming booking** (7 days out) linked to `owner1-acme`'s first event type, with a realistic attendee (James Wilson)

3. **Inserts 15 audit log entries** covering:
   - All 13 `BookingAuditAction` types (REASSIGNMENT and NO_SHOW_UPDATED each have two variants)
   - All 5 actor types: USER, ATTENDEE, GUEST, SYSTEM, APP
   - All 6 `BookingAuditSource` values: WEBAPP, API_V1, API_V2, WEBHOOK, MAGIC_LINK, SYSTEM

Only seeds for `owner1-acme` since audit logs is an org-only feature. Each run creates a fresh booking + logs.

**Run with:** `npx ts-node scripts/seed-booking-audit.ts` (after running the main seed)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — seed script only, no production code changes.

## How should this be tested?

1. Run the main seed: `yarn db-seed`
2. Run this seed: `npx ts-node scripts/seed-booking-audit.ts`
3. Start the dev server: `yarn dev`
4. Log in as `owner1-acme:owner1-acme` (org user)
5. Navigate to `/booking/{bookingUid}/logs` (the booking UID is printed by the seed script)
6. Verify all 15 audit log entries appear with correct action labels, actor names, and source badges

> The seed script automatically enables `bookings-v3` globally and `booking-audit` for the organization, so no manual feature flag setup is needed.

## Human Review Checklist

- [ ] **Verify `data` JSON structures match the Zod schemas** in each `*AuditActionService.ts` — the seed writes raw JSON that the viewer parses at runtime. Mismatches will cause parse errors.
- [ ] **Feature flag side effects** — the script sets `bookings-v3` to `enabled: true` globally and creates a `TeamFeatures` entry for `booking-audit`. Verify this doesn't conflict with existing flag configurations in your environment.
- [ ] **Not idempotent at booking level** — each run creates a new booking + audit logs. This is intentional (fresh upcoming booking each time) but worth noting.

Link to Devin run: https://app.devin.ai/sessions/ce8a8293399749d39a11fdd7070b7ec6
Requested by: @hariombalhara