### PR TITLE
fix: atoms build

### DIFF
--- a/packages/platform/atoms/vite.config.ts
+++ b/packages/platform/atoms/vite.config.ts
@@ -84,6 +84,7 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       alias: {
+        "~": path.resolve(__dirname, "../../../apps/web/modules"),
         "@": path.resolve(__dirname, "./src"),
         "@calcom/lib/markdownToSafeHTML": path.resolve(__dirname, "./lib/markdownToSafeHTML"),
         "@calcom/lib/hooks/useLocale": path.resolve(__dirname, "./lib/useLocale"),


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary 
Fixes the atoms package build by adding a Vite alias "~" to ../../../apps/web/modules. This makes "~" imports resolve correctly and prevents module resolution errors during build and dev.

i'm not sure how but this actually fixes the atoms build breaking



