### PR TITLE
feat: add UserLock table and lock notification system

### DIFF
--- a/packages/emails/src/templates/AccountLockedEmail.tsx
+++ b/packages/emails/src/templates/AccountLockedEmail.tsx
@@ -1,0 +1,38 @@
+import { CallToAction, V2BaseEmailHtml } from "../components";
+
+export const AccountLockedEmail = (props: {
+  user: {
+    name: string;
+    email: string;
+  };
+  reason: string;
+  supportUrl: string;
+}) => {
+  const { user, reason, supportUrl } = props;
+
+  return (
+    <V2BaseEmailHtml subject="Your Cal.com account has been locked">
+      <p style={{ fontWeight: 400, lineHeight: "24px" }}>Hi {user.name || user.email},</p>
+      <p style={{ fontWeight: 400, lineHeight: "24px", marginBottom: "20px" }}>
+        Your Cal.com account has been locked for the following reason:
+      </p>
+      <p
+        style={{
+          fontWeight: 600,
+          lineHeight: "24px",
+          marginBottom: "20px",
+          padding: "12px 16px",
+          backgroundColor: "#f3f4f6",
+          borderRadius: "6px",
+        }}>
+        {reason}
+      </p>
+      <p style={{ fontWeight: 400, lineHeight: "24px", marginBottom: "20px" }}>
+        If you believe this was done in error, please contact our support team for assistance.
+      </p>
+      <div style={{ textAlign: "center", marginTop: "24px" }}>
+        <CallToAction label="Contact Support" href={supportUrl} endIconName="linkIcon" />
+      </div>
+    </V2BaseEmailHtml>
+  );
+};

--- a/packages/emails/src/templates/index.ts
+++ b/packages/emails/src/templates/index.ts
@@ -1,4 +1,5 @@
 export * from "@calcom/app-store/routing-forms/emails/components";
+export { AccountLockedEmail } from "./AccountLockedEmail";
 export { AdminOAuthClientNotificationEmail } from "./AdminOAuthClientNotificationEmail";
 export { AdminOrganizationNotificationEmail } from "./AdminOrganizationNotificationEmail";
 export { AttendeeAddGuestsEmail } from "./AttendeeAddGuestsEmail";

--- a/packages/emails/templates/account-locked-email.ts
+++ b/packages/emails/templates/account-locked-email.ts
@@ -1,0 +1,43 @@
+import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
+import renderEmail from "../src/renderEmail";
+import BaseEmail from "./_base-email";
+
+export interface AccountLockedEmailInput {
+  user: {
+    name: string | null;
+    email: string;
+  };
+  reason: string;
+  supportUrl: string;
+}
+
+export default class AccountLockedEmail extends BaseEmail {
+  private input: AccountLockedEmailInput;
+
+  constructor(input: AccountLockedEmailInput) {
+    super();
+    this.name = "SEND_ACCOUNT_LOCKED";
+    this.input = input;
+  }
+
+  protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    return {
+      from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
+      to: this.input.user.email,
+      subject: "Your Cal.com account has been locked",
+      html: await renderEmail("AccountLockedEmail", {
+        user: {
+          name: this.input.user.name || "",
+          email: this.input.user.email,
+        },
+        reason: this.input.reason,
+        supportUrl: this.input.supportUrl,
+      }),
+      text: this.getTextBody(),
+    };
+  }
+
+  protected getTextBody(): string {
+    return `Your Cal.com account has been locked. Reason: ${this.input.reason}. If you believe this was done in error, please contact support at ${this.input.supportUrl}`;
+  }
+}

--- a/packages/features/di/tokens.ts
+++ b/packages/features/di/tokens.ts
@@ -1,11 +1,12 @@
-import { BOOKING_DI_TOKENS } from "@calcom/features/bookings/di/tokens";
 import { BOOKING_AUDIT_DI_TOKENS } from "@calcom/features/booking-audit/di/tokens";
+import { BOOKING_DI_TOKENS } from "@calcom/features/bookings/di/tokens";
+import { USER_LOCK_DI_TOKENS } from "@calcom/features/ee/api-keys/di/tokens";
 import { ACTIVE_USER_BILLING_DI_TOKENS } from "@calcom/features/ee/billing/active-user/di/tokens";
