### PR TITLE
fix: Atom build failing due to dependency on @calcom/web

### DIFF
--- a/apps/web/modules/event-types/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/EventAdvancedTab.tsx
@@ -34,7 +34,7 @@ import type {
   SettingsToggleClassNames,
 } from "@calcom/features/eventtypes/lib/types";
 import { FormBuilder } from "./FormBuilder";
-import { BookerLayoutSelector } from "~/settings/components/BookerLayoutSelector";
+import { BookerLayoutSelector } from "@calcom/web/modules/settings/components/BookerLayoutSelector";
 import {
   DEFAULT_LIGHT_BRAND_COLOR,
   DEFAULT_DARK_BRAND_COLOR,


### PR DESCRIPTION
Atom build fails when it relies on web components that use the alias `"~/..."`. Atoms shouldn't rely on web components in the first place, but until then this is a clean fix.