### PR TITLE
fix(trpc): add password presence validation at input stage

### DIFF
--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -26,6 +26,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/trpc/server/routers/viewer/me/deleteMe.handler.ts
+++ b/packages/trpc/server/routers/viewer/me/deleteMe.handler.ts
@@ -18,8 +18,6 @@ type DeleteMeOptions = {
 };
 
 export const deleteMeHandler = async ({ ctx, input }: DeleteMeOptions) => {
-  // TODO: First check password is part of input and meets requirements.
-
   // Check if input.password is correct
   const user = await prisma.user.findUnique({
     where: {

--- a/packages/trpc/server/routers/viewer/me/deleteMe.schema.ts
+++ b/packages/trpc/server/routers/viewer/me/deleteMe.schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const ZDeleteMeInputSchema = z.object({
-  password: z.string(),
+  password: z.string().min(1),
   totpCode: z.string().optional(),
 });
 


### PR DESCRIPTION
## Description

Fixes #27633

This PR adds password presence validation at the input validation stage in the deleteMe handler.

## Problem
Password validation was missing at the input validation stage. The schema only had z.string() which allows empty strings to pass through, meaning requests without a password or with an empty password could reach the handler without proper validation.

## Solution
- Added .min(1) constraint to the password field in deleteMe.schema.ts to ensure non-empty passwords at input validation
- Removed the TODO comment from deleteMe.handler.ts as the validation is now implemented

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)