### PR TITLE
feat(bookings): add no-show filter to bookings list (#27720)

### DIFF
--- a/apps/web/modules/bookings/components/BookingListContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingListContainer.tsx
@@ -231,7 +231,7 @@ function BookingListInner({
 
 export function BookingListContainer(props: BookingListContainerProps) {
   const { limit, offset, setPageIndex } = useDataTable();
-  const { eventTypeIds, teamIds, userIds, dateRange, attendeeName, attendeeEmail, bookingUid } =
+  const { eventTypeIds, teamIds, userIds, dateRange, attendeeName, attendeeEmail, bookingUid, noShow } =
     useBookingFilters();
 
   // Build query input once - shared between query and prefetching
@@ -247,6 +247,7 @@ export function BookingListContainer(props: BookingListContainerProps) {
         attendeeName,
         attendeeEmail,
         bookingUid,
+        noShow,
         afterStartDate: dateRange?.startDate
           ? dayjs(dateRange?.startDate).startOf("day").toISOString()
           : undefined,
@@ -263,6 +264,7 @@ export function BookingListContainer(props: BookingListContainerProps) {
       attendeeName,
       attendeeEmail,
       bookingUid,
+      noShow,
       dateRange,
     ]
   );

--- a/apps/web/modules/bookings/hooks/useBookingFilters.ts
+++ b/apps/web/modules/bookings/hooks/useBookingFilters.ts
@@ -3,6 +3,7 @@ import {
   ZMultiSelectFilterValue,
   ZDateRangeFilterValue,
   ZTextFilterValue,
+  ZSingleSelectFilterValue,
 } from "@calcom/features/data-table";
 
 export function useBookingFilters() {
@@ -13,6 +14,8 @@ export function useBookingFilters() {
   const attendeeName = useFilterValue("attendeeName", ZTextFilterValue);
   const attendeeEmail = useFilterValue("attendeeEmail", ZTextFilterValue);
   const bookingUid = useFilterValue("bookingUid", ZTextFilterValue)?.data?.operand as string | undefined;
+  const noShowValue = useFilterValue("noShow", ZSingleSelectFilterValue)?.data;
+  const noShow = noShowValue === "true" ? true : noShowValue === "false" ? false : undefined;
 
   return {
     eventTypeIds,
@@ -22,5 +25,6 @@ export function useBookingFilters() {
     attendeeName,
     attendeeEmail,
     bookingUid,
+    noShow,
   };
 }

--- a/apps/web/modules/bookings/hooks/useBookingListColumns.tsx
+++ b/apps/web/modules/bookings/hooks/useBookingListColumns.tsx
@@ -117,6 +117,18 @@ export function useBookingListColumns({
           },
         },
       }),
+      columnHelper.accessor((row) => row, {
+        id: "noShow",
+        header: t("no_show"),
+        enableColumnFilter: true,
+        enableSorting: false,
+        cell: () => null,
+        meta: {
+          filter: {
+            type: ColumnFilterType.SINGLE_SELECT,
+          },
+        },
+      }),
       columnHelper.display({
         id: "customView",
         cell: (props) => {

--- a/apps/web/modules/bookings/hooks/useFacetedUniqueValues.ts
+++ b/apps/web/modules/bookings/hooks/useFacetedUniqueValues.ts
@@ -55,6 +55,10 @@ export function useFacetedUniqueValues({
               }))
               .filter((option): option is { label: string; value: number } => Boolean(option.label))
           );
+        } else if (columnId === "noShow") {
+          return convertFacetedValuesToMap([
+            { label: "Yes", value: "true" },
+          ]);
         }
         return new Map<FacetedValue, number>();
       },

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -26,6 +26,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.test.ts
@@ -408,3 +408,123 @@ describe("getBookings - PBAC Permission Checks", () => {
     });
   });
 });
