### PR TITLE
feat: booking-audit-create-reschedule

### DIFF
--- a/packages/features/booking-audit/lib/service/BookingAuditProducerService.interface.ts
+++ b/packages/features/booking-audit/lib/service/BookingAuditProducerService.interface.ts
@@ -199,6 +199,7 @@ export interface BookingAuditProducerService {
     organizationId: number | null;
     source: ActionSource;
     operationId?: string | null;
+    context?: BookingAuditContext;
   }): Promise<void>;
 
   queueBulkRescheduledAudit(params: {
@@ -210,6 +211,7 @@ export interface BookingAuditProducerService {
     organizationId: number | null;
     source: ActionSource;
     operationId?: string | null;
+    context?: BookingAuditContext;
   }): Promise<void>;
 
   queueBulkRejectedAudit(params: {

--- a/packages/features/booking-audit/lib/service/BookingAuditTaskerProducerService.ts
+++ b/packages/features/booking-audit/lib/service/BookingAuditTaskerProducerService.ts
@@ -397,6 +397,7 @@ export class BookingAuditTaskerProducerService implements BookingAuditProducerSe
         organizationId: number | null;
         source: ActionSource;
         operationId?: string | null;
+        context?: BookingAuditContext;
     }): Promise<void> {
         await this.queueBulkTask({
             ...params,
@@ -413,6 +414,7 @@ export class BookingAuditTaskerProducerService implements BookingAuditProducerSe
         organizationId: number | null;
         source: ActionSource;
         operationId?: string | null;
+        context?: BookingAuditContext;
     }): Promise<void> {
         await this.queueBulkTask({
             ...params,

--- a/packages/features/bookings/lib/handleNewBooking/buildBookingEventAuditData.ts
+++ b/packages/features/bookings/lib/handleNewBooking/buildBookingEventAuditData.ts
@@ -50,3 +50,62 @@ export const buildBookingRescheduledAuditData = ({
     },
   };
 };
+
+export const buildSeatBookedAuditData = ({
+  seatReferenceUid,
+  attendeeEmail,
+  attendeeName,
+  startTime,
+  endTime,
+}: {
+  seatReferenceUid: string;
+  attendeeEmail: string;
+  attendeeName: string;
+  startTime: Date;
+  endTime: Date;
+}) => {
+  return {
+    seatReferenceUid,
+    attendeeEmail,
+    attendeeName,
+    startTime: startTime.getTime(),
+    endTime: endTime.getTime(),
+  };
+};
+
+export const buildSeatRescheduledAuditData = ({
+  seatReferenceUid,
+  attendeeEmail,
+  oldBooking,
+  newBooking,
+  rescheduledToBookingUid,
+}: {
+  seatReferenceUid: string;
+  attendeeEmail: string;
+  oldBooking: {
+    startTime: Date;
+    endTime: Date;
+  };
+  newBooking: {
+    startTime: Date;
+    endTime: Date;
+  };
+  rescheduledToBookingUid: string | null;
+}) => {
+  return {
+    seatReferenceUid,
+    attendeeEmail,
+    startTime: {
+      old: oldBooking.startTime.getTime(),
+      new: newBooking.startTime.getTime(),
+    },
+    endTime: {
+      old: oldBooking.endTime.getTime(),
+      new: newBooking.endTime.getTime(),
+    },
+    rescheduledToBookingUid: {
+      old: null,
+      new: rescheduledToBookingUid,
+    },
+  };
+};

--- a/packages/features/bookings/lib/onBookingEvents/BookingEventHandlerService.ts
+++ b/packages/features/bookings/lib/onBookingEvents/BookingEventHandlerService.ts
@@ -355,8 +355,9 @@ export class BookingEventHandlerService {
     organizationId: number | null;
     operationId?: string | null;
     source: ActionSource;
+    context?: BookingAuditContext;
   }) {
-    const { bookings, actor, organizationId, operationId, source } = params;
+    const { bookings, actor, organizationId, operationId, source, context } = params;
     await this.bookingAuditProducerService.queueBulkCreatedAudit({
       bookings: bookings.map((booking) => ({
         bookingUid: booking.bookingUid,
@@ -366,6 +367,7 @@ export class BookingEventHandlerService {
       organizationId,
       source,
       operationId,
+      context,
     });
   }
 
@@ -378,8 +380,9 @@ export class BookingEventHandlerService {
     organizationId: number | null;
     operationId?: string | null;
     source: ActionSource;
+    context?: BookingAuditContext;
   }) {
-    const { bookings, actor, organizationId, operationId, source } = params;
+    const { bookings, actor, organizationId, operationId, source, context } = params;
     await this.bookingAuditProducerService.queueBulkRescheduledAudit({
       bookings: bookings.map((booking) => ({
         bookingUid: booking.bookingUid,
@@ -389,6 +392,7 @@ export class BookingEventHandlerService {
       organizationId,
       source,
       operationId,
+      context,
     });
   }
 


### PR DESCRIPTION
closes: #22832

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds BookingAudit logging for core booking lifecycle events such as booking, rescheduling, and seat actions.

Audit tasks are queued via a specialized `BookingAuditProducerService` with strongly typed action-specific methods for strict schema validation.


- Fixes #22832 
- Fixes CAL-6181

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.