### PR TITLE
fix: block original slot when rescheduling non seated bookings

### DIFF
--- a/packages/features/busyTimes/services/getBusyTimes.test.ts
+++ b/packages/features/busyTimes/services/getBusyTimes.test.ts
@@ -105,6 +105,41 @@ describe("getBusyTimes", () => {
       }),
     ]);
   });
+  it("should block the original booking slot when rescheduling", async () => {
+    const busyTimesService = getBusyTimesService();
+    const rescheduleUid = "xxxx1";
+
+    const busyTimes = await busyTimesService.getBusyTimes({
+      credentials: [],
+      userId: 1,
+      userEmail: "exampleuser1@example.com",
+      username: "exampleuser1",
+      bypassBusyCalendarTimes: false,
+      selectedCalendars: [],
+      startTime: startOfTomorrow.format(),
+      endTime: startOfTomorrow.endOf("day").format(),
+      currentBookings: mockBookings({}),
+      rescheduleUid,
+    });
+
+    expect(busyTimes).toEqual([
+      expect.objectContaining({
+        start: dayjs(`${tomorrowDate}`).startOf("day").set("hour", 10).toDate(),
+        end: dayjs(`${tomorrowDate}`).startOf("day").set("hour", 11).toDate(),
+        source: "eventType-1-booking-1",
+        title: "Booking Between X and Y",
+      }),
+      expect.objectContaining({
+        start: dayjs(`${tomorrowDate}`).startOf("day").set("hour", 14).toDate(),
+        end: dayjs(`${tomorrowDate}`).startOf("day").set("hour", 15).toDate(),
+        source: "eventType-1-booking-2",
+        title: "Booking Between X and Y",
+      }),
+    ]);
+
+    expect(busyTimes).toHaveLength(2);
+    expect(busyTimes.some((bt) => bt.source === "eventType-1-booking-1")).toBe(true);
+  });
   it("should block before and after buffer times", async () => {
     const busyTimesService = getBusyTimesService();
     const busyTimes = await busyTimesService.getBusyTimes({

--- a/packages/features/busyTimes/services/getBusyTimes.ts
+++ b/packages/features/busyTimes/services/getBusyTimes.ts
@@ -169,10 +169,6 @@ export class BusyTimesService {
         // doing this allows using the map later to remove the ranges from calendar busy times.
         delete bookingSeatCountMap[bookedAt];
       }
-      // rescheduling the same booking to the same time should be possible. Why?
-      if (rest.uid === rescheduleUid) {
-        return aggregate;
-      }
       aggregate.push({
         start: dayjs(startTime).subtract(minutesToBlockBeforeEvent, "minute").toDate(),
         end: dayjs(endTime).add(minutesToBlockAfterEvent, "minute").toDate(),


### PR DESCRIPTION
## What does this PR do?

This PR ensures that when rescheduling a booking the original time slot is blocked preventing users from rescheduling to the exact same time. Previously non seated bookings would exclude the original booking from busy times during rescheduling, allowing selection of the same slot. This change aligns non seated booking behavior with seated bookings which already block the original slot.


- Fixes #24712  (GitHub issue number)
- Fixes CAL-6648 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

[Screencast from 2026-02-08 02-52-47.webm](https://github.com/user-attachments/assets/8f565c26-e69c-4b90-a6b5-643be8bc343f)



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks the original slot when rescheduling non-seated bookings by removing the rescheduleUid bypass in getBusyTimes, so the current booking (with buffers) is treated as busy. Adds a test verifying the slot is disabled, aligning with seated bookings and CAL-6648.

<sup>Written for commit eea6ae74c2032c58d9022f3f509e8193bd6f813e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->




<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
