### PR TITLE
fix: improve embedded confirmation screen mobile styles

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -486,7 +486,9 @@ export default function Success(props: PageProps) {
           <div
             className={classNames(
               shouldAlignCentrally ? "text-center" : "",
-              "flex items-end justify-center px-4 pb-20 pt-4 sm:flex sm:p-0"
+              isEmbed
+                ? "flex items-end justify-center p-0 sm:flex sm:p-0"
+                : "flex items-end justify-center px-4 pb-20 pt-4 sm:flex sm:p-0"
             )}>
             <div
               className={classNames(
@@ -496,7 +498,9 @@ export default function Success(props: PageProps) {
               aria-hidden="true">
               <div
                 className={classNames(
-                  "inline-block transform overflow-hidden rounded-lg border sm:my-8 sm:max-w-xl",
+                  isEmbed
+                    ? "block w-full transform overflow-hidden border-0 sm:inline-block sm:rounded-lg sm:border sm:my-8 sm:max-w-xl"
+                    : "inline-block transform overflow-hidden rounded-lg border sm:my-8 sm:max-w-xl",
                   !isBackgroundTransparent &&
                     " bg-default dark:bg-cal-muted border-booker border-booker-width",
                   "px-8 pb-4 pt-5 text-left align-bottom transition-all sm:w-full sm:py-8 sm:align-middle"


### PR DESCRIPTION
## Summary
- Fix the booking confirmation dialog in embedded mode to properly fill the screen on mobile devices

## Problem
The embedded booking confirmation screen appears centered with fixed size, rounded corners, and excess padding on mobile devices. This causes the dialog to look cramped and creates awkward scrolling in mobile webviews (see issue screenshots).

## Fix
Apply mobile-first responsive styles when in embed mode:
- Remove outer container padding on mobile for embeds (`p-0` instead of `px-4 pb-20 pt-4`)
- Use `block w-full` for the dialog on mobile (instead of `inline-block`)
- Remove `rounded-lg` and `border` on mobile for embeds
- Restore `sm:` prefixed styles for larger screens (inline-block, rounded-lg, border, max-w-xl)

Non-embed mode is unchanged.

## Test plan
- [ ] Open an embedded booking link on a mobile viewport (e.g. iPhone XR in Chrome DevTools)
- [ ] Complete a booking and verify the confirmation screen fills the mobile screen properly
- [ ] Verify no rounded corners on mobile in embed mode
- [ ] Verify the dialog still looks correct on desktop/tablet in embed mode
- [ ] Verify non-embedded booking confirmation is unchanged

Fixes #20361