### PR TITLE
feat: move billing to adopt strategy methodology 

### DIFF
--- a/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
@@ -11,7 +11,7 @@ import { prisma } from "@calcom/prisma";
 import { z } from "zod";
 import { getTeamBillingServiceFactory } from "../../di/containers/Billing";
 import type { SWHMap } from "./__handler";
-import { handleHwmResetAfterRenewal, validateInvoiceLinesForHwm } from "./hwm-webhook-utils";
+import { handlePostRenewalReset, validateInvoiceLinesForHwm } from "./hwm-webhook-utils";
 
 const invoicePaidSchema = z.object({
   object: z.object({
@@ -68,7 +68,7 @@ const handler = async (data: SWHMap["invoice.paid"]["data"]) => {
       logger.info(`Processing renewal invoice for subscription ${subscriptionId}`);
       const validation = validateInvoiceLinesForHwm(invoice.lines.data, subscriptionId, logger);
       if (validation.isValid) {
-        await handleHwmResetAfterRenewal(subscriptionId, validation.periodStart, logger);
+        await handlePostRenewalReset(subscriptionId, validation.periodStart, logger);
       }
     } else {
       logger.info(
@@ -107,7 +107,7 @@ const handler = async (data: SWHMap["invoice.paid"]["data"]) => {
         logger.info(`Processing renewal invoice for completed org, subscription ${subscriptionId}`);
         const validation = validateInvoiceLinesForHwm(invoice.lines.data, subscriptionId, logger);
         if (validation.isValid) {
-          await handleHwmResetAfterRenewal(subscriptionId, validation.periodStart, logger);
+          await handlePostRenewalReset(subscriptionId, validation.periodStart, logger);
         }
       }
       return {

--- a/packages/features/ee/billing/api/webhook/_invoice.paid.team.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.paid.team.ts
@@ -1,7 +1,7 @@
 import logger from "@calcom/lib/logger";
 import { z } from "zod";
 import type { SWHMap } from "./__handler";
-import { handleHwmResetAfterRenewal, validateInvoiceLinesForHwm } from "./hwm-webhook-utils";
+import { handlePostRenewalReset, validateInvoiceLinesForHwm } from "./hwm-webhook-utils";
 
 const log = logger.getSubLogger({ prefix: ["invoice-paid-team"] });
 
@@ -40,7 +40,7 @@ const handler = async (data: SWHMap["invoice.paid"]["data"]) => {
     log.info(`Processing renewal invoice for team subscription ${subscriptionId}`);
     const validation = validateInvoiceLinesForHwm(invoice.lines.data, subscriptionId, log);
     if (validation.isValid) {
-      await handleHwmResetAfterRenewal(subscriptionId, validation.periodStart, log);
+      await handlePostRenewalReset(subscriptionId, validation.periodStart, log);
     }
   }
 

--- a/packages/features/ee/billing/api/webhook/_invoice.upcoming.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.upcoming.ts
@@ -25,7 +25,7 @@ const handler = async (data: Data) => {
   });
 
   try {
-    const result = await getStrategyForSubscription(subscriptionId, undefined, log);
+    const result = await getStrategyForSubscription(subscriptionId, log);
 
     if (!result) {
       log.debug("No billing record found, skipping", { subscriptionId });

--- a/packages/features/ee/billing/api/webhook/hwm-webhook-utils.ts
+++ b/packages/features/ee/billing/api/webhook/hwm-webhook-utils.ts
@@ -45,7 +45,7 @@ export async function handlePostRenewalReset(
     return { success: false, error: "No period start timestamp" };
   }
 
-  const result = await getStrategyForSubscription(subscriptionId, undefined, log);
+  const result = await getStrategyForSubscription(subscriptionId, log);
 
   if (!result) {
     log.warn(`No billing record found for subscription ${subscriptionId}, skipping post-renewal reset`);

--- a/packages/features/ee/billing/di/containers/Billing.ts
+++ b/packages/features/ee/billing/di/containers/Billing.ts
@@ -2,7 +2,9 @@ import { createContainer } from "@calcom/features/di/di";
 
 import type { ITeamBillingDataRepository } from "../../repository/teamBillingData/ITeamBillingDataRepository";
 import type { StripeBillingService } from "../../service/billingProvider/StripeBillingService";
+import type { BillingModelRepository } from "../../service/billingModelStrategy/BillingModelRepository";
 import type { TeamBillingServiceFactory } from "../../service/teams/TeamBillingServiceFactory";
+import { billingModelRepositoryModuleLoader } from "../modules/BillingModelRepository";
 import { billingProviderServiceModuleLoader } from "../modules/BillingProviderService";
 import { teamBillingServiceFactoryModuleLoader } from "../modules/TeamBillingServiceFactory";
 import { DI_TOKENS } from "../tokens";
@@ -12,6 +14,7 @@ const billingContainer = createContainer();
 // Load all modules (dependencies are loaded recursively)
 teamBillingServiceFactoryModuleLoader.loadModule(billingContainer);
 billingProviderServiceModuleLoader.loadModule(billingContainer);
+billingModelRepositoryModuleLoader.loadModule(billingContainer);
 
 export function getTeamBillingServiceFactory(): TeamBillingServiceFactory {
   return billingContainer.get<TeamBillingServiceFactory>(DI_TOKENS.TEAM_BILLING_SERVICE_FACTORY);
@@ -23,4 +26,8 @@ export function getBillingProviderService(): StripeBillingService {
 
 export function getTeamBillingDataRepository(): ITeamBillingDataRepository {
   return billingContainer.get<ITeamBillingDataRepository>(DI_TOKENS.TEAM_BILLING_DATA_REPOSITORY);
+}
+
+export function getBillingModelRepository(): BillingModelRepository {
+  return billingContainer.get<BillingModelRepository>(DI_TOKENS.BILLING_MODEL_REPOSITORY);
 }

--- a/packages/features/ee/billing/di/modules/BillingModelRepository.ts
+++ b/packages/features/ee/billing/di/modules/BillingModelRepository.ts
@@ -1,0 +1,24 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as prismaModuleLoader } from "@calcom/features/di/modules/Prisma";
+import { BillingModelRepository } from "@calcom/features/ee/billing/service/billingModelStrategy/BillingModelRepository";
+
+import { DI_TOKENS } from "../tokens";
+
+const thisModule = createModule();
+const token = DI_TOKENS.BILLING_MODEL_REPOSITORY;
+const moduleToken = DI_TOKENS.BILLING_MODEL_REPOSITORY_MODULE;
+
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: BillingModelRepository,
+  dep: prismaModuleLoader,
+});
+
+export const billingModelRepositoryModuleLoader: ModuleLoader = {
+  token,
+  loadModule,
+};
+
+export type { BillingModelRepository };

--- a/packages/features/ee/billing/di/tokens.ts
+++ b/packages/features/ee/billing/di/tokens.ts
@@ -17,4 +17,6 @@ export const DI_TOKENS = {
   HIGH_WATER_MARK_REPOSITORY_MODULE: Symbol("HighWaterMarkRepositoryModule"),
   MONTHLY_PRORATION_TEAM_REPOSITORY: Symbol("MonthlyProrationTeamRepository"),
   MONTHLY_PRORATION_TEAM_REPOSITORY_MODULE: Symbol("MonthlyProrationTeamRepositoryModule"),
+  BILLING_MODEL_REPOSITORY: Symbol("BillingModelRepository"),
+  BILLING_MODEL_REPOSITORY_MODULE: Symbol("BillingModelRepositoryModule"),
 };

--- a/packages/features/ee/billing/service/billingModelStrategy/ActiveUsersBillingStrategy.test.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/ActiveUsersBillingStrategy.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActiveUsersBillingStrategy } from "./ActiveUsersBillingStrategy";
+
+const mockLogSeatAddition = vi.fn();
+const mockLogSeatRemoval = vi.fn();
+
+const createMockLogger = () =>
+  ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }) as unknown;
+
+function createStrategy() {
+  return new ActiveUsersBillingStrategy({
+    logSeatAddition: mockLogSeatAddition,
+    logSeatRemoval: mockLogSeatRemoval,
+  } as never);
+}
+
+describe("ActiveUsersBillingStrategy", () => {
+  let strategy: ActiveUsersBillingStrategy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    strategy = createStrategy();
+  });
+
+  describe("handleInvoiceUpcoming", () => {
+    it("returns applied: false (no-op)", async () => {
+      const result = await strategy.handleInvoiceUpcoming(
+        { subscriptionId: "sub_123" },
+        createMockLogger() as never
+      );
+      expect(result).toEqual({ applied: false });
+    });
+  });
+
+  describe("handlePostRenewalReset", () => {
+    it("returns success with no update (no-op)", async () => {
+      const result = await strategy.handlePostRenewalReset(
+        { subscriptionId: "sub_123", periodStartTimestamp: 1704067200 },
+        createMockLogger() as never
+      );
+      expect(result).toEqual({ success: true, updated: false });
+    });
+  });
+
+  describe("handleMemberAddition", () => {
+    it("logs seat addition for audit but does not update billing", async () => {
+      mockLogSeatAddition.mockResolvedValue(undefined);
+
+      await strategy.handleMemberAddition(
+        { teamId: 42, userId: 7, triggeredBy: 1, seatCount: 1 },
+        createMockLogger() as never
+      );
+
+      expect(mockLogSeatAddition).toHaveBeenCalledWith({
+        teamId: 42,
+        userId: 7,
+        triggeredBy: 1,
+        seatCount: 1,
+      });
+    });
+  });
+
+  describe("handleMemberRemoval", () => {
+    it("logs seat removal for audit but does not update billing", async () => {
+      mockLogSeatRemoval.mockResolvedValue(undefined);
+
+      await strategy.handleMemberRemoval(
+        { teamId: 42, userId: 7, triggeredBy: 1, seatCount: 1 },
+        createMockLogger() as never
+      );
+
+      expect(mockLogSeatRemoval).toHaveBeenCalledWith({
+        teamId: 42,
+        userId: 7,
+        triggeredBy: 1,
+        seatCount: 1,
+      });
+    });
+  });
+
+  describe("syncBillingQuantity", () => {
+    it("is a no-op", async () => {
+      await strategy.syncBillingQuantity({ teamId: 42 }, createMockLogger() as never);
+
+      expect(mockLogSeatAddition).not.toHaveBeenCalled();
+      expect(mockLogSeatRemoval).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/features/ee/billing/service/billingModelStrategy/ActiveUsersBillingStrategy.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/ActiveUsersBillingStrategy.ts
@@ -1,0 +1,66 @@
+import type { Logger } from "tslog";
+import { SeatChangeTrackingService } from "../seatTracking/SeatChangeTrackingService";
+import type {
+  IBillingModelStrategy,
+  InvoiceUpcomingPayload,
+  InvoiceUpcomingResult,
+  MemberChangePayload,
+  PostRenewalResetPayload,
+  PostRenewalResetResult,
+} from "./IBillingModelStrategy";
+
+/**
+ * ACTIVE_USERS billing strategy.
+ * Webhook hooks are no-ops because active user counting and invoice
+ * processing are handled by ActiveUserBillingService / OrgActiveUserInvoiceService
+ * through separate code paths.
+ *
+ * Member changes are logged for audit purposes only -- no Stripe quantity update.
+ */
+export class ActiveUsersBillingStrategy implements IBillingModelStrategy {
+  constructor(private readonly seatTracker: SeatChangeTrackingService = new SeatChangeTrackingService()) {}
+
+  async handleInvoiceUpcoming(
+    payload: InvoiceUpcomingPayload,
+    logger: Logger<unknown>
+  ): Promise<InvoiceUpcomingResult> {
+    logger.debug(`ACTIVE_USERS: skipping invoice.upcoming for ${payload.subscriptionId}`);
+    return { applied: false };
+  }
+
+  async handlePostRenewalReset(
+    payload: PostRenewalResetPayload,
+    logger: Logger<unknown>
+  ): Promise<PostRenewalResetResult> {
+    logger.debug(`ACTIVE_USERS: skipping post-renewal reset for ${payload.subscriptionId}`);
+    return { success: true, updated: false };
+  }
+
+  async handleMemberAddition(payload: MemberChangePayload, logger: Logger<unknown>): Promise<void> {
+    await this.seatTracker.logSeatAddition({
+      teamId: payload.teamId,
+      userId: payload.userId,
+      triggeredBy: payload.triggeredBy,
+      seatCount: payload.seatCount,
+    });
+    logger.debug("ACTIVE_USERS: seat addition logged for audit, no billing update", {
+      teamId: payload.teamId,
+    });
+  }
+
+  async handleMemberRemoval(payload: MemberChangePayload, logger: Logger<unknown>): Promise<void> {
+    await this.seatTracker.logSeatRemoval({
+      teamId: payload.teamId,
+      userId: payload.userId,
+      triggeredBy: payload.triggeredBy,
+      seatCount: payload.seatCount,
+    });
+    logger.debug("ACTIVE_USERS: seat removal logged for audit, no billing update", {
+      teamId: payload.teamId,
+    });
+  }
+
+  async syncBillingQuantity(_payload: { teamId: number }, logger: Logger<unknown>): Promise<void> {
+    logger.debug("ACTIVE_USERS: skipping billing quantity sync");
+  }
+}

--- a/packages/features/ee/billing/service/billingModelStrategy/BillingModelRepository.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/BillingModelRepository.ts
@@ -1,0 +1,45 @@
+import { prisma } from "@calcom/prisma";
+import type { BillingModel, BillingPeriod } from "@calcom/prisma/enums";
+
+export interface BillingModelRecord {
+  billingModel: BillingModel;
+  billingPeriod: BillingPeriod | null;
+}
+
+const billingModelSelect = { billingModel: true, billingPeriod: true } as const;
+
+export class BillingModelRepository {
+  async findBySubscriptionId(
+    subscriptionId: string
+  ): Promise<BillingModelRecord | null> {
+    const teamBilling = await prisma.teamBilling.findUnique({
+      where: { subscriptionId },
+      select: billingModelSelect,
+    });
+
+    if (teamBilling) return teamBilling;
+
+    const orgBilling = await prisma.organizationBilling.findUnique({
+      where: { subscriptionId },
+      select: billingModelSelect,
+    });
+
+    return orgBilling ?? null;
+  }
+
+  async findByTeamId(teamId: number): Promise<BillingModelRecord | null> {
+    const teamBilling = await prisma.teamBilling.findUnique({
+      where: { teamId },
+      select: billingModelSelect,
+    });
+
+    if (teamBilling) return teamBilling;
+
+    const orgBilling = await prisma.organizationBilling.findUnique({
+      where: { teamId },
+      select: billingModelSelect,
+    });
+
+    return orgBilling ?? null;
+  }
+}

--- a/packages/features/ee/billing/service/billingModelStrategy/BillingModelRepository.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/BillingModelRepository.ts
@@ -1,4 +1,5 @@
-import { prisma } from "@calcom/prisma";
+import type { PrismaClient } from "@calcom/prisma";
+import { prisma as defaultPrisma } from "@calcom/prisma";
 import type { BillingModel, BillingPeriod } from "@calcom/prisma/enums";
 
 export interface BillingModelRecord {
@@ -9,17 +10,23 @@ export interface BillingModelRecord {
 const billingModelSelect = { billingModel: true, billingPeriod: true } as const;
 
 export class BillingModelRepository {
+  private prisma: PrismaClient;
+
+  constructor(prisma?: PrismaClient) {
+    this.prisma = prisma || defaultPrisma;
+  }
+
   async findBySubscriptionId(
     subscriptionId: string
   ): Promise<BillingModelRecord | null> {
-    const teamBilling = await prisma.teamBilling.findUnique({
+    const teamBilling = await this.prisma.teamBilling.findUnique({
       where: { subscriptionId },
       select: billingModelSelect,
     });
 
     if (teamBilling) return teamBilling;
 
-    const orgBilling = await prisma.organizationBilling.findUnique({
+    const orgBilling = await this.prisma.organizationBilling.findUnique({
       where: { subscriptionId },
       select: billingModelSelect,
     });
@@ -28,14 +35,14 @@ export class BillingModelRepository {
   }
 
   async findByTeamId(teamId: number): Promise<BillingModelRecord | null> {
-    const teamBilling = await prisma.teamBilling.findUnique({
+    const teamBilling = await this.prisma.teamBilling.findUnique({
       where: { teamId },
       select: billingModelSelect,
     });
 
     if (teamBilling) return teamBilling;
 
-    const orgBilling = await prisma.organizationBilling.findUnique({
+    const orgBilling = await this.prisma.organizationBilling.findUnique({
       where: { teamId },
       select: billingModelSelect,
     });

--- a/packages/features/ee/billing/service/billingModelStrategy/BillingModelStrategyFactory.test.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/BillingModelStrategyFactory.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActiveUsersBillingStrategy } from "./ActiveUsersBillingStrategy";
+import type { BillingModelRecord } from "./BillingModelRepository";
+import { BillingModelRepository } from "./BillingModelRepository";
+import { getStrategyForSubscription, getStrategyForTeam } from "./BillingModelStrategyFactory";
+import { SeatsHwmBillingStrategy } from "./SeatsHwmBillingStrategy";
+import { SeatsProrationBillingStrategy } from "./SeatsProrationBillingStrategy";
+
+function createMockRepository() {
+  return {
+    findBySubscriptionId: vi.fn<(id: string) => Promise<BillingModelRecord | null>>(),
+    findByTeamId: vi.fn<(id: number) => Promise<BillingModelRecord | null>>(),
+  } as unknown as BillingModelRepository & {
+    findBySubscriptionId: ReturnType<typeof vi.fn>;
+    findByTeamId: ReturnType<typeof vi.fn>;
+  };
+}
+
+const createMockLogger = () =>
+  ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }) as unknown;
+
+describe("BillingModelStrategyFactory", () => {
+  let repo: ReturnType<typeof createMockRepository>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repo = createMockRepository();
+  });
+
+  describe("getStrategyForSubscription", () => {
+    it("returns SeatsHwmBillingStrategy for SEATS + MONTHLY", async () => {
+      repo.findBySubscriptionId.mockResolvedValue({
+        billingModel: "SEATS",
+        billingPeriod: "MONTHLY",
+      });
+
+      const result = await getStrategyForSubscription("sub_123", repo, createMockLogger() as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.strategy).toBeInstanceOf(SeatsHwmBillingStrategy);
+      expect(result!.billingModel).toBe("SEATS");
+      expect(result!.billingPeriod).toBe("MONTHLY");
+    });
+
+    it("returns SeatsProrationBillingStrategy for SEATS + ANNUALLY", async () => {
+      repo.findBySubscriptionId.mockResolvedValue({
+        billingModel: "SEATS",
+        billingPeriod: "ANNUALLY",
+      });
+
+      const result = await getStrategyForSubscription("sub_123", repo, createMockLogger() as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.strategy).toBeInstanceOf(SeatsProrationBillingStrategy);
+      expect(result!.billingModel).toBe("SEATS");
+      expect(result!.billingPeriod).toBe("ANNUALLY");
+    });
+
+    it("returns SeatsProrationBillingStrategy for SEATS + null billingPeriod", async () => {
+      repo.findBySubscriptionId.mockResolvedValue({
+        billingModel: "SEATS",
+        billingPeriod: null,
+      });
+
+      const result = await getStrategyForSubscription("sub_123", repo, createMockLogger() as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.strategy).toBeInstanceOf(SeatsProrationBillingStrategy);
+    });
+
+    it("returns ActiveUsersBillingStrategy for ACTIVE_USERS", async () => {
+      repo.findBySubscriptionId.mockResolvedValue({
+        billingModel: "ACTIVE_USERS",
+        billingPeriod: "MONTHLY",
+      });
+
+      const result = await getStrategyForSubscription("sub_123", repo, createMockLogger() as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.strategy).toBeInstanceOf(ActiveUsersBillingStrategy);
+      expect(result!.billingModel).toBe("ACTIVE_USERS");
+    });
+
+    it("returns null when no billing record exists", async () => {
+      repo.findBySubscriptionId.mockResolvedValue(null);
+
+      const mockLog = createMockLogger() as { warn: ReturnType<typeof vi.fn> };
+      const result = await getStrategyForSubscription("sub_unknown", repo, mockLog as never);
+
+      expect(result).toBeNull();
+      expect(mockLog.warn).toHaveBeenCalledWith("No billing record found for subscription sub_unknown");
+    });
+  });
+
+  describe("getStrategyForTeam", () => {
+    it("returns SeatsHwmBillingStrategy for SEATS + MONTHLY", async () => {
+      repo.findByTeamId.mockResolvedValue({
+        billingModel: "SEATS",
+        billingPeriod: "MONTHLY",
+      });
+
+      const result = await getStrategyForTeam(42, repo, createMockLogger() as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.strategy).toBeInstanceOf(SeatsHwmBillingStrategy);
+      expect(result!.billingModel).toBe("SEATS");
+    });
+
+    it("returns ActiveUsersBillingStrategy for ACTIVE_USERS", async () => {
+      repo.findByTeamId.mockResolvedValue({
+        billingModel: "ACTIVE_USERS",
+        billingPeriod: "MONTHLY",
+      });
+
+      const result = await getStrategyForTeam(42, repo, createMockLogger() as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.strategy).toBeInstanceOf(ActiveUsersBillingStrategy);
+    });
+
+    it("returns SeatsProrationBillingStrategy for SEATS + ANNUALLY", async () => {
+      repo.findByTeamId.mockResolvedValue({
+        billingModel: "SEATS",
+        billingPeriod: "ANNUALLY",
+      });
+
+      const result = await getStrategyForTeam(99, repo, createMockLogger() as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.strategy).toBeInstanceOf(SeatsProrationBillingStrategy);
+    });
+
+    it("returns null when no billing record exists for team", async () => {
+      repo.findByTeamId.mockResolvedValue(null);
+
+      const mockLog = createMockLogger() as { warn: ReturnType<typeof vi.fn> };
+      const result = await getStrategyForTeam(999, repo, mockLog as never);
+
+      expect(result).toBeNull();
+      expect(mockLog.warn).toHaveBeenCalledWith("No billing record found for team 999");
+    });
+  });
+});

--- a/packages/features/ee/billing/service/billingModelStrategy/BillingModelStrategyFactory.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/BillingModelStrategyFactory.ts
@@ -1,0 +1,91 @@
+import logger from "@calcom/lib/logger";
+import type { BillingModel, BillingPeriod } from "@calcom/prisma/enums";
+import type { Logger } from "tslog";
+import { ActiveUsersBillingStrategy } from "./ActiveUsersBillingStrategy";
+import { BillingModelRepository } from "./BillingModelRepository";
+import type { IBillingModelStrategy } from "./IBillingModelStrategy";
+import { SeatsHwmBillingStrategy } from "./SeatsHwmBillingStrategy";
+import { SeatsProrationBillingStrategy } from "./SeatsProrationBillingStrategy";
+
+const defaultLog = logger.getSubLogger({
+  prefix: ["BillingModelStrategyFactory"],
+});
+
+// Stateless singletons
+const seatsHwm = new SeatsHwmBillingStrategy();
+const seatsProration = new SeatsProrationBillingStrategy();
+const activeUsers = new ActiveUsersBillingStrategy();
+
+const defaultRepository = new BillingModelRepository();
+
+export interface StrategyLookupResult {
+  strategy: IBillingModelStrategy;
+  billingModel: BillingModel;
+  billingPeriod: BillingPeriod | null;
+}
+
+function resolveStrategy(
+  billingModel: BillingModel,
+  billingPeriod: BillingPeriod | null
+): IBillingModelStrategy {
+  if (billingModel === "ACTIVE_USERS") {
+    return activeUsers;
+  }
+  // SEATS: pick HWM vs proration based on billing period
+  if (billingPeriod === "MONTHLY") {
+    return seatsHwm;
+  }
+  return seatsProration;
+}
+
+export async function getStrategyForSubscription(
+  subscriptionId: string,
+  repository: BillingModelRepository = defaultRepository,
+  log: Logger<unknown> = defaultLog
+): Promise<StrategyLookupResult | null> {
+  const record = await repository.findBySubscriptionId(subscriptionId);
+
+  if (!record) {
+    log.warn(`No billing record found for subscription ${subscriptionId}`);
+    return null;
+  }
+
+  const strategy = resolveStrategy(record.billingModel, record.billingPeriod);
+  log.debug("Found billing strategy for subscription", {
+    subscriptionId,
+    billingModel: record.billingModel,
+    billingPeriod: record.billingPeriod,
+  });
+
+  return {
+    strategy,
+    billingModel: record.billingModel,
+    billingPeriod: record.billingPeriod,
+  };
+}
+
+export async function getStrategyForTeam(
+  teamId: number,
+  repository: BillingModelRepository = defaultRepository,
+  log: Logger<unknown> = defaultLog
+): Promise<StrategyLookupResult | null> {
+  const record = await repository.findByTeamId(teamId);
+
+  if (!record) {
+    log.warn(`No billing record found for team ${teamId}`);
+    return null;
+  }
+
+  const strategy = resolveStrategy(record.billingModel, record.billingPeriod);
+  log.debug("Found billing strategy for team", {
+    teamId,
+    billingModel: record.billingModel,
+    billingPeriod: record.billingPeriod,
+  });
+
+  return {
+    strategy,
+    billingModel: record.billingModel,
+    billingPeriod: record.billingPeriod,
+  };
+}

--- a/packages/features/ee/billing/service/billingModelStrategy/BillingModelStrategyFactory.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/BillingModelStrategyFactory.ts
@@ -1,8 +1,8 @@
 import logger from "@calcom/lib/logger";
 import type { BillingModel, BillingPeriod } from "@calcom/prisma/enums";
 import type { Logger } from "tslog";
+import { getBillingModelRepository } from "../../di/containers/Billing";
 import { ActiveUsersBillingStrategy } from "./ActiveUsersBillingStrategy";
-import { BillingModelRepository } from "./BillingModelRepository";
 import type { IBillingModelStrategy } from "./IBillingModelStrategy";
 import { SeatsHwmBillingStrategy } from "./SeatsHwmBillingStrategy";
 import { SeatsProrationBillingStrategy } from "./SeatsProrationBillingStrategy";
@@ -15,8 +15,6 @@ const defaultLog = logger.getSubLogger({
 const seatsHwm = new SeatsHwmBillingStrategy();
 const seatsProration = new SeatsProrationBillingStrategy();
 const activeUsers = new ActiveUsersBillingStrategy();
-
-const defaultRepository = new BillingModelRepository();
 
 export interface StrategyLookupResult {
   strategy: IBillingModelStrategy;
@@ -40,9 +38,9 @@ function resolveStrategy(
 
 export async function getStrategyForSubscription(
   subscriptionId: string,
-  repository: BillingModelRepository = defaultRepository,
   log: Logger<unknown> = defaultLog
 ): Promise<StrategyLookupResult | null> {
+  const repository = getBillingModelRepository();
   const record = await repository.findBySubscriptionId(subscriptionId);
 
   if (!record) {
@@ -66,9 +64,9 @@ export async function getStrategyForSubscription(
 
 export async function getStrategyForTeam(
   teamId: number,
-  repository: BillingModelRepository = defaultRepository,
   log: Logger<unknown> = defaultLog
 ): Promise<StrategyLookupResult | null> {
+  const repository = getBillingModelRepository();
   const record = await repository.findByTeamId(teamId);
 
   if (!record) {

--- a/packages/features/ee/billing/service/billingModelStrategy/BillingModelStrategyIntegration.test.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/BillingModelStrategyIntegration.test.ts
@@ -1,0 +1,617 @@
+/**
+ * Integration tests for the Billing Strategy pattern.
+ *
+ * These tests exercise the FULL factory -> strategy -> service -> repository -> DB chain:
+ *   1. Creates real teams, users, memberships, and billing records (via Prismock in-memory DB)
+ *   2. Runs real BillingModelRepository, SeatChangeTrackingService, HighWaterMarkRepository
+ *   3. Mocks only the Stripe API boundary (getBillingProviderService, getTeamBillingServiceFactory)
+ *   4. Verifies real DB state: SeatChangeLog entries, TeamBilling HWM updates
+ *
+ * Covers all 3 strategies across all 5 IBillingModelStrategy methods.
+ */
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { prisma } from "@calcom/prisma";
+
+import { getStrategyForSubscription, getStrategyForTeam } from "./BillingModelStrategyFactory";
+import { ActiveUsersBillingStrategy } from "./ActiveUsersBillingStrategy";
+import { SeatsHwmBillingStrategy } from "./SeatsHwmBillingStrategy";
+import { SeatsProrationBillingStrategy } from "./SeatsProrationBillingStrategy";
+
+// ---------------------------------------------------------------------------
+// Mock ONLY the Stripe-facing boundaries. Everything else is real code
+// running against Prismock (in-memory DB provided by vitest setup).
+// ---------------------------------------------------------------------------
+
+const { mockUpdateQuantity, mockFindAndInit, mockApplyHwm, mockResetHwm } = vi.hoisted(() => {
+  const mockUpdateQuantity = vi.fn().mockResolvedValue(undefined);
+  return {
+    mockUpdateQuantity,
+    mockFindAndInit: vi.fn().mockResolvedValue({ updateQuantity: mockUpdateQuantity }),
+    mockApplyHwm: vi.fn().mockResolvedValue(true),
+    mockResetHwm: vi.fn().mockResolvedValue(true),
+  };
+});
+
+vi.mock("../../di/containers/Billing", () => ({
+  getBillingProviderService: vi.fn(() => ({})),
+  getTeamBillingServiceFactory: vi.fn(() => ({ findAndInit: mockFindAndInit })),
+}));
+
+vi.mock("../highWaterMark/HighWaterMarkService", () => ({
+  HighWaterMarkService: class {
+    applyHighWaterMarkToSubscription = mockApplyHwm;
+    resetSubscriptionAfterRenewal = mockResetHwm;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockLogger = () =>
+  ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }) as unknown;
+
+let idCounter = Date.now();
+function nextId() {
+  return idCounter++;
+}
+
+async function createUser(name: string) {
+  return prisma.user.create({
+    data: {
+      email: `strat-integ-${name}-${nextId()}@test.local`,
+      name: `Test ${name}`,
+      username: `strat-integ-${name}-${nextId()}`,
+    },
+  });
+}
+
+async function createTeamWithBilling(opts: {
+  slug: string;
+  billingModel: "SEATS" | "ACTIVE_USERS";
+  billingPeriod: "MONTHLY" | "ANNUALLY";
+  isOrganization?: boolean;
+}) {
+  const team = await prisma.team.create({
+    data: {
+      name: `StratInteg ${opts.slug}`,
+      slug: `strat-integ-${opts.slug}-${nextId()}`,
+      isOrganization: opts.isOrganization ?? false,
+    },
+  });
+
+  const subId = `sub_test_${opts.slug}_${nextId()}`;
+  const billing = await prisma.teamBilling.create({
+    data: {
+      teamId: team.id,
+      customerId: `cus_test_${opts.slug}_${nextId()}`,
+      subscriptionId: subId,
+      subscriptionItemId: `si_test_${opts.slug}_${nextId()}`,
+      status: "ACTIVE",
+      planName: "TEAM",
+      billingPeriod: opts.billingPeriod,
+      billingModel: opts.billingModel,
+      pricePerSeat: 1500,
+      paidSeats: 1,
+      subscriptionStart: new Date(),
+      highWaterMark: opts.billingPeriod === "MONTHLY" && opts.billingModel === "SEATS" ? 1 : null,
+      highWaterMarkPeriodStart:
+        opts.billingPeriod === "MONTHLY" && opts.billingModel === "SEATS" ? new Date() : null,
+    },
+  });
+
+  return { team, billing, subscriptionId: subId };
+}
+
+async function addMember(teamId: number, userId: number, role: "OWNER" | "MEMBER" = "MEMBER") {
+  await prisma.membership.create({
+    data: { teamId, userId, role, accepted: true },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Strategy configs
+// ---------------------------------------------------------------------------
+
+interface StrategyTestConfig {
+  label: string;
+  billingModel: "SEATS" | "ACTIVE_USERS";
+  billingPeriod: "MONTHLY" | "ANNUALLY";
+  expectedClass: typeof SeatsHwmBillingStrategy | typeof SeatsProrationBillingStrategy | typeof ActiveUsersBillingStrategy;
+  expectsStripeSync: boolean;
+  expectsHwmApply: boolean;
+  expectsHwmReset: boolean;
+}
+
+const STRATEGIES: StrategyTestConfig[] = [
+  {
+    label: "SEATS + MONTHLY (HWM)",
+    billingModel: "SEATS",
+    billingPeriod: "MONTHLY",
+    expectedClass: SeatsHwmBillingStrategy,
+    expectsStripeSync: true,
+    expectsHwmApply: true,
+    expectsHwmReset: true,
+  },
+  {
+    label: "SEATS + ANNUALLY (Proration)",
+    billingModel: "SEATS",
+    billingPeriod: "ANNUALLY",
+    expectedClass: SeatsProrationBillingStrategy,
+    expectsStripeSync: false,
+    expectsHwmApply: false,
+    expectsHwmReset: false,
+  },
+  {
+    label: "ACTIVE_USERS",
+    billingModel: "ACTIVE_USERS",
+    billingPeriod: "MONTHLY",
+    expectedClass: ActiveUsersBillingStrategy,
+    expectsStripeSync: false,
+    expectsHwmApply: false,
+    expectsHwmReset: false,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Billing Strategy Integration", () => {
+  beforeAll(async () => {
+    // Seed the hwm-seating feature flag so HWM updates fire for monthly billing
+    await prisma.feature.upsert({
+      where: { slug: "hwm-seating" },
+      update: { enabled: true },
+      create: { slug: "hwm-seating", enabled: true, type: "RELEASE", description: "HWM test flag" },
+    });
+  });
+
+  describe.each(STRATEGIES)(
+    "$label",
+    ({
+      label,
+      billingModel,
+      billingPeriod,
+      expectedClass,
+      expectsStripeSync,
+      expectsHwmApply,
+      expectsHwmReset,
+    }) => {
+      let teamId: number;
+      let subscriptionId: string;
+      let adminId: number;
+      let memberId: number;
+
+      beforeAll(async () => {
+        // Create a team with the right billing config
+        const { team, subscriptionId: subId } = await createTeamWithBilling({
+          slug: label.replace(/[^a-z0-9]/gi, "-").toLowerCase(),
+          billingModel,
+          billingPeriod,
+        });
+        teamId = team.id;
+        subscriptionId = subId;
+
+        // Create users
+        const admin = await createUser(`admin-${label}`);
+        const member = await createUser(`member-${label}`);
+        adminId = admin.id;
+        memberId = member.id;
+
+        // Add admin as owner
+        await addMember(teamId, adminId, "OWNER");
+      });
+
+      beforeEach(() => {
+        vi.clearAllMocks();
+        mockFindAndInit.mockResolvedValue({ updateQuantity: mockUpdateQuantity });
+      });
+
+      // -----------------------------------------------------------------
+      // Factory resolution from real DB records
+      // -----------------------------------------------------------------
+
+      it("factory resolves the correct strategy from DB billing record", async () => {
+        const byTeam = await getStrategyForTeam(teamId);
+        expect(byTeam).not.toBeNull();
+        expect(byTeam!.strategy).toBeInstanceOf(expectedClass);
+        expect(byTeam!.billingModel).toBe(billingModel);
+        expect(byTeam!.billingPeriod).toBe(billingPeriod);
+      });
+
+      it("factory resolves by subscriptionId from DB", async () => {
+        const bySub = await getStrategyForSubscription(subscriptionId);
+        expect(bySub).not.toBeNull();
+        expect(bySub!.strategy).toBeInstanceOf(expectedClass);
+      });
+
+      // -----------------------------------------------------------------
+      // handleMemberAddition: add user, verify DB + Stripe
+      // -----------------------------------------------------------------
+
+      it("handleMemberAddition creates ADDITION seat change log in DB", async () => {
+        const logsBefore = await prisma.seatChangeLog.count({
+          where: { teamId, changeType: "ADDITION" },
+        });
+
+        const { strategy } = (await getStrategyForTeam(teamId))!;
+        await strategy.handleMemberAddition(
+          { teamId, userId: memberId, triggeredBy: adminId, seatCount: 1 },
+          mockLogger() as never
+        );
+
+        const logsAfter = await prisma.seatChangeLog.count({
+          where: { teamId, changeType: "ADDITION" },
+        });
+        expect(logsAfter).toBe(logsBefore + 1);
+
+        // Verify the log entry content
+        const lastLog = await prisma.seatChangeLog.findFirst({
+          where: { teamId, changeType: "ADDITION" },
+          orderBy: { changeDate: "desc" },
+        });
+        expect(lastLog).not.toBeNull();
+        expect(lastLog!.userId).toBe(memberId);
+        expect(lastLog!.seatCount).toBe(1);
+      });
+
+      it(`handleMemberAddition ${expectsStripeSync ? "syncs" : "does NOT sync"} Stripe quantity`, async () => {
+        const { strategy } = (await getStrategyForTeam(teamId))!;
+        await strategy.handleMemberAddition(
+          { teamId, userId: memberId, triggeredBy: adminId, seatCount: 1 },
+          mockLogger() as never
+        );
+
+        if (expectsStripeSync) {
+          expect(mockFindAndInit).toHaveBeenCalledWith(teamId);
+          expect(mockUpdateQuantity).toHaveBeenCalled();
+        } else {
+          expect(mockUpdateQuantity).not.toHaveBeenCalled();
+        }
+      });
+
+      // -----------------------------------------------------------------
+      // handleMemberRemoval: remove user, verify DB + Stripe
+      // -----------------------------------------------------------------
+
+      it("handleMemberRemoval creates REMOVAL seat change log in DB", async () => {
+        const logsBefore = await prisma.seatChangeLog.count({
+          where: { teamId, changeType: "REMOVAL" },
+        });
+
+        const { strategy } = (await getStrategyForTeam(teamId))!;
+        await strategy.handleMemberRemoval(
+          { teamId, userId: memberId, triggeredBy: adminId, seatCount: 1 },
+          mockLogger() as never
+        );
+
+        const logsAfter = await prisma.seatChangeLog.count({
+          where: { teamId, changeType: "REMOVAL" },
+        });
+        expect(logsAfter).toBe(logsBefore + 1);
+
+        const lastLog = await prisma.seatChangeLog.findFirst({
+          where: { teamId, changeType: "REMOVAL" },
+          orderBy: { changeDate: "desc" },
+        });
+        expect(lastLog).not.toBeNull();
+        expect(lastLog!.userId).toBe(memberId);
+      });
+
+      it(`handleMemberRemoval ${expectsStripeSync ? "syncs" : "does NOT sync"} Stripe quantity`, async () => {
+        const { strategy } = (await getStrategyForTeam(teamId))!;
+        await strategy.handleMemberRemoval(
+          { teamId, userId: memberId, triggeredBy: adminId, seatCount: 1 },
+          mockLogger() as never
+        );
+
+        if (expectsStripeSync) {
+          expect(mockFindAndInit).toHaveBeenCalledWith(teamId);
+          expect(mockUpdateQuantity).toHaveBeenCalled();
+        } else {
+          expect(mockUpdateQuantity).not.toHaveBeenCalled();
+        }
+      });
+
+      // -----------------------------------------------------------------
+      // syncBillingQuantity: no seat logs, just Stripe sync (or no-op)
+      // -----------------------------------------------------------------
+
+      it("syncBillingQuantity does not create any seat change logs", async () => {
+        const logsBefore = await prisma.seatChangeLog.count({ where: { teamId } });
+
+        const { strategy } = (await getStrategyForTeam(teamId))!;
+        await strategy.syncBillingQuantity({ teamId }, mockLogger() as never);
+
+        const logsAfter = await prisma.seatChangeLog.count({ where: { teamId } });
+        expect(logsAfter).toBe(logsBefore);
+      });
+
+      it(`syncBillingQuantity ${expectsStripeSync ? "calls" : "skips"} Stripe updateQuantity`, async () => {
+        const { strategy } = (await getStrategyForTeam(teamId))!;
+        await strategy.syncBillingQuantity({ teamId }, mockLogger() as never);
+
+        if (expectsStripeSync) {
+          expect(mockFindAndInit).toHaveBeenCalledWith(teamId);
+          expect(mockUpdateQuantity).toHaveBeenCalled();
+        } else {
+          expect(mockFindAndInit).not.toHaveBeenCalled();
+        }
+      });
+
+      // -----------------------------------------------------------------
+      // handleInvoiceUpcoming (webhook path)
+      // -----------------------------------------------------------------
+
+      it(`handleInvoiceUpcoming ${expectsHwmApply ? "applies HWM" : "is a no-op"}`, async () => {
+        const { strategy } = (await getStrategyForSubscription(subscriptionId))!;
+        const result = await strategy.handleInvoiceUpcoming(
+          { subscriptionId },
+          mockLogger() as never
+        );
+
+        if (expectsHwmApply) {
+          expect(mockApplyHwm).toHaveBeenCalledWith(subscriptionId);
+          expect(result.applied).toBe(true);
+        } else {
+          expect(mockApplyHwm).not.toHaveBeenCalled();
+          expect(result.applied).toBe(false);
+        }
+      });
+
+      // -----------------------------------------------------------------
+      // handlePostRenewalReset (webhook path)
+      // -----------------------------------------------------------------
+
+      it(`handlePostRenewalReset ${expectsHwmReset ? "resets HWM" : "is a no-op"}`, async () => {
+        const timestamp = Math.floor(Date.now() / 1000);
+        const { strategy } = (await getStrategyForSubscription(subscriptionId))!;
+        const result = await strategy.handlePostRenewalReset(
+          { subscriptionId, periodStartTimestamp: timestamp },
+          mockLogger() as never
+        );
+
+        if (expectsHwmReset) {
+          expect(mockResetHwm).toHaveBeenCalledWith({
+            subscriptionId,
+            newPeriodStart: new Date(timestamp * 1000),
+          });
+          expect(result).toEqual({ success: true, updated: true });
+        } else {
+          expect(mockResetHwm).not.toHaveBeenCalled();
+          expect(result).toEqual({ success: true, updated: false });
+        }
+      });
+    }
+  );
+
+  // -----------------------------------------------------------------------
+  // Organization billing path (billingModel lookup via OrganizationBilling)
+  // -----------------------------------------------------------------------
+
+  describe("organization billing path", () => {
+    let orgId: number;
+    let orgSubId: string;
+    let orgAdminId: number;
+    let orgMemberId: number;
+
+    beforeAll(async () => {
+      const org = await prisma.team.create({
+        data: {
+          name: "StratInteg Org",
+          slug: `strat-integ-org-${nextId()}`,
+          isOrganization: true,
+        },
+      });
+      orgId = org.id;
+
+      orgSubId = `sub_test_org_${nextId()}`;
+      await prisma.organizationBilling.create({
+        data: {
+          teamId: orgId,
+          customerId: `cus_test_org_${nextId()}`,
+          subscriptionId: orgSubId,
+          subscriptionItemId: `si_test_org_${nextId()}`,
+          status: "ACTIVE",
+          planName: "ORGANIZATION",
+          billingPeriod: "MONTHLY",
+          billingModel: "SEATS",
+          pricePerSeat: 3700,
+          paidSeats: 1,
+          subscriptionStart: new Date(),
+          highWaterMark: 1,
+          highWaterMarkPeriodStart: new Date(),
+        },
+      });
+
+      const admin = await createUser("org-admin");
+      const member = await createUser("org-member");
+      orgAdminId = admin.id;
+      orgMemberId = member.id;
+
+      await addMember(orgId, orgAdminId, "OWNER");
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockFindAndInit.mockResolvedValue({ updateQuantity: mockUpdateQuantity });
+    });
+
+    it("factory resolves strategy from OrganizationBilling record", async () => {
+      const result = await getStrategyForTeam(orgId);
+      expect(result).not.toBeNull();
+      expect(result!.strategy).toBeInstanceOf(SeatsHwmBillingStrategy);
+      expect(result!.billingModel).toBe("SEATS");
+      expect(result!.billingPeriod).toBe("MONTHLY");
+    });
+
+    it("factory resolves by org subscriptionId", async () => {
+      const result = await getStrategyForSubscription(orgSubId);
+      expect(result).not.toBeNull();
+      expect(result!.strategy).toBeInstanceOf(SeatsHwmBillingStrategy);
+    });
+
+    it("handleMemberAddition creates seat log linked to organizationBillingId", async () => {
+      const { strategy } = (await getStrategyForTeam(orgId))!;
+      await strategy.handleMemberAddition(
+        { teamId: orgId, userId: orgMemberId, triggeredBy: orgAdminId, seatCount: 1 },
+        mockLogger() as never
+      );
+
+      const log = await prisma.seatChangeLog.findFirst({
+        where: { teamId: orgId, changeType: "ADDITION" },
+        orderBy: { changeDate: "desc" },
+      });
+      expect(log).not.toBeNull();
+      expect(log!.organizationBillingId).not.toBeNull();
+      expect(log!.teamBillingId).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Multi-member scenario: add 3, remove 1, verify log counts
+  // -----------------------------------------------------------------------
+
+  describe("multi-member lifecycle", () => {
+    let teamId: number;
+    let adminId: number;
+    let memberIds: number[];
+
+    beforeAll(async () => {
+      const { team } = await createTeamWithBilling({
+        slug: "lifecycle",
+        billingModel: "SEATS",
+        billingPeriod: "MONTHLY",
+      });
+      teamId = team.id;
+
+      const admin = await createUser("lifecycle-admin");
+      adminId = admin.id;
+      await addMember(teamId, adminId, "OWNER");
+
+      memberIds = [];
+      for (let i = 0; i < 3; i++) {
+        const m = await createUser(`lifecycle-member-${i}`);
+        memberIds.push(m.id);
+        await addMember(teamId, m.id, "MEMBER");
+      }
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockFindAndInit.mockResolvedValue({ updateQuantity: mockUpdateQuantity });
+    });
+
+    it("tracks 3 additions and 1 removal correctly", async () => {
+      const { strategy } = (await getStrategyForTeam(teamId))!;
+
+      // Add 3 members
+      for (const uid of memberIds) {
+        await strategy.handleMemberAddition(
+          { teamId, userId: uid, triggeredBy: adminId, seatCount: 1 },
+          mockLogger() as never
+        );
+      }
+
+      // Remove 1 member
+      await strategy.handleMemberRemoval(
+        { teamId, userId: memberIds[2], triggeredBy: adminId, seatCount: 1 },
+        mockLogger() as never
+      );
+
+      const additions = await prisma.seatChangeLog.count({
+        where: { teamId, changeType: "ADDITION" },
+      });
+      const removals = await prisma.seatChangeLog.count({
+        where: { teamId, changeType: "REMOVAL" },
+      });
+
+      expect(additions).toBe(3);
+      expect(removals).toBe(1);
+
+      // HWM strategy should have synced Stripe on each operation (4 total)
+      expect(mockFindAndInit).toHaveBeenCalledTimes(4);
+      expect(mockUpdateQuantity).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error resilience: Stripe failures should not prevent seat logging
+  // -----------------------------------------------------------------------
+
+  describe("error resilience", () => {
+    let teamId: number;
+    let adminId: number;
+    let memberId: number;
+
+    beforeAll(async () => {
+      const { team } = await createTeamWithBilling({
+        slug: "error-resilience",
+        billingModel: "SEATS",
+        billingPeriod: "MONTHLY",
+      });
+      teamId = team.id;
+
+      const admin = await createUser("err-admin");
+      const member = await createUser("err-member");
+      adminId = admin.id;
+      memberId = member.id;
+      await addMember(teamId, adminId, "OWNER");
+    });
+
+    it("still creates seat log even when Stripe sync fails", async () => {
+      mockFindAndInit.mockRejectedValueOnce(new Error("Stripe API down"));
+
+      const logsBefore = await prisma.seatChangeLog.count({
+        where: { teamId, changeType: "ADDITION" },
+      });
+
+      const { strategy } = (await getStrategyForTeam(teamId))!;
+      // Should not throw
+      await strategy.handleMemberAddition(
+        { teamId, userId: memberId, triggeredBy: adminId, seatCount: 1 },
+        mockLogger() as never
+      );
+
+      const logsAfter = await prisma.seatChangeLog.count({
+        where: { teamId, changeType: "ADDITION" },
+      });
+      // Seat log was still written despite Stripe failure
+      expect(logsAfter).toBe(logsBefore + 1);
+    });
+
+    it("handlePostRenewalReset returns failure when HWM service throws", async () => {
+      mockResetHwm.mockRejectedValueOnce(new Error("Stripe timeout"));
+
+      const { strategy } = (await getStrategyForTeam(teamId))!;
+      const result = await strategy.handlePostRenewalReset(
+        { subscriptionId: "sub_doesnt_matter", periodStartTimestamp: Math.floor(Date.now() / 1000) },
+        mockLogger() as never
+      );
+
+      expect(result).toEqual({ success: false, error: "Stripe timeout" });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Factory returns null for teams with no billing record
+  // -----------------------------------------------------------------------
+
+  describe("no billing record", () => {
+    it("getStrategyForTeam returns null for team without billing", async () => {
+      const team = await prisma.team.create({
+        data: { name: "No Billing Team", slug: `strat-integ-no-billing-${nextId()}` },
+      });
+
+      const result = await getStrategyForTeam(team.id);
+      expect(result).toBeNull();
+    });
+
+    it("getStrategyForSubscription returns null for unknown subscription", async () => {
+      const result = await getStrategyForSubscription("sub_does_not_exist");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/features/ee/billing/service/billingModelStrategy/IBillingModelStrategy.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/IBillingModelStrategy.ts
@@ -1,0 +1,62 @@
+import type { Logger } from "tslog";
+
+export interface InvoiceUpcomingPayload {
+  subscriptionId: string;
+}
+
+export interface InvoiceUpcomingResult {
+  applied: boolean;
+}
+
+export interface PostRenewalResetPayload {
+  subscriptionId: string;
+  periodStartTimestamp: number;
+}
+
+export interface PostRenewalResetResult {
+  success: boolean;
+  updated?: boolean;
+  error?: string;
+}
+
+export interface MemberChangePayload {
+  teamId: number;
+  seatCount: number;
+  userId?: number;
+  triggeredBy?: number;
+}
+
+/**
+ * Strategy interface for billing-model-specific behavior.
+ *
+ * The factory selects a strategy based on billingModel + billingPeriod:
+ *   SEATS + MONTHLY   -> SeatsHwmBillingStrategy
+ *   SEATS + ANNUALLY  -> SeatsProrationBillingStrategy
+ *   ACTIVE_USERS      -> ActiveUsersBillingStrategy
+ */
+export interface IBillingModelStrategy {
+  /** Called on invoice.upcoming: prepare the subscription before Stripe generates the renewal invoice. */
+  handleInvoiceUpcoming(
+    payload: InvoiceUpcomingPayload,
+    logger: Logger<unknown>
+  ): Promise<InvoiceUpcomingResult>;
+
+  /** Called on invoice.paid (subscription_cycle): reset state after a successful renewal payment. */
+  handlePostRenewalReset(
+    payload: PostRenewalResetPayload,
+    logger: Logger<unknown>
+  ): Promise<PostRenewalResetResult>;
+
+  /** Called when members are added to a team/org. Handles seat logging and billing updates. */
+  handleMemberAddition(payload: MemberChangePayload, logger: Logger<unknown>): Promise<void>;
+
+  /** Called when members are removed from a team/org. Handles seat logging and billing updates. */
+  handleMemberRemoval(payload: MemberChangePayload, logger: Logger<unknown>): Promise<void>;
+
+  /**
+   * Sync Stripe subscription quantity without logging seat changes.
+   * Use this when seat tracking has already been handled separately (e.g. by invite utils)
+   * or when called for child teams where updateQuantity resolves to the parent org internally.
+   */
+  syncBillingQuantity(payload: { teamId: number }, logger: Logger<unknown>): Promise<void>;
+}

--- a/packages/features/ee/billing/service/billingModelStrategy/SeatsHwmBillingStrategy.test.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/SeatsHwmBillingStrategy.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SeatsHwmBillingStrategy } from "./SeatsHwmBillingStrategy";
+
+const mockApplyHighWaterMarkToSubscription = vi.fn();
+const mockResetSubscriptionAfterRenewal = vi.fn();
+
+vi.mock("../highWaterMark/HighWaterMarkService", () => ({
+  HighWaterMarkService: class MockHighWaterMarkService {
+    applyHighWaterMarkToSubscription = mockApplyHighWaterMarkToSubscription;
+    resetSubscriptionAfterRenewal = mockResetSubscriptionAfterRenewal;
+  },
+}));
+
+const mockUpdateQuantity = vi.fn();
+const mockFindAndInit = vi.fn(() => Promise.resolve({ updateQuantity: mockUpdateQuantity }));
+const mockLogSeatAddition = vi.fn();
+const mockLogSeatRemoval = vi.fn();
+
+const createMockLogger = () =>
+  ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }) as unknown;
+
+function createStrategy() {
+  return new SeatsHwmBillingStrategy({
+    seatTracker: { logSeatAddition: mockLogSeatAddition, logSeatRemoval: mockLogSeatRemoval } as never,
+    billingProviderService: {} as never,
+    teamBillingServiceFactory: { findAndInit: mockFindAndInit } as never,
+  });
+}
+
+describe("SeatsHwmBillingStrategy", () => {
+  let strategy: SeatsHwmBillingStrategy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    strategy = createStrategy();
+  });
+
+  describe("handleInvoiceUpcoming", () => {
+    it("delegates to HighWaterMarkService.applyHighWaterMarkToSubscription", async () => {
+      mockApplyHighWaterMarkToSubscription.mockResolvedValue(true);
+
+      const result = await strategy.handleInvoiceUpcoming(
+        { subscriptionId: "sub_123" },
+        createMockLogger() as never
+      );
+
+      expect(result).toEqual({ applied: true });
+      expect(mockApplyHighWaterMarkToSubscription).toHaveBeenCalledWith("sub_123");
+    });
+
+    it("returns applied: false when HWM service returns false", async () => {
+      mockApplyHighWaterMarkToSubscription.mockResolvedValue(false);
+
+      const result = await strategy.handleInvoiceUpcoming(
+        { subscriptionId: "sub_123" },
+        createMockLogger() as never
+      );
+
+      expect(result).toEqual({ applied: false });
+    });
+  });
+
+  describe("handlePostRenewalReset", () => {
+    it("delegates to HighWaterMarkService.resetSubscriptionAfterRenewal", async () => {
+      mockResetSubscriptionAfterRenewal.mockResolvedValue(true);
+      const timestamp = 1704067200;
+
+      const result = await strategy.handlePostRenewalReset(
+        { subscriptionId: "sub_123", periodStartTimestamp: timestamp },
+        createMockLogger() as never
+      );
+
+      expect(result).toEqual({ success: true, updated: true });
+      expect(mockResetSubscriptionAfterRenewal).toHaveBeenCalledWith({
+        subscriptionId: "sub_123",
+        newPeriodStart: new Date(timestamp * 1000),
+      });
+    });
+
+    it("returns success with updated=false when no update needed", async () => {
+      mockResetSubscriptionAfterRenewal.mockResolvedValue(false);
+
+      const result = await strategy.handlePostRenewalReset(
+        { subscriptionId: "sub_123", periodStartTimestamp: 1704067200 },
+        createMockLogger() as never
+      );
+
+      expect(result).toEqual({ success: true, updated: false });
+    });
+
+    it("returns failure when reset throws an error", async () => {
+      mockResetSubscriptionAfterRenewal.mockRejectedValue(new Error("Stripe API error"));
+      const mockLog = createMockLogger() as { error: ReturnType<typeof vi.fn> };
+
+      const result = await strategy.handlePostRenewalReset(
+        { subscriptionId: "sub_err", periodStartTimestamp: 1704067200 },
+        mockLog as never
+      );
+
+      expect(result).toEqual({ success: false, error: "Stripe API error" });
+      expect(mockLog.error).toHaveBeenCalledWith("Failed to reset HWM after invoice paid", {
+        subscriptionId: "sub_err",
+        error: "Stripe API error",
+      });
+    });
+  });
+
+  describe("handleMemberAddition", () => {
+    it("logs seat addition and updates quantity", async () => {
+      mockLogSeatAddition.mockResolvedValue(undefined);
+      mockUpdateQuantity.mockResolvedValue(undefined);
+
+      await strategy.handleMemberAddition(
+        { teamId: 42, userId: 7, triggeredBy: 1, seatCount: 1 },
+        createMockLogger() as never
+      );
+
+      expect(mockLogSeatAddition).toHaveBeenCalledWith({
+        teamId: 42,
+        userId: 7,
+        triggeredBy: 1,
+        seatCount: 1,
+      });
+      expect(mockFindAndInit).toHaveBeenCalledWith(42);
+      expect(mockUpdateQuantity).toHaveBeenCalledOnce();
+    });
+
+    it("logs error but does not throw when updateQuantity fails", async () => {
+      mockLogSeatAddition.mockResolvedValue(undefined);
+      mockFindAndInit.mockRejectedValueOnce(new Error("Billing not found"));
+      const mockLog = createMockLogger() as { error: ReturnType<typeof vi.fn> };
+
+      await expect(
+        strategy.handleMemberAddition({ teamId: 42, seatCount: 1 }, mockLog as never)
+      ).resolves.toBeUndefined();
+
+      expect(mockLog.error).toHaveBeenCalledWith("Failed to sync billing quantity", {
+        teamId: 42,
+        error: "Billing not found",
+      });
+    });
+  });
+
+  describe("handleMemberRemoval", () => {
+    it("logs seat removal and updates quantity", async () => {
+      mockLogSeatRemoval.mockResolvedValue(undefined);
+      mockUpdateQuantity.mockResolvedValue(undefined);
+
+      await strategy.handleMemberRemoval(
+        { teamId: 42, userId: 7, triggeredBy: 1, seatCount: 1 },
+        createMockLogger() as never
+      );
+
+      expect(mockLogSeatRemoval).toHaveBeenCalledWith({
+        teamId: 42,
+        userId: 7,
+        triggeredBy: 1,
+        seatCount: 1,
+      });
+      expect(mockFindAndInit).toHaveBeenCalledWith(42);
+      expect(mockUpdateQuantity).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("syncBillingQuantity", () => {
+    it("updates quantity without logging seat changes", async () => {
+      mockUpdateQuantity.mockResolvedValue(undefined);
+
+      await strategy.syncBillingQuantity({ teamId: 42 }, createMockLogger() as never);
+
+      expect(mockFindAndInit).toHaveBeenCalledWith(42);
+      expect(mockUpdateQuantity).toHaveBeenCalledOnce();
+      expect(mockLogSeatAddition).not.toHaveBeenCalled();
+      expect(mockLogSeatRemoval).not.toHaveBeenCalled();
+    });
+
+    it("logs error but does not throw when updateQuantity fails", async () => {
+      mockFindAndInit.mockRejectedValueOnce(new Error("Billing not found"));
+      const mockLog = createMockLogger() as { error: ReturnType<typeof vi.fn> };
+
+      await expect(
+        strategy.syncBillingQuantity({ teamId: 42 }, mockLog as never)
+      ).resolves.toBeUndefined();
+
+      expect(mockLog.error).toHaveBeenCalledWith("Failed to sync billing quantity", {
+        teamId: 42,
+        error: "Billing not found",
+      });
+    });
+  });
+});

--- a/packages/features/ee/billing/service/billingModelStrategy/SeatsHwmBillingStrategy.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/SeatsHwmBillingStrategy.ts
@@ -1,0 +1,112 @@
+import type { Logger } from "tslog";
+import type { IBillingProviderService } from "../billingProvider/IBillingProviderService";
+import { getBillingProviderService, getTeamBillingServiceFactory } from "../../di/containers/Billing";
+import { HighWaterMarkService } from "../highWaterMark/HighWaterMarkService";
+import { SeatChangeTrackingService } from "../seatTracking/SeatChangeTrackingService";
+import type {
+  IBillingModelStrategy,
+  InvoiceUpcomingPayload,
+  InvoiceUpcomingResult,
+  MemberChangePayload,
+  PostRenewalResetPayload,
+  PostRenewalResetResult,
+} from "./IBillingModelStrategy";
+
+export interface SeatsHwmBillingStrategyDeps {
+  seatTracker?: SeatChangeTrackingService;
+  billingProviderService?: IBillingProviderService;
+  teamBillingServiceFactory?: ReturnType<typeof getTeamBillingServiceFactory>;
+}
+
+/**
+ * SEATS + MONTHLY billing strategy.
+ * Uses High Water Mark to adjust subscription quantity before renewal
+ * and reset after payment.
+ */
+export class SeatsHwmBillingStrategy implements IBillingModelStrategy {
+  private readonly seatTracker: SeatChangeTrackingService;
+  private readonly getBillingProvider: () => IBillingProviderService;
+  private readonly getFactory: () => ReturnType<typeof getTeamBillingServiceFactory>;
+
+  constructor(deps?: SeatsHwmBillingStrategyDeps) {
+    this.seatTracker = deps?.seatTracker ?? new SeatChangeTrackingService();
+    this.getBillingProvider = () => deps?.billingProviderService ?? getBillingProviderService();
+    this.getFactory = () => deps?.teamBillingServiceFactory ?? getTeamBillingServiceFactory();
+  }
+
+  async handleInvoiceUpcoming(
+    payload: InvoiceUpcomingPayload,
+    logger: Logger<unknown>
+  ): Promise<InvoiceUpcomingResult> {
+    const billingService = this.getBillingProvider();
+    const hwmService = new HighWaterMarkService({ logger, billingService });
+    const applied = await hwmService.applyHighWaterMarkToSubscription(payload.subscriptionId);
+    return { applied };
+  }
+
+  async handlePostRenewalReset(
+    payload: PostRenewalResetPayload,
+    logger: Logger<unknown>
+  ): Promise<PostRenewalResetResult> {
+    const newPeriodStart = new Date(payload.periodStartTimestamp * 1000);
+    const billingService = this.getBillingProvider();
+    const hwmService = new HighWaterMarkService({ logger, billingService });
+
+    try {
+      const updated = await hwmService.resetSubscriptionAfterRenewal({
+        subscriptionId: payload.subscriptionId,
+        newPeriodStart,
+      });
+
+      logger.info("HWM reset after invoice paid", {
+        subscriptionId: payload.subscriptionId,
+        newPeriodStart,
+        updated,
+      });
+
+      return { success: true, updated };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error("Failed to reset HWM after invoice paid", {
+        subscriptionId: payload.subscriptionId,
+        error: errorMessage,
+      });
+      return { success: false, error: errorMessage };
+    }
+  }
+
+  async handleMemberAddition(payload: MemberChangePayload, logger: Logger<unknown>): Promise<void> {
+    await this.seatTracker.logSeatAddition({
+      teamId: payload.teamId,
+      userId: payload.userId,
+      triggeredBy: payload.triggeredBy,
+      seatCount: payload.seatCount,
+    });
+
+    await this.syncBillingQuantity({ teamId: payload.teamId }, logger);
+  }
+
+  async handleMemberRemoval(payload: MemberChangePayload, logger: Logger<unknown>): Promise<void> {
+    await this.seatTracker.logSeatRemoval({
+      teamId: payload.teamId,
+      userId: payload.userId,
+      triggeredBy: payload.triggeredBy,
+      seatCount: payload.seatCount,
+    });
+
+    await this.syncBillingQuantity({ teamId: payload.teamId }, logger);
+  }
+
+  async syncBillingQuantity(payload: { teamId: number }, logger: Logger<unknown>): Promise<void> {
+    try {
+      const factory = this.getFactory();
+      const billingService = await factory.findAndInit(payload.teamId);
+      await billingService.updateQuantity();
+    } catch (error) {
+      logger.error("Failed to sync billing quantity", {
+        teamId: payload.teamId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}

--- a/packages/features/ee/billing/service/billingModelStrategy/SeatsProrationBillingStrategy.test.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/SeatsProrationBillingStrategy.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SeatsProrationBillingStrategy } from "./SeatsProrationBillingStrategy";
+
+const mockLogSeatAddition = vi.fn();
+const mockLogSeatRemoval = vi.fn();
+
+const createMockLogger = () =>
+  ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }) as unknown;
+
+function createStrategy() {
+  return new SeatsProrationBillingStrategy({
+    seatTracker: { logSeatAddition: mockLogSeatAddition, logSeatRemoval: mockLogSeatRemoval } as never,
+  });
+}
+
+describe("SeatsProrationBillingStrategy", () => {
+  let strategy: SeatsProrationBillingStrategy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    strategy = createStrategy();
+  });
+
+  describe("handleInvoiceUpcoming", () => {
+    it("returns applied: false (no-op for annual)", async () => {
+      const result = await strategy.handleInvoiceUpcoming(
+        { subscriptionId: "sub_123" },
+        createMockLogger() as never
+      );
+      expect(result).toEqual({ applied: false });
+    });
+  });
+
+  describe("handlePostRenewalReset", () => {
+    it("returns success with no update (no-op for annual)", async () => {
+      const result = await strategy.handlePostRenewalReset(
+        { subscriptionId: "sub_123", periodStartTimestamp: 1704067200 },
+        createMockLogger() as never
+      );
+      expect(result).toEqual({ success: true, updated: false });
+    });
+  });
+
+  describe("handleMemberAddition", () => {
+    it("logs seat addition but does not sync Stripe quantity", async () => {
+      mockLogSeatAddition.mockResolvedValue(undefined);
+
+      await strategy.handleMemberAddition(
+        { teamId: 42, userId: 7, triggeredBy: 1, seatCount: 1 },
+        createMockLogger() as never
+      );
+
+      expect(mockLogSeatAddition).toHaveBeenCalledWith({
+        teamId: 42,
+        userId: 7,
+        triggeredBy: 1,
+        seatCount: 1,
+      });
+    });
+  });
+
+  describe("handleMemberRemoval", () => {
+    it("logs seat removal but does not sync Stripe quantity", async () => {
+      mockLogSeatRemoval.mockResolvedValue(undefined);
+
+      await strategy.handleMemberRemoval(
+        { teamId: 42, userId: 7, triggeredBy: 1, seatCount: 1 },
+        createMockLogger() as never
+      );
+
+      expect(mockLogSeatRemoval).toHaveBeenCalledWith({
+        teamId: 42,
+        userId: 7,
+        triggeredBy: 1,
+        seatCount: 1,
+      });
+    });
+  });
+
+  describe("syncBillingQuantity", () => {
+    it("is a no-op (Stripe sync deferred to MonthlyProrationService)", async () => {
+      await strategy.syncBillingQuantity({ teamId: 42 }, createMockLogger() as never);
+
+      expect(mockLogSeatAddition).not.toHaveBeenCalled();
+      expect(mockLogSeatRemoval).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/features/ee/billing/service/billingModelStrategy/SeatsProrationBillingStrategy.ts
+++ b/packages/features/ee/billing/service/billingModelStrategy/SeatsProrationBillingStrategy.ts
@@ -1,0 +1,69 @@
+import type { Logger } from "tslog";
+import { SeatChangeTrackingService } from "../seatTracking/SeatChangeTrackingService";
+import type {
+  IBillingModelStrategy,
+  InvoiceUpcomingPayload,
+  InvoiceUpcomingResult,
+  MemberChangePayload,
+  PostRenewalResetPayload,
+  PostRenewalResetResult,
+} from "./IBillingModelStrategy";
+
+export interface SeatsProrationBillingStrategyDeps {
+  seatTracker?: SeatChangeTrackingService;
+}
+
+/**
+ * SEATS + ANNUALLY billing strategy.
+ * Stripe subscription quantity is NOT updated at member-change time.
+ * Instead, MonthlyProrationService (trigger.dev cron on 1st of month)
+ * reads seat change logs, creates a prorated invoice, and updates
+ * the Stripe quantity only after payment succeeds.
+ */
+export class SeatsProrationBillingStrategy implements IBillingModelStrategy {
+  private readonly seatTracker: SeatChangeTrackingService;
+
+  constructor(deps?: SeatsProrationBillingStrategyDeps) {
+    this.seatTracker = deps?.seatTracker ?? new SeatChangeTrackingService();
+  }
+
+  async handleInvoiceUpcoming(
+    payload: InvoiceUpcomingPayload,
+    logger: Logger<unknown>
+  ): Promise<InvoiceUpcomingResult> {
+    logger.debug(`SEATS+ANNUAL: skipping invoice.upcoming for ${payload.subscriptionId}`);
+    return { applied: false };
+  }
+
+  async handlePostRenewalReset(
+    payload: PostRenewalResetPayload,
+    logger: Logger<unknown>
+  ): Promise<PostRenewalResetResult> {
+    logger.debug(`SEATS+ANNUAL: skipping post-renewal reset for ${payload.subscriptionId}`);
+    return { success: true, updated: false };
+  }
+
+  async handleMemberAddition(payload: MemberChangePayload, logger: Logger<unknown>): Promise<void> {
+    await this.seatTracker.logSeatAddition({
+      teamId: payload.teamId,
+      userId: payload.userId,
+      triggeredBy: payload.triggeredBy,
+      seatCount: payload.seatCount,
+    });
+    logger.debug(`SEATS+ANNUAL: seat addition logged for team ${payload.teamId}, Stripe sync deferred to MonthlyProrationService`);
+  }
+
+  async handleMemberRemoval(payload: MemberChangePayload, logger: Logger<unknown>): Promise<void> {
+    await this.seatTracker.logSeatRemoval({
+      teamId: payload.teamId,
+      userId: payload.userId,
+      triggeredBy: payload.triggeredBy,
+      seatCount: payload.seatCount,
+    });
+    logger.debug(`SEATS+ANNUAL: seat removal logged for team ${payload.teamId}, Stripe sync deferred to MonthlyProrationService`);
+  }
+
+  async syncBillingQuantity(_payload: { teamId: number }, logger: Logger<unknown>): Promise<void> {
+    logger.debug("SEATS+ANNUAL: skipping billing quantity sync -- handled by MonthlyProrationService");
+  }
+}

--- a/packages/features/ee/dsync/lib/users/createUsersAndConnectToOrg.ts
+++ b/packages/features/ee/dsync/lib/users/createUsersAndConnectToOrg.ts
@@ -81,7 +81,7 @@ export const createUsersAndConnectToOrg = async ({
 
   if (membershipResult.count > 0) {
     const log = logger.getSubLogger({ prefix: ["dsync-createUsersAndConnectToOrg"] });
-    const result = await getStrategyForTeam(org.id, undefined, log);
+    const result = await getStrategyForTeam(org.id, log);
     if (result) {
       await result.strategy.handleMemberAddition({ teamId: org.id, seatCount: membershipResult.count }, log);
     }

--- a/packages/features/ee/teams/services/teamService.ts
+++ b/packages/features/ee/teams/services/teamService.ts
@@ -213,7 +213,7 @@ export class TeamService {
       } else throw e;
     }
 
-    const strategyResult = await getStrategyForTeam(verificationToken.teamId, undefined, log);
+    const strategyResult = await getStrategyForTeam(verificationToken.teamId, log);
     if (strategyResult) {
       if (!verificationToken.team.parentId) {
         await strategyResult.strategy.handleMemberAddition(
@@ -305,7 +305,7 @@ export class TeamService {
         });
       }
 
-      const strategyResult = await getStrategyForTeam(teamId, undefined, log);
+      const strategyResult = await getStrategyForTeam(teamId, log);
       if (strategyResult) {
         if (!membership.team.parentId) {
           await strategyResult.strategy.handleMemberRemoval(
@@ -395,7 +395,7 @@ export class TeamService {
 
     await deleteWorkfowRemindersOfRemovedMember(team, userId, isOrg);
 
-    const strategyResult = await getStrategyForTeam(teamId, undefined, log);
+    const strategyResult = await getStrategyForTeam(teamId, log);
     if (strategyResult) {
       if (!team.parentId) {
         await strategyResult.strategy.handleMemberRemoval(

--- a/packages/prisma/migrations/20260206000000_add_billing_model_enum/migration.sql
+++ b/packages/prisma/migrations/20260206000000_add_billing_model_enum/migration.sql
@@ -1,0 +1,12 @@
+-- Note: We are defaulting these enums to SEATS based approach - the tables are pretty damn small in size so its easier i
+-- we just set defaults here
+-- CreateEnum
+CREATE TYPE "BillingModel" AS ENUM ('SEATS', 'ACTIVE_USERS');
+
+-- AlterTable
+-- ~3,700 in length right now (not fully backfilled)
+ALTER TABLE "TeamBilling" ADD COLUMN "billingModel" "BillingModel" NOT NULL DEFAULT 'SEATS';
+
+-- AlterTable
+-- 290 in length right now
+ALTER TABLE "OrganizationBilling" ADD COLUMN "billingModel" "BillingModel" NOT NULL DEFAULT 'SEATS';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2559,6 +2559,11 @@ enum BillingPeriod {
   ANNUALLY
 }
 
+enum BillingModel {
+  SEATS
+  ACTIVE_USERS
+}
+
 model OrganizationOnboarding {
   // TODO: Use uuid for id
   id String @id @default(uuid())
@@ -3003,6 +3008,8 @@ model TeamBilling {
   monthlyProrations MonthlyProration[]
   seatChangeLogs    SeatChangeLog[]
 
+  billingModel BillingModel @default(SEATS)
+
   // High water mark tracking for monthly billing
   highWaterMark            Int?
   highWaterMarkPeriodStart DateTime?
@@ -3030,6 +3037,8 @@ model OrganizationBilling {
   paidSeats         Int?
   monthlyProrations MonthlyProration[]
   seatChangeLogs    SeatChangeLog[]
+
+  billingModel BillingModel @default(SEATS)
 
   // High water mark tracking for monthly billing
   highWaterMark            Int?

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
@@ -232,7 +232,7 @@ export const inviteMembersWithNoInviterPermissionCheck = async (
 
   // Seat tracking already logged by invite utils.
   // Sync billing quantity -- the strategy decides whether to update Stripe.
-  const strategyResult = await getStrategyForTeam(team.id, undefined, log);
+  const strategyResult = await getStrategyForTeam(team.id, log);
   if (strategyResult) {
     await strategyResult.strategy.syncBillingQuantity({ teamId: team.id }, log);
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moves billing to a strategy pattern and routes webhooks and member changes to model-specific logic (SEATS monthly HWM, SEATS annual proration, ACTIVE_USERS). This centralizes behavior, simplifies team/invite flows, and improves test coverage.

- **New Features**
  - Added BillingModelRepository with DI bindings; factory selects a strategy by subscription or team.
  - Strategies: SeatsHwm (monthly HWM), SeatsProration (annual), ActiveUsers (audit-only).
  - Webhooks: invoice.upcoming now dispatches to the selected strategy; post-renewal reset uses the factory; handleHwmResetAfterRenewal renamed to handlePostRenewalReset.
  - TeamService, org DSYNC user creation, and inviteMember now call the strategy for seat logging and Stripe sync; child teams use syncBillingQuantity only.
  - Added unit and integration tests for the factory, strategies, webhook utilities, and DB seat logs.

- **Migration**
  - Adds BillingModel enum (SEATS, ACTIVE_USERS) to TeamBilling and OrganizationBilling with a default of SEATS.
  - Updates Prisma schema to store billingModel and use it when selecting strategies.

<sup>Written for commit efdfe7c29ee6bf51be0d00dac85c5bb08614dd00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

