### PR TITLE
docs: add code comment guidelines to AGENTS.md and update rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ You are a senior Cal.com engineer working in a Yarn/Turbo monorepo. You prioriti
 - Put permission checks in `page.tsx`, never in `layout.tsx`
 - Use `ast-grep` for searching if available; otherwise use `rg` (ripgrep), then fall back to `grep`
 - Use Biome for formatting and linting
-- Only add code comments that explain **why**, not **what** — the "what" is already conveyed by function names, parameters, and return types. Good reasons to comment: business logic rationale, non-obvious side effects, workarounds with context. If there is no meaningful "why" to explain, do not add a comment.
+- Only add code comments that explain **why**, not **what** — see [code comment guidelines](agents/rules/quality-code-comments.md)
 
 
 ## Don't
@@ -176,31 +176,6 @@ const booking = await prisma.booking.findFirst({
 const booking = await prisma.booking.findFirst({
   include: { user: true }
 });
-```
-
-### Good comments
-
-```typescript
-// Bad - Restates what the code already tells you
-// Get the user
-const user = await getUser(userId);
-
-// Bad - Obvious from the code
-// Loop through bookings
-for (const booking of bookings) {
-  // Process booking
-  processBooking(booking);
-}
-
-// Good - Explains WHY, not what
-// We need to fetch availability before slots because the timezone
-// conversion depends on the user's configured availability rules
-const availability = await getAvailability(userId);
-const slots = convertToSlots(availability, timezone);
-
-// Good - Documents a non-obvious constraint
-// Google Calendar API has a 2500 event limit per sync request
-const BATCH_SIZE = 2500;
 ```
 
 ### Good imports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ You are a senior Cal.com engineer working in a Yarn/Turbo monorepo. You prioriti
 - Put permission checks in `page.tsx`, never in `layout.tsx`
 - Use `ast-grep` for searching if available; otherwise use `rg` (ripgrep), then fall back to `grep`
 - Use Biome for formatting and linting
+- Only add code comments that explain **why**, not **what** — the "what" is already conveyed by function names, parameters, and return types. Good reasons to comment: business logic rationale, non-obvious side effects, workarounds with context. If there is no meaningful "why" to explain, do not add a comment.
 
 
 ## Don't
@@ -29,6 +30,7 @@ You are a senior Cal.com engineer working in a Yarn/Turbo monorepo. You prioriti
 - Never use barrel imports from index.ts files
 - Never skip running type checks before pushing
 - Never create large PRs (>500 lines or >10 files) - split them instead
+- Never add comments that simply restate what the code does (e.g., `// Get the user` above a `getUser()` call)
 
 ## PR Size Guidelines
 
@@ -174,6 +176,31 @@ const booking = await prisma.booking.findFirst({
 const booking = await prisma.booking.findFirst({
   include: { user: true }
 });
+```
+
+### Good comments
+
+```typescript
+// Bad - Restates what the code already tells you
+// Get the user
+const user = await getUser(userId);
+
+// Bad - Obvious from the code
+// Loop through bookings
+for (const booking of bookings) {
+  // Process booking
+  processBooking(booking);
+}
+
+// Good - Explains WHY, not what
+// We need to fetch availability before slots because the timezone
+// conversion depends on the user's configured availability rules
+const availability = await getAvailability(userId);
+const slots = convertToSlots(availability, timezone);
+
+// Good - Documents a non-obvious constraint
+// Google Calendar API has a 2500 event limit per sync request
+const BATCH_SIZE = 2500;
 ```
 
 ### Good imports

--- a/agents/rules/quality-code-comments.md
+++ b/agents/rules/quality-code-comments.md
@@ -13,10 +13,13 @@ Keep comments limited and avoid obvious ones. Comments should explain "why" not 
 
 ## When to Comment
 
-- Complex business logic that isn't obvious from the code
+- Business decisions or domain logic that isn't obvious from the code
 - Workarounds or hacks with explanation of why they're needed
 - Non-obvious performance optimizations
 - Important security considerations
+- Troubleshooting context (e.g., why a particular approach was chosen after hitting issues)
+
+If none of these apply, skip the comment entirely. The function name, parameters, and return type should speak for themselves.
 
 ## When NOT to Comment
 


### PR DESCRIPTION
## What does this PR do?

Adds code comment guidelines to `AGENTS.md` to prevent AI-generated comments that simply restate what the code does. This was prompted by team feedback:

> Anyone else thinks we should stop allowing ai generated comments that simply restate what the function does?

Changes to **AGENTS.md** (kept lean, referencing the dedicated rule file):
- **Do section**: Added bullet linking to [code comment guidelines](agents/rules/quality-code-comments.md) — focus on "why", not "what"
- **Don't section**: Added explicit rule against restating code in comments

Changes to **agents/rules/quality-code-comments.md**:
- Broadened "when to comment" to include business decisions and troubleshooting context
- Added explicit guidance to skip comments entirely when no "why" is needed

No functional code changes — documentation only.

## How should this be tested?

N/A — this is a documentation change to AI agent guidelines. Verify that the wording and examples align with the team's expectations for comment quality.

## Human Review Checklist

- [ ] Wording in the "Do" bullet accurately captures the intent (focus on "why", skip comments when no explanation is needed)
- [ ] The link from AGENTS.md to `agents/rules/quality-code-comments.md` renders correctly
- [ ] Updates to the rule file ("business decisions", "troubleshooting context", skip guidance) match the team's expectations
- [ ] No unintended formatting issues in the markdown

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — docs only.

---

> 🔗 [Devin session](https://app.devin.ai/sessions/f02e30805cb34692a57b375a72b28713) | Requested by @eunjae-lee