### PR TITLE
docs: add Trigger.dev task implementation rule

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -65,6 +65,7 @@
 - [patterns-factory-pattern](rules/patterns-factory-pattern.md) - Factory pattern
 - [patterns-workflow-triggers](rules/patterns-workflow-triggers.md) - Workflow implementation
 - [patterns-app-store](rules/patterns-app-store.md) - App store integration patterns
+- [patterns-trigger-dev](rules/patterns-trigger-dev.md) - Trigger.dev task implementation
 
 ### Culture
 

--- a/agents/rules/patterns-trigger-dev.md
+++ b/agents/rules/patterns-trigger-dev.md
@@ -26,7 +26,7 @@ packages/features/<domain>/lib/tasker/
     <task-name>.ts            # schemaTask definition
 ```
 
-Reference implementation: `packages/features/calendars/lib/tasker/`
+Reference implementation: `packages/features/calendars/lib/tasker/` — see `CalendarsTasker.ts` for the Tasker subclass pattern and `trigger/config.ts` for queue/retry/machine configuration
 
 ## Creating a New Task
 
@@ -44,6 +44,8 @@ export const myTaskSchema = z.object({
 ```
 
 ### 2. Configure queue, retry, and machine
+
+See `packages/features/calendars/lib/tasker/trigger/config.ts` for a real example.
 
 ```typescript
 // trigger/config.ts
@@ -130,6 +132,8 @@ Concurrency limits control how many task runs execute in parallel within a queue
 - Time-sensitive tasks (emails, webhooks) need higher concurrency
 - Background jobs that are not time-sensitive can use lower concurrency
 - Start conservative and increase based on production metrics
+
+See `packages/features/calendars/lib/tasker/trigger/config.ts` (`concurrencyLimit: 10`) and `packages/features/webhooks/lib/tasker/trigger/config.ts` (`concurrencyLimit: 20`) for real examples of how concurrency is tuned per domain.
 
 Reference: [Trigger.dev Concurrency & Queues](https://trigger.dev/docs/queue-concurrency)
 

--- a/agents/rules/patterns-trigger-dev.md
+++ b/agents/rules/patterns-trigger-dev.md
@@ -1,0 +1,236 @@
+---
+title: Trigger.dev Task Implementation
+impact: HIGH
+impactDescription: Consistent Trigger.dev patterns ensure reliable async task execution across web and API v2
+tags: trigger.dev, async, tasker, concurrency, cron, scheduled-tasks
+---
+
+# Trigger.dev Task Implementation
+
+Trigger.dev is the async task runner used in both `apps/web` and `apps/api/v2`. Tasks can be disabled via the `ENABLE_ASYNC_TASKER` env var (set to `"false"` to fall back to synchronous execution).
+
+## Tasker Architecture
+
+Every Trigger.dev feature follows the Tasker pattern with these layers:
+
+```
+packages/features/<domain>/lib/tasker/
+  types.ts                    # ITasker interface + payload types
+  <Domain>Tasker.ts           # Tasker subclass (dispatches async or sync)
+  <Domain>TriggerTasker.ts    # Async implementation (calls .trigger())
+  <Domain>SyncTasker.ts       # Sync fallback (executes inline)
+  <Domain>TaskService.ts      # Business logic consumed by both
+  trigger/
+    config.ts                 # Queue + retry + machine config
+    schema.ts                 # Zod payload schema
+    <task-name>.ts            # schemaTask definition
+```
+
+Reference implementation: `packages/features/calendars/lib/tasker/`
+
+## Creating a New Task
+
+### 1. Define the Zod schema for payload validation
+
+Always use `schemaTask` with a Zod schema for payload validation:
+
+```typescript
+// trigger/schema.ts
+import { z } from "zod";
+
+export const myTaskSchema = z.object({
+  userId: z.number(),
+});
+```
+
+### 2. Configure queue, retry, and machine
+
+```typescript
+// trigger/config.ts
+import { type schemaTask, queue } from "@trigger.dev/sdk";
+
+type MyTask = Pick<Parameters<typeof schemaTask>[0], "machine" | "retry" | "queue">;
+
+export const myQueue = queue({
+  name: "my-domain",
+  concurrencyLimit: 10,
+});
+
+export const myTaskConfig: MyTask = {
+  machine: "small-2x",
+  queue: myQueue,
+  retry: {
+    maxAttempts: 3,
+    factor: 2,
+    minTimeoutInMs: 60000,
+    maxTimeoutInMs: 300000,
+    randomize: true,
+    outOfMemory: {
+      machine: "medium-1x",
+    },
+  },
+};
+```
+
+### 3. Define the task using schemaTask
+
+```typescript
+// trigger/my-task.ts
+import { schemaTask, type TaskWithSchema } from "@trigger.dev/sdk";
+import type { z } from "zod";
+
+import { myTaskConfig } from "./config";
+import { myTaskSchema } from "./schema";
+
+export const MY_TASK_JOB_ID = "domain.my-task";
+
+export const myTask: TaskWithSchema<typeof MY_TASK_JOB_ID, typeof myTaskSchema> =
+  schemaTask({
+    id: MY_TASK_JOB_ID,
+    ...myTaskConfig,
+    schema: myTaskSchema,
+    run: async (payload: z.infer<typeof myTaskSchema>) => {
+      const { getMyService } = await import("@calcom/features/<domain>/di/<container>");
+      const service = getMyService();
+      await service.execute(payload);
+    },
+  });
+```
+
+### 4. For scheduled (cron) tasks, use `schedules.task`
+
+```typescript
+import { schedules } from "@trigger.dev/sdk";
+
+export const myScheduledTask = schedules.task({
+  id: "domain.my-scheduled-task",
+  ...myTaskConfig,
+  cron: {
+    pattern: "0 0 1 * *",
+    timezone: "UTC",
+  },
+  run: async (payload) => {
+    // task logic
+  },
+});
+```
+
+Reference: [Trigger.dev Scheduled Tasks](https://trigger.dev/docs/tasks/scheduled)
+
+## Concurrency Configuration
+
+Concurrency limits control how many task runs execute in parallel within a queue. Getting this right is critical for production stability.
+
+**How to estimate concurrency:**
+1. Analyze production logs for the number of requests per minute that will trigger the task (from both `apps/web` and `apps/api/v2`)
+2. Measure the average execution time of the task
+3. Factor in burst patterns (e.g., peak booking hours)
+
+**Guidelines:**
+- Time-sensitive tasks (emails, webhooks) need higher concurrency
+- Background jobs that are not time-sensitive can use lower concurrency
+- Start conservative and increase based on production metrics
+
+Reference: [Trigger.dev Concurrency & Queues](https://trigger.dev/docs/queue-concurrency)
+
+## Local Development
+
+1. Set env vars:
+   ```
+   TRIGGER_SECRET_KEY=<your-trigger-secret>
+   TRIGGER_API_URL=https://api.trigger.dev
+   ENABLE_ASYNC_TASKER="true"
+   ```
+
+2. Run the Trigger.dev CLI from the features package:
+   ```bash
+   cd packages/features && npx trigger.dev@latest dev --analyze
+   ```
+
+3. Keep the CLI running while developing. Tasks appear in the Trigger.dev dashboard under **Tasks**.
+
+## Before Merging
+
+1. **Deploy to staging**: `cd packages/features && yarn deploy:trigger:staging`
+2. **Test on Trigger.dev dashboard**: Switch to staging environment and use the **Test** tab
+3. **Right-size machines**: Start with the smallest machine; increase only if you see `OutOfMemory` errors
+4. **Set retry with OOM handling**: Always include `outOfMemory` in retry config with a larger machine than the default
+5. **Set concurrency**: Analyze production request volume and task completion time to determine the appropriate `concurrencyLimit`
+6. **Cherry-pick caveat**: Cherry-picking does not redeploy Trigger.dev tasks. Only the `draft-release` CI action does. If cherry-picking a change that impacts Trigger.dev tasks, manually promote the new version in the Trigger.dev deployment dashboard after the fix is deployed
+
+## Common Mistakes
+
+**Using `task` instead of `schemaTask`:**
+
+```typescript
+// Bad - no payload validation
+import { task } from "@trigger.dev/sdk";
+export const myTask = task({
+  id: "my-task",
+  run: async (payload: any) => { ... },
+});
+
+// Good - validated payload with Zod
+import { schemaTask } from "@trigger.dev/sdk";
+export const myTask = schemaTask({
+  id: "my-task",
+  schema: myTaskSchema,
+  run: async (payload) => { ... },
+});
+```
+
+**Missing retry or queue config:**
+
+```typescript
+// Bad - no retry or queue, will use defaults
+export const myTask = schemaTask({
+  id: "my-task",
+  schema: myTaskSchema,
+  run: async (payload) => { ... },
+});
+
+// Good - explicit config from shared config file
+import { myTaskConfig } from "./config";
+
+export const myTask = schemaTask({
+  id: "my-task",
+  ...myTaskConfig,
+  schema: myTaskSchema,
+  run: async (payload) => { ... },
+});
+```
+
+**Importing eagerly inside task files instead of using dynamic imports:**
+
+```typescript
+// Bad - eager import of heavy modules at file scope
+import { MyService } from "@calcom/features/domain/service/MyService";
+
+export const myTask = schemaTask({
+  id: "my-task",
+  schema: myTaskSchema,
+  run: async (payload) => {
+    const service = new MyService();
+    await service.execute(payload);
+  },
+});
+
+// Good - dynamic import inside run function
+export const myTask = schemaTask({
+  id: "my-task",
+  schema: myTaskSchema,
+  run: async (payload) => {
+    const { getMyService } = await import("@calcom/features/domain/di/container");
+    const service = getMyService();
+    await service.execute(payload);
+  },
+});
+```
+
+## Key References
+
+- Trigger.dev docs: [Concurrency & Queues](https://trigger.dev/docs/queue-concurrency), [Scheduled Tasks](https://trigger.dev/docs/tasks/scheduled), [schemaTask](https://trigger.dev/docs/tasks/schemaTask)
+- Example taskers in the codebase:
+  - `packages/features/calendars/lib/tasker/` (standard pattern)
+  - `packages/features/webhooks/lib/tasker/` (webhook delivery)
+  - `packages/features/ee/billing/service/proration/tasker/` (scheduled cron task)


### PR DESCRIPTION
## What does this PR do?

Adds an agent rule documenting the Trigger.dev Tasker pattern used across the codebase. The rule was written based on the internal Trigger.dev setup guide PDF, the Slack announcement about Trigger.dev availability in web and API v2, and by studying existing Tasker implementations in the codebase (calendars, webhooks, billing proration).

**Changes:**
- New rule file `agents/rules/patterns-trigger-dev.md` covering:
  - Tasker architecture (the layered async/sync fallback pattern)
  - Step-by-step guide for creating new tasks (schema → config → schemaTask)
  - Scheduled (cron) task pattern using `schedules.task`
  - Concurrency estimation guidance with real codebase examples
  - Local development setup
  - Pre-merge checklist (staging deploy, machine sizing, OOM retry, cherry-pick caveat)
  - Common mistakes (missing schema validation, missing config, eager imports)
- Updated `agents/README.md` to index the new rule under Patterns
- Added specific file path references to `CalendarsTasker.ts` and `trigger/config.ts` as concrete examples throughout the rule

No runtime code changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A — this is agent rule documentation only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — documentation only.

## How should this be tested?

Documentation-only change. Review for:
- Accuracy of the Tasker architecture description against existing implementations (`packages/features/calendars/lib/tasker/`, `packages/features/webhooks/lib/tasker/`)
- Correctness of the deploy command path (`cd packages/features && yarn deploy:trigger:staging` — the original PDF had the path segments reversed as `cd features/packages`)
- Whether the cherry-pick / `draft-release` CI caveat is still current

## Human Review Checklist

- [ ] Verify deploy command `cd packages/features && yarn deploy:trigger:staging` is the correct path (the source PDF had `cd features/packages` which appears inverted)
- [ ] Confirm concurrency estimation guidance matches team practices
- [ ] Confirm the `ENABLE_ASYNC_TASKER` fallback behavior description is accurate
- [ ] Check that the cherry-pick caveat about `draft-release` CI action is still current

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small and focused (2 files, ~240 lines of documentation)

---

Requested by: @eunjae-lee
Link to Devin run: https://app.devin.ai/sessions/1fdcb039d28347cd987fbc3d5d3c0c80