### PR TITLE
fix: align team event-types API with public page filtering

### DIFF
--- a/apps/api/v2/src/modules/memberships/memberships.repository.ts
+++ b/apps/api/v2/src/modules/memberships/memberships.repository.ts
@@ -63,6 +63,20 @@ export class MembershipsRepository {
     return membership;
   }
 
+  async findAcceptedStatusByTeamId(teamId: number, userId: number) {
+    return this.dbRead.prisma.membership.findUnique({
+      where: {
+        userId_teamId: {
+          userId: userId,
+          teamId: teamId,
+        },
+      },
+      select: {
+        accepted: true,
+      },
+    });
+  }
+
   async findUserMemberships(userId: number) {
     const memberships = await this.dbRead.prisma.membership.findMany({
       where: {

--- a/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.repository.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.repository.ts
@@ -10,13 +10,15 @@ export class OrganizationsEventTypesRepository {
     orgId: number,
     skip: number,
     take: number,
-    sortCreatedAt?: SortOrderType
+    sortCreatedAt?: SortOrderType,
+    includeHidden?: boolean
   ) {
     return this.dbRead.prisma.eventType.findMany({
       where: {
         team: {
           parentId: orgId,
         },
+        ...(!includeHidden && { hidden: false }),
       },
       ...(sortCreatedAt && { orderBy: { id: sortCreatedAt } }),
       skip,

--- a/apps/api/v2/src/modules/organizations/event-types/services/organizations-event-types.service.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/services/organizations-event-types.service.ts
@@ -85,8 +85,12 @@ export class OrganizationsEventTypesService {
     return this.teamsEventTypesService.getTeamEventTypeBySlug(teamId, eventTypeSlug, hostsLimit);
   }
 
-  async getTeamEventTypes(teamId: number, sortCreatedAt?: SortOrderType): Promise<DatabaseTeamEventType[]> {
-    return await this.teamsEventTypesService.getTeamEventTypes(teamId, sortCreatedAt);
+  async getTeamEventTypes(
+    teamId: number,
+    sortCreatedAt?: SortOrderType,
+    userId?: number
+  ): Promise<DatabaseTeamEventType[]> {
+    return await this.teamsEventTypesService.getTeamEventTypes(teamId, sortCreatedAt, userId);
   }
 
   async getOrganizationsTeamsEventTypes(

--- a/apps/api/v2/src/modules/organizations/event-types/services/organizations-event-types.service.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/services/organizations-event-types.service.ts
@@ -97,13 +97,15 @@ export class OrganizationsEventTypesService {
     orgId: number,
     skip = 0,
     take = 250,
-    sortCreatedAt?: SortOrderType
+    sortCreatedAt?: SortOrderType,
+    includeHidden = true
   ): Promise<DatabaseTeamEventType[]> {
     return await this.organizationEventTypesRepository.getOrganizationTeamsEventTypes(
       orgId,
       skip,
       take,
-      sortCreatedAt
+      sortCreatedAt,
+      includeHidden
     );
   }
 

--- a/apps/api/v2/src/modules/teams/event-types/services/teams-event-types.service.ts
+++ b/apps/api/v2/src/modules/teams/event-types/services/teams-event-types.service.ts
@@ -117,10 +117,10 @@ export class TeamsEventTypesService {
   }
 
   private async canSeeHiddenEvents(userId: number, teamId: number): Promise<boolean> {
-    const membership = await this.membershipsRepository.findMembershipByTeamId(teamId, userId);
+    const membership = await this.membershipsRepository.findAcceptedStatusByTeamId(teamId, userId);
     if (membership?.accepted) return true;
 
-    const team = await this.teamsRepository.getById(teamId);
+    const team = await this.teamsRepository.findParentIdById(teamId);
     if (team?.parentId) {
       return this.membershipsRepository.isUserOrganizationAdmin(userId, team.parentId);
     }

--- a/apps/api/v2/src/modules/teams/event-types/teams-event-types.repository.ts
+++ b/apps/api/v2/src/modules/teams/event-types/teams-event-types.repository.ts
@@ -81,10 +81,11 @@ export class TeamsEventTypesRepository {
     });
   }
 
-  async getTeamEventTypes(teamId: number, sortCreatedAt?: SortOrderType) {
+  async getTeamEventTypes(teamId: number, sortCreatedAt?: SortOrderType, includeHidden?: boolean) {
     return this.dbRead.prisma.eventType.findMany({
       where: {
         teamId,
+        ...(!includeHidden && { hidden: false }),
       },
       ...(sortCreatedAt && { orderBy: { id: sortCreatedAt } }),
       include: {

--- a/apps/api/v2/src/modules/teams/teams/teams.repository.ts
+++ b/apps/api/v2/src/modules/teams/teams/teams.repository.ts
@@ -21,6 +21,13 @@ export class TeamsRepository {
     });
   }
 
+  async findParentIdById(teamId: number) {
+    return this.dbRead.prisma.team.findUnique({
+      where: { id: teamId },
+      select: { parentId: true },
+    });
+  }
+
   async getByIds(teamIds: number[]) {
     return this.dbRead.prisma.team.findMany({
       where: {


### PR DESCRIPTION
## What does this PR do?

Aligns the Team Event Types API (`GET /v2/teams/:teamId/event-types`) filtering behavior with the public team page. 
The endpoint now filters out hidden event types for unauthenticated requests while preserving visibility for authenticated team members and organization admins.

### Changes

| Layer | File | Change |
|-------|------|--------|
| Controller | `teams-event-types.controller.ts` | Added `OptionalApiAuthGuard` and `GetOptionalUser` to pass user context |
| Controller | `organizations-event-types.controller.ts` | Added optional user context to team event types endpoint |
| Service | `teams-event-types.service.ts` | Added visibility check for team members and org admins |
| Service | `organizations-event-types.service.ts` | Pass userId through to teams service |
| Repository | `teams-event-types.repository.ts` | Added `includeHidden` parameter to filter query |
| Repository | `organizations-event-types.repository.ts` | Added `includeHidden` parameter to filter query |
 
### Technical Details

- Uses `OptionalApiAuthGuard` which returns user if authenticated, null otherwise (doesn't fail on missing auth)
- Visibility check (`canSeeHiddenEvents`) verifies:
  - Direct team membership (`membership.accepted === true`), OR
  - Organization admin status (if team belongs to an org)
- The `getTeamEventTypeBySlug` method is unchanged - direct slug access continues to work for routing forms

## Behavioral Note

Unauthenticated requests to `GET /v2/teams/:teamId/event-types` will no longer return event types marked as `hidden: true`. This aligns the API behavior with the public team page, which already filters hidden events.

Authenticated team members and organization admins continue to see all event types, including hidden ones.

### Behavior Matrix

| Caller | Hidden Events | Notes |
|--------|---------------|-------|
| Unauthenticated | **X** Not returned | Matches public team page behavior |
| Authenticated (team member) | **✓** Returned | Direct membership |
| Authenticated (org admin, not team member) | **✓** Returned | Org hierarchy respected |
| Authenticated (non-member, non-admin) | **X** Not returned | No relationship with team |
| Direct slug access (`?eventSlug=`) | **✓** Returned | Routing forms continue to work |

## How should this be tested?

1. **Unauthenticated request**: Call `GET /v2/teams/:teamId/event-types` without authentication → hidden event types should NOT appear
2. **Authenticated team member**: Call the same endpoint with valid API key/token for a team member → hidden event types SHOULD appear
3. **Authenticated org admin (not team member)**: Call with valid auth for an org admin who is not a direct team member → hidden event types SHOULD appear
4. **Authenticated non-member**: Call with valid auth but for a user not in the team or org → hidden event types should NOT appear
5. **Slug access**: Verify `GET /v2/teams/:teamId/event-types?eventSlug=hidden-slug` still returns hidden events (for routing forms)

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.