### PR TITLE
fix: skip flaky no-show-updated-action integration test to unblock CI

### DIFF
--- a/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
@@ -15,7 +15,7 @@ import {
   enableFeatureForOrganization,
 } from "./integration-utils";
 
-describe.skip("No-Show Updated Action Integration", () => {
+describe("No-Show Updated Action Integration", () => {
   let bookingAuditTaskConsumer: BookingAuditTaskConsumer;
   let bookingAuditViewerService: BookingAuditViewerService;
 
@@ -173,7 +173,7 @@ describe.skip("No-Show Updated Action Integration", () => {
       expect(storedAttendeesNoShow[0].noShow.new).toBe(true);
     });
 
-    it("should handle multiple attendees marked as no-show", async () => {
+    it.skip("should handle multiple attendees marked as no-show", async () => {
       const { prisma } = await import("@calcom/prisma");
       const secondAttendeeEmail = `second-attendee-${Date.now()}@example.com`;
       additionalAttendeeEmails.push(secondAttendeeEmail);

--- a/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/no-show-updated-action.integration-test.ts
@@ -15,7 +15,7 @@ import {
   enableFeatureForOrganization,
 } from "./integration-utils";
 
-describe("No-Show Updated Action Integration", () => {
+describe.skip("No-Show Updated Action Integration", () => {
   let bookingAuditTaskConsumer: BookingAuditTaskConsumer;
   let bookingAuditViewerService: BookingAuditViewerService;
 


### PR DESCRIPTION
## What does this PR do?

Skips the flaky `No-Show Updated Action Integration` test suite (`no-show-updated-action.integration-test.ts`) to unblock CI for other contributors.

This test has been failing intermittently with `BOOKING_NOT_FOUND_OR_PERMISSION_DENIED` across unrelated PRs. Extensive debugging in [#27774](https://github.com/calcom/cal.com/pull/27774) — including 930+ test executions with `repeats` across 6 CI runs — failed to reproduce the flake, suggesting an extremely low occurrence rate tied to specific CI runner conditions.

**This is a temporary workaround.** Investigation continues on #27774 to identify the root cause.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No testing needed — this is a one-line change from `describe(` to `describe.skip(` which tells vitest to skip the entire test suite. CI should pass without integration test failures from this file.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My PR is small and focused

---

> **Link to Devin run:** https://app.devin.ai/sessions/96da5faf48c14894be8ae68b68807d00
> **Requested by:** @hariombalhara
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
