### PR TITLE
fix(routing-forms): use direct eventTypeId lookup instead of brittle slug extraction

### DIFF
--- a/apps/api/v2/src/modules/organizations/routing-forms/services/shared-routing-form-response.service.ts
+++ b/apps/api/v2/src/modules/organizations/routing-forms/services/shared-routing-form-response.service.ts
@@ -21,7 +21,7 @@ export class SharedRoutingFormResponseService {
     private readonly slotsService: SlotsService_2024_09_04,
     private readonly teamsEventTypesRepository: TeamsEventTypesRepository,
     private readonly eventTypesRepository: EventTypesRepository_2024_06_14
-  ) {}
+  ) { }
 
   async createRoutingFormResponseWithSlots(
     routingFormId: string,
@@ -153,8 +153,24 @@ export class SharedRoutingFormResponseService {
   }
 
   private async extractEventTypeAndCrmParams(userId: number, routingUrl: URL) {
-    // Extract team and event type information
-    // TODO: Route action also has eventTypeId directly now and instead of using this brittle approach for getting event type by slug, we should get by eventTypeId
+    const urlParams = routingUrl.searchParams;
+
+    // Prefer direct eventTypeId lookup if available (more reliable than slug-based)
+    const eventTypeIdParam = urlParams.get("cal.eventTypeId");
+    if (eventTypeIdParam) {
+      const eventTypeId = parseInt(eventTypeIdParam, 10);
+      if (!isNaN(eventTypeId)) {
+        const eventType = await this.eventTypesRepository.getEventTypeById(eventTypeId);
+        if (eventType?.id) {
+          return {
+            eventTypeId: eventType.id,
+            crmParams: this.extractCrmParamsFromUrl(urlParams),
+          };
+        }
+      }
+    }
+
+    // Fall back to slug-based lookup for backward compatibility
     const { teamId, eventTypeSlug } = this.extractTeamIdAndEventTypeSlugFromRedirectUrl(routingUrl);
     const eventType = teamId
       ? await this.teamsEventTypesRepository.getEventTypeByTeamIdAndSlug(teamId, eventTypeSlug)
@@ -167,15 +183,20 @@ export class SharedRoutingFormResponseService {
       );
     }
 
-    // Extract CRM parameters from URL
-    const urlParams = routingUrl.searchParams;
-    const crmParams = {
+    return {
+      eventTypeId: eventType.id,
+      crmParams: this.extractCrmParamsFromUrl(routingUrl.searchParams),
+    };
+  }
+
+  private extractCrmParamsFromUrl(urlParams: URLSearchParams) {
+    return {
       teamMemberEmail: urlParams.get("cal.crmContactOwnerEmail") || undefined,
       routedTeamMemberIds: urlParams.get("cal.routedTeamMemberIds")
         ? urlParams
-            .get("cal.routedTeamMemberIds")!
-            .split(",")
-            .map((id) => parseInt(id))
+          .get("cal.routedTeamMemberIds")!
+          .split(",")
+          .map((id) => parseInt(id))
         : undefined,
       routingFormResponseId: urlParams.get("cal.routingFormResponseId")
         ? parseInt(urlParams.get("cal.routingFormResponseId")!)
@@ -186,11 +207,6 @@ export class SharedRoutingFormResponseService {
       skipContactOwner: urlParams.get("cal.skipContactOwner") === "true" ? true : false,
       crmAppSlug: urlParams.get("cal.crmAppSlug") || undefined,
       crmOwnerRecordType: urlParams.get("cal.crmContactOwnerRecordType") || undefined,
-    };
-
-    return {
-      eventTypeId: eventType.id,
-      crmParams,
     };
   }
 

--- a/packages/features/routing-forms/lib/getRoutedUrl.ts
+++ b/packages/features/routing-forms/lib/getRoutedUrl.ts
@@ -252,6 +252,7 @@ const _getRoutedUrl = async (context: Pick<GetServerSidePropsContext, "query" | 
             crmLookupDone: fetchCrm,
             teamId: form?.teamId,
             orgId: form.team?.parentId,
+            eventTypeId: decidedAction.eventTypeId ?? null,
           }),
           isEmbed: pageProps.isEmbed,
         }),

--- a/packages/features/routing-forms/lib/getUrlSearchParamsToForward.ts
+++ b/packages/features/routing-forms/lib/getUrlSearchParamsToForward.ts
@@ -34,6 +34,7 @@ type GetUrlSearchParamsToForwardOptions = {
   reroutingFormResponses?: FormResponseValueOnly;
   teamId?: number | null;
   orgId?: number | null;
+  eventTypeId?: number | null;
 };
 
 export function getUrlSearchParamsToForward({
@@ -51,6 +52,7 @@ export function getUrlSearchParamsToForward({
   reroutingFormResponses,
   teamId,
   orgId,
+  eventTypeId,
 }: GetUrlSearchParamsToForwardOptions) {
   type Params = Record<string, string | string[]>;
   const paramsFromResponse: Params = {};
@@ -138,6 +140,7 @@ export function getUrlSearchParamsToForward({
     ...(reroutingFormResponses
       ? { ["cal.reroutingFormResponses"]: JSON.stringify(reroutingFormResponses) }
       : null),
+    ...(eventTypeId ? { ["cal.eventTypeId"]: String(eventTypeId) } : null),
   };
 
   const allQueryURLSearchParams = new URLSearchParams();


### PR DESCRIPTION
## What does this PR do?

Addresses the TODO in SharedRoutingFormResponseService to use direct eventTypeId lookup instead of extracting event type from the URL slug.

## Changes

- Added cal.eventTypeId to URL search params in getUrlSearchParamsToForward.ts
- Passed decidedAction.eventTypeId in getRoutedUrl.ts
- Updated API V2 SharedRoutingFormResponseService to:
  - First try direct ID lookup using cal.eventTypeId param
  - Fall back to slug-based lookup for backward compatibility
- Extracted extractCrmParamsFromUrl helper method to avoid duplication

## Why?

The slug-based lookup was fragile and could break if slugs change. Using direct eventTypeId is more reliable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)