### PR TITLE
ci: Add workflow dedicated for package dependency graph

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -19,6 +19,11 @@ jobs:
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
+  check-circular-deps:
+    name: Circular Dependency Check
+    uses: ./.github/workflows/check-circular-deps.yml
+    secrets: inherit
+
   unit-test:
     name: Tests
     uses: ./.github/workflows/unit-tests.yml
@@ -80,7 +85,7 @@ jobs:
     secrets: inherit
 
   required:
-    needs: [lint, type-check, unit-test, api-v2-unit-test, integration-test, build, build-api-v1, build-api-v2, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
+    needs: [lint, check-circular-deps, type-check, unit-test, api-v2-unit-test, integration-test, build, build-api-v1, build-api-v2, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
     if: always()
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:

--- a/.github/workflows/check-circular-deps.yml
+++ b/.github/workflows/check-circular-deps.yml
@@ -26,7 +26,6 @@ jobs:
             ./packages/lib \
             ./packages/testing
           # Clean packages only. Add more as violations are fixed:
-          # ./packages/lib          (3 errors - @calcom/features imports)
           # ./packages/platform/atoms (4 errors - @calcom/trpc imports)
           # ./apps/api/v2           (6 errors - disallowed @calcom/* imports)
           # ./packages/features     (~60 errors - @calcom/trpc imports)

--- a/.github/workflows/check-circular-deps.yml
+++ b/.github/workflows/check-circular-deps.yml
@@ -1,0 +1,31 @@
+name: Check Circular Dependencies
+on:
+  workflow_call:
+permissions:
+  actions: write
+  contents: read
+jobs:
+  check-circular-deps:
+    name: No circular imports
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/cache-checkout
+      - uses: ./.github/actions/yarn-install
+      - name: Check for circular dependency imports
+        run: |
+          npx biome lint \
+            --only=style/noRestrictedImports \
+            --diagnostic-level=error \
+            --max-diagnostics=none \
+            --reporter=github \
+            --skip-parse-errors \
+            ./packages/lib \
+            ./packages/app-store \
+            ./packages/features \
+            ./packages/trpc \
+            ./packages/testing \
+            ./packages/platform/atoms \
+            ./apps/api/v2

--- a/.github/workflows/check-circular-deps.yml
+++ b/.github/workflows/check-circular-deps.yml
@@ -22,10 +22,12 @@ jobs:
             --max-diagnostics=none \
             --reporter=github \
             --skip-parse-errors \
-            ./packages/lib \
-            ./packages/app-store \
-            ./packages/features \
             ./packages/trpc \
-            ./packages/testing \
-            ./packages/platform/atoms \
-            ./apps/api/v2
+            ./packages/lib \
+            ./packages/testing
+          # Clean packages only. Add more as violations are fixed:
+          # ./packages/lib          (3 errors - @calcom/features imports)
+          # ./packages/platform/atoms (4 errors - @calcom/trpc imports)
+          # ./apps/api/v2           (6 errors - disallowed @calcom/* imports)
+          # ./packages/features     (~60 errors - @calcom/trpc imports)
+          # ./packages/app-store    (~100+ errors - @calcom/features imports)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -322,6 +322,13 @@ jobs:
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
+  check-circular-deps:
+    name: Circular Dependency Check
+    needs: [prepare]
+    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    uses: ./.github/workflows/check-circular-deps.yml
+    secrets: inherit
+
   unit-test:
     name: Tests
     needs: [prepare]
@@ -477,6 +484,7 @@ jobs:
         prepare,
         validate-agents-format,
         lint,
+        check-circular-deps,
         type-check,
         unit-test,
         api-v2-unit-test,
@@ -520,6 +528,7 @@ jobs:
             needs.prepare.outputs.has-files-requiring-all-checks == 'true' &&
             (
             needs.lint.result != 'success' ||
+            needs.check-circular-deps.result != 'success' ||
             needs.type-check.result != 'success' ||
             needs.unit-test.result != 'success' ||
             needs.api-v2-unit-test.result != 'success' ||

--- a/biome.json
+++ b/biome.json
@@ -208,7 +208,13 @@
       }
     },
     {
-      "includes": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.e2e-spec.ts", "**/*.integration-test.ts"],
+      "includes": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.e2e-spec.ts",
+        "**/*.integration-test.ts"
+      ],
       "linter": {
         "rules": {
           "complexity": {

--- a/biome.json
+++ b/biome.json
@@ -228,15 +228,15 @@
               "options": {
                 "patterns": [
                   {
-                    "group": ["../app-store/**"],
+                    "group": ["../app-store/**", "@calcom/app-store", "@calcom/app-store/**"],
                     "message": "lib package should not import from app-store to avoid circular dependencies."
                   },
                   {
-                    "group": ["../features/**"],
+                    "group": ["../features/**", "@calcom/features", "@calcom/features/**"],
                     "message": "lib package should not import from features to avoid circular dependencies."
                   },
                   {
-                    "group": ["../trpc/**"],
+                    "group": ["../trpc/**", "@calcom/trpc", "@calcom/trpc/**"],
                     "message": "lib package should not import from trpc to avoid circular dependencies."
                   },
                   {
@@ -260,11 +260,11 @@
               "options": {
                 "patterns": [
                   {
-                    "group": ["../features/**"],
+                    "group": ["../features/**", "@calcom/features", "@calcom/features/**"],
                     "message": "app-store package should not import from features to avoid circular dependencies."
                   },
                   {
-                    "group": ["../trpc/**"],
+                    "group": ["../trpc/**", "@calcom/trpc", "@calcom/trpc/**"],
                     "message": "app-store package should not import from trpc to avoid circular dependencies."
                   }
                 ]
@@ -284,7 +284,7 @@
               "options": {
                 "patterns": [
                   {
-                    "group": ["../trpc/**"],
+                    "group": ["../trpc/**", "@calcom/trpc", "@calcom/trpc/**"],
                     "message": "features package should not import from trpc to avoid circular dependencies."
                   },
                   {
@@ -312,7 +312,7 @@
               "options": {
                 "patterns": [
                   {
-                    "group": ["../apps/web/**"],
+                    "group": ["../apps/web/**", "@calcom/web", "@calcom/web/**"],
                     "message": "trpc package should not import from apps/web to avoid circular dependencies."
                   }
                 ]

--- a/packages/lib/test/builder.ts
+++ b/packages/lib/test/builder.ts
@@ -3,7 +3,6 @@ import type { TFunction } from "i18next";
 
 import getICalUID from "@calcom/emails/lib/getICalUID";
 import type { Booking, EventType, Prisma, Webhook, BookingReference } from "@calcom/prisma/client";
-import { WebhookVersion } from "@calcom/features/webhooks/lib/interface/IWebhookRepository";
 import { CreationSource, BookingStatus } from "@calcom/prisma/enums";
 import type { CalendarEvent, Person, VideoCallData } from "@calcom/types/Calendar";
 
@@ -189,7 +188,7 @@ export const buildWebhook = (webhook?: Partial<Webhook>): Webhook => {
     platformOAuthClientId: null,
     time: null,
     timeUnit: null,
-    version: WebhookVersion.V_2021_10_20,
+    version: "2021-10-20",
     ...webhook,
     platform: false,
   };


### PR DESCRIPTION
## What does the PR do?

- Add a dedicated CI workflow (`check-circular-deps.yml`) that runs `biome lint --only=style/noRestrictedImports` to catch circular dependency imports
- Fix `noRestrictedImports` rules in `biome.json` to also match `@calcom/*` package aliases (e.g. `@calcom/features`), not just relative paths (e.g. `../features/**`) which are never used in practice
- Wire the check into `pr.yml` and `all-checks.yml` as a required gate

## Why

The general lint workflow passes intentionally due to the volume of pre-existing lint errors, which means circular dependency violations slip through undetected. This adds a focused, enforceable check that only targets the `noRestrictedImports` rule.

Currently gating on `packages/trpc`, `packages/lib` and `packages/testing` (the only clean packages). Other packages are documented inline with their violation counts for incremental adoption.

## Test plan

- [x] Verify `npx biome lint --only=style/noRestrictedImports --skip-parse-errors ./packages/trpc ./packages/lib ./packages/testing` exits 0
- [ ] Workflow runs on subsequent PRs after merge (uses `pull_request_target`)