### PR TITLE
feat(security): disable X-Powered-By and make proxy-conflicting heade…

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -222,6 +222,7 @@ const nextConfig = (phase: string): NextConfig => {
   }
 
   return {
+    poweredByHeader: false,
     output: process.env.BUILD_STANDALONE === "true" ? "standalone" : undefined,
     serverExternalPackages: [
       "deasync",
@@ -408,19 +409,23 @@ const nextConfig = (phase: string): NextConfig => {
             },
           ],
         },
-        {
-          source: "/:path*",
-          headers: [
-            {
-              key: "X-Content-Type-Options",
-              value: "nosniff",
-            },
-            {
-              key: "Referrer-Policy",
-              value: "strict-origin-when-cross-origin",
-            },
-          ],
-        },
+        ...(process.env.SKIP_PROXY_SECURITY_HEADERS !== "true"
+          ? [
+              {
+                source: "/:path*",
+                headers: [
+                  {
+                    key: "X-Content-Type-Options",
+                    value: "nosniff",
+                  },
+                  {
+                    key: "Referrer-Policy",
+                    value: "strict-origin-when-cross-origin",
+                  },
+                ],
+              },
+            ]
+          : []),
         {
           source: "/embed/embed.js",
           headers: [CORP_CROSS_ORIGIN_HEADER],


### PR DESCRIPTION
## Problem

When Cal.com is deployed behind a reverse proxy (NGINX, Caddy, Traefik), the security headers defined in `next.config.ts` create **duplicate headers** in HTTP responses because both the reverse proxy and Next.js add the same headers independently.

Additionally, Next.js exposes `X-Powered-By: Next.js` by default, revealing the application framework — contrary to OWASP security hardening recommendations.

### Current response (behind NGINX):

```
x-content-type-options: nosniff          ← from Next.js
referrer-policy: strict-origin-when-cross-origin  ← from Next.js
x-powered-by: Next.js                   ← framework exposed
strict-transport-security: max-age=31536000; includeSubDomains  ← weaker than proxy
x-content-type-options: nosniff          ← from reverse proxy (duplicate)
referrer-policy: strict-origin-when-cross-origin  ← from reverse proxy (duplicate)
```

## Changes

1. **`poweredByHeader: false`** — suppresses `X-Powered-By: Next.js` header unconditionally
2. **`SKIP_PROXY_SECURITY_HEADERS` env var** — when set to `"true"`, skips `X-Content-Type-Options` and `Referrer-Policy` headers that are typically managed by the reverse proxy

## No breaking changes

- `poweredByHeader: false` has no impact on functionality
- Security headers remain **active by default** — only skipped when the env var is explicitly set
- Application-specific headers preserved (`X-Frame-Options DENY` on `/auth/*` and `/signup`, `Cross-Origin-Resource-Policy` on embed endpoints)

## References

- [[OWASP — Remove Server Information](https://owasp.org/www-project-secure-headers/)](https://owasp.org/www-project-secure-headers/)
- [[Next.js — poweredByHeader](https://nextjs.org/docs/app/api-reference/config/next-config-js/poweredByHeader)](https://nextjs.org/docs/app/api-reference/config/next-config-js/poweredByHeader)
- [[RFC 6797 §8.1 — Only one HSTS header should be present](https://www.rfc-editor.org/rfc/rfc6797#section-8.1)](https://www.rfc-editor.org/rfc/rfc6797#section-8.1)