### PR TITLE
refactor(companion): one click flow for new availability on ios app

### DIFF
--- a/companion/app/(tabs)/(availability)/index.tsx
+++ b/companion/app/(tabs)/(availability)/index.tsx
@@ -100,14 +100,10 @@ export default function Availability() {
       >
         <Stack.Header.Title large>Availability</Stack.Header.Title>
         <Stack.Header.Right>
-          {/* New Menu */}
-          <Stack.Header.Menu>
+          {/* New Button - directly opens create dialog */}
+          <Stack.Header.Button onPress={handleCreateNew}>
             <Stack.Header.Icon sf="plus" />
-
-            <Stack.Header.MenuAction icon="clock" onPress={handleCreateNew}>
-              New Availability
-            </Stack.Header.MenuAction>
-          </Stack.Header.Menu>
+          </Stack.Header.Button>
 
           {/* Profile Button */}
           {userProfile?.avatarUrl ? (


### PR DESCRIPTION

https://github.com/user-attachments/assets/b7508295-e357-493c-b8c7-a6c1345c85bd



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted the Availability screen’s “New” action from a header menu to a single plus button that immediately opens the create dialog. This delivers a one‑tap flow on iOS by removing the menu step.

<sup>Written for commit 2b38c34af0e20c370ab0aff207bf9d0c96516ea0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

