### PR TITLE
fix: add missing req parameter to exchange calendar getHandler

### DIFF
--- a/packages/app-store/exchange2013calendar/api/add.ts
+++ b/packages/app-store/exchange2013calendar/api/add.ts
@@ -60,7 +60,7 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   return { url: getInstalledAppPath({ variant: "calendar", slug: "exchange2013-calendar" }) };
 }
 
-async function getHandler() {
+async function getHandler(_req: NextApiRequest) {
   return { url: "/apps/exchange2013-calendar/setup" };
 }
 

--- a/packages/app-store/exchange2016calendar/api/add.ts
+++ b/packages/app-store/exchange2016calendar/api/add.ts
@@ -60,7 +60,7 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   return { url: getInstalledAppPath({ variant: "calendar", slug: "exchange2016-calendar" }) };
 }
 
-async function getHandler() {
+async function getHandler(_req: NextApiRequest) {
   return { url: "/apps/exchange2016-calendar/setup" };
 }
 


### PR DESCRIPTION
## Summary
- Add missing `_req: NextApiRequest` parameter to `getHandler` in exchange2013calendar and exchange2016calendar add.ts files

## Problem
The `getHandler` functions were declared without parameters, which is inconsistent with the `defaultResponder` handler signature that passes `(req, res)` to handlers. This causes TypeScript to infer a handler type mismatch and could lead to runtime issues if the handler is ever extended to use the request object.

## Fix
Added `_req: NextApiRequest` parameter to both `getHandler` functions, matching the pattern used by other calendar integrations (e.g., `feishucalendar`, `googlecalendar`).

## Test plan
- [ ] Verify exchange2013calendar add endpoint still redirects to setup page
- [ ] Verify exchange2016calendar add endpoint still redirects to setup page

Fixes #24184
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
