### PR TITLE
fix: resolve flaky no-show-updated-action integration test

### DIFF
--- a/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
@@ -1,19 +1,18 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
-
 import type { BookingStatus } from "@calcom/prisma/enums";
-import type { BookingAuditTaskConsumer } from "../BookingAuditTaskConsumer";
-import type { BookingAuditViewerService } from "../BookingAuditViewerService";
-import { makeUserActor } from "../../makeActor";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBookingAuditTaskConsumer } from "../../../di/BookingAuditTaskConsumer.container";
 import { getBookingAuditViewerService } from "../../../di/BookingAuditViewerService.container";
+import { makeUserActor } from "../../makeActor";
+import type { BookingAuditTaskConsumer } from "../BookingAuditTaskConsumer";
+import type { BookingAuditViewerService } from "../BookingAuditViewerService";
 import {
-  createTestUser,
-  createTestOrganization,
-  createTestMembership,
-  createTestEventType,
-  createTestBooking,
-  enableFeatureForOrganization,
   cleanupTestData,
+  createTestBooking,
+  createTestEventType,
+  createTestMembership,
+  createTestOrganization,
+  createTestUser,
+  enableFeatureForOrganization,
 } from "./integration-utils";
 
 describe("No-Show Updated Action Integration", () => {
@@ -25,9 +24,10 @@ describe("No-Show Updated Action Integration", () => {
     attendee: { id: number; email: string };
     organization: { id: number };
     eventType: { id: number };
-    booking: { uid: string; startTime: Date; endTime: Date; status: BookingStatus };
-    attendeeIds: number[];
+    booking: { id: number; uid: string; startTime: Date; endTime: Date; status: BookingStatus };
   };
+
+  const additionalAttendeeEmails: string[] = [];
 
   beforeEach(async () => {
     bookingAuditTaskConsumer = getBookingAuditTaskConsumer();
@@ -50,25 +50,18 @@ describe("No-Show Updated Action Integration", () => {
       ],
     });
 
-    // Get the attendee IDs from the booking
-    const { prisma } = await import("@calcom/prisma");
-    const bookingWithAttendees = await prisma.booking.findUnique({
-      where: { uid: booking.uid },
-      include: { attendees: true },
-    });
-
     testData = {
       owner: { id: owner.id, uuid: owner.uuid, email: owner.email },
       attendee: { id: attendee.id, email: attendee.email },
       organization: { id: organization.id },
       eventType: { id: eventType.id },
       booking: {
+        id: booking.id,
         uid: booking.uid,
         startTime: booking.startTime,
         endTime: booking.endTime,
         status: booking.status,
       },
-      attendeeIds: bookingWithAttendees?.attendees.map((a) => a.id) || [],
     };
   });
 
@@ -78,12 +71,16 @@ describe("No-Show Updated Action Integration", () => {
     await cleanupTestData({
       bookingUid: testData.booking?.uid,
       userUuids: testData.owner?.uuid ? [testData.owner.uuid] : [],
-      attendeeEmails: testData.attendee?.email ? [testData.attendee.email] : [],
+      attendeeEmails: [
+        ...(testData.attendee?.email ? [testData.attendee.email] : []),
+        ...additionalAttendeeEmails,
+      ],
       eventTypeId: testData.eventType?.id,
       organizationId: testData.organization?.id,
       userIds: [testData.owner?.id, testData.attendee?.id].filter((id): id is number => id !== undefined),
       featureSlug: "booking-audit",
     });
+    additionalAttendeeEmails.length = 0;
   });
 
   describe("when host is marked as no-show", () => {
@@ -133,9 +130,7 @@ describe("No-Show Updated Action Integration", () => {
     it("should create audit record with attendeesNoShow array", async () => {
       const actor = makeUserActor(testData.owner.uuid);
 
-      const attendeesNoShow = [
-        { attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } },
-      ];
+      const attendeesNoShow = [{ attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } }];
 
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
@@ -179,15 +174,15 @@ describe("No-Show Updated Action Integration", () => {
     });
 
     it("should handle multiple attendees marked as no-show", async () => {
-      // Create a second attendee for this test
       const { prisma } = await import("@calcom/prisma");
       const secondAttendeeEmail = `second-attendee-${Date.now()}@example.com`;
-      const secondAttendee = await prisma.attendee.create({
+      additionalAttendeeEmails.push(secondAttendeeEmail);
+      await prisma.attendee.create({
         data: {
           email: secondAttendeeEmail,
           name: "Second Attendee",
           timeZone: "UTC",
-          bookingId: (await prisma.booking.findUnique({ where: { uid: testData.booking.uid } }))!.id,
+          bookingId: testData.booking.id,
         },
       });
 
@@ -231,9 +226,6 @@ describe("No-Show Updated Action Integration", () => {
       const secondAttendeeData = storedAttendeesNoShow.find((a) => a.attendeeEmail === secondAttendeeEmail);
       expect(firstAttendee?.noShow).toEqual({ old: null, new: true });
       expect(secondAttendeeData?.noShow).toEqual({ old: false, new: true });
-
-      // Cleanup the second attendee
-      await prisma.attendee.delete({ where: { id: secondAttendee.id } });
     });
   });
 
@@ -252,9 +244,7 @@ describe("No-Show Updated Action Integration", () => {
             userUuid: testData.owner.uuid,
             noShow: { old: null, new: true },
           },
-          attendeesNoShow: [
-            { attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } },
-          ],
+          attendeesNoShow: [{ attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } }],
         },
         timestamp: Date.now(),
       });
@@ -293,9 +283,7 @@ describe("No-Show Updated Action Integration", () => {
       const actor = makeUserActor(testData.owner.uuid);
 
       const dataWithArrayFormat = {
-        attendeesNoShow: [
-          { attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } },
-        ],
+        attendeesNoShow: [{ attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } }],
       };
 
       await bookingAuditTaskConsumer.onBookingAction({


### PR DESCRIPTION
## What does this PR do?

Fixes the flaky `no-show-updated-action.integration-test.ts` that was failing intermittently across unrelated PRs (#27546, #26792, #27664) due to fragile inline Prisma operations and improper cleanup of dynamically created test data.

### Root cause

This was the **only** booking-audit integration test that performed raw Prisma queries inside the test body. When integration tests run in parallel against a shared Postgres database, cascade deletes from other test files' cleanup (`User → Booking → Attendee`) could remove this test's data mid-execution, causing:

- `PrismaClientKnownRequestError (P2025)` — `prisma.attendee.delete` on an already-gone record
- `BookingAuditPermissionError: BOOKING_NOT_FOUND` — `prisma.booking.findUnique` returning null after cascade

### Changes

1. **Removed unnecessary `prisma.booking.findUnique`** from `beforeEach` — it populated `attendeeIds` which was never read by any test
2. **Stored `booking.id` in `testData`** — eliminates the need to re-query the booking mid-test to get its ID
3. **Replaced fragile `prisma.attendee.delete`** (throws on missing) with proper `afterEach` cleanup via `cleanupTestData` (uses `deleteMany`, no-throw)
4. **Added `additionalAttendeeEmails` tracking** — second attendee created in "multiple attendees" test is now properly cleaned up via the shared `afterEach`, following the same pattern as `accepted-action.integration-test.ts`

## How should this be tested?

Run all integration tests multiple times to verify the no-show test no longer flakes:

```bash
TZ=UTC VITEST_MODE=integration yarn test
```

Locally verified with **4 consecutive runs** — the no-show test passed all 4 times. (Other pre-existing flaky tests like `managedEventManualReassignment` still fail intermittently, unrelated to this change.)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — test-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Review checklist for humans

- [ ] Verify that `attendeeIds` was truly unused — it was populated but never referenced in any assertion
- [ ] Confirm `booking.id` is available from `createTestBooking` return value (it calls `prisma.booking.create` which returns all scalar fields)
- [ ] Note: import reordering and single-line array formatting are auto-applied by biome — no logic changes

---

> **Link to Devin run**: https://app.devin.ai/sessions/1effb12fa2904b36a152dc3560f16eaf
> **Requested by**: @hariombalhara
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
