### PR TITLE
fix: remove extra scrollbar and fix MultiSelect label in booking questions

### DIFF
--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -614,7 +614,7 @@ function FieldEditDialog({
     <Dialog open={dialog.isOpen} onOpenChange={onOpenChange} modal={false}>
       <DialogContent className="max-h-none" data-testid="edit-field-dialog" forceOverlayWhenNoModal={true}>
         <Form id="form-builder" form={fieldForm} handleSubmit={handleSubmit}>
-          <div className="h-auto max-h-[85vh] overflow-auto">
+          <div className="h-auto max-h-[85vh] overflow-auto no-scrollbar">
             <DialogHeader
               title={t("add_a_booking_question")}
               subtitle={

--- a/packages/features/form-builder/fieldTypes.ts
+++ b/packages/features/form-builder/fieldTypes.ts
@@ -120,7 +120,7 @@ const configMap: Record<FieldType, Omit<z.infer<typeof fieldTypeConfigSchema>, "
     optionsSupportPricing: true,
   },
   multiselect: {
-    label: "MultiSelect",
+    label: "Multi Select",
     value: "multiselect",
     needsOptions: true,
     isTextType: false,


### PR DESCRIPTION
## What does this PR do?

Fixes #27591

This PR addresses two UI issues in the booking questions configuration dialog:

1. **Extra scrollbar** — When selecting input types that display options (Checkbox Group, Radio Group, Select, Multi Select), an unwanted native scrollbar appears in the dialog. This is fixed by adding the `no-scrollbar` utility class to the inner scrollable container, which hides the scrollbar while preserving scroll functionality. This follows the same pattern used in [#26339](https://github.com/calcom/cal.com/pull/26339) for the AvailableTimeSlots component.

2. **"MultiSelect" label** — The label reads "MultiSelect" without a space, inconsistent with other compound labels like "Checkbox Group", "Radio Group", "Short Text", "Long Text", and "Multiple Emails". Changed to "Multi Select".

## How should this be tested?

1. Navigate to any Event Type → Advanced tab → Booking Questions
2. Click "Add a question"
3. In the input type dropdown, verify "Multi Select" now has a space
4. Select "Checkbox Group" (or "Radio Group", "Select", "Multi Select") as the input type
5. Verify no extra scrollbar appears in the dialog, even when options are added

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] New/updated tests aren't required (CSS class addition + label text fix, no logic change)