+import { ORGANIZATION_DI_TOKENS } from "@calcom/features/ee/organizations/di/tokens";
 import { FEATURE_OPT_IN_DI_TOKENS } from "@calcom/features/feature-opt-in/di/tokens";
 import { FLAGS_DI_TOKENS } from "@calcom/features/flags/di/tokens";
 import { HASHED_LINK_DI_TOKENS } from "@calcom/features/hashedLink/di/tokens";
 import { OAUTH_DI_TOKENS } from "@calcom/features/oauth/di/tokens";
-import { ORGANIZATION_DI_TOKENS } from "@calcom/features/ee/organizations/di/tokens";
 import { WATCHLIST_DI_TOKENS } from "./watchlist/Watchlist.tokens";
 import { WEBHOOK_TOKENS } from "./webhooks/Webhooks.tokens";
 
@@ -87,4 +88,5 @@ export const DI_TOKENS = {
   ...ACTIVE_USER_BILLING_DI_TOKENS,
   ...ORGANIZATION_DI_TOKENS,
   ...WEBHOOK_TOKENS,
+  ...USER_LOCK_DI_TOKENS,
 };

--- a/packages/features/ee/api-keys/di/PrismaUserLockRepository.container.ts
+++ b/packages/features/ee/api-keys/di/PrismaUserLockRepository.container.ts
@@ -1,0 +1,12 @@
+import { createContainer } from "@calcom/features/di/di";
+import {
+  type PrismaUserLockRepository,
+  moduleLoader as userLockRepositoryModuleLoader,
+} from "./PrismaUserLockRepository.module";
+
+const userLockRepositoryContainer = createContainer();
+
+export function getUserLockRepository(): PrismaUserLockRepository {
+  userLockRepositoryModuleLoader.loadModule(userLockRepositoryContainer);
+  return userLockRepositoryContainer.get<PrismaUserLockRepository>(userLockRepositoryModuleLoader.token);
+}

--- a/packages/features/ee/api-keys/di/PrismaUserLockRepository.module.ts
+++ b/packages/features/ee/api-keys/di/PrismaUserLockRepository.module.ts
@@ -1,0 +1,22 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as prismaModuleLoader } from "@calcom/features/di/modules/Prisma";
+import { PrismaUserLockRepository } from "@calcom/features/ee/api-keys/repositories/PrismaUserLockRepository";
+import { USER_LOCK_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = USER_LOCK_DI_TOKENS.USER_LOCK_REPOSITORY;
+const moduleToken = USER_LOCK_DI_TOKENS.USER_LOCK_REPOSITORY_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: PrismaUserLockRepository,
+  dep: prismaModuleLoader,
+});
+
+export const moduleLoader: ModuleLoader = {
+  token,
+  loadModule,
+};
+
+export type { PrismaUserLockRepository };

--- a/packages/features/ee/api-keys/di/tokens.ts
+++ b/packages/features/ee/api-keys/di/tokens.ts
@@ -1,0 +1,4 @@
+export const USER_LOCK_DI_TOKENS = {
+  USER_LOCK_REPOSITORY: Symbol("UserLockRepository"),
+  USER_LOCK_REPOSITORY_MODULE: Symbol("UserLockRepositoryModule"),
+};

--- a/packages/features/ee/api-keys/lib/autoLock.test.ts
+++ b/packages/features/ee/api-keys/lib/autoLock.test.ts
@@ -3,24 +3,24 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { hashAPIKey } from "@calcom/features/ee/api-keys/lib/apiKeys";
 import { RedisService } from "@calcom/features/redis/RedisService";
-import prisma from "@calcom/prisma";
 
 import { handleAutoLock } from "./autoLock";
 
-// Mock the dependencies
+const mockUserLockRepository = {
+  create: vi.fn(),
+  findByUserId: vi.fn(),
+  findUserEmailAndName: vi.fn(),
+  updateLockedStatus: vi.fn(),
+  lockUserByEmail: vi.fn(),
+  findUserByApiKeyHash: vi.fn(),
+};
+
 vi.mock("@calcom/features/redis/RedisService");
 vi.mock("@calcom/features/ee/api-keys/lib/apiKeys", () => ({
   hashAPIKey: vi.fn((key) => `hashed_${key}`),
 }));
