### PR TITLE
fix: use outside list-style-position for markdown bullet points

### DIFF
--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -18,11 +18,11 @@ export function markdownToSafeHTML(markdown: string | null) {
   let safeHTMLWithListFormatting = safeHTML
     .replace(
       /<ul>/g,
-      "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
+      "<ul style='list-style-type: disc; list-style-position: outside; padding-left: 24px; margin-bottom: 4px'>"
     )
     .replace(
       /<ol>/g,
-      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
+      "<ol style='list-style-type: decimal; list-style-position: outside; padding-left: 24px; margin-bottom: 4px'>"
     )
     .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
 

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -18,11 +18,11 @@ export function markdownToSafeHTMLClient(markdown: string | null) {
   let safeHTMLWithListFormatting = safeHTML
     .replace(
       /<ul>/g,
-      "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
+      "<ul style='list-style-type: disc; list-style-position: outside; padding-left: 24px; margin-bottom: 4px'>"
     )
     .replace(
       /<ol>/g,
-      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
+      "<ol style='list-style-type: decimal; list-style-position: outside; padding-left: 24px; margin-bottom: 4px'>"
     )
     .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
 


### PR DESCRIPTION
## Summary
- Fix bullet points in event type descriptions going out of format on the booking page
- Change `list-style-position` from `inside` to `outside` and use `padding-left` instead of `margin-left`

## Problem
With `list-style-position: inside`, wrapped text in list items flows under the bullet marker instead of aligning under the text. This causes the second bullet point (and any multi-line list item) to display incorrectly on the booking page.

## Fix
Both `markdownToSafeHTML` (server) and `markdownToSafeHTMLClient` (client) apply inline styles to `<ul>` and `<ol>` tags. Changed:
- `list-style-position: inside` → `outside` — keeps the bullet/number in the margin
- `margin-left: 12px` → `padding-left: 24px` — indents the list content, leaving room for the marker

## Test plan
- [ ] Create an event type with bullet points in the description (e.g. `- Item one\n- Item two`)
- [ ] View the booking page and verify bullets are properly formatted
- [ ] Verify ordered lists (`1. First\n2. Second`) also display correctly
- [ ] Check that nested lists still render properly

Fixes #24366