### PR TITLE
test: add i18n config integrity tests for locale file migration

### DIFF
--- a/packages/config/i18n/next-i18next.config.test.ts
+++ b/packages/config/i18n/next-i18next.config.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const i18nJson = require("../../../i18n.json");
+const config = require("./next-i18next.config");
+
+describe("@calcom/config/i18n/next-i18next.config", () => {
+  it("exports i18n with defaultLocale and locales", () => {
+    expect(config.i18n).toBeDefined();
+    expect(config.i18n.defaultLocale).toBe("en");
+    expect(Array.isArray(config.i18n.locales)).toBe(true);
+    expect(config.i18n.locales).toContain("en");
+  });
+
+  it("includes all target locales from i18n.json plus the source locale", () => {
+    const expectedLocales = [...i18nJson.locale.targets, i18nJson.locale.source];
+    for (const locale of expectedLocales) {
+      expect(config.i18n.locales).toContain(locale);
+    }
+    expect(config.i18n.locales.length).toBe(expectedLocales.length);
+  });
+
+  it("has localePath pointing to existing locales directory", () => {
+    expect(config.localePath).toBeDefined();
+    expect(typeof config.localePath).toBe("string");
+    expect(fs.existsSync(config.localePath)).toBe(true);
+  });
+
+  it("localePath resolves to packages/config/i18n/locales", () => {
+    const expectedDir = path.resolve(__dirname, "./locales");
+    expect(config.localePath).toBe(expectedDir);
+  });
+
+  it("has fallbackLng configured", () => {
+    expect(config.fallbackLng).toBeDefined();
+    expect(config.fallbackLng.default).toEqual(["en"]);
+    expect(config.fallbackLng.zh).toEqual(["zh-CN"]);
+  });
+
+  it("has reloadOnPrerender based on NODE_ENV", () => {
+    expect(typeof config.reloadOnPrerender).toBe("boolean");
+  });
+
+  it("every locale in config has a corresponding locale directory with common.json", () => {
+    const localesDir = config.localePath;
+    for (const locale of config.i18n.locales) {
+      const localeDir = path.join(localesDir, locale);
+      const commonJson = path.join(localeDir, "common.json");
+      expect(fs.existsSync(localeDir)).toBe(true);
+      expect(fs.existsSync(commonJson)).toBe(true);
+    }
+  });
+
+  it("english common.json is valid JSON with translation keys", () => {
+    const enPath = path.join(config.localePath, "en", "common.json");
+    const enTranslations = JSON.parse(fs.readFileSync(enPath, "utf-8"));
+    expect(typeof enTranslations).toBe("object");
+    expect(Object.keys(enTranslations).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds unit tests for the shared i18n config at `packages/config/i18n/next-i18next.config.js` introduced by #27731. These tests act as a safety net to catch regressions from the locale file migration (moving locales from `apps/web/public/static/locales/` to `packages/config/i18n/locales/`).

**Tests cover:**
- Config shape: `defaultLocale`, `locales` array, `fallbackLng`, `reloadOnPrerender`
- Locale completeness: every locale listed in `i18n.json` has a matching directory with `common.json`
- `localePath` resolves to the correct physical directory (`packages/config/i18n/locales`)
- English translations file is valid JSON with at least one key

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

```bash
TZ=UTC yarn vitest run packages/config/i18n/next-i18next.config.test.ts
```

All 8 tests should pass. No environment variables or test data needed — the tests read directly from the config and locale files on disk.

## Human Review Checklist

- [ ] Verify the `every locale in config has a corresponding locale directory` test — this is the most valuable regression guard and should be confirmed to fail if a locale directory is accidentally removed.
- [ ] Confirm relative `require("../../../i18n.json")` path is stable — it matches the pattern used by the config file itself, but worth a glance.

---

Link to Devin run: https://app.devin.ai/sessions/ef9d5b75c1574cc6a151fd7a0b412e34
Requested by: @hbjORbj