-vi.mock("@calcom/prisma", () => ({
-  default: {
-    user: {
-      update: vi.fn(),
-    },
-    apiKey: {
-      findUnique: vi.fn(),
-    },
-  },
+vi.mock("@calcom/features/ee/api-keys/di/PrismaUserLockRepository.container", () => ({
+  getUserLockRepository: () => mockUserLockRepository,
 }));
 
 describe("autoLock", () => {
@@ -103,7 +103,8 @@ describe("autoLock", () => {
 
       expect(mockRedis.set).toHaveBeenCalledWith("autolock:email:test@example.com.count", "3");
       expect(mockRedis.expire).toHaveBeenCalledWith("autolock:email:test@example.com.count", 1800);
-      expect(prisma.user.update).not.toHaveBeenCalled();
+      expect(mockUserLockRepository.updateLockedStatus).not.toHaveBeenCalled();
+      expect(mockUserLockRepository.lockUserByEmail).not.toHaveBeenCalled();
     });
 
     it("should lock user when threshold is reached", async () => {
@@ -122,15 +123,7 @@ describe("autoLock", () => {
         rateLimitResponse,
       });
 
-      expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { email: "test@example.com" },
-        data: { locked: true },
-        select: {
-          id: true,
-          email: true,
-          username: true,
-        },
-      });
+      expect(mockUserLockRepository.lockUserByEmail).toHaveBeenCalledWith({ email: "test@example.com" });
       expect(mockRedis.del).toHaveBeenCalledWith("autolock:email:test@example.com.count");
     });
 
@@ -154,7 +147,8 @@ describe("autoLock", () => {
 
       expect(mockRedis.set).toHaveBeenCalledWith("autolock:email:test@example.com.count", "2");
       expect(mockRedis.expire).toHaveBeenCalledWith("autolock:email:test@example.com.count", 1800);
-      expect(prisma.user.update).not.toHaveBeenCalled();
+      expect(mockUserLockRepository.updateLockedStatus).not.toHaveBeenCalled();
+      expect(mockUserLockRepository.lockUserByEmail).not.toHaveBeenCalled();
     });
 
     it("should lock API key and associated user", async () => {
@@ -168,11 +162,9 @@ describe("autoLock", () => {
       mockRedis.get.mockResolvedValue("4");
       const testApiKey = "test_api_key_123";
 
-      // Mock API key lookup
-      vi.mocked(prisma.apiKey.findUnique).mockResolvedValue({
-        hashedKey: `hashed_${testApiKey}`,
-        user: { id: 456 },
-      } as any);
+      mockUserLockRepository.findUserByApiKeyHash.mockResolvedValue({
+        user: { id: 456, email: "user@example.com", username: "testuser" },
+      });
 
       await handleAutoLock({
         identifier: testApiKey,
@@ -180,19 +172,9 @@ describe("autoLock", () => {
         rateLimitResponse,
       });
 
-      // Verify the API key was hashed
       expect(hashAPIKey).toHaveBeenCalledWith(testApiKey);
-
-      // Verify the associated user was locked
-      expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { id: 456 },
-        data: { locked: true },
-        select: {
-          id: true,
-          email: true,
-          username: true,
-        },
-      });
+      expect(mockUserLockRepository.findUserByApiKeyHash).toHaveBeenCalledWith({ hashedKey: `hashed_${testApiKey}` });
+      expect(mockUserLockRepository.updateLockedStatus).toHaveBeenCalledWith({ userId: 456, locked: true });
     });
 
     it("should throw error when API key has no associated user", async () => {
@@ -206,8 +188,7 @@ describe("autoLock", () => {
       mockRedis.get.mockResolvedValue("4"); // Over threshold to trigger lock
       const testApiKey = "test_api_key_123";
 
-      // Mock API key lookup with no user
-      vi.mocked(prisma.apiKey.findUnique).mockResolvedValue(null);
+      mockUserLockRepository.findUserByApiKeyHash.mockResolvedValue(null);
 
       // Expect handleAutoLock to throw the error from lockUser
       await expect(async () => {
@@ -294,15 +275,7 @@ describe("autoLock", () => {
         rateLimitResponse,
       });
 
-      expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { email: "test@example.com" },
-        data: { locked: true },
-        select: {
-          id: true,
-          email: true,
-          username: true,
-        },
-      });
+      expect(mockUserLockRepository.lockUserByEmail).toHaveBeenCalledWith({ email: "test@example.com" });
     });
 
     it("should lock user by userId", async () => {
@@ -321,15 +294,7 @@ describe("autoLock", () => {
         rateLimitResponse,
       });
 
-      expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { id: 123 },
-        data: { locked: true },
-        select: {
-          id: true,
-          email: true,
-          username: true,
-        },
-      });
+      expect(mockUserLockRepository.updateLockedStatus).toHaveBeenCalledWith({ userId: 123, locked: true });
     });
   });
 });

--- a/packages/features/ee/api-keys/lib/lock-notification/LockNotificationService.ts
+++ b/packages/features/ee/api-keys/lib/lock-notification/LockNotificationService.ts
@@ -1,0 +1,28 @@
+import logger from "@calcom/lib/logger";
+import type { SendLockNotificationPayload } from "./tasker/types";
+
+const log = logger.getSubLogger({ prefix: ["[LockNotificationService]"] });
+
+export class LockNotificationService {
+  async sendLockNotification(payload: SendLockNotificationPayload): Promise<void> {
+    const { default: AccountLockedEmail } = await import("@calcom/emails/templates/account-locked-email");
+
+    log.info(`Sending lock notification email to userId=${payload.userId}`, {
+      email: payload.userEmail,
+      reason: payload.reason,
+    });
+
+    const email = new AccountLockedEmail({
+      user: {
+        name: payload.userName,
+        email: payload.userEmail,
+      },
+      reason: payload.reason,
+      supportUrl: payload.supportUrl,
+    });
+
+    await email.sendEmail();
+
+    log.info(`Lock notification email sent to userId=${payload.userId}`);
+  }
+}

--- a/packages/features/ee/api-keys/lib/lock-notification/index.ts
+++ b/packages/features/ee/api-keys/lib/lock-notification/index.ts
@@ -1,5 +1,5 @@
+import { getUserLockRepository } from "@calcom/features/ee/api-keys/di/PrismaUserLockRepository.container";
 import logger from "@calcom/lib/logger";
-import prisma from "@calcom/prisma";
 import type { UserLockReason } from "@calcom/prisma/enums";
 import { LockNotificationSyncTasker } from "./tasker/LockNotificationSyncTasker";
 import { LockNotificationTasker } from "./tasker/LockNotificationTasker";
@@ -35,20 +35,11 @@ export async function createUserLockAndNotify({
   userId: number;
   reason: UserLockReason;
 }): Promise<void> {
-  await prisma.userLock.create({
-    data: {
-      userId,
-      reason,
-    },
-  });
+  const userLockRepository = getUserLockRepository();
 
-  const user = await prisma.user.findUniqueOrThrow({
-    where: { id: userId },
-    select: {
-      email: true,
-      name: true,
-    },
-  });
+  await userLockRepository.create({ userId, reason });
+
+  const user = await userLockRepository.findUserEmailAndName({ userId });
 
   const tasker = getLockNotificationTasker();
   try {

--- a/packages/features/ee/api-keys/lib/lock-notification/index.ts
+++ b/packages/features/ee/api-keys/lib/lock-notification/index.ts
@@ -1,0 +1,69 @@
+import logger from "@calcom/lib/logger";
+import prisma from "@calcom/prisma";
+import type { UserLockReason } from "@calcom/prisma/enums";
+import { LockNotificationSyncTasker } from "./tasker/LockNotificationSyncTasker";
+import { LockNotificationTasker } from "./tasker/LockNotificationTasker";
+import { LockNotificationTriggerTasker } from "./tasker/LockNotificationTriggerTasker";
+
+const SUPPORT_URL = "https://cal.com/support";
+
+const REASON_LABELS: Record<UserLockReason, string> = {
+  WATCHLIST_EMAIL_MATCH: "Your account matched our security watchlist based on email address",
+  WATCHLIST_DOMAIN_MATCH: "Your account matched our security watchlist based on email domain",
+  RATE_LIMIT_EXCEEDED: "Your account exceeded the allowed API rate limits",
+  SPAM_WORKFLOW_BODY: "Spam content was detected in your workflow",
+  MALICIOUS_URL_IN_WORKFLOW: "A malicious URL was detected in your workflow",
+  ADMIN_ACTION: "An administrator has locked your account",
+};
+
+const log = logger.getSubLogger({ prefix: ["[lock-notification]"] });
+
+function getLockNotificationTasker(): LockNotificationTasker {
+  const triggerTasker = new LockNotificationTriggerTasker({ logger: log });
+  const syncTasker = new LockNotificationSyncTasker(log);
+  return new LockNotificationTasker({
+    asyncTasker: triggerTasker,
+    syncTasker,
+    logger: log,
+  });
+}
+
+export async function createUserLockAndNotify({
+  userId,
+  reason,
+}: {
+  userId: number;
+  reason: UserLockReason;
+}): Promise<void> {
+  await prisma.userLock.create({
+    data: {
+      userId,
+      reason,
+    },
+  });
+
+  const user = await prisma.user.findUniqueOrThrow({
+    where: { id: userId },
+    select: {
+      email: true,
+      name: true,
+    },
+  });
+
+  const tasker = getLockNotificationTasker();
+  try {
+    await tasker.sendLockNotification({
+      userId,
+      userEmail: user.email,
+      userName: user.name,
+      reason: REASON_LABELS[reason],
+      supportUrl: SUPPORT_URL,
+    });
+  } catch (err) {
+    log.error("Failed to dispatch lock notification", {
+      userId,
+      reason,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/packages/features/ee/api-keys/lib/lock-notification/tasker/LockNotificationSyncTasker.ts
+++ b/packages/features/ee/api-keys/lib/lock-notification/tasker/LockNotificationSyncTasker.ts
@@ -1,0 +1,16 @@
+import { nanoid } from "nanoid";
+import type { Logger } from "tslog";
+import type { ILockNotificationTasker } from "./types";
+
+export class LockNotificationSyncTasker implements ILockNotificationTasker {
+  constructor(private readonly logger: Logger<unknown>) {}
+
+  async sendLockNotification(payload: Parameters<ILockNotificationTasker["sendLockNotification"]>[0]) {
+    const runId = `sync_${nanoid(10)}`;
+    this.logger.info(`[LockNotificationSyncTasker] sendLockNotification runId=${runId}`);
+    const { LockNotificationService } = await import("../LockNotificationService");
+    const service = new LockNotificationService();
+    await service.sendLockNotification(payload);
+    return { runId };
+  }
+}

--- a/packages/features/ee/api-keys/lib/lock-notification/tasker/LockNotificationTasker.ts
+++ b/packages/features/ee/api-keys/lib/lock-notification/tasker/LockNotificationTasker.ts
@@ -1,0 +1,21 @@
+import { Tasker } from "@calcom/lib/tasker/Tasker";
+import type { Logger } from "tslog";
+import type { LockNotificationSyncTasker } from "./LockNotificationSyncTasker";
+import type { LockNotificationTriggerTasker } from "./LockNotificationTriggerTasker";
+import type { ILockNotificationTasker, SendLockNotificationPayload } from "./types";
+
+export interface LockNotificationTaskerDependencies {
+  asyncTasker: LockNotificationTriggerTasker;
+  syncTasker: LockNotificationSyncTasker;
+  logger: Logger<unknown>;
+}
+
+export class LockNotificationTasker extends Tasker<ILockNotificationTasker> {
+  constructor(dependencies: LockNotificationTaskerDependencies) {
+    super(dependencies);
+  }
+
+  async sendLockNotification(payload: SendLockNotificationPayload): Promise<{ runId: string }> {
+    return await this.dispatch("sendLockNotification", payload);
+  }
+}

--- a/packages/features/ee/api-keys/lib/lock-notification/tasker/LockNotificationTriggerTasker.ts
+++ b/packages/features/ee/api-keys/lib/lock-notification/tasker/LockNotificationTriggerTasker.ts
@@ -1,0 +1,12 @@
+import type { ITaskerDependencies } from "@calcom/lib/tasker/types";
+import type { ILockNotificationTasker } from "./types";
+
+export class LockNotificationTriggerTasker implements ILockNotificationTasker {
+  constructor(public readonly dependencies: ITaskerDependencies) {}
+
+  async sendLockNotification(payload: Parameters<ILockNotificationTasker["sendLockNotification"]>[0]) {
+    const { sendLockNotificationTask } = await import("./trigger/send-lock-notification");
+    const handle = await sendLockNotificationTask.trigger(payload);
+    return { runId: handle.id };
+  }
+}

--- a/packages/features/ee/api-keys/lib/lock-notification/tasker/trigger/config.ts
+++ b/packages/features/ee/api-keys/lib/lock-notification/tasker/trigger/config.ts
@@ -1,0 +1,20 @@
+import { queue, type schemaTask } from "@trigger.dev/sdk";
+
+type LockNotificationTaskConfig = Pick<Parameters<typeof schemaTask>[0], "machine" | "retry" | "queue">;
+
+export const lockNotificationQueue = queue({
+  name: "lock-notification",
+  concurrencyLimit: 10,
+});
+
+export const lockNotificationTaskConfig: LockNotificationTaskConfig = {
+  queue: lockNotificationQueue,
+  machine: "small-1x",
+  retry: {
+    maxAttempts: 3,
+    factor: 2,
+    minTimeoutInMs: 1_000,
+    maxTimeoutInMs: 30_000,
+    randomize: true,
+  },
+};

--- a/packages/features/ee/api-keys/lib/lock-notification/tasker/trigger/schema.ts
+++ b/packages/features/ee/api-keys/lib/lock-notification/tasker/trigger/schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const sendLockNotificationSchema = z.object({
+  userId: z.number().int().positive(),
+  userEmail: z.string().email(),
+  userName: z.string().nullable(),
+  reason: z.string(),
+  supportUrl: z.string().url(),
+});
+
+export type SendLockNotificationPayload = z.infer<typeof sendLockNotificationSchema>;

--- a/packages/features/ee/api-keys/lib/lock-notification/tasker/trigger/send-lock-notification.ts
+++ b/packages/features/ee/api-keys/lib/lock-notification/tasker/trigger/send-lock-notification.ts
@@ -1,0 +1,15 @@
+import { schemaTask } from "@trigger.dev/sdk";
+import { lockNotificationTaskConfig } from "./config";
+import { sendLockNotificationSchema } from "./schema";
+
+export const sendLockNotificationTask = schemaTask({
+  id: "lock-notification.send-lock-notification",
+  ...lockNotificationTaskConfig,
+  schema: sendLockNotificationSchema,
+  run: async (payload) => {
+    const { LockNotificationService } = await import("../../LockNotificationService");
+    const service = new LockNotificationService();
+    await service.sendLockNotification(payload);
+    return { success: true };
+  },
+});

--- a/packages/features/ee/api-keys/lib/lock-notification/tasker/types.ts
+++ b/packages/features/ee/api-keys/lib/lock-notification/tasker/types.ts
@@ -1,0 +1,11 @@
+export interface SendLockNotificationPayload {
+  userId: number;
+  userEmail: string;
+  userName: string | null;
+  reason: string;
+  supportUrl: string;
+}
+
+export interface ILockNotificationTasker {
+  sendLockNotification(payload: SendLockNotificationPayload): Promise<{ runId: string }>;
+}

--- a/packages/features/ee/api-keys/repositories/PrismaUserLockRepository.ts
+++ b/packages/features/ee/api-keys/repositories/PrismaUserLockRepository.ts
@@ -1,0 +1,83 @@
+import type { PrismaClient } from "@calcom/prisma";
+import type { UserLockReason } from "@calcom/prisma/enums";
+
+export class PrismaUserLockRepository {
+  constructor(private prismaClient: PrismaClient) {}
+
+  async create({ userId, reason }: { userId: number; reason: UserLockReason }) {
+    return this.prismaClient.userLock.create({
+      data: {
+        userId,
+        reason,
+      },
+      select: {
+        id: true,
+        userId: true,
+        reason: true,
+        createdAt: true,
+      },
+    });
+  }
+
+  async findByUserId({ userId }: { userId: number }) {
+    return this.prismaClient.userLock.findMany({
+      where: { userId },
+      select: {
+        id: true,
+        userId: true,
+        reason: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async findUserEmailAndName({ userId }: { userId: number }) {
+    return this.prismaClient.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: {
+        email: true,
+        name: true,
+      },
+    });
+  }
+
+  async updateLockedStatus({ userId, locked }: { userId: number; locked: boolean }) {
+    return this.prismaClient.user.update({
+      where: { id: userId },
+      data: { locked },
+      select: {
+        id: true,
+        email: true,
+        username: true,
+      },
+    });
+  }
+
+  async lockUserByEmail({ email }: { email: string }) {
+    return this.prismaClient.user.update({
+      where: { email },
+      data: { locked: true },
+      select: {
+        id: true,
+        email: true,
+        username: true,
+      },
+    });
+  }
+
+  async findUserByApiKeyHash({ hashedKey }: { hashedKey: string }) {
+    return this.prismaClient.apiKey.findUnique({
+      where: { hashedKey },
+      select: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            username: true,
+          },
+        },
+      },
+    });
+  }
+}

--- a/packages/features/trigger.config.ts
+++ b/packages/features/trigger.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     "./calendars/lib/tasker/trigger",
     "./ee/billing/service/proration/tasker/trigger",
     "./ee/organizations/lib/billing/tasker/trigger",
+    "./ee/api-keys/lib/lock-notification/tasker/trigger",
   ], // Customize based on your project structure
 
   // Retry configuration

--- a/packages/prisma/migrations/20260207102210_add_user_lock_tracking/migration.sql
+++ b/packages/prisma/migrations/20260207102210_add_user_lock_tracking/migration.sql
@@ -1,0 +1,19 @@
+-- CreateEnum
+CREATE TYPE "public"."UserLockReason" AS ENUM ('WATCHLIST_EMAIL_MATCH', 'WATCHLIST_DOMAIN_MATCH', 'RATE_LIMIT_EXCEEDED', 'SPAM_WORKFLOW_BODY', 'MALICIOUS_URL_IN_WORKFLOW', 'ADMIN_ACTION');
+
+-- CreateTable
+CREATE TABLE "public"."user_locks" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "reason" "public"."UserLockReason" NOT NULL,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_locks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_locks_userId_idx" ON "public"."user_locks"("userId");
+
+-- AddForeignKey
+ALTER TABLE "public"."user_locks" ADD CONSTRAINT "user_locks_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -477,6 +477,7 @@ model User {
 
   // Used to lock the user account
   locked                         Boolean                       @default(false)
+  locks                          UserLock[]
   platformOAuthClients           PlatformOAuthClient[]
   AccessToken                    AccessToken[]
   RefreshToken                   RefreshToken[]
@@ -2212,6 +2213,27 @@ enum SMSLockState {
   LOCKED
   UNLOCKED
   REVIEW_NEEDED
+}
+
+enum UserLockReason {
+  WATCHLIST_EMAIL_MATCH
+  WATCHLIST_DOMAIN_MATCH
+  RATE_LIMIT_EXCEEDED
+  SPAM_WORKFLOW_BODY
+  MALICIOUS_URL_IN_WORKFLOW
+  ADMIN_ACTION
+}
+
+model UserLock {
+  id        Int            @id @default(autoincrement())
+  userId    Int
+  user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  reason    UserLockReason
+  metadata  Json?
+  createdAt DateTime       @default(now())
+
+  @@index([userId])
+  @@map(name: "user_locks")
 }
 
 model ManagedOrganization {

--- a/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.ts
@@ -1,6 +1,6 @@
+import { getUserLockRepository } from "@calcom/features/ee/api-keys/di/PrismaUserLockRepository.container";
 import { createUserLockAndNotify } from "@calcom/features/ee/api-keys/lib/lock-notification";
 import logger from "@calcom/lib/logger";
-import { prisma } from "@calcom/prisma";
 import { UserLockReason } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "../../../types";
 import type { TAdminLockUserAccountSchema } from "./lockUserAccount.schema";
@@ -17,22 +17,8 @@ type GetOptions = {
 const lockUserAccountHandler = async ({ input }: GetOptions) => {
   const { userId, locked } = input;
 
-  const user = await prisma.user.update({
-    where: {
-      id: userId,
-    },
-    data: {
-      locked,
-    },
-    select: {
-      id: true,
-      locked: true,
-    },
-  });
-
-  if (!user) {
-    throw new Error("User not found");
-  }
+  const userLockRepository = getUserLockRepository();
+  await userLockRepository.updateLockedStatus({ userId, locked });
 
   if (locked) {
     try {

--- a/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.ts
@@ -1,7 +1,11 @@
+import { createUserLockAndNotify } from "@calcom/features/ee/api-keys/lib/lock-notification";
+import logger from "@calcom/lib/logger";
 import { prisma } from "@calcom/prisma";
-
+import { UserLockReason } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "../../../types";
 import type { TAdminLockUserAccountSchema } from "./lockUserAccount.schema";
+
+const log = logger.getSubLogger({ prefix: ["[lockUserAccountHandler]"] });
 
 type GetOptions = {
   ctx: {
@@ -20,10 +24,28 @@ const lockUserAccountHandler = async ({ input }: GetOptions) => {
     data: {
       locked,
     },
+    select: {
+      id: true,
+      locked: true,
+    },
   });
 
   if (!user) {
     throw new Error("User not found");
+  }
+
+  if (locked) {
+    try {
+      await createUserLockAndNotify({
+        userId,
+        reason: UserLockReason.ADMIN_ACTION,
+      });
+    } catch (err) {
+      log.error("Failed to create UserLock record for admin lock", {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   return {


### PR DESCRIPTION
## What does this PR do?

Introduces a `UserLock` table to track lock events across users and dispatches a notification email via Trigger.dev when a user is locked. Previously, users were silently locked with no audit trail and no explanation sent to them.

**Changes:**

1. **Prisma schema**: New `UserLock` model and `UserLockReason` enum (6 reasons: watchlist email/domain, rate limit, spam workflow, malicious URL, admin action)
2. **Email template**: `AccountLockedEmail` — explains the lock reason and links to support
3. **Trigger.dev Tasker**: Full async/sync tasker pattern (`LockNotificationTasker` → `LockNotificationService` → email send) with queue config, Zod schema, and schemaTask
4. **Integration into all lock paths**:
   - `lockUser()` in `autoLock.ts` — rate limit + malicious URL locks
   - `lockUserAccountHandler` — admin locks
   - `userCreationService` — watchlist locks at signup
5. **`PrismaUserLockRepository`** with full DI wiring (tokens, module, container) — all direct Prisma calls for lock operations are abstracted behind the repository, accessed via `getUserLockRepository()` from the DI container
6. **Tests**: Updated `autoLock.test.ts` to mock the repository instead of direct Prisma calls (all 12 tests passing)
7. Also fixes `include` → `select` on the apiKey lookup in `autoLock.ts` per Prisma best practices

### Updates since last revision

- Added `PrismaUserLockRepository` in `packages/features/ee/api-keys/repositories/` with methods: `create`, `findByUserId`, `findUserEmailAndName`, `updateLockedStatus`, `lockUserByEmail`, `findUserByApiKeyHash`
- Created DI tokens (`USER_LOCK_DI_TOKENS`), module (`PrismaUserLockRepository.module.ts`), and container (`PrismaUserLockRepository.container.ts`) following the established `@evyweb/ioctopus` pattern
- Registered tokens in `packages/features/di/tokens.ts`
- Removed all direct `prisma` imports from `lock-notification/index.ts`, `autoLock.ts`, and `lockUserAccount.handler.ts` — all DB access now goes through the repository
- Updated `autoLock.test.ts` to mock `getUserLockRepository` instead of raw Prisma client

Link to Devin run: https://app.devin.ai/sessions/35d30ed7285b47258ad34e10e3277345
Requested by: @sean-brydon

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Things for reviewer to verify

- [ ] **Repository scope**: `PrismaUserLockRepository` contains both `UserLock` table operations and user-locking helper methods (`updateLockedStatus`, `lockUserByEmail`, `findUserByApiKeyHash` which query `User`/`ApiKey` tables). Confirm this grouping makes sense vs. splitting user-lock-status methods into the existing `UserRepository`.
- [ ] **Support URL**: `https://cal.com/support` is hardcoded in `lock-notification/index.ts` — is this the correct destination?
- [ ] **Watchlist reason granularity**: `userCreationService` always records `WATCHLIST_EMAIL_MATCH` because the watchlist controller returns a boolean without distinguishing email vs domain match. Should we add a generic `WATCHLIST_MATCH` reason?
- [ ] **Email content/design**: The `AccountLockedEmail` template is new — review subject line, body copy, and styling
- [ ] **Test coverage**: Only `autoLock.test.ts` was updated. No new tests for `PrismaUserLockRepository`, `LockNotificationService`, or the Trigger.dev task.

## How should this be tested?

1. **Rate limit lock**: Trigger rate limit auto-lock (5 consecutive rate limit hits within 30 min) → verify `UserLock` record created + email sent
2. **Admin lock**: Use admin panel to lock a user → verify `UserLock` record created + email sent
3. **Watchlist lock**: Create user with email matching watchlist → verify `UserLock` record created + email sent
4. **Malicious URL lock**: Create workflow with malicious URL → verify `UserLock` record created + email sent

**Environment variables for Trigger.dev async mode:**
- `TRIGGER_SECRET_KEY`
- `TRIGGER_API_URL`
- `ENABLE_ASYNC_TASKER="true"`

Without these, the sync fallback will execute inline.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings