### PR TITLE
fix: return 404 for apps without a setup page

### DIFF
--- a/packages/app-store/_pages/setup/_getServerSideProps.tsx
+++ b/packages/app-store/_pages/setup/_getServerSideProps.tsx
@@ -12,7 +12,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { slug } = ctx.params || {};
   if (typeof slug !== "string") return { notFound: true } as const;
 
-  if (!(slug in AppSetupPageMap)) return { props: {} };
+  if (!(slug in AppSetupPageMap)) return { notFound: true } as const;
 
   const page = await AppSetupPageMap[slug as keyof typeof AppSetupPageMap];
 


### PR DESCRIPTION
## Summary
- Shows a proper 404 page instead of a blank screen when visiting `/apps/{slug}/setup` for apps that don't have a setup page

## Changes
- `packages/app-store/_pages/setup/_getServerSideProps.tsx`: Return `{ notFound: true }` instead of `{ props: {} }` when the slug is not in `AppSetupPageMap`

## Root Cause
When visiting `/apps/umami/setup` (or any app not in `AppSetupPageMap`), `getServerSideProps` returns `{ props: {} }`. The `DynamicComponent` then receives a slug with no matching component and returns `null`, rendering a blank screen. Users report this as a bug (see #23801).

## Fix
Return `{ notFound: true }` for apps not in `AppSetupPageMap`, which tells Next.js to render the 404 page.

## Test plan
- [x] Visit `/apps/umami/setup` → shows 404 page instead of blank screen
- [x] Visit `/apps/stripe/setup` → still works correctly (app is in AppSetupPageMap)
- [x] Biome lint passes — no new warnings

Fixes #24128