### PR TITLE
feat: add ARIA labels to time format and layout toggle controls

### DIFF
--- a/packages/features/bookings/components/Header.tsx
+++ b/packages/features/bookings/components/Header.tsx
@@ -234,7 +234,14 @@ const LayoutToggle = ({
   // the layout can be toggled via props in the booker atom
   if (isPlatform) return null;
 
-  return <ToggleGroup onValueChange={onLayoutToggle} defaultValue={layout} options={layoutOptions} />;
+  return (
+    <ToggleGroup
+      onValueChange={onLayoutToggle}
+      defaultValue={layout}
+      aria-label={t("layout")}
+      options={layoutOptions}
+    />
+  );
 };
 
 const LayoutToggleWithData = ({

--- a/packages/features/bookings/components/TimeFormatToggle.tsx
+++ b/packages/features/bookings/components/TimeFormatToggle.tsx
@@ -17,6 +17,7 @@ export const TimeFormatToggle = ({ customClassName }: { customClassName?: string
       }}
       defaultValue={timeFormat}
       value={timeFormat}
+      aria-label={t("time_format")}
       options={[
         { value: TimeFormat.TWELVE_HOUR, label: t("12_hour_short") },
         { value: TimeFormat.TWENTY_FOUR_HOUR, label: t("24_hour_short") },


### PR DESCRIPTION
## Summary
- Adds `aria-label` to the time format toggle (`TimeFormatToggle`) and the layout toggle (`LayoutToggle`) on the booking page
- Screen readers can now properly identify these radio groups and announce their purpose

## Changes
- `packages/features/bookings/components/TimeFormatToggle.tsx`: Add `aria-label={t("time_format")}` to the ToggleGroup
- `packages/features/bookings/components/Header.tsx`: Add `aria-label={t("layout")}` to the layout ToggleGroup

## Root Cause
The Radix UI ToggleGroup renders as a `radiogroup` role element, but without an `aria-label`, screen readers cannot convey the purpose of these controls. This violates WCAG 4.1.2 (Name, Role, Value).

## Fix
Pass `aria-label` using existing translation keys (`"time_format"` → "Time format", `"layout"` → "Layout") to the ToggleGroup components. The prop flows through to the Radix root element via the spread props.

## Test plan
- [x] Verify the time format toggle has `aria-label="Time format"` in the DOM
- [x] Verify the layout toggle has `aria-label="Layout"` in the DOM
- [x] Screen reader announces "Time format" when focusing the 12h/24h toggle
- [x] Screen reader announces "Layout" when focusing the month/week/column toggle
- [x] No visual changes — purely accessibility improvement
- [x] Biome lint passes — no new warnings
- [x] Pre-existing type errors only (confirmed unrelated to changes)

Fixes #20703