### PR TITLE
debug: add logging to no-show integration test to find root cause of flaky CI failure

### DIFF
--- a/packages/features/booking-audit/lib/service/__tests__/integration-utils.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/integration-utils.ts
@@ -115,11 +115,6 @@ export const enableFeatureForOrganization = async (organizationId: number, featu
   });
 };
 
-function cleanupLog(step: string, detail?: string) {
-  const ts = new Date().toISOString();
-  process.stderr.write(`[CLEANUP][pid:${process.pid}][${ts}] ${step}${detail ? ` | ${detail}` : ""}\n`);
-}
-
 export const cleanupTestData = async (testData: {
   bookingUid?: string;
   userUuids?: string[];
@@ -129,17 +124,13 @@ export const cleanupTestData = async (testData: {
   userIds?: number[];
   featureSlug?: string;
 }) => {
-  cleanupLog("START", `bookingUid=${testData.bookingUid} userIds=${JSON.stringify(testData.userIds)}`);
-
   if (testData.bookingUid) {
-    cleanupLog("deleting bookingAudit", testData.bookingUid);
     await prisma.bookingAudit.deleteMany({
       where: { bookingUid: testData.bookingUid },
     });
   }
 
   if (testData.userUuids?.length || testData.attendeeEmails?.length) {
-    cleanupLog("deleting auditActor", `uuids=${JSON.stringify(testData.userUuids)} emails=${JSON.stringify(testData.attendeeEmails)}`);
     await prisma.auditActor.deleteMany({
       where: {
         OR: [
@@ -151,21 +142,18 @@ export const cleanupTestData = async (testData: {
   }
 
   if (testData.attendeeEmails?.length) {
-    cleanupLog("deleting attendees", JSON.stringify(testData.attendeeEmails));
     await prisma.attendee.deleteMany({
       where: { email: { in: testData.attendeeEmails } },
     });
   }
 
   if (testData.bookingUid) {
-    cleanupLog("deleting booking", testData.bookingUid);
     await prisma.booking.deleteMany({
       where: { uid: testData.bookingUid },
     });
   }
 
   if (testData.eventTypeId) {
-    cleanupLog("deleting eventType", String(testData.eventTypeId));
     await prisma.eventType.deleteMany({
       where: { id: testData.eventTypeId },
     });
@@ -173,7 +161,6 @@ export const cleanupTestData = async (testData: {
 
   if (testData.organizationId) {
     if (testData.featureSlug) {
-      cleanupLog("deleting teamFeatures", `orgId=${testData.organizationId} feature=${testData.featureSlug}`);
       await prisma.teamFeatures.deleteMany({
         where: {
           teamId: testData.organizationId,
@@ -181,22 +168,17 @@ export const cleanupTestData = async (testData: {
         },
       });
     }
-    cleanupLog("deleting membership", `orgId=${testData.organizationId}`);
     await prisma.membership.deleteMany({
       where: { teamId: testData.organizationId },
     });
-    cleanupLog("deleting team", `orgId=${testData.organizationId}`);
     await prisma.team.deleteMany({
       where: { id: testData.organizationId },
     });
   }
 
   if (testData.userIds?.length) {
-    cleanupLog("deleting users", JSON.stringify(testData.userIds));
     await prisma.user.deleteMany({
       where: { id: { in: testData.userIds } },
     });
   }
-
-  cleanupLog("END", `bookingUid=${testData.bookingUid}`);
 };

--- a/packages/features/booking-audit/lib/service/__tests__/integration-utils.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/integration-utils.ts
@@ -159,8 +159,6 @@ export const cleanupTestData = async (testData: {
 
   if (testData.bookingUid) {
     cleanupLog("deleting booking", testData.bookingUid);
-    const bookingBefore = await prisma.booking.findFirst({ where: { uid: testData.bookingUid }, select: { id: true, uid: true } });
-    cleanupLog("booking exists before delete?", JSON.stringify(bookingBefore));
     await prisma.booking.deleteMany({
       where: { uid: testData.bookingUid },
     });
@@ -195,12 +193,6 @@ export const cleanupTestData = async (testData: {
 
   if (testData.userIds?.length) {
     cleanupLog("deleting users", JSON.stringify(testData.userIds));
-    for (const uid of testData.userIds) {
-      const userBookings = await prisma.booking.findMany({ where: { userId: uid }, select: { id: true, uid: true } });
-      if (userBookings.length > 0) {
-        cleanupLog(`user ${uid} still has bookings at delete time`, JSON.stringify(userBookings));
-      }
-    }
     await prisma.user.deleteMany({
       where: { id: { in: testData.userIds } },
     });

--- a/packages/features/booking-audit/lib/service/__tests__/integration-utils.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/integration-utils.ts
@@ -117,7 +117,7 @@ export const enableFeatureForOrganization = async (organizationId: number, featu
 
 function cleanupLog(step: string, detail?: string) {
   const ts = new Date().toISOString();
-  console.log(`[CLEANUP][pid:${process.pid}][${ts}] ${step}${detail ? ` | ${detail}` : ""}`);
+  process.stderr.write(`[CLEANUP][pid:${process.pid}][${ts}] ${step}${detail ? ` | ${detail}` : ""}\n`);
 }
 
 export const cleanupTestData = async (testData: {

--- a/packages/features/booking-audit/lib/service/__tests__/integration-utils.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/integration-utils.ts
@@ -115,6 +115,11 @@ export const enableFeatureForOrganization = async (organizationId: number, featu
   });
 };
 
+function cleanupLog(step: string, detail?: string) {
+  const ts = new Date().toISOString();
+  console.log(`[CLEANUP][pid:${process.pid}][${ts}] ${step}${detail ? ` | ${detail}` : ""}`);
+}
+
 export const cleanupTestData = async (testData: {
   bookingUid?: string;
   userUuids?: string[];
@@ -124,13 +129,17 @@ export const cleanupTestData = async (testData: {
   userIds?: number[];
   featureSlug?: string;
 }) => {
+  cleanupLog("START", `bookingUid=${testData.bookingUid} userIds=${JSON.stringify(testData.userIds)}`);
+
   if (testData.bookingUid) {
+    cleanupLog("deleting bookingAudit", testData.bookingUid);
     await prisma.bookingAudit.deleteMany({
       where: { bookingUid: testData.bookingUid },
     });
   }
 
   if (testData.userUuids?.length || testData.attendeeEmails?.length) {
+    cleanupLog("deleting auditActor", `uuids=${JSON.stringify(testData.userUuids)} emails=${JSON.stringify(testData.attendeeEmails)}`);
     await prisma.auditActor.deleteMany({
       where: {
         OR: [
@@ -142,18 +151,23 @@ export const cleanupTestData = async (testData: {
   }
 
   if (testData.attendeeEmails?.length) {
+    cleanupLog("deleting attendees", JSON.stringify(testData.attendeeEmails));
     await prisma.attendee.deleteMany({
       where: { email: { in: testData.attendeeEmails } },
     });
   }
 
   if (testData.bookingUid) {
+    cleanupLog("deleting booking", testData.bookingUid);
+    const bookingBefore = await prisma.booking.findFirst({ where: { uid: testData.bookingUid }, select: { id: true, uid: true } });
+    cleanupLog("booking exists before delete?", JSON.stringify(bookingBefore));
     await prisma.booking.deleteMany({
       where: { uid: testData.bookingUid },
     });
   }
 
   if (testData.eventTypeId) {
+    cleanupLog("deleting eventType", String(testData.eventTypeId));
     await prisma.eventType.deleteMany({
       where: { id: testData.eventTypeId },
     });
@@ -161,6 +175,7 @@ export const cleanupTestData = async (testData: {
 
   if (testData.organizationId) {
     if (testData.featureSlug) {
+      cleanupLog("deleting teamFeatures", `orgId=${testData.organizationId} feature=${testData.featureSlug}`);
       await prisma.teamFeatures.deleteMany({
         where: {
           teamId: testData.organizationId,
@@ -168,17 +183,28 @@ export const cleanupTestData = async (testData: {
         },
       });
     }
+    cleanupLog("deleting membership", `orgId=${testData.organizationId}`);
     await prisma.membership.deleteMany({
       where: { teamId: testData.organizationId },
     });
+    cleanupLog("deleting team", `orgId=${testData.organizationId}`);
     await prisma.team.deleteMany({
       where: { id: testData.organizationId },
     });
   }
 
   if (testData.userIds?.length) {
+    cleanupLog("deleting users", JSON.stringify(testData.userIds));
+    for (const uid of testData.userIds) {
+      const userBookings = await prisma.booking.findMany({ where: { userId: uid }, select: { id: true, uid: true } });
+      if (userBookings.length > 0) {
+        cleanupLog(`user ${uid} still has bookings at delete time`, JSON.stringify(userBookings));
+      }
+    }
     await prisma.user.deleteMany({
       where: { id: { in: testData.userIds } },
     });
   }
+
+  cleanupLog("END", `bookingUid=${testData.bookingUid}`);
 };

--- a/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@calcom/prisma";
 import type { BookingStatus } from "@calcom/prisma/enums";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBookingAuditTaskConsumer } from "../../../di/BookingAuditTaskConsumer.container";
 import { getBookingAuditViewerService } from "../../../di/BookingAuditViewerService.container";
 import { makeUserActor } from "../../makeActor";
@@ -17,135 +17,9 @@ import {
 } from "./integration-utils";
 
 const FILE_ID = `no-show-${process.pid}`;
-const DELETE_LOG_TABLE = `_debug_booking_deletes_${process.pid}`;
 
-function debugLog(testName: string, message: string, data?: Record<string, unknown>) {
-  const timestamp = new Date().toISOString();
-  const dataStr = data ? ` | ${JSON.stringify(data)}` : "";
-  process.stderr.write(`[DEBUG][${FILE_ID}][${timestamp}][${testName}] ${message}${dataStr}\n`);
-}
-
-async function setupDeleteTrigger() {
-  try {
-    await prisma.$executeRawUnsafe(`
-      CREATE TABLE IF NOT EXISTS "${DELETE_LOG_TABLE}" (
-        id SERIAL PRIMARY KEY,
-        deleted_booking_id INTEGER,
-        deleted_booking_uid TEXT,
-        deleted_booking_user_id INTEGER,
-        deleted_at TIMESTAMP DEFAULT NOW(),
-        pg_backend_pid INTEGER DEFAULT pg_backend_pid(),
-        query_text TEXT
-      )
-    `);
-    await prisma.$executeRawUnsafe(`
-      CREATE OR REPLACE FUNCTION log_booking_delete_${process.pid}()
-      RETURNS TRIGGER AS $$
-      BEGIN
-        INSERT INTO "${DELETE_LOG_TABLE}" (deleted_booking_id, deleted_booking_uid, deleted_booking_user_id)
-        VALUES (OLD.id, OLD.uid, OLD."userId");
-        RETURN OLD;
-      END;
-      $$ LANGUAGE plpgsql
-    `);
-    await prisma.$executeRawUnsafe(`
-      DROP TRIGGER IF EXISTS trg_log_booking_delete_${process.pid} ON "Booking"
-    `);
-    await prisma.$executeRawUnsafe(`
-      CREATE TRIGGER trg_log_booking_delete_${process.pid}
-      BEFORE DELETE ON "Booking"
-      FOR EACH ROW
-      EXECUTE FUNCTION log_booking_delete_${process.pid}()
-    `);
-    debugLog("setup", "PostgreSQL delete trigger installed");
-  } catch (err) {
-    debugLog("setup", "Failed to install delete trigger", { error: String(err) });
-  }
-}
-
-async function teardownDeleteTrigger() {
-  try {
-    await prisma.$executeRawUnsafe(`DROP TRIGGER IF EXISTS trg_log_booking_delete_${process.pid} ON "Booking"`);
-    await prisma.$executeRawUnsafe(`DROP FUNCTION IF EXISTS log_booking_delete_${process.pid}()`);
-    await prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS "${DELETE_LOG_TABLE}"`);
-    debugLog("teardown", "PostgreSQL delete trigger removed");
-  } catch (err) {
-    debugLog("teardown", "Failed to remove delete trigger", { error: String(err) });
-  }
-}
-
-async function getDeleteLog(): Promise<unknown[]> {
-  try {
-    const rows = await prisma.$queryRawUnsafe(`SELECT * FROM "${DELETE_LOG_TABLE}" ORDER BY id`);
-    return rows as unknown[];
-  } catch {
-    return [];
-  }
-}
-
-async function checkBookingExists(bookingUid: string, context: string): Promise<boolean> {
-  const booking = await prisma.booking.findFirst({ where: { uid: bookingUid }, select: { id: true, uid: true, userId: true } });
-  const rawResult = await prisma.$queryRawUnsafe(
-    `SELECT id, uid, "userId" FROM "Booking" WHERE uid = $1 LIMIT 1`,
-    bookingUid
-  ) as Array<{ id: number; uid: string; userId: number }>;
-  const exists = booking !== null;
-  const rawExists = rawResult.length > 0;
-  if (exists !== rawExists) {
-    debugLog("verify", `!!! PRISMA/RAW MISMATCH (${context}) !!! prisma=${exists} raw=${rawExists}`, { bookingUid, booking: booking ?? "null", rawResult });
-  }
-  debugLog("verify", `Booking check (${context}): exists=${exists} raw=${rawExists}`, { bookingUid, booking: booking ?? "null" });
-  return exists;
-}
-
-async function checkUserExists(userId: number, context: string): Promise<boolean> {
-  const user = await prisma.user.findFirst({ where: { id: userId }, select: { id: true, email: true } });
-  const exists = user !== null;
-  debugLog("verify", `User check (${context}): exists=${exists}`, { userId, user: user ?? "null" });
-  return exists;
-}
-
-async function getAllBookingsSummary(): Promise<unknown[]> {
-  try {
-    return (await prisma.$queryRawUnsafe(
-      `SELECT id, uid, "userId", status, "createdAt" FROM "Booking" ORDER BY id DESC LIMIT 20`
-    )) as unknown[];
-  } catch { return []; }
-}
-
-async function dumpDiagnostics(testName: string, bookingUid: string, ownerId: number) {
-  debugLog(testName, "!!! BOOKING DISAPPEARED !!! Running full diagnostics...");
-  const ownerExists = await checkUserExists(ownerId, "disappeared-owner-check");
-  const bookingCount = await prisma.booking.count();
-  const userCount = await prisma.user.count();
-  const allBookings = await getAllBookingsSummary();
-  const auditRecords = await prisma.bookingAudit.findMany({
-    where: { bookingUid },
-    select: { id: true, bookingUid: true, action: true },
-  });
-  const deleteLog = await getDeleteLog();
-  let pgActivity: unknown[] = [];
-  try {
-    pgActivity = (await prisma.$queryRawUnsafe(
-      `SELECT pid, state, query, query_start, backend_start FROM pg_stat_activity WHERE state != 'idle' AND pid != pg_backend_pid() ORDER BY query_start DESC LIMIT 20`
-    )) as unknown[];
-  } catch { /* ignore */ }
-  let pgConnCount: unknown[] = [];
-  try {
-    pgConnCount = (await prisma.$queryRawUnsafe(
-      `SELECT count(*) as total, state FROM pg_stat_activity GROUP BY state`
-    )) as unknown[];
-  } catch { /* ignore */ }
-  debugLog(testName, "DIAGNOSTICS", {
-    ownerExists,
-    totalBookings: bookingCount,
-    totalUsers: userCount,
-    allRecentBookings: allBookings,
-    auditRecordsForBooking: auditRecords,
-    bookingDeleteLog: deleteLog,
-    activePgQueries: pgActivity,
-    pgConnectionCounts: pgConnCount,
-  });
+function debugLog(msg: string) {
+  process.stderr.write(`[${FILE_ID}][${new Date().toISOString()}] ${msg}\n`);
 }
 
 describe("No-Show Updated Action Integration", () => {
@@ -163,48 +37,19 @@ describe("No-Show Updated Action Integration", () => {
   const additionalAttendeeEmails: string[] = [];
   let currentTestName = "unknown";
 
-  beforeAll(async () => {
-    debugLog("beforeAll", "=== SUITE START ===");
-    await setupDeleteTrigger();
-  });
-
-  afterAll(async () => {
-    await teardownDeleteTrigger();
-    debugLog("afterAll", "=== SUITE END ===");
-  });
-
   beforeEach(async () => {
-    debugLog("beforeEach", "=== START beforeEach ===");
-    const beforeEachStartMs = Date.now();
+    debugLog("beforeEach START");
 
     bookingAuditTaskConsumer = getBookingAuditTaskConsumer();
     bookingAuditViewerService = getBookingAuditViewerService();
 
-    debugLog("beforeEach", "Creating owner...");
     const owner = await createTestUser({ name: "Test Host User" });
-    debugLog("beforeEach", "Owner created", { id: owner.id, uuid: owner.uuid, email: owner.email });
-
-    debugLog("beforeEach", "Creating organization...");
     const organization = await createTestOrganization();
-    debugLog("beforeEach", "Organization created", { id: organization.id });
-
-    debugLog("beforeEach", "Creating membership...");
     await createTestMembership(owner.id, organization.id);
-    debugLog("beforeEach", "Membership created");
-
-    debugLog("beforeEach", "Enabling feature...");
     await enableFeatureForOrganization(organization.id, "booking-audit");
-    debugLog("beforeEach", "Feature enabled");
-
-    debugLog("beforeEach", "Creating event type...");
     const eventType = await createTestEventType(owner.id);
-    debugLog("beforeEach", "Event type created", { id: eventType.id });
-
-    debugLog("beforeEach", "Creating attendee user...");
     const attendee = await createTestUser({ name: "Test Attendee" });
-    debugLog("beforeEach", "Attendee user created", { id: attendee.id, email: attendee.email });
 
-    debugLog("beforeEach", "Creating booking...");
     const booking = await createTestBooking(owner.id, eventType.id, {
       attendees: [
         {
@@ -214,7 +59,6 @@ describe("No-Show Updated Action Integration", () => {
         },
       ],
     });
-    debugLog("beforeEach", "Booking created", { id: booking.id, uid: booking.uid, userId: booking.userId });
 
     testData = {
       owner: { id: owner.id, uuid: owner.uuid, email: owner.email },
@@ -230,41 +74,15 @@ describe("No-Show Updated Action Integration", () => {
       },
     };
 
-    await checkBookingExists(booking.uid, "end-of-beforeEach");
-    await checkUserExists(owner.id, "end-of-beforeEach-owner");
-
-    const setupDurationMs = Date.now() - beforeEachStartMs;
-    debugLog("beforeEach", "=== END beforeEach ===", {
-      ownerId: owner.id,
-      bookingUid: booking.uid,
-      bookingId: booking.id,
-      setupDurationMs,
-    });
-
-    debugLog("beforeEach", "Adding deliberate delay to widen race window...");
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    const stillExists = await checkBookingExists(booking.uid, "after-delay");
-    if (!stillExists) {
-      await dumpDiagnostics("beforeEach-post-delay", booking.uid, owner.id);
-    }
-    debugLog("beforeEach", "Delay complete, booking still exists: " + stillExists);
+    debugLog(`beforeEach END | owner=${owner.id} booking=${booking.uid} bookingId=${booking.id}`);
   });
 
   afterEach(async () => {
-    debugLog("afterEach", `=== START afterEach (test: ${currentTestName}) ==="`);
+    debugLog(`afterEach START (${currentTestName})`);
     if (!testData) {
-      debugLog("afterEach", "No testData, skipping cleanup");
+      debugLog("afterEach: no testData, skipping");
       return;
     }
-
-    await checkBookingExists(testData.booking.uid, "start-of-afterEach");
-    await checkUserExists(testData.owner.id, "start-of-afterEach-owner");
-
-    debugLog("afterEach", "Starting cleanup...", {
-      bookingUid: testData.booking?.uid,
-      ownerId: testData.owner?.id,
-      attendeeId: testData.attendee?.id,
-    });
 
     await cleanupTestData({
       bookingUid: testData.booking?.uid,
@@ -279,21 +97,42 @@ describe("No-Show Updated Action Integration", () => {
       featureSlug: "booking-audit",
     });
     additionalAttendeeEmails.length = 0;
-    debugLog("afterEach", `=== END afterEach (test: ${currentTestName}) ==="`);
+    debugLog(`afterEach END (${currentTestName})`);
   });
+
+  async function getAuditLogsWithDiagnostics(bookingUid: string, userId: number, userEmail: string, organizationId: number) {
+    try {
+      return await bookingAuditViewerService.getAuditLogsForBooking({
+        bookingUid,
+        userId,
+        userEmail,
+        userTimeZone: "UTC",
+        organizationId,
+      });
+    } catch (err) {
+      const booking = await prisma.booking.findFirst({ where: { uid: bookingUid }, select: { id: true, uid: true, userId: true } });
+      const owner = await prisma.user.findFirst({ where: { id: userId }, select: { id: true, email: true } });
+      const eventType = await prisma.eventType.findFirst({ where: { userId }, select: { id: true, userId: true } });
+      const membership = await prisma.membership.findFirst({ where: { userId, teamId: organizationId } });
+      const bookingCount = await prisma.booking.count();
+      const userCount = await prisma.user.count();
+      debugLog(`!!! FAILURE (${currentTestName}) !!! error=${err}`);
+      debugLog(`  booking: ${JSON.stringify(booking)}`);
+      debugLog(`  owner: ${JSON.stringify(owner)}`);
+      debugLog(`  eventType: ${JSON.stringify(eventType)}`);
+      debugLog(`  membership: ${JSON.stringify(membership)}`);
+      debugLog(`  counts: bookings=${bookingCount} users=${userCount}`);
+      throw err;
+    }
+  }
 
   describe("when host is marked as no-show", () => {
     it("should create audit record with host field containing userUuid and noShow", async () => {
       currentTestName = "host-no-show";
-      debugLog(currentTestName, "=== TEST START ===");
-
-      const bookingExistsBefore = await checkBookingExists(testData.booking.uid, "test-start");
-      const ownerExistsBefore = await checkUserExists(testData.owner.id, "test-start-owner");
-      debugLog(currentTestName, "Pre-test verification", { bookingExistsBefore, ownerExistsBefore });
+      debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 
       const actor = makeUserActor(testData.owner.uuid);
 
-      debugLog(currentTestName, "Calling onBookingAction...");
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
         actor,
@@ -308,25 +147,10 @@ describe("No-Show Updated Action Integration", () => {
         },
         timestamp: Date.now(),
       });
-      debugLog(currentTestName, "onBookingAction completed");
 
-      const bookingExistsAfterAction = await checkBookingExists(testData.booking.uid, "before-getAuditLogs");
-      const ownerExistsAfterAction = await checkUserExists(testData.owner.id, "before-getAuditLogs-owner");
-      debugLog(currentTestName, "Pre-getAuditLogs verification", { bookingExistsAfterAction, ownerExistsAfterAction });
-
-      if (!bookingExistsAfterAction) {
-        await dumpDiagnostics(currentTestName, testData.booking.uid, testData.owner.id);
-      }
-
-      debugLog(currentTestName, "Calling getAuditLogsForBooking...");
-      const result = await bookingAuditViewerService.getAuditLogsForBooking({
-        bookingUid: testData.booking.uid,
-        userId: testData.owner.id,
-        userEmail: testData.owner.email,
-        userTimeZone: "UTC",
-        organizationId: testData.organization.id,
-      });
-      debugLog(currentTestName, "getAuditLogsForBooking completed", { auditLogCount: result.auditLogs.length });
+      const result = await getAuditLogsWithDiagnostics(
+        testData.booking.uid, testData.owner.id, testData.owner.email, testData.organization.id
+      );
 
       expect(result.bookingUid).toBe(testData.booking.uid);
       expect(result.auditLogs).toHaveLength(1);
@@ -340,22 +164,18 @@ describe("No-Show Updated Action Integration", () => {
       expect(displayData).toBeDefined();
       expect(displayData.hostNoShow).toBe(true);
       expect(displayData.previousHostNoShow).toBe(null);
-      debugLog(currentTestName, "=== TEST END ===");
+      debugLog(`TEST END: ${currentTestName}`);
     });
   });
 
   describe("when attendees are marked as no-show", () => {
     it("should create audit record with attendeesNoShow array", async () => {
       currentTestName = "attendees-no-show";
-      debugLog(currentTestName, "=== TEST START ===");
-
-      const bookingExistsBefore = await checkBookingExists(testData.booking.uid, "test-start");
-      debugLog(currentTestName, "Pre-test verification", { bookingExistsBefore });
+      debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 
       const actor = makeUserActor(testData.owner.uuid);
       const attendeesNoShow = [{ attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } }];
 
-      debugLog(currentTestName, "Calling onBookingAction...");
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
         actor,
@@ -365,24 +185,10 @@ describe("No-Show Updated Action Integration", () => {
         data: { attendeesNoShow },
         timestamp: Date.now(),
       });
-      debugLog(currentTestName, "onBookingAction completed");
 
-      const bookingExistsAfterAction = await checkBookingExists(testData.booking.uid, "before-getAuditLogs");
-      debugLog(currentTestName, "Pre-getAuditLogs verification", { bookingExistsAfterAction });
-
-      if (!bookingExistsAfterAction) {
-        await dumpDiagnostics(currentTestName, testData.booking.uid, testData.owner.id);
-      }
-
-      debugLog(currentTestName, "Calling getAuditLogsForBooking...");
-      const result = await bookingAuditViewerService.getAuditLogsForBooking({
-        bookingUid: testData.booking.uid,
-        userId: testData.owner.id,
-        userEmail: testData.owner.email,
-        userTimeZone: "UTC",
-        organizationId: testData.organization.id,
-      });
-      debugLog(currentTestName, "getAuditLogsForBooking completed");
+      const result = await getAuditLogsWithDiagnostics(
+        testData.booking.uid, testData.owner.id, testData.owner.email, testData.organization.id
+      );
 
       expect(result.bookingUid).toBe(testData.booking.uid);
       expect(result.auditLogs).toHaveLength(1);
@@ -403,21 +209,16 @@ describe("No-Show Updated Action Integration", () => {
       expect(storedAttendeesNoShow[0].attendeeEmail).toBe(testData.attendee.email);
       expect(storedAttendeesNoShow[0].noShow.old).toBe(null);
       expect(storedAttendeesNoShow[0].noShow.new).toBe(true);
-      debugLog(currentTestName, "=== TEST END ===");
+      debugLog(`TEST END: ${currentTestName}`);
     });
 
     it("should handle multiple attendees marked as no-show", async () => {
       currentTestName = "multiple-attendees-no-show";
-      debugLog(currentTestName, "=== TEST START ===");
-
-      const bookingExistsBefore = await checkBookingExists(testData.booking.uid, "test-start");
-      const ownerExistsBefore = await checkUserExists(testData.owner.id, "test-start-owner");
-      debugLog(currentTestName, "Pre-test verification", { bookingExistsBefore, ownerExistsBefore });
+      debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid} bookingId=${testData.booking.id}`);
 
       const secondAttendeeEmail = `second-attendee-${Date.now()}@example.com`;
       additionalAttendeeEmails.push(secondAttendeeEmail);
 
-      debugLog(currentTestName, "Creating second attendee...", { bookingId: testData.booking.id });
       await prisma.attendee.create({
         data: {
           email: secondAttendeeEmail,
@@ -426,10 +227,6 @@ describe("No-Show Updated Action Integration", () => {
           bookingId: testData.booking.id,
         },
       });
-      debugLog(currentTestName, "Second attendee created");
-
-      const bookingExistsAfterAttendee = await checkBookingExists(testData.booking.uid, "after-attendee-create");
-      debugLog(currentTestName, "Post-attendee-create verification", { bookingExistsAfterAttendee });
 
       const actor = makeUserActor(testData.owner.uuid);
       const attendeesNoShow = [
@@ -437,7 +234,6 @@ describe("No-Show Updated Action Integration", () => {
         { attendeeEmail: secondAttendeeEmail, noShow: { old: false, new: true } },
       ];
 
-      debugLog(currentTestName, "Calling onBookingAction...");
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
         actor,
@@ -447,25 +243,10 @@ describe("No-Show Updated Action Integration", () => {
         data: { attendeesNoShow },
         timestamp: Date.now(),
       });
-      debugLog(currentTestName, "onBookingAction completed");
 
-      const bookingExistsAfterAction = await checkBookingExists(testData.booking.uid, "before-getAuditLogs");
-      const ownerExistsAfterAction = await checkUserExists(testData.owner.id, "before-getAuditLogs-owner");
-      debugLog(currentTestName, "Pre-getAuditLogs verification", { bookingExistsAfterAction, ownerExistsAfterAction });
-
-      if (!bookingExistsAfterAction) {
-        await dumpDiagnostics(currentTestName, testData.booking.uid, testData.owner.id);
-      }
-
-      debugLog(currentTestName, "Calling getAuditLogsForBooking...");
-      const result = await bookingAuditViewerService.getAuditLogsForBooking({
-        bookingUid: testData.booking.uid,
-        userId: testData.owner.id,
-        userEmail: testData.owner.email,
-        userTimeZone: "UTC",
-        organizationId: testData.organization.id,
-      });
-      debugLog(currentTestName, "getAuditLogsForBooking completed");
+      const result = await getAuditLogsWithDiagnostics(
+        testData.booking.uid, testData.owner.id, testData.owner.email, testData.organization.id
+      );
 
       expect(result.auditLogs).toHaveLength(1);
 
@@ -480,21 +261,17 @@ describe("No-Show Updated Action Integration", () => {
       const secondAttendeeData = storedAttendeesNoShow.find((a) => a.attendeeEmail === secondAttendeeEmail);
       expect(firstAttendee?.noShow).toEqual({ old: null, new: true });
       expect(secondAttendeeData?.noShow).toEqual({ old: false, new: true });
-      debugLog(currentTestName, "=== TEST END ===");
+      debugLog(`TEST END: ${currentTestName}`);
     });
   });
 
   describe("when both host and attendees are marked as no-show", () => {
     it("should create single audit record with both host and attendeesNoShow fields", async () => {
       currentTestName = "both-host-and-attendees";
-      debugLog(currentTestName, "=== TEST START ===");
-
-      const bookingExistsBefore = await checkBookingExists(testData.booking.uid, "test-start");
-      debugLog(currentTestName, "Pre-test verification", { bookingExistsBefore });
+      debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 
       const actor = makeUserActor(testData.owner.uuid);
 
-      debugLog(currentTestName, "Calling onBookingAction...");
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
         actor,
@@ -510,27 +287,10 @@ describe("No-Show Updated Action Integration", () => {
         },
         timestamp: Date.now(),
       });
-      debugLog(currentTestName, "onBookingAction completed");
 
-      const bookingExistsAfterAction = await checkBookingExists(testData.booking.uid, "before-getAuditLogs");
-      debugLog(currentTestName, "Pre-getAuditLogs verification", { bookingExistsAfterAction });
-
-      if (!bookingExistsAfterAction) {
-        debugLog(currentTestName, "!!! BOOKING DISAPPEARED !!!");
-        const ownerExists = await checkUserExists(testData.owner.id, "booking-disappeared");
-        const bookingCount = await prisma.booking.count();
-        debugLog(currentTestName, "DB state", { ownerExists, totalBookings: bookingCount });
-      }
-
-      debugLog(currentTestName, "Calling getAuditLogsForBooking...");
-      const result = await bookingAuditViewerService.getAuditLogsForBooking({
-        bookingUid: testData.booking.uid,
-        userId: testData.owner.id,
-        userEmail: testData.owner.email,
-        userTimeZone: "UTC",
-        organizationId: testData.organization.id,
-      });
-      debugLog(currentTestName, "getAuditLogsForBooking completed");
+      const result = await getAuditLogsWithDiagnostics(
+        testData.booking.uid, testData.owner.id, testData.owner.email, testData.organization.id
+      );
 
       expect(result.auditLogs).toHaveLength(1);
 
@@ -550,24 +310,20 @@ describe("No-Show Updated Action Integration", () => {
       expect(storedAttendeesNoShow).toHaveLength(1);
       expect(storedAttendeesNoShow[0].attendeeEmail).toBe(testData.attendee.email);
       expect(storedAttendeesNoShow[0].noShow).toEqual({ old: null, new: true });
-      debugLog(currentTestName, "=== TEST END ===");
+      debugLog(`TEST END: ${currentTestName}`);
     });
   });
 
   describe("schema validation with array format", () => {
     it("should accept attendeesNoShow data with array format", async () => {
       currentTestName = "schema-validation";
-      debugLog(currentTestName, "=== TEST START ===");
-
-      const bookingExistsBefore = await checkBookingExists(testData.booking.uid, "test-start");
-      debugLog(currentTestName, "Pre-test verification", { bookingExistsBefore });
+      debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 
       const actor = makeUserActor(testData.owner.uuid);
       const dataWithArrayFormat = {
         attendeesNoShow: [{ attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } }],
       };
 
-      debugLog(currentTestName, "Calling onBookingAction...");
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
         actor,
@@ -577,24 +333,10 @@ describe("No-Show Updated Action Integration", () => {
         data: dataWithArrayFormat,
         timestamp: Date.now(),
       });
-      debugLog(currentTestName, "onBookingAction completed");
 
-      const bookingExistsAfterAction = await checkBookingExists(testData.booking.uid, "before-getAuditLogs");
-      debugLog(currentTestName, "Pre-getAuditLogs verification", { bookingExistsAfterAction });
-
-      if (!bookingExistsAfterAction) {
-        await dumpDiagnostics(currentTestName, testData.booking.uid, testData.owner.id);
-      }
-
-      debugLog(currentTestName, "Calling getAuditLogsForBooking...");
-      const result = await bookingAuditViewerService.getAuditLogsForBooking({
-        bookingUid: testData.booking.uid,
-        userId: testData.owner.id,
-        userEmail: testData.owner.email,
-        userTimeZone: "UTC",
-        organizationId: testData.organization.id,
-      });
-      debugLog(currentTestName, "getAuditLogsForBooking completed");
+      const result = await getAuditLogsWithDiagnostics(
+        testData.booking.uid, testData.owner.id, testData.owner.email, testData.organization.id
+      );
 
       expect(result.auditLogs).toHaveLength(1);
 
@@ -607,7 +349,7 @@ describe("No-Show Updated Action Integration", () => {
       }>;
       expect(storedAttendeesNoShow).toHaveLength(1);
       expect(storedAttendeesNoShow[0].attendeeEmail).toBe(testData.attendee.email);
-      debugLog(currentTestName, "=== TEST END ===");
+      debugLog(`TEST END: ${currentTestName}`);
     });
   });
 });

--- a/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
@@ -21,7 +21,7 @@ const FILE_ID = `no-show-${process.pid}`;
 function debugLog(testName: string, message: string, data?: Record<string, unknown>) {
   const timestamp = new Date().toISOString();
   const dataStr = data ? ` | ${JSON.stringify(data)}` : "";
-  console.log(`[DEBUG][${FILE_ID}][${timestamp}][${testName}] ${message}${dataStr}`);
+  process.stderr.write(`[DEBUG][${FILE_ID}][${timestamp}][${testName}] ${message}${dataStr}\n`);
 }
 
 async function checkBookingExists(bookingUid: string, context: string): Promise<boolean> {

--- a/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
@@ -127,7 +127,7 @@ describe("No-Show Updated Action Integration", () => {
   }
 
   describe("when host is marked as no-show", () => {
-    it("should create audit record with host field containing userUuid and noShow", async () => {
+    it("should create audit record with host field containing userUuid and noShow", { repeats: 20 }, async () => {
       currentTestName = "host-no-show";
       debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 
@@ -169,7 +169,7 @@ describe("No-Show Updated Action Integration", () => {
   });
 
   describe("when attendees are marked as no-show", () => {
-    it("should create audit record with attendeesNoShow array", async () => {
+    it("should create audit record with attendeesNoShow array", { repeats: 20 }, async () => {
       currentTestName = "attendees-no-show";
       debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 
@@ -212,7 +212,7 @@ describe("No-Show Updated Action Integration", () => {
       debugLog(`TEST END: ${currentTestName}`);
     });
 
-    it("should handle multiple attendees marked as no-show", async () => {
+    it("should handle multiple attendees marked as no-show", { repeats: 20 }, async () => {
       currentTestName = "multiple-attendees-no-show";
       debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid} bookingId=${testData.booking.id}`);
 
@@ -266,7 +266,7 @@ describe("No-Show Updated Action Integration", () => {
   });
 
   describe("when both host and attendees are marked as no-show", () => {
-    it("should create single audit record with both host and attendeesNoShow fields", async () => {
+    it("should create single audit record with both host and attendeesNoShow fields", { repeats: 20 }, async () => {
       currentTestName = "both-host-and-attendees";
       debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 
@@ -315,7 +315,7 @@ describe("No-Show Updated Action Integration", () => {
   });
 
   describe("schema validation with array format", () => {
-    it("should accept attendeesNoShow data with array format", async () => {
+    it("should accept attendeesNoShow data with array format", { repeats: 20 }, async () => {
       currentTestName = "schema-validation";
       debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 

--- a/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
@@ -1,3 +1,4 @@
+// Flaky test debugging - trigger CI
 import type { BookingStatus } from "@calcom/prisma/enums";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBookingAuditTaskConsumer } from "../../../di/BookingAuditTaskConsumer.container";

--- a/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
@@ -127,7 +127,7 @@ describe("No-Show Updated Action Integration", () => {
   }
 
   describe("when host is marked as no-show", () => {
-    it("should create audit record with host field containing userUuid and noShow", { repeats: 20 }, async () => {
+    it("should create audit record with host field containing userUuid and noShow", { repeats: 50 }, async () => {
       currentTestName = "host-no-show";
       debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 
@@ -169,7 +169,7 @@ describe("No-Show Updated Action Integration", () => {
   });
 
   describe("when attendees are marked as no-show", () => {
-    it("should create audit record with attendeesNoShow array", { repeats: 20 }, async () => {
+    it("should create audit record with attendeesNoShow array", { repeats: 50 }, async () => {
       currentTestName = "attendees-no-show";
       debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 
@@ -212,7 +212,7 @@ describe("No-Show Updated Action Integration", () => {
       debugLog(`TEST END: ${currentTestName}`);
     });
 
-    it("should handle multiple attendees marked as no-show", { repeats: 20 }, async () => {
+    it("should handle multiple attendees marked as no-show", { repeats: 50 }, async () => {
       currentTestName = "multiple-attendees-no-show";
       debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid} bookingId=${testData.booking.id}`);
 
@@ -266,7 +266,7 @@ describe("No-Show Updated Action Integration", () => {
   });
 
   describe("when both host and attendees are marked as no-show", () => {
-    it("should create single audit record with both host and attendeesNoShow fields", { repeats: 20 }, async () => {
+    it("should create single audit record with both host and attendeesNoShow fields", { repeats: 50 }, async () => {
       currentTestName = "both-host-and-attendees";
       debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 
@@ -315,7 +315,7 @@ describe("No-Show Updated Action Integration", () => {
   });
 
   describe("schema validation with array format", () => {
-    it("should accept attendeesNoShow data with array format", { repeats: 20 }, async () => {
+    it("should accept attendeesNoShow data with array format", { repeats: 50 }, async () => {
       currentTestName = "schema-validation";
       debugLog(`TEST START: ${currentTestName} | bookingUid=${testData.booking.uid}`);
 

--- a/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@calcom/prisma";
 import type { BookingStatus } from "@calcom/prisma/enums";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBookingAuditTaskConsumer } from "../../../di/BookingAuditTaskConsumer.container";
@@ -15,6 +16,28 @@ import {
   enableFeatureForOrganization,
 } from "./integration-utils";
 
+const FILE_ID = `no-show-${process.pid}`;
+
+function debugLog(testName: string, message: string, data?: Record<string, unknown>) {
+  const timestamp = new Date().toISOString();
+  const dataStr = data ? ` | ${JSON.stringify(data)}` : "";
+  console.log(`[DEBUG][${FILE_ID}][${timestamp}][${testName}] ${message}${dataStr}`);
+}
+
+async function checkBookingExists(bookingUid: string, context: string): Promise<boolean> {
+  const booking = await prisma.booking.findFirst({ where: { uid: bookingUid }, select: { id: true, uid: true, userId: true } });
+  const exists = booking !== null;
+  debugLog("verify", `Booking check (${context}): exists=${exists}`, { bookingUid, booking: booking ?? "null" });
+  return exists;
+}
+
+async function checkUserExists(userId: number, context: string): Promise<boolean> {
+  const user = await prisma.user.findFirst({ where: { id: userId }, select: { id: true, email: true } });
+  const exists = user !== null;
+  debugLog("verify", `User check (${context}): exists=${exists}`, { userId, user: user ?? "null" });
+  return exists;
+}
+
 describe("No-Show Updated Action Integration", () => {
   let bookingAuditTaskConsumer: BookingAuditTaskConsumer;
   let bookingAuditViewerService: BookingAuditViewerService;
@@ -28,18 +51,39 @@ describe("No-Show Updated Action Integration", () => {
   };
 
   const additionalAttendeeEmails: string[] = [];
+  let currentTestName = "unknown";
 
   beforeEach(async () => {
+    debugLog("beforeEach", "=== START beforeEach ===");
+
     bookingAuditTaskConsumer = getBookingAuditTaskConsumer();
     bookingAuditViewerService = getBookingAuditViewerService();
 
+    debugLog("beforeEach", "Creating owner...");
     const owner = await createTestUser({ name: "Test Host User" });
-    const organization = await createTestOrganization();
-    await createTestMembership(owner.id, organization.id);
-    await enableFeatureForOrganization(organization.id, "booking-audit");
-    const eventType = await createTestEventType(owner.id);
-    const attendee = await createTestUser({ name: "Test Attendee" });
+    debugLog("beforeEach", "Owner created", { id: owner.id, uuid: owner.uuid, email: owner.email });
 
+    debugLog("beforeEach", "Creating organization...");
+    const organization = await createTestOrganization();
+    debugLog("beforeEach", "Organization created", { id: organization.id });
+
+    debugLog("beforeEach", "Creating membership...");
+    await createTestMembership(owner.id, organization.id);
+    debugLog("beforeEach", "Membership created");
+
+    debugLog("beforeEach", "Enabling feature...");
+    await enableFeatureForOrganization(organization.id, "booking-audit");
+    debugLog("beforeEach", "Feature enabled");
+
+    debugLog("beforeEach", "Creating event type...");
+    const eventType = await createTestEventType(owner.id);
+    debugLog("beforeEach", "Event type created", { id: eventType.id });
+
+    debugLog("beforeEach", "Creating attendee user...");
+    const attendee = await createTestUser({ name: "Test Attendee" });
+    debugLog("beforeEach", "Attendee user created", { id: attendee.id, email: attendee.email });
+
+    debugLog("beforeEach", "Creating booking...");
     const booking = await createTestBooking(owner.id, eventType.id, {
       attendees: [
         {
@@ -49,6 +93,7 @@ describe("No-Show Updated Action Integration", () => {
         },
       ],
     });
+    debugLog("beforeEach", "Booking created", { id: booking.id, uid: booking.uid, userId: booking.userId });
 
     testData = {
       owner: { id: owner.id, uuid: owner.uuid, email: owner.email },
@@ -63,10 +108,32 @@ describe("No-Show Updated Action Integration", () => {
         status: booking.status,
       },
     };
+
+    await checkBookingExists(booking.uid, "end-of-beforeEach");
+    await checkUserExists(owner.id, "end-of-beforeEach-owner");
+
+    debugLog("beforeEach", "=== END beforeEach ===", {
+      ownerId: owner.id,
+      bookingUid: booking.uid,
+      bookingId: booking.id,
+    });
   });
 
   afterEach(async () => {
-    if (!testData) return;
+    debugLog("afterEach", `=== START afterEach (test: ${currentTestName}) ==="`);
+    if (!testData) {
+      debugLog("afterEach", "No testData, skipping cleanup");
+      return;
+    }
+
+    await checkBookingExists(testData.booking.uid, "start-of-afterEach");
+    await checkUserExists(testData.owner.id, "start-of-afterEach-owner");
+
+    debugLog("afterEach", "Starting cleanup...", {
+      bookingUid: testData.booking?.uid,
+      ownerId: testData.owner?.id,
+      attendeeId: testData.attendee?.id,
+    });
 
     await cleanupTestData({
       bookingUid: testData.booking?.uid,
@@ -81,12 +148,21 @@ describe("No-Show Updated Action Integration", () => {
       featureSlug: "booking-audit",
     });
     additionalAttendeeEmails.length = 0;
+    debugLog("afterEach", `=== END afterEach (test: ${currentTestName}) ==="`);
   });
 
   describe("when host is marked as no-show", () => {
     it("should create audit record with host field containing userUuid and noShow", async () => {
+      currentTestName = "host-no-show";
+      debugLog(currentTestName, "=== TEST START ===");
+
+      const bookingExistsBefore = await checkBookingExists(testData.booking.uid, "test-start");
+      const ownerExistsBefore = await checkUserExists(testData.owner.id, "test-start-owner");
+      debugLog(currentTestName, "Pre-test verification", { bookingExistsBefore, ownerExistsBefore });
+
       const actor = makeUserActor(testData.owner.uuid);
 
+      debugLog(currentTestName, "Calling onBookingAction...");
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
         actor,
@@ -94,7 +170,6 @@ describe("No-Show Updated Action Integration", () => {
         source: "WEBAPP",
         operationId: `op-${Date.now()}`,
         data: {
-          // New schema: host contains userUuid and noShow change
           host: {
             userUuid: testData.owner.uuid,
             noShow: { old: null, new: true },
@@ -102,7 +177,24 @@ describe("No-Show Updated Action Integration", () => {
         },
         timestamp: Date.now(),
       });
+      debugLog(currentTestName, "onBookingAction completed");
 
+      const bookingExistsAfterAction = await checkBookingExists(testData.booking.uid, "before-getAuditLogs");
+      const ownerExistsAfterAction = await checkUserExists(testData.owner.id, "before-getAuditLogs-owner");
+      debugLog(currentTestName, "Pre-getAuditLogs verification", { bookingExistsAfterAction, ownerExistsAfterAction });
+
+      if (!bookingExistsAfterAction) {
+        debugLog(currentTestName, "!!! BOOKING DISAPPEARED !!! Checking DB state...");
+        const bookingCount = await prisma.booking.count();
+        const userCount = await prisma.user.count();
+        const auditRecords = await prisma.bookingAudit.findMany({
+          where: { bookingUid: testData.booking.uid },
+          select: { id: true, bookingUid: true, action: true },
+        });
+        debugLog(currentTestName, "DB state after disappearance", { totalBookings: bookingCount, totalUsers: userCount, auditRecords });
+      }
+
+      debugLog(currentTestName, "Calling getAuditLogsForBooking...");
       const result = await bookingAuditViewerService.getAuditLogsForBooking({
         bookingUid: testData.booking.uid,
         userId: testData.owner.id,
@@ -110,6 +202,7 @@ describe("No-Show Updated Action Integration", () => {
         userTimeZone: "UTC",
         organizationId: testData.organization.id,
       });
+      debugLog(currentTestName, "getAuditLogsForBooking completed", { auditLogCount: result.auditLogs.length });
 
       expect(result.bookingUid).toBe(testData.booking.uid);
       expect(result.auditLogs).toHaveLength(1);
@@ -123,27 +216,44 @@ describe("No-Show Updated Action Integration", () => {
       expect(displayData).toBeDefined();
       expect(displayData.hostNoShow).toBe(true);
       expect(displayData.previousHostNoShow).toBe(null);
+      debugLog(currentTestName, "=== TEST END ===");
     });
   });
 
   describe("when attendees are marked as no-show", () => {
     it("should create audit record with attendeesNoShow array", async () => {
-      const actor = makeUserActor(testData.owner.uuid);
+      currentTestName = "attendees-no-show";
+      debugLog(currentTestName, "=== TEST START ===");
 
+      const bookingExistsBefore = await checkBookingExists(testData.booking.uid, "test-start");
+      debugLog(currentTestName, "Pre-test verification", { bookingExistsBefore });
+
+      const actor = makeUserActor(testData.owner.uuid);
       const attendeesNoShow = [{ attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } }];
 
+      debugLog(currentTestName, "Calling onBookingAction...");
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
         actor,
         action: "NO_SHOW_UPDATED",
         source: "WEBAPP",
         operationId: `op-${Date.now()}`,
-        data: {
-          attendeesNoShow,
-        },
+        data: { attendeesNoShow },
         timestamp: Date.now(),
       });
+      debugLog(currentTestName, "onBookingAction completed");
 
+      const bookingExistsAfterAction = await checkBookingExists(testData.booking.uid, "before-getAuditLogs");
+      debugLog(currentTestName, "Pre-getAuditLogs verification", { bookingExistsAfterAction });
+
+      if (!bookingExistsAfterAction) {
+        debugLog(currentTestName, "!!! BOOKING DISAPPEARED !!!");
+        const ownerExists = await checkUserExists(testData.owner.id, "booking-disappeared-check-owner");
+        const bookingCount = await prisma.booking.count();
+        debugLog(currentTestName, "DB state", { ownerExists, totalBookings: bookingCount });
+      }
+
+      debugLog(currentTestName, "Calling getAuditLogsForBooking...");
       const result = await bookingAuditViewerService.getAuditLogsForBooking({
         bookingUid: testData.booking.uid,
         userId: testData.owner.id,
@@ -151,6 +261,7 @@ describe("No-Show Updated Action Integration", () => {
         userTimeZone: "UTC",
         organizationId: testData.organization.id,
       });
+      debugLog(currentTestName, "getAuditLogsForBooking completed");
 
       expect(result.bookingUid).toBe(testData.booking.uid);
       expect(result.auditLogs).toHaveLength(1);
@@ -171,12 +282,21 @@ describe("No-Show Updated Action Integration", () => {
       expect(storedAttendeesNoShow[0].attendeeEmail).toBe(testData.attendee.email);
       expect(storedAttendeesNoShow[0].noShow.old).toBe(null);
       expect(storedAttendeesNoShow[0].noShow.new).toBe(true);
+      debugLog(currentTestName, "=== TEST END ===");
     });
 
     it("should handle multiple attendees marked as no-show", async () => {
-      const { prisma } = await import("@calcom/prisma");
+      currentTestName = "multiple-attendees-no-show";
+      debugLog(currentTestName, "=== TEST START ===");
+
+      const bookingExistsBefore = await checkBookingExists(testData.booking.uid, "test-start");
+      const ownerExistsBefore = await checkUserExists(testData.owner.id, "test-start-owner");
+      debugLog(currentTestName, "Pre-test verification", { bookingExistsBefore, ownerExistsBefore });
+
       const secondAttendeeEmail = `second-attendee-${Date.now()}@example.com`;
       additionalAttendeeEmails.push(secondAttendeeEmail);
+
+      debugLog(currentTestName, "Creating second attendee...", { bookingId: testData.booking.id });
       await prisma.attendee.create({
         data: {
           email: secondAttendeeEmail,
@@ -185,26 +305,45 @@ describe("No-Show Updated Action Integration", () => {
           bookingId: testData.booking.id,
         },
       });
+      debugLog(currentTestName, "Second attendee created");
+
+      const bookingExistsAfterAttendee = await checkBookingExists(testData.booking.uid, "after-attendee-create");
+      debugLog(currentTestName, "Post-attendee-create verification", { bookingExistsAfterAttendee });
 
       const actor = makeUserActor(testData.owner.uuid);
-
       const attendeesNoShow = [
         { attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } },
         { attendeeEmail: secondAttendeeEmail, noShow: { old: false, new: true } },
       ];
 
+      debugLog(currentTestName, "Calling onBookingAction...");
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
         actor,
         action: "NO_SHOW_UPDATED",
         source: "WEBAPP",
         operationId: `op-${Date.now()}`,
-        data: {
-          attendeesNoShow,
-        },
+        data: { attendeesNoShow },
         timestamp: Date.now(),
       });
+      debugLog(currentTestName, "onBookingAction completed");
 
+      const bookingExistsAfterAction = await checkBookingExists(testData.booking.uid, "before-getAuditLogs");
+      const ownerExistsAfterAction = await checkUserExists(testData.owner.id, "before-getAuditLogs-owner");
+      debugLog(currentTestName, "Pre-getAuditLogs verification", { bookingExistsAfterAction, ownerExistsAfterAction });
+
+      if (!bookingExistsAfterAction) {
+        debugLog(currentTestName, "!!! BOOKING DISAPPEARED !!!");
+        const bookingCount = await prisma.booking.count();
+        const userCount = await prisma.user.count();
+        const auditRecords = await prisma.bookingAudit.findMany({
+          where: { bookingUid: testData.booking.uid },
+          select: { id: true, bookingUid: true, action: true },
+        });
+        debugLog(currentTestName, "DB state", { totalBookings: bookingCount, totalUsers: userCount, auditRecords });
+      }
+
+      debugLog(currentTestName, "Calling getAuditLogsForBooking...");
       const result = await bookingAuditViewerService.getAuditLogsForBooking({
         bookingUid: testData.booking.uid,
         userId: testData.owner.id,
@@ -212,6 +351,7 @@ describe("No-Show Updated Action Integration", () => {
         userTimeZone: "UTC",
         organizationId: testData.organization.id,
       });
+      debugLog(currentTestName, "getAuditLogsForBooking completed");
 
       expect(result.auditLogs).toHaveLength(1);
 
@@ -226,13 +366,21 @@ describe("No-Show Updated Action Integration", () => {
       const secondAttendeeData = storedAttendeesNoShow.find((a) => a.attendeeEmail === secondAttendeeEmail);
       expect(firstAttendee?.noShow).toEqual({ old: null, new: true });
       expect(secondAttendeeData?.noShow).toEqual({ old: false, new: true });
+      debugLog(currentTestName, "=== TEST END ===");
     });
   });
 
   describe("when both host and attendees are marked as no-show", () => {
     it("should create single audit record with both host and attendeesNoShow fields", async () => {
+      currentTestName = "both-host-and-attendees";
+      debugLog(currentTestName, "=== TEST START ===");
+
+      const bookingExistsBefore = await checkBookingExists(testData.booking.uid, "test-start");
+      debugLog(currentTestName, "Pre-test verification", { bookingExistsBefore });
+
       const actor = makeUserActor(testData.owner.uuid);
 
+      debugLog(currentTestName, "Calling onBookingAction...");
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
         actor,
@@ -248,7 +396,19 @@ describe("No-Show Updated Action Integration", () => {
         },
         timestamp: Date.now(),
       });
+      debugLog(currentTestName, "onBookingAction completed");
 
+      const bookingExistsAfterAction = await checkBookingExists(testData.booking.uid, "before-getAuditLogs");
+      debugLog(currentTestName, "Pre-getAuditLogs verification", { bookingExistsAfterAction });
+
+      if (!bookingExistsAfterAction) {
+        debugLog(currentTestName, "!!! BOOKING DISAPPEARED !!!");
+        const ownerExists = await checkUserExists(testData.owner.id, "booking-disappeared");
+        const bookingCount = await prisma.booking.count();
+        debugLog(currentTestName, "DB state", { ownerExists, totalBookings: bookingCount });
+      }
+
+      debugLog(currentTestName, "Calling getAuditLogsForBooking...");
       const result = await bookingAuditViewerService.getAuditLogsForBooking({
         bookingUid: testData.booking.uid,
         userId: testData.owner.id,
@@ -256,6 +416,7 @@ describe("No-Show Updated Action Integration", () => {
         userTimeZone: "UTC",
         organizationId: testData.organization.id,
       });
+      debugLog(currentTestName, "getAuditLogsForBooking completed");
 
       expect(result.auditLogs).toHaveLength(1);
 
@@ -275,17 +436,24 @@ describe("No-Show Updated Action Integration", () => {
       expect(storedAttendeesNoShow).toHaveLength(1);
       expect(storedAttendeesNoShow[0].attendeeEmail).toBe(testData.attendee.email);
       expect(storedAttendeesNoShow[0].noShow).toEqual({ old: null, new: true });
+      debugLog(currentTestName, "=== TEST END ===");
     });
   });
 
   describe("schema validation with array format", () => {
     it("should accept attendeesNoShow data with array format", async () => {
-      const actor = makeUserActor(testData.owner.uuid);
+      currentTestName = "schema-validation";
+      debugLog(currentTestName, "=== TEST START ===");
 
+      const bookingExistsBefore = await checkBookingExists(testData.booking.uid, "test-start");
+      debugLog(currentTestName, "Pre-test verification", { bookingExistsBefore });
+
+      const actor = makeUserActor(testData.owner.uuid);
       const dataWithArrayFormat = {
         attendeesNoShow: [{ attendeeEmail: testData.attendee.email, noShow: { old: null, new: true } }],
       };
 
+      debugLog(currentTestName, "Calling onBookingAction...");
       await bookingAuditTaskConsumer.onBookingAction({
         bookingUid: testData.booking.uid,
         actor,
@@ -295,7 +463,18 @@ describe("No-Show Updated Action Integration", () => {
         data: dataWithArrayFormat,
         timestamp: Date.now(),
       });
+      debugLog(currentTestName, "onBookingAction completed");
 
+      const bookingExistsAfterAction = await checkBookingExists(testData.booking.uid, "before-getAuditLogs");
+      debugLog(currentTestName, "Pre-getAuditLogs verification", { bookingExistsAfterAction });
+
+      if (!bookingExistsAfterAction) {
+        debugLog(currentTestName, "!!! BOOKING DISAPPEARED !!!");
+        const ownerExists = await checkUserExists(testData.owner.id, "booking-disappeared");
+        debugLog(currentTestName, "Owner exists?", { ownerExists });
+      }
+
+      debugLog(currentTestName, "Calling getAuditLogsForBooking...");
       const result = await bookingAuditViewerService.getAuditLogsForBooking({
         bookingUid: testData.booking.uid,
         userId: testData.owner.id,
@@ -303,6 +482,7 @@ describe("No-Show Updated Action Integration", () => {
         userTimeZone: "UTC",
         organizationId: testData.organization.id,
       });
+      debugLog(currentTestName, "getAuditLogsForBooking completed");
 
       expect(result.auditLogs).toHaveLength(1);
 
@@ -315,6 +495,7 @@ describe("No-Show Updated Action Integration", () => {
       }>;
       expect(storedAttendeesNoShow).toHaveLength(1);
       expect(storedAttendeesNoShow[0].attendeeEmail).toBe(testData.attendee.email);
+      debugLog(currentTestName, "=== TEST END ===");
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds temporary debug logging to `no-show-updated-action.integration-test.ts` and `integration-utils.ts` to diagnose a flaky CI failure where the booking intermittently disappears between `beforeEach` and the test body assertion (`getAuditLogsForBooking` throws `BOOKING_NOT_FOUND_OR_PERMISSION_DENIED`).

This test passes locally every time but fails intermittently in CI across multiple unrelated PRs (#27546, #26792, #27664, #27772). The root cause is unknown — each test file creates unique data and no broad deletes exist. This PR instruments the test to capture exactly **when** the booking/user disappear relative to the test lifecycle.

**This is a temporary debugging PR — not intended for permanent merge.**

### Instrumentation added:

- **`no-show-updated-action.integration-test.ts`**: `checkBookingExists()` and `checkUserExists()` calls at every key point — end of `beforeEach`, start of each test, after `onBookingAction`, before `getAuditLogsForBooking`, and start of `afterEach`. When booking disappearance is detected, logs total booking/user counts and whether audit records still exist.
- **`integration-utils.ts`**: `cleanupLog()` at each step of `cleanupTestData` with PID and timestamp. Before user deletion, checks if the user still has associated bookings (to catch cascade delete evidence). This affects all 6 sibling booking-audit test files since they share this utility.

All logs include `process.pid` and ISO timestamps to correlate events across parallel test file processes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- N/A - No docs changes needed (temporary debugging instrumentation).
- N/A - No fix to test; this PR adds diagnostic logging only.

## How should this be tested?

1. CI integration tests will run automatically
2. If the flaky test fails, the CI logs will now contain `[DEBUG]` and `[CLEANUP]` lines showing the exact DB state at each point
3. Look for `!!! BOOKING DISAPPEARED !!!` in CI output to find the failure point
4. Cross-reference `[CLEANUP]` logs from other PIDs to see if a parallel file's cleanup overlapped

## Human Review Checklist

- [ ] **`integration-utils.ts` changes affect all 6 booking-audit test files** — the extra DB queries in `cleanupTestData` (checking user bookings before delete) add overhead to every test file that imports this utility. Acceptable for debugging but must be reverted.
- [ ] Verify this PR is kept in draft and not merged permanently — all logging should be removed once root cause is identified.

---

Link to Devin run: https://app.devin.ai/sessions/1effb12fa2904b36a152dc3560f16eaf
Requested by: @hariombalhara