+
+describe("getBookings - Filter Logic", () => {
+  const mockUser = {
+    id: 1,
+    email: "user@example.com",
+    orgId: null,
+  };
+
+  const mockPrisma = {
+    user: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    eventType: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    booking: {
+      groupBy: vi.fn().mockResolvedValue([]),
+    },
+    $queryRaw: vi.fn().mockResolvedValue([]),
+  } as unknown as PrismaClient;
+
+  const orSpy = vi.fn();
+  const existsSpy = vi.fn();
+
+  // Mock Expression Builder to capture logic inside .where() callbacks
+  const mockExpressionBuilder = {
+    or: orSpy,
+    exists: existsSpy,
+    // Helper for eb("Booking.noShowHost", "=", true)
+    call: vi.fn(),
+    selectFrom: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    whereRef: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+  };
+  // Make the mock function-like to handle eb("field", "=", value) syntax
+  const mockEbFunc = Object.assign(vi.fn(), mockExpressionBuilder);
+
+
+  const createMockKysely = () => {
+    const mockQueryBuilder = {
+      select: vi.fn().mockReturnThis(),
+      selectAll: vi.fn().mockReturnThis(),
+      where: vi.fn((arg) => {
+        // If argument is a function, execute it with our mock builder to trigger spies
+        if (typeof arg === 'function') {
+          try { arg(mockEbFunc); } catch (e) { }
+        }
+        return mockQueryBuilder;
+      }),
+      innerJoin: vi.fn().mockReturnThis(),
+      union: vi.fn().mockReturnThis(),
+      as: vi.fn().mockReturnThis(),
+      $if: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      offset: vi.fn().mockReturnThis(),
+      compile: vi.fn(() => ({ sql: "SELECT * FROM bookings" })),
+      executeTakeFirst: vi.fn().mockResolvedValue({ bookingCount: 0 }),
+      execute: vi.fn().mockResolvedValue([]),
+    };
+
+    return {
+      selectFrom: vi.fn(() => mockQueryBuilder),
+      executeQuery: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as Kysely<DB>;
+  };
+
+  let mockKysely: Kysely<DB>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKysely = createMockKysely();
+    // Reset permissions mock
+    vi.mocked(PermissionCheckService).mockImplementation(function () {
+      return {
+        getTeamIdsWithPermission: vi.fn().mockResolvedValue([]),
+      } as unknown as PermissionCheckService;
+    });
+  });
+
+  it("should apply no-show filter when enabled", async () => {
+    await getBookings({
+      user: mockUser,
+      prisma: mockPrisma,
+      kysely: mockKysely,
+      bookingListingByStatus: ["upcoming"],
+      filters: {
+        noShow: true,
+      },
+      take: 10,
+      skip: 0,
+    });
+
+    // Verify that .or() was called on the expression builder
+    // This confirms that the noShow filter logic (which wraps conditions in OR) was executed
+    expect(orSpy).toHaveBeenCalled();
+    // Verify that .exists() was called (checking for attendee noShow)
+    expect(existsSpy).toHaveBeenCalled();
+  });
+
+  it("should NOT apply no-show filter when disabled", async () => {
+    await getBookings({
+      user: mockUser,
+      prisma: mockPrisma,
+      kysely: mockKysely,
+      bookingListingByStatus: ["upcoming"],
+      filters: {
+        noShow: undefined, // disabled
+      },
+      take: 10,
+      skip: 0,
+    });
+
+    // Verify that .or() was NOT called
+    expect(orSpy).not.toHaveBeenCalled();
+    expect(existsSpy).not.toHaveBeenCalled();
+  });
+});
+

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -399,6 +399,22 @@ export async function getBookings({
       fullQuery = fullQuery.where("Booking.endTime", "<=", dayjs.utc(filters.beforeEndDate).toDate());
     }
 
+    // 8. Filter by No Show (if provided)
+    if (filters?.noShow) {
+      fullQuery = fullQuery.where((eb) =>
+        eb.or([
+          eb("Booking.noShowHost", "=", true),
+          eb.exists(
+            eb
+              .selectFrom("Attendee")
+              .select("Attendee.id")
+              .whereRef("Attendee.bookingId", "=", "Booking.id")
+              .where("Attendee.noShow", "=", true)
+          ),
+        ])
+      );
+    }
+
     return fullQuery;
   });
 
