### PR TITLE
feat(app-store): add tooltip for truncated app descriptions in AppCard

### DIFF
--- a/apps/web/modules/apps/components/AppCard.tsx
+++ b/apps/web/modules/apps/components/AppCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import posthog from "posthog-js";
 
 import { InstallAppButton } from "@calcom/app-store/InstallAppButton";
@@ -21,6 +21,7 @@ import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
 import type { ButtonProps } from "@calcom/ui/components/button";
 import { showToast } from "@calcom/ui/components/toast";
+import { Tooltip } from "@calcom/ui/components/tooltip";
 
 interface AppCardProps {
   app: App;
@@ -53,10 +54,28 @@ export function AppCard({ app, credentials, searchText, userAdminTeams }: AppCar
   });
 
   const [searchTextIndex, setSearchTextIndex] = useState<number | undefined>(undefined);
+  const descriptionRef = useRef<HTMLParagraphElement>(null);
+  const [isDescriptionTruncated, setIsDescriptionTruncated] = useState(false);
+
+  const checkTruncation = useCallback(() => {
+    const el = descriptionRef.current;
+    if (el) {
+      setIsDescriptionTruncated(el.scrollHeight > el.clientHeight);
+    }
+  }, []);
 
   useEffect(() => {
     setSearchTextIndex(searchText ? app.name.toLowerCase().indexOf(searchText.toLowerCase()) : undefined);
   }, [app.name, searchText]);
+
+  useEffect(() => {
+    checkTruncation();
+    const el = descriptionRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(checkTruncation);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [app.description, checkTruncation]);
 
   const handleAppInstall = () => {
     posthog.capture("app_install_button_clicked", {
@@ -127,9 +146,20 @@ export function AppCard({ app, credentials, searchText, userAdminTeams }: AppCar
             <span>{props.rating} stars</span> <Icon name="star" className="ml-1 mt-0.5 h-4 w-4 text-yellow-600" />
             <span className="pl-1 text-subtle">{props.reviews} reviews</span>
           </div> */}
-      <p className="text-default mt-2 text-sm line-clamp-3">
-        {markdownToSafeHTML(app.description).replace(/<[^>]+>/g, "")}
-      </p>
+      {isDescriptionTruncated ? (
+        <Tooltip
+          content={markdownToSafeHTML(app.description).replace(/<[^>]+>/g, "")}
+          side="bottom"
+          sideOffset={4}>
+          <p ref={descriptionRef} className="text-default mt-2 cursor-pointer text-sm line-clamp-3">
+            {markdownToSafeHTML(app.description).replace(/<[^>]+>/g, "")}
+          </p>
+        </Tooltip>
+      ) : (
+        <p ref={descriptionRef} className="text-default mt-2 text-sm line-clamp-3">
+          {markdownToSafeHTML(app.description).replace(/<[^>]+>/g, "")}
+        </p>
+      )}
 
       <div className="mt-auto flex max-w-full flex-row justify-between gap-2">
         <Button

--- a/apps/web/modules/apps/components/AppCard.tsx
+++ b/apps/web/modules/apps/components/AppCard.tsx
@@ -75,7 +75,7 @@ export function AppCard({ app, credentials, searchText, userAdminTeams }: AppCar
     const observer = new ResizeObserver(checkTruncation);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [app.description, checkTruncation]);
+  }, [app.description, checkTruncation, isDescriptionTruncated]);
 
   const handleAppInstall = () => {
     posthog.capture("app_install_button_clicked", {

--- a/apps/web/modules/apps/components/AppCard.tsx
+++ b/apps/web/modules/apps/components/AppCard.tsx
@@ -150,7 +150,8 @@ export function AppCard({ app, credentials, searchText, userAdminTeams }: AppCar
         <Tooltip
           content={markdownToSafeHTML(app.description).replace(/<[^>]+>/g, "")}
           side="bottom"
-          sideOffset={4}>
+          sideOffset={4}
+          className="max-w-xs whitespace-normal text-left font-normal">
           <p ref={descriptionRef} className="text-default mt-2 cursor-pointer text-sm line-clamp-3">
             {markdownToSafeHTML(app.description).replace(/<[^>]+>/g, "")}
           </p>


### PR DESCRIPTION
## Summary
- Adds a tooltip that shows the full app description on hover when the text is truncated by `line-clamp-3`
- Uses `ResizeObserver` to dynamically detect when description text is truncated
- Only shows tooltip when content actually overflows (no unnecessary tooltips for short descriptions)

## Changes
- `apps/web/modules/apps/components/AppCard.tsx`: Add truncation detection with `ResizeObserver` and conditional `Tooltip` wrapper

## Root Cause
App descriptions in the App Store are truncated to 3 lines using CSS `line-clamp-3`, but there was no way to view the full text. This hid content and hurt discoverability — users had no indication that more content was available.

## Fix
1. **Truncation detection**: Use a `ref` on the description paragraph and a `ResizeObserver` to detect when `scrollHeight > clientHeight`
2. **Conditional tooltip**: Only wrap the description in a `Tooltip` when text is actually truncated
3. **Visual feedback**: Add `cursor-pointer` when tooltip is available to indicate interactivity
4. **Performance**: `ResizeObserver` fires only on size changes, and cleanup is handled in the effect's return

## Test plan
- [x] App cards with short descriptions: no tooltip shown
- [x] App cards with long descriptions (3+ lines): tooltip appears on hover showing full text
- [x] Tooltip content matches the full description text (stripped of markdown)
- [x] Resizing the window updates truncation detection correctly
- [x] Biome lint passes — no new warnings

Fixes #25860