@@ -443,209 +459,209 @@ export async function getBookings({
 
   const plainBookings = !(bookingsFromUnion?.length === 0)
     ? await kysely
-        .selectFrom("Booking")
-        .where(
-          "id",
-          "in",
-          bookingsFromUnion.map((booking) => booking.id)
-        )
-        .select((eb) => [
-          "Booking.id",
-          "Booking.title",
-          "Booking.userPrimaryEmail",
-          "Booking.description",
-          "Booking.customInputs",
-          "Booking.startTime",
-          "Booking.createdAt",
-          "Booking.updatedAt",
-          "Booking.endTime",
-          "Booking.metadata",
-          "Booking.uid",
+      .selectFrom("Booking")
+      .where(
+        "id",
+        "in",
+        bookingsFromUnion.map((booking) => booking.id)
+      )
+      .select((eb) => [
+        "Booking.id",
+        "Booking.title",
+        "Booking.userPrimaryEmail",
+        "Booking.description",
+        "Booking.customInputs",
+        "Booking.startTime",
+        "Booking.createdAt",
+        "Booking.updatedAt",
+        "Booking.endTime",
+        "Booking.metadata",
+        "Booking.uid",
+        eb
+          .cast<Prisma.JsonValue>(
+            // Target TypeScript type
+            eb.ref("Booking.responses"), // Source column
+            "jsonb" // Target SQL type
+          )
+          .as("responses"),
+        "Booking.recurringEventId",
+        "Booking.location",
+        eb
+          .cast<BookingStatus>(
+            eb
+              .case()
+              .when("Booking.status", "=", "cancelled")
+              .then(BookingStatus.CANCELLED)
+              .when("Booking.status", "=", "accepted")
+              .then(BookingStatus.ACCEPTED)
+              .when("Booking.status", "=", "rejected")
+              .then(BookingStatus.REJECTED)
+              .when("Booking.status", "=", "pending")
+              .then(BookingStatus.PENDING)
+              .when("Booking.status", "=", "awaiting_host")
+              .then(BookingStatus.AWAITING_HOST)
+              .else(BookingStatus.PENDING)
+              .end(), // End of CASE expression
+            "varchar"
+          )
+          .as("status"),
+        "Booking.paid",
+        "Booking.fromReschedule",
+        "Booking.rescheduled",
+        "Booking.rescheduledBy",
+        "Booking.cancelledBy",
+        "Booking.isRecorded",
+        "Booking.cancellationReason",
+        "Booking.rejectionReason",
+        jsonObjectFrom(
           eb
-            .cast<Prisma.JsonValue>(
-              // Target TypeScript type
-              eb.ref("Booking.responses"), // Source column
-              "jsonb" // Target SQL type
-            )
-            .as("responses"),
-          "Booking.recurringEventId",
-          "Booking.location",
+            .selectFrom("App_RoutingForms_FormResponse")
+            .select("id")
+            .whereRef("App_RoutingForms_FormResponse.routedToBookingUid", "=", "Booking.uid")
+        ).as("routedFromRoutingFormReponse"),
+        jsonObjectFrom(
           eb
-            .cast<BookingStatus>(
+            .selectFrom("EventType")
+            .select((eb) => [
+              "EventType.slug",
+              "EventType.id",
+              "EventType.title",
+              "EventType.eventName",
+              "EventType.price",
+              "EventType.recurringEvent",
+              "EventType.currency",
+              "EventType.metadata",
+              "EventType.disableGuests",
+              "EventType.bookingFields",
+              "EventType.seatsPerTimeSlot",
+              "EventType.seatsShowAttendees",
+              "EventType.seatsShowAvailabilityCount",
+              "EventType.eventTypeColor",
+              "EventType.customReplyToEmail",
+              "EventType.allowReschedulingPastBookings",
+              "EventType.hideOrganizerEmail",
+              "EventType.disableCancelling",
+              "EventType.disableRescheduling",
+              "EventType.minimumRescheduleNotice",
+              "EventType.teamId",
+              "EventType.parentId",
               eb
-                .case()
-                .when("Booking.status", "=", "cancelled")
-                .then(BookingStatus.CANCELLED)
-                .when("Booking.status", "=", "accepted")
-                .then(BookingStatus.ACCEPTED)
-                .when("Booking.status", "=", "rejected")
-                .then(BookingStatus.REJECTED)
-                .when("Booking.status", "=", "pending")
-                .then(BookingStatus.PENDING)
-                .when("Booking.status", "=", "awaiting_host")
-                .then(BookingStatus.AWAITING_HOST)
-                .else(BookingStatus.PENDING)
-                .end(), // End of CASE expression
-              "varchar"
-            )
-            .as("status"),
-          "Booking.paid",
-          "Booking.fromReschedule",
-          "Booking.rescheduled",
-          "Booking.rescheduledBy",
-          "Booking.cancelledBy",
-          "Booking.isRecorded",
-          "Booking.cancellationReason",
-          "Booking.rejectionReason",
-          jsonObjectFrom(
-            eb
-              .selectFrom("App_RoutingForms_FormResponse")
-              .select("id")
-              .whereRef("App_RoutingForms_FormResponse.routedToBookingUid", "=", "Booking.uid")
-          ).as("routedFromRoutingFormReponse"),
-          jsonObjectFrom(
-            eb
-              .selectFrom("EventType")
-              .select((eb) => [
-                "EventType.slug",
-                "EventType.id",
-                "EventType.title",
-                "EventType.eventName",
-                "EventType.price",
-                "EventType.recurringEvent",
-                "EventType.currency",
-                "EventType.metadata",
-                "EventType.disableGuests",
-                "EventType.bookingFields",
-                "EventType.seatsPerTimeSlot",
-                "EventType.seatsShowAttendees",
-                "EventType.seatsShowAvailabilityCount",
-                "EventType.eventTypeColor",
-                "EventType.customReplyToEmail",
-                "EventType.allowReschedulingPastBookings",
-                "EventType.hideOrganizerEmail",
-                "EventType.disableCancelling",
-                "EventType.disableRescheduling",
-                "EventType.minimumRescheduleNotice",
-                "EventType.teamId",
-                "EventType.parentId",
+                .cast<SchedulingType | null>(
+                  eb
+                    .case()
+                    .when("EventType.schedulingType", "=", "roundRobin")
+                    .then(SchedulingType.ROUND_ROBIN)
+                    .when("EventType.schedulingType", "=", "collective")
+                    .then(SchedulingType.COLLECTIVE)
+                    .when("EventType.schedulingType", "=", "managed")
+                    .then(SchedulingType.MANAGED)
+                    .else(null)
+                    .end(),
+                  "varchar" // Or 'text' - use the actual SQL data type
+                )
+                .as("schedulingType"),
+              jsonArrayFrom(
                 eb
-                  .cast<SchedulingType | null>(
-                    eb
-                      .case()
-                      .when("EventType.schedulingType", "=", "roundRobin")
-                      .then(SchedulingType.ROUND_ROBIN)
-                      .when("EventType.schedulingType", "=", "collective")
-                      .then(SchedulingType.COLLECTIVE)
-                      .when("EventType.schedulingType", "=", "managed")
-                      .then(SchedulingType.MANAGED)
-                      .else(null)
-                      .end(),
-                    "varchar" // Or 'text' - use the actual SQL data type
-                  )
-                  .as("schedulingType"),
-                jsonArrayFrom(
-                  eb
-                    .selectFrom("Host")
-                    .select((eb) => [
-                      "Host.userId",
-                      jsonObjectFrom(
-                        eb
-                          .selectFrom("users")
-                          .select(["users.id", "users.email"])
-                          .whereRef("Host.userId", "=", "users.id")
-                      ).as("user"),
-                    ])
-                    .whereRef("Host.eventTypeId", "=", "EventType.id")
-                ).as("hosts"),
-                "EventType.length",
-                jsonObjectFrom(
-                  eb
-                    .selectFrom("Team")
-                    .select(["Team.id", "Team.name", "Team.slug"])
-                    .whereRef("EventType.teamId", "=", "Team.id")
-                ).as("team"),
-                jsonArrayFrom(
-                  eb
-                    .selectFrom("HostGroup")
-                    .select(["HostGroup.id", "HostGroup.name"])
-                    .whereRef("HostGroup.eventTypeId", "=", "EventType.id")
-                ).as("hostGroups"),
-              ])
-              .whereRef("EventType.id", "=", "Booking.eventTypeId")
-          ).as("eventType"),
-          jsonArrayFrom(
-            eb
-              .selectFrom("BookingReference")
-              .selectAll()
-              .whereRef("BookingReference.bookingId", "=", "Booking.id")
-          ).as("references"),
-          jsonArrayFrom(
-            eb
-              .selectFrom("Payment")
-              .select([
-                "Payment.paymentOption",
-                "Payment.amount",
-                "Payment.currency",
-                "Payment.success",
-                "Payment.appId",
-                "Payment.refunded",
-              ])
-              .whereRef("Payment.bookingId", "=", "Booking.id")
-          ).as("payment"),
-          jsonObjectFrom(
-            eb
-              .selectFrom("users")
-              .select([
-                "users.id",
-                "users.name",
-                "users.email",
-                "users.avatarUrl",
-                "users.username",
-                "users.timeZone",
-              ])
-              .whereRef("Booking.userId", "=", "users.id")
-          ).as("user"),
-          jsonArrayFrom(
-            eb.selectFrom("Attendee").selectAll().whereRef("Attendee.bookingId", "=", "Booking.id")
-          ).as("attendees"),
-          jsonArrayFrom(
-            eb
-              .selectFrom("BookingSeat")
-              .select((eb) => [
-                "BookingSeat.referenceUid",
-                jsonObjectFrom(
-                  eb
-                    .selectFrom("Attendee")
-                    .select(["Attendee.email"])
-                    .whereRef("BookingSeat.attendeeId", "=", "Attendee.id")
-                ).as("attendee"),
-              ])
-              .whereRef("BookingSeat.bookingId", "=", "Booking.id")
-          ).as("seatsReferences"),
-          jsonArrayFrom(
-            eb
-              .selectFrom("AssignmentReason")
-              .selectAll()
-              .whereRef("AssignmentReason.bookingId", "=", "Booking.id")
-              .orderBy("AssignmentReason.createdAt", "desc")
-              .limit(1)
-          ).as("assignmentReason"),
-          jsonObjectFrom(
-            eb
-              .selectFrom("BookingReport")
-              .select([
-                "BookingReport.id",
-                "BookingReport.reportedById",
-                "BookingReport.reason",
-                "BookingReport.description",
-                "BookingReport.createdAt",
-              ])
-              .whereRef("BookingReport.bookingUid", "=", "Booking.uid")
-          ).as("report"),
-        ])
-        .orderBy(orderBy.key, orderBy.order)
-        .execute()
+                  .selectFrom("Host")
+                  .select((eb) => [
+                    "Host.userId",
+                    jsonObjectFrom(
+                      eb
+                        .selectFrom("users")
+                        .select(["users.id", "users.email"])
+                        .whereRef("Host.userId", "=", "users.id")
+                    ).as("user"),
+                  ])
+                  .whereRef("Host.eventTypeId", "=", "EventType.id")
+              ).as("hosts"),
+              "EventType.length",
+              jsonObjectFrom(
+                eb
+                  .selectFrom("Team")
+                  .select(["Team.id", "Team.name", "Team.slug"])
+                  .whereRef("EventType.teamId", "=", "Team.id")
+              ).as("team"),
+              jsonArrayFrom(
+                eb
+                  .selectFrom("HostGroup")
+                  .select(["HostGroup.id", "HostGroup.name"])
+                  .whereRef("HostGroup.eventTypeId", "=", "EventType.id")
+              ).as("hostGroups"),
+            ])
+            .whereRef("EventType.id", "=", "Booking.eventTypeId")
+        ).as("eventType"),
+        jsonArrayFrom(
+          eb
+            .selectFrom("BookingReference")
+            .selectAll()
+            .whereRef("BookingReference.bookingId", "=", "Booking.id")
+        ).as("references"),
+        jsonArrayFrom(
+          eb
+            .selectFrom("Payment")
+            .select([
+              "Payment.paymentOption",
+              "Payment.amount",
+              "Payment.currency",
+              "Payment.success",
+              "Payment.appId",
+              "Payment.refunded",
+            ])
+            .whereRef("Payment.bookingId", "=", "Booking.id")
+        ).as("payment"),
+        jsonObjectFrom(
+          eb
+            .selectFrom("users")
+            .select([
+              "users.id",
+              "users.name",
+              "users.email",
+              "users.avatarUrl",
+              "users.username",
+              "users.timeZone",
+            ])
+            .whereRef("Booking.userId", "=", "users.id")
+        ).as("user"),
+        jsonArrayFrom(
+          eb.selectFrom("Attendee").selectAll().whereRef("Attendee.bookingId", "=", "Booking.id")
+        ).as("attendees"),
+        jsonArrayFrom(
+          eb
+            .selectFrom("BookingSeat")
+            .select((eb) => [
+              "BookingSeat.referenceUid",
+              jsonObjectFrom(
+                eb
+                  .selectFrom("Attendee")
+                  .select(["Attendee.email"])
+                  .whereRef("BookingSeat.attendeeId", "=", "Attendee.id")
+              ).as("attendee"),
+            ])
+            .whereRef("BookingSeat.bookingId", "=", "Booking.id")
+        ).as("seatsReferences"),
+        jsonArrayFrom(
+          eb
+            .selectFrom("AssignmentReason")
+            .selectAll()
+            .whereRef("AssignmentReason.bookingId", "=", "Booking.id")
+            .orderBy("AssignmentReason.createdAt", "desc")
+            .limit(1)
+        ).as("assignmentReason"),
+        jsonObjectFrom(
+          eb
+            .selectFrom("BookingReport")
+            .select([
+              "BookingReport.id",
+              "BookingReport.reportedById",
+              "BookingReport.reason",
+              "BookingReport.description",
+              "BookingReport.createdAt",
+            ])
+            .whereRef("BookingReport.bookingUid", "=", "Booking.uid")
+        ).as("report"),
+      ])
+      .orderBy(orderBy.key, orderBy.order)
+      .execute()
     : [];
 
   const [
@@ -826,11 +842,11 @@ async function enrichAttendeesWithUserData<
   const enrichedAttendees =
     uniqueAttendeeIds.length > 0
       ? await kysely
-          .selectFrom("Attendee")
-          .leftJoin("users", "users.email", "Attendee.email")
-          .select(["Attendee.id", "users.name", "Attendee.email", "users.avatarUrl", "users.username"])
-          .where("Attendee.id", "in", uniqueAttendeeIds)
-          .execute()
+        .selectFrom("Attendee")
+        .leftJoin("users", "users.email", "Attendee.email")
+        .select(["Attendee.id", "users.name", "Attendee.email", "users.avatarUrl", "users.username"])
+        .where("Attendee.id", "in", uniqueAttendeeIds)
+        .execute()
       : [];
 
   // Create a lookup map for O(1) access by attendee ID

--- a/packages/trpc/server/routers/viewer/bookings/get.schema.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.schema.ts
@@ -20,6 +20,7 @@ type TGetInputSchemaFilters = {
   beforeUpdatedDate?: string;
   afterCreatedDate?: string;
   beforeCreatedDate?: string;
+  noShow?: boolean;
 };
 
 type TGetInputSchemaSort = {
@@ -59,6 +60,7 @@ export const ZGetInputSchema: z.ZodType<TGetInputSchema, z.ZodTypeDef, TGetInput
     beforeUpdatedDate: z.string().optional(),
     afterCreatedDate: z.string().optional(),
     beforeCreatedDate: z.string().optional(),
+    noShow: z.boolean().optional(),
   }),
   limit: z.number().min(1).max(100),
   offset: z.number().default(0),


### PR DESCRIPTION
## What does this PR do?

Adds a 'No Show' filter to the bookings list, allowing users to filter bookings where either the host or any attendee was marked as no-show.

### Changes:

**Backend:**
- Updated get.schema.ts to add 
oShow?: boolean filter parameter
- Updated get.handler.ts to filter bookings where Booking.noShowHost = true OR any Attendee.noShow = true

**Frontend:**
- Updated useBookingListColumns.tsx to add 
oShow column with single-select filter
- Updated useBookingFilters.ts to extract the 
oShow filter value
- Updated BookingListContainer.tsx to pass 
oShow filter to the backend query

Fixes #27720