### PR TITLE
feat: split advanced tab into advanced and privacy & security tabs

### DIFF
--- a/apps/web/modules/event-types/components/EventType.tsx
+++ b/apps/web/modules/event-types/components/EventType.tsx
@@ -36,6 +36,7 @@ const tabs = [
   "team",
   "limits",
   "advanced",
+  "privacy",
   "instant",
   "recurring",
   "apps",

--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -70,6 +70,10 @@ const EventAdvancedTab = dynamic(() =>
   import("./tabs/advanced/EventAdvancedWebWrapper").then((mod) => mod)
 );
 
+const EventPrivacyTab = dynamic(() =>
+  import("./tabs/privacy/EventPrivacyWebWrapper").then((mod) => mod)
+);
+
 const EventInstantTab = dynamic(() =>
   import("./tabs/instant/EventInstantTab").then((mod) => mod.EventInstantTab)
 );
@@ -270,6 +274,7 @@ const EventTypeWeb = ({
         orgId={orgBranding?.id ?? null}
       />
     ),
+    privacy: <EventPrivacyTab eventType={eventType} team={team} />,
     instant: <EventInstantTab eventType={eventType} isTeamEvent={!!team} />,
     recurring: <EventRecurringTab eventType={eventType} />,
     apps: (
@@ -316,6 +321,7 @@ const EventTypeWeb = ({
         EventTeamAssignmentTab,
         EventLimitsTab,
         EventAdvancedTab,
+        EventPrivacyTab,
         EventInstantTab,
         EventRecurringTab,
         EventAppsTab,
@@ -347,6 +353,7 @@ const EventTypeWeb = ({
         "team",
         "limits",
         "advanced",
+        "privacy",
         "instant",
         "recurring",
         "apps",

--- a/apps/web/modules/event-types/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/EventAdvancedTab.tsx
@@ -20,7 +20,6 @@ import {
   allowDisablingAttendeeConfirmationEmails,
   allowDisablingHostConfirmationEmails,
 } from "@calcom/features/ee/workflows/lib/allowDisablingStandardEmails";
-import { MultiplePrivateLinksController } from "@calcom/web/modules/event-types/components";
 import AddVerifiedEmail from "@calcom/web/modules/event-types/components/AddVerifiedEmail";
 import { LearnMoreLink } from "@calcom/features/eventtypes/components/LearnMoreLink";
 import type { EventNameObjectType } from "@calcom/features/eventtypes/lib/eventNaming";
@@ -40,9 +39,7 @@ import {
   DEFAULT_DARK_BRAND_COLOR,
   MAX_SEATS_PER_TIME_SLOT,
 } from "@calcom/lib/constants";
-import { generateHashedLink } from "@calcom/lib/generateHashedLink";
 import { checkWCAGContrastColor } from "@calcom/lib/getBrandColours";
-import { extractHostTimezone } from "@calcom/lib/hashedLinksUtils";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { Prisma } from "@calcom/prisma/client";
 import { SchedulingType } from "@calcom/prisma/enums";
@@ -70,9 +67,7 @@ import CustomEventTypeModal from "./CustomEventTypeModal";
 import type { EmailNotificationToggleCustomClassNames } from "./DisableAllEmailsSetting";
 import { DisableAllEmailsSetting } from "./DisableAllEmailsSetting";
 import type { DisableReschedulingCustomClassNames } from "./DisableReschedulingController";
-import DisableReschedulingController from "./DisableReschedulingController";
 import type { RequiresConfirmationCustomClassNames } from "./RequiresConfirmationController";
-import RequiresConfirmationController from "./RequiresConfirmationController";
 
 export type EventAdvancedTabCustomClassNames = {
   destinationCalendar?: SelectClassNames;
@@ -432,10 +427,6 @@ export const EventAdvancedTab = ({
   const [showEventNameTip, setShowEventNameTip] = useState(false);
   const [darkModeError, setDarkModeError] = useState(false);
   const [lightModeError, setLightModeError] = useState(false);
-  const [multiplePrivateLinksVisible, setMultiplePrivateLinksVisible] = useState(
-    !!formMethods.getValues("multiplePrivateLinks") &&
-      formMethods.getValues("multiplePrivateLinks")?.length !== 0
-  );
   const watchedInterfaceLanguage = formMethods.watch("interfaceLanguage");
   const [interfaceLanguageVisible, setInterfaceLanguageVisible] = useState(
     watchedInterfaceLanguage !== null && watchedInterfaceLanguage !== undefined
@@ -522,33 +513,11 @@ export const EventAdvancedTab = ({
 
   const successRedirectUrlLocked = shouldLockDisableProps("successRedirectUrl");
   const seatsLocked = shouldLockDisableProps("seatsPerTimeSlotEnabled");
-  const requiresBookerEmailVerificationProps = shouldLockDisableProps("requiresBookerEmailVerification");
   const sendCalVideoTranscriptionEmailsProps = shouldLockDisableProps("canSendCalVideoTranscriptionEmails");
-  const hideCalendarNotesLocked = shouldLockDisableProps("hideCalendarNotes");
-  const hideCalendarEventDetailsLocked = shouldLockDisableProps("hideCalendarEventDetails");
   const eventTypeColorLocked = shouldLockDisableProps("eventTypeColor");
-  const lockTimeZoneToggleOnBookingPageLocked = shouldLockDisableProps("lockTimeZoneToggleOnBookingPage");
-  const multiplePrivateLinksLocked = shouldLockDisableProps("multiplePrivateLinks");
-  const reschedulingPastBookingsLocked = shouldLockDisableProps("allowReschedulingPastBookings");
-  const hideOrganizerEmailLocked = shouldLockDisableProps("hideOrganizerEmail");
   const customReplyToEmailLocked = shouldLockDisableProps("customReplyToEmail");
 
-  const disableCancellingLocked = shouldLockDisableProps("disableCancelling");
-  const allowReschedulingCancelledBookingsLocked = shouldLockDisableProps(
-    "allowReschedulingCancelledBookings"
-  );
-
   const { isLocked: _isLocked, ...eventNameLocked } = shouldLockDisableProps("eventName");
-
-  if (isManagedEventType) {
-    multiplePrivateLinksLocked.disabled = true;
-  }
-
-  const [disableRescheduling, setDisableRescheduling] = useState(eventType.disableRescheduling || false);
-
-  const [allowReschedulingCancelledBookings, setallowReschedulingCancelledBookings] = useState(
-    eventType.allowReschedulingCancelledBookings ?? false
-  );
 
   const showOptimizedSlotsLocked = shouldLockDisableProps("showOptimizedSlots");
 
@@ -565,15 +534,7 @@ export const EventAdvancedTab = ({
     }
   );
 
-  const userTimeZone = extractHostTimezone({
-    userId: eventType.userId,
-    teamId: eventType.teamId,
-    hosts: eventType.hosts,
-    owner: eventType.owner,
-    team: eventType.team,
-  });
-
-  let verifiedSecondaryEmails = [
+  let verifiedSecondaryEmails= [
     {
       label: user?.email || "",
       value: -1,
@@ -679,52 +640,6 @@ export const EventAdvancedTab = ({
           />
         </div>
       </div>
-      <RequiresConfirmationController
-        eventType={eventType}
-        seatsEnabled={seatsEnabled}
-        metadata={formMethods.getValues("metadata")}
-        requiresConfirmation={requiresConfirmation}
-        requiresConfirmationWillBlockSlot={formMethods.getValues("requiresConfirmationWillBlockSlot")}
-        onRequiresConfirmation={setRequiresConfirmation}
-        customClassNames={customClassNames?.requiresConfirmation}
-      />
-
-      {!isPlatform && (
-        <>
-          <Controller
-            name="disabledCancelling"
-            render={({ field: { onChange, value } }) => (
-              <SettingsToggle
-                labelClassName="text-sm"
-                toggleSwitchAtTheEnd={true}
-                switchContainerClassName="border-subtle rounded-lg border py-6 px-4 sm:px-6"
-                title={t("disable_cancelling")}
-                data-testid="disable-cancelling-toggle"
-                {...disableCancellingLocked}
-                description={
-                  <LearnMoreLink
-                    t={t}
-                    i18nKey="description_disable_cancelling"
-                    href="https://cal.com/help/event-types/disable-canceling-rescheduling#disable-cancelling"
-                  />
-                }
-                checked={value}
-                onCheckedChange={(val) => {
-                  onChange(val);
-                }}
-              />
-            )}
-          />
-
-          <DisableReschedulingController
-            eventType={eventType}
-            disableRescheduling={disableRescheduling}
-            onDisableRescheduling={setDisableRescheduling}
-            customClassNames={customClassNames?.disableRescheduling}
-          />
-        </>
-      )}
-
       <Controller
         name="canSendCalVideoTranscriptionEmails"
         render={({ field: { value, onChange } }) => (
@@ -811,71 +726,6 @@ export const EventAdvancedTab = ({
           )}
         />
       )}
-      <Controller
-        name="requiresBookerEmailVerification"
-        render={({ field: { value, onChange } }) => (
-          <SettingsToggle
-            labelClassName={classNames("text-sm", customClassNames?.bookerEmailVerification?.label)}
-            toggleSwitchAtTheEnd={true}
-            switchContainerClassName={classNames(
-              "border-subtle rounded-lg border py-6 px-4 sm:px-6",
-              customClassNames?.bookerEmailVerification?.container
-            )}
-            title={t("requires_booker_email_verification")}
-            data-testid="requires-booker-email-verification"
-            {...requiresBookerEmailVerificationProps}
-            description={t("description_requires_booker_email_verification")}
-            descriptionClassName={customClassNames?.bookerEmailVerification?.description}
-            checked={value}
-            onCheckedChange={(e) => onChange(e)}
-          />
-        )}
-      />
-      <Controller
-        name="hideCalendarNotes"
-        render={({ field: { value, onChange } }) => (
-          <SettingsToggle
-            labelClassName={classNames("text-sm", customClassNames?.calendarNotes?.label)}
-            toggleSwitchAtTheEnd={true}
-            switchContainerClassName={classNames(
-              "border-subtle rounded-lg border py-6 px-4 sm:px-6",
-              customClassNames?.calendarNotes?.container
-            )}
-            descriptionClassName={customClassNames?.calendarNotes?.description}
-            data-testid="disable-notes"
-            title={t("disable_notes")}
-            {...hideCalendarNotesLocked}
-            description={
-              <LearnMoreLink
-                t={t}
-                i18nKey="disable_notes_description"
-                href="https://cal.com/help/event-types/hide-notes"
-              />
-            }
-            checked={value}
-            onCheckedChange={(e) => onChange(e)}
-          />
-        )}
-      />
-      <Controller
-        name="hideCalendarEventDetails"
-        render={({ field: { value, onChange } }) => (
-          <SettingsToggle
-            labelClassName={classNames("text-sm", customClassNames?.eventDetailsVisibility?.label)}
-            toggleSwitchAtTheEnd={true}
-            switchContainerClassName={classNames(
-              "border-subtle rounded-lg border py-6 px-4 sm:px-6",
-              customClassNames?.eventDetailsVisibility?.container
-            )}
-            descriptionClassName={customClassNames?.eventDetailsVisibility?.description}
-            title={t("hide_calendar_event_details")}
-            {...hideCalendarEventDetailsLocked}
-            description={t("description_hide_calendar_event_details")}
-            checked={value}
-            onCheckedChange={(e) => onChange(e)}
-          />
-        )}
-      />
       <Controller
         name="successRedirectUrl"
         render={({ field: { value, onChange } }) => (
@@ -997,58 +847,6 @@ export const EventAdvancedTab = ({
           </>
         )}
       />
-      {!isPlatform && (
-        <Controller
-          name="multiplePrivateLinks"
-          render={() => {
-            return (
-              <SettingsToggle
-                labelClassName="text-sm"
-                toggleSwitchAtTheEnd={true}
-                switchContainerClassName={classNames(
-                  "border-subtle rounded-lg border py-6 px-4 sm:px-6",
-                  multiplePrivateLinksVisible && "rounded-b-none"
-                )}
-                childrenClassName="lg:ml-0"
-                data-testid="multiplePrivateLinksCheck"
-                title={t("multiple_private_links_title")}
-                {...multiplePrivateLinksLocked}
-                description={
-                  <LearnMoreLink
-                    t={t}
-                    i18nKey="multiple_private_links_description"
-                    href="https://cal.com/help/event-types/private-links"
-                  />
-                }
-                tooltip={isManagedEventType ? t("managed_event_field_parent_control_disabled") : ""}
-                checked={multiplePrivateLinksVisible}
-                onCheckedChange={(e) => {
-                  if (!e) {
-                    formMethods.setValue("multiplePrivateLinks", [], { shouldDirty: true });
-                  } else {
-                    formMethods.setValue(
-                      "multiplePrivateLinks",
-                      [generateHashedLink(formMethods.getValues("users")[0]?.id ?? team?.id)],
-                      { shouldDirty: true }
-                    );
-                  }
-                  setMultiplePrivateLinksVisible(e);
-                }}>
-                {!isManagedEventType && (
-                  <div className="border-subtle rounded-b-lg border border-t-0 p-6">
-                    <MultiplePrivateLinksController
-                      team={team}
-                      bookerUrl={eventType.bookerUrl}
-                      setMultiplePrivateLinksVisible={setMultiplePrivateLinksVisible}
-                      userTimeZone={userTimeZone}
-                    />
-                  </div>
-                )}
-              </SettingsToggle>
-            );
-          }}
-        />
-      )}
       <Controller
         name="seatsPerTimeSlotEnabled"
         render={({ field: { value, onChange } }) => (
@@ -1184,139 +982,6 @@ export const EventAdvancedTab = ({
             </SettingsToggle>
             {noShowFeeEnabled && <Alert severity="warning" title={t("seats_and_no_show_fee_error")} />}
           </>
-        )}
-      />
-      <Controller
-        name="hideOrganizerEmail"
-        render={({ field: { value, onChange } }) => (
-          <SettingsToggle
-            labelClassName={classNames("text-sm", customClassNames?.hideOrganizerEmail?.label)}
-            toggleSwitchAtTheEnd={true}
-            switchContainerClassName={classNames(
-              "border-subtle rounded-lg border py-6 px-4 sm:px-6",
-              customClassNames?.hideOrganizerEmail?.container
-            )}
-            title={t("hide_organizer_email")}
-            {...hideOrganizerEmailLocked}
-            description={
-              <LearnMoreLink
-                t={t}
-                i18nKey="hide_organizer_email_description"
-                href="https://cal.com/help/event-types/hideorganizersemail#hide-organizers-email"
-              />
-            }
-            descriptionClassName={customClassNames?.hideOrganizerEmail?.description}
-            checked={value}
-            onCheckedChange={(e) => onChange(e)}
-            data-testid="hide-organizer-email"
-          />
-        )}
-      />
-      <Controller
-        name="lockTimeZoneToggleOnBookingPage"
-        render={({ field: { value, onChange } }) => {
-          // Calculate if we should show the selector based on current form state & handle backward compatibility
-          const currentLockedTimeZone = formMethods.getValues("lockedTimeZone");
-          const showSelector =
-            value &&
-            (!(eventType.lockTimeZoneToggleOnBookingPage && !eventType.lockedTimeZone) ||
-              !!currentLockedTimeZone);
-
-          return (
-            <SettingsToggle
-              labelClassName={classNames("text-sm", customClassNames?.timezoneLock?.label)}
-              descriptionClassName={customClassNames?.timezoneLock?.description}
-              toggleSwitchAtTheEnd={true}
-              switchContainerClassName={classNames(
-                "border-subtle rounded-lg border py-6 px-4 sm:px-6",
-                customClassNames?.timezoneLock?.container,
-                showSelector && "rounded-b-none"
-              )}
-              title={t("lock_timezone_toggle_on_booking_page")}
-              {...lockTimeZoneToggleOnBookingPageLocked}
-              description={
-                <LearnMoreLink
-                  t={t}
-                  i18nKey="description_lock_timezone_toggle_on_booking_page"
-                  href="https://cal.com/help/event-types/timezone-lock"
-                />
-              }
-              checked={value}
-              onCheckedChange={(e) => {
-                onChange(e);
-                const lockedTimeZone = e ? eventType.lockedTimeZone ?? "Europe/London" : null;
-                formMethods.setValue("lockedTimeZone", lockedTimeZone, { shouldDirty: true });
-              }}
-              data-testid="lock-timezone-toggle"
-              childrenClassName="lg:ml-0">
-              {showSelector && (
-                <div className="border-subtle flex flex-col gap-6 rounded-b-lg border border-t-0 p-6">
-                  <div>
-                    <Controller
-                      name="lockedTimeZone"
-                      control={formMethods.control}
-                      render={({ field: { value } }) => (
-                        <>
-                          <Label className="text-default mb-2 block text-sm font-medium">
-                            <>{t("timezone")}</>
-                          </Label>
-                          <TimezoneSelect
-                            id="lockedTimeZone"
-                            value={value ?? "Europe/London"}
-                            onChange={(event) => {
-                              if (event)
-                                formMethods.setValue("lockedTimeZone", event.value, { shouldDirty: true });
-                            }}
-                          />
-                        </>
-                      )}
-                    />
-                  </div>
-                </div>
-              )}
-            </SettingsToggle>
-          );
-        }}
-      />
-      <Controller
-        name="allowReschedulingPastBookings"
-        render={({ field: { value, onChange } }) => (
-          <SettingsToggle
-            labelClassName={classNames("text-sm")}
-            toggleSwitchAtTheEnd={true}
-            switchContainerClassName={classNames("border-subtle rounded-lg border py-6 px-4 sm:px-6")}
-            title={t("allow_rescheduling_past_events")}
-            {...reschedulingPastBookingsLocked}
-            description={
-              <LearnMoreLink
-                t={t}
-                i18nKey="allow_rescheduling_past_events_description"
-                href="https://cal.com/help/event-types/allow-rescheduling"
-              />
-            }
-            checked={value}
-            onCheckedChange={(e) => onChange(e)}
-          />
-        )}
-      />
-
-      <Controller
-        name="allowReschedulingCancelledBookings"
-        render={({ field: { onChange } }) => (
-          <SettingsToggle
-            labelClassName="text-sm"
-            toggleSwitchAtTheEnd={true}
-            switchContainerClassName="border-subtle rounded-lg border py-6 px-4 sm:px-6"
-            title={t("allow_rescheduling_cancelled_bookings")}
-            data-testid="allow-rescheduling-cancelled-bookings-toggle"
-            {...allowReschedulingCancelledBookingsLocked}
-            description={t("description_allow_rescheduling_cancelled_bookings")}
-            checked={allowReschedulingCancelledBookings}
-            onCheckedChange={(val) => {
-              setallowReschedulingCancelledBookings(val);
-              onChange(val);
-            }}
-          />
         )}
       />
       <>

--- a/apps/web/modules/event-types/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/EventAdvancedTab.tsx
@@ -11,10 +11,8 @@ import {
   SelectedCalendarSettingsScope,
   SelectedCalendarsSettingsWebWrapperSkeleton,
 } from "@calcom/web/modules/calendars/components/SelectedCalendarsSettingsWebWrapper";
-import { Timezone as PlatformTimzoneSelect } from "@calcom/atoms/timezone";
 import getLocationsOptionsForSelect from "@calcom/features/bookings/lib/getLocationOptionsForSelect";
 import DestinationCalendarSelector from "@calcom/features/calendars/components/DestinationCalendarSelector";
-import { TimezoneSelect as WebTimezoneSelect } from "@calcom/web/modules/timezone/components/TimezoneSelect";
 import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
 import {
   allowDisablingAttendeeConfirmationEmails,
@@ -534,7 +532,7 @@ export const EventAdvancedTab = ({
     }
   );
 
-  let verifiedSecondaryEmails= [
+  let verifiedSecondaryEmails = [
     {
       label: user?.email || "",
       value: -1,
@@ -571,10 +569,6 @@ export const EventAdvancedTab = ({
     () => !Number.isNaN(paymentAppData.price) && paymentAppData.price > 0,
     [paymentAppData]
   );
-
-  const TimezoneSelect = useMemo(() => {
-    return isPlatform ? PlatformTimzoneSelect : WebTimezoneSelect;
-  }, [isPlatform]);
 
   return (
     <div className="stack-y-4 flex flex-col">

--- a/apps/web/modules/event-types/components/tabs/privacy/EventPrivacyTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/privacy/EventPrivacyTab.tsx
@@ -1,0 +1,402 @@
+import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
+import { Timezone as PlatformTimzoneSelect } from "@calcom/atoms/timezone";
+import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
+import { LearnMoreLink } from "@calcom/features/eventtypes/components/LearnMoreLink";
+import type {
+  EventTypeSetupProps,
+  FormValues,
+  SettingsToggleClassNames,
+} from "@calcom/features/eventtypes/lib/types";
+import { generateHashedLink } from "@calcom/lib/generateHashedLink";
+import { extractHostTimezone } from "@calcom/lib/hashedLinksUtils";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import classNames from "@calcom/ui/classNames";
+import { Label, SettingsToggle } from "@calcom/ui/components/form";
+import { MultiplePrivateLinksController } from "@calcom/web/modules/event-types/components";
+import { TimezoneSelect as WebTimezoneSelect } from "@calcom/web/modules/timezone/components/TimezoneSelect";
+import { useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import type { DisableReschedulingCustomClassNames } from "../advanced/DisableReschedulingController";
+import DisableReschedulingController from "../advanced/DisableReschedulingController";
+import type { RequiresConfirmationCustomClassNames } from "../advanced/RequiresConfirmationController";
+import RequiresConfirmationController from "../advanced/RequiresConfirmationController";
+
+export type EventPrivacyTabCustomClassNames = {
+  requiresConfirmation?: RequiresConfirmationCustomClassNames;
+  disableRescheduling?: DisableReschedulingCustomClassNames;
+  bookerEmailVerification?: SettingsToggleClassNames;
+  calendarNotes?: SettingsToggleClassNames;
+  eventDetailsVisibility?: SettingsToggleClassNames;
+  hideOrganizerEmail?: SettingsToggleClassNames;
+  timezoneLock?: SettingsToggleClassNames;
+};
+
+export type EventPrivacyTabProps = {
+  eventType: EventTypeSetupProps["eventType"];
+  team: EventTypeSetupProps["team"];
+  customClassNames?: EventPrivacyTabCustomClassNames;
+};
+
+export const EventPrivacyTab = ({ eventType, team, customClassNames }: EventPrivacyTabProps) => {
+  const isPlatform = useIsPlatform();
+  const formMethods = useFormContext<FormValues>();
+  const { t } = useLocale();
+
+  const [requiresConfirmation, setRequiresConfirmation] = useState(
+    formMethods.getValues("requiresConfirmation")
+  );
+  const seatsEnabled = formMethods.watch("seatsPerTimeSlotEnabled");
+
+  const [disableRescheduling, setDisableRescheduling] = useState(eventType.disableRescheduling || false);
+
+  const [multiplePrivateLinksVisible, setMultiplePrivateLinksVisible] = useState(
+    !!formMethods.getValues("multiplePrivateLinks") &&
+      formMethods.getValues("multiplePrivateLinks")?.length !== 0
+  );
+
+  const {
+    isChildrenManagedEventType: _isChildrenManagedEventType,
+    isManagedEventType,
+    shouldLockDisableProps,
+  } = useLockedFieldsManager({
+    eventType,
+    translate: t,
+    formMethods,
+  });
+
+  const requiresBookerEmailVerificationProps = shouldLockDisableProps("requiresBookerEmailVerification");
+  const hideCalendarNotesLocked = shouldLockDisableProps("hideCalendarNotes");
+  const hideCalendarEventDetailsLocked = shouldLockDisableProps("hideCalendarEventDetails");
+  const hideOrganizerEmailLocked = shouldLockDisableProps("hideOrganizerEmail");
+  const lockTimeZoneToggleOnBookingPageLocked = shouldLockDisableProps("lockTimeZoneToggleOnBookingPage");
+  const multiplePrivateLinksLocked = shouldLockDisableProps("multiplePrivateLinks");
+  const reschedulingPastBookingsLocked = shouldLockDisableProps("allowReschedulingPastBookings");
+  const disableCancellingLocked = shouldLockDisableProps("disableCancelling");
+  const allowReschedulingCancelledBookingsLocked = shouldLockDisableProps(
+    "allowReschedulingCancelledBookings"
+  );
+
+  if (isManagedEventType) {
+    multiplePrivateLinksLocked.disabled = true;
+  }
+
+  const [allowReschedulingCancelledBookings, setAllowReschedulingCancelledBookings] = useState(
+    eventType.allowReschedulingCancelledBookings ?? false
+  );
+
+  const userTimeZone = extractHostTimezone({
+    userId: eventType.userId,
+    teamId: eventType.teamId,
+    hosts: eventType.hosts,
+    owner: eventType.owner,
+    team: eventType.team,
+  });
+
+  const TimezoneSelect = isPlatform ? PlatformTimzoneSelect : WebTimezoneSelect;
+
+  return (
+    <div className="stack-y-4 flex flex-col">
+      <RequiresConfirmationController
+        eventType={eventType}
+        seatsEnabled={seatsEnabled}
+        metadata={formMethods.getValues("metadata")}
+        requiresConfirmation={requiresConfirmation}
+        requiresConfirmationWillBlockSlot={formMethods.getValues("requiresConfirmationWillBlockSlot")}
+        onRequiresConfirmation={setRequiresConfirmation}
+        customClassNames={customClassNames?.requiresConfirmation}
+      />
+
+      {!isPlatform && (
+        <>
+          <Controller
+            name="disabledCancelling"
+            render={({ field: { onChange, value } }) => (
+              <SettingsToggle
+                labelClassName="text-sm"
+                toggleSwitchAtTheEnd={true}
+                switchContainerClassName="border-subtle rounded-lg border py-6 px-4 sm:px-6"
+                title={t("disable_cancelling")}
+                data-testid="disable-cancelling-toggle"
+                {...disableCancellingLocked}
+                description={
+                  <LearnMoreLink
+                    t={t}
+                    i18nKey="description_disable_cancelling"
+                    href="https://cal.com/help/event-types/disable-canceling-rescheduling#disable-cancelling"
+                  />
+                }
+                checked={value}
+                onCheckedChange={(val) => {
+                  onChange(val);
+                }}
+              />
+            )}
+          />
+
+          <DisableReschedulingController
+            eventType={eventType}
+            disableRescheduling={disableRescheduling}
+            onDisableRescheduling={setDisableRescheduling}
+            customClassNames={customClassNames?.disableRescheduling}
+          />
+        </>
+      )}
+
+      <Controller
+        name="requiresBookerEmailVerification"
+        render={({ field: { value, onChange } }) => (
+          <SettingsToggle
+            labelClassName={classNames("text-sm", customClassNames?.bookerEmailVerification?.label)}
+            toggleSwitchAtTheEnd={true}
+            switchContainerClassName={classNames(
+              "border-subtle rounded-lg border py-6 px-4 sm:px-6",
+              customClassNames?.bookerEmailVerification?.container
+            )}
+            title={t("requires_booker_email_verification")}
+            data-testid="requires-booker-email-verification"
+            {...requiresBookerEmailVerificationProps}
+            description={t("description_requires_booker_email_verification")}
+            descriptionClassName={customClassNames?.bookerEmailVerification?.description}
+            checked={value}
+            onCheckedChange={(e) => onChange(e)}
+          />
+        )}
+      />
+
+      <Controller
+        name="hideCalendarNotes"
+        render={({ field: { value, onChange } }) => (
+          <SettingsToggle
+            labelClassName={classNames("text-sm", customClassNames?.calendarNotes?.label)}
+            toggleSwitchAtTheEnd={true}
+            switchContainerClassName={classNames(
+              "border-subtle rounded-lg border py-6 px-4 sm:px-6",
+              customClassNames?.calendarNotes?.container
+            )}
+            descriptionClassName={customClassNames?.calendarNotes?.description}
+            data-testid="disable-notes"
+            title={t("disable_notes")}
+            {...hideCalendarNotesLocked}
+            description={
+              <LearnMoreLink
+                t={t}
+                i18nKey="disable_notes_description"
+                href="https://cal.com/help/event-types/hide-notes"
+              />
+            }
+            checked={value}
+            onCheckedChange={(e) => onChange(e)}
+          />
+        )}
+      />
+
+      <Controller
+        name="hideCalendarEventDetails"
+        render={({ field: { value, onChange } }) => (
+          <SettingsToggle
+            labelClassName={classNames("text-sm", customClassNames?.eventDetailsVisibility?.label)}
+            toggleSwitchAtTheEnd={true}
+            switchContainerClassName={classNames(
+              "border-subtle rounded-lg border py-6 px-4 sm:px-6",
+              customClassNames?.eventDetailsVisibility?.container
+            )}
+            descriptionClassName={customClassNames?.eventDetailsVisibility?.description}
+            title={t("hide_calendar_event_details")}
+            {...hideCalendarEventDetailsLocked}
+            description={t("description_hide_calendar_event_details")}
+            checked={value}
+            onCheckedChange={(e) => onChange(e)}
+          />
+        )}
+      />
+
+      <Controller
+        name="hideOrganizerEmail"
+        render={({ field: { value, onChange } }) => (
+          <SettingsToggle
+            labelClassName={classNames("text-sm", customClassNames?.hideOrganizerEmail?.label)}
+            toggleSwitchAtTheEnd={true}
+            switchContainerClassName={classNames(
+              "border-subtle rounded-lg border py-6 px-4 sm:px-6",
+              customClassNames?.hideOrganizerEmail?.container
+            )}
+            title={t("hide_organizer_email")}
+            {...hideOrganizerEmailLocked}
+            description={
+              <LearnMoreLink
+                t={t}
+                i18nKey="hide_organizer_email_description"
+                href="https://cal.com/help/event-types/hideorganizersemail#hide-organizers-email"
+              />
+            }
+            descriptionClassName={customClassNames?.hideOrganizerEmail?.description}
+            checked={value}
+            onCheckedChange={(e) => onChange(e)}
+            data-testid="hide-organizer-email"
+          />
+        )}
+      />
+
+      {!isPlatform && (
+        <Controller
+          name="multiplePrivateLinks"
+          render={() => {
+            return (
+              <SettingsToggle
+                labelClassName="text-sm"
+                toggleSwitchAtTheEnd={true}
+                switchContainerClassName={classNames(
+                  "border-subtle rounded-lg border py-6 px-4 sm:px-6",
+                  multiplePrivateLinksVisible && "rounded-b-none"
+                )}
+                childrenClassName="lg:ml-0"
+                data-testid="multiplePrivateLinksCheck"
+                title={t("multiple_private_links_title")}
+                {...multiplePrivateLinksLocked}
+                description={
+                  <LearnMoreLink
+                    t={t}
+                    i18nKey="multiple_private_links_description"
+                    href="https://cal.com/help/event-types/private-links"
+                  />
+                }
+                tooltip={isManagedEventType ? t("managed_event_field_parent_control_disabled") : ""}
+                checked={multiplePrivateLinksVisible}
+                onCheckedChange={(e) => {
+                  if (!e) {
+                    formMethods.setValue("multiplePrivateLinks", [], { shouldDirty: true });
+                  } else {
+                    formMethods.setValue(
+                      "multiplePrivateLinks",
+                      [generateHashedLink(formMethods.getValues("users")[0]?.id ?? team?.id)],
+                      { shouldDirty: true }
+                    );
+                  }
+                  setMultiplePrivateLinksVisible(e);
+                }}>
+                {!isManagedEventType && (
+                  <div className="border-subtle rounded-b-lg border border-t-0 p-6">
+                    <MultiplePrivateLinksController
+                      team={team}
+                      bookerUrl={eventType.bookerUrl}
+                      setMultiplePrivateLinksVisible={setMultiplePrivateLinksVisible}
+                      userTimeZone={userTimeZone}
+                    />
+                  </div>
+                )}
+              </SettingsToggle>
+            );
+          }}
+        />
+      )}
+
+      <Controller
+        name="lockTimeZoneToggleOnBookingPage"
+        render={({ field: { value, onChange } }) => {
+          const currentLockedTimeZone = formMethods.getValues("lockedTimeZone");
+          const showSelector =
+            value &&
+            (!(eventType.lockTimeZoneToggleOnBookingPage && !eventType.lockedTimeZone) ||
+              !!currentLockedTimeZone);
+
+          return (
+            <SettingsToggle
+              labelClassName={classNames("text-sm", customClassNames?.timezoneLock?.label)}
+              descriptionClassName={customClassNames?.timezoneLock?.description}
+              toggleSwitchAtTheEnd={true}
+              switchContainerClassName={classNames(
+                "border-subtle rounded-lg border py-6 px-4 sm:px-6",
+                customClassNames?.timezoneLock?.container,
+                showSelector && "rounded-b-none"
+              )}
+              title={t("lock_timezone_toggle_on_booking_page")}
+              {...lockTimeZoneToggleOnBookingPageLocked}
+              description={
+                <LearnMoreLink
+                  t={t}
+                  i18nKey="description_lock_timezone_toggle_on_booking_page"
+                  href="https://cal.com/help/event-types/timezone-lock"
+                />
+              }
+              checked={value}
+              onCheckedChange={(e) => {
+                onChange(e);
+                const lockedTimeZone = e ? (eventType.lockedTimeZone ?? "Europe/London") : null;
+                formMethods.setValue("lockedTimeZone", lockedTimeZone, { shouldDirty: true });
+              }}
+              data-testid="lock-timezone-toggle"
+              childrenClassName="lg:ml-0">
+              {showSelector && (
+                <div className="border-subtle flex flex-col gap-6 rounded-b-lg border border-t-0 p-6">
+                  <div>
+                    <Controller
+                      name="lockedTimeZone"
+                      control={formMethods.control}
+                      render={({ field: { value } }) => (
+                        <>
+                          <Label className="text-default mb-2 block text-sm font-medium">
+                            <>{t("timezone")}</>
+                          </Label>
+                          <TimezoneSelect
+                            id="lockedTimeZone"
+                            value={value ?? "Europe/London"}
+                            onChange={(event) => {
+                              if (event)
+                                formMethods.setValue("lockedTimeZone", event.value, { shouldDirty: true });
+                            }}
+                          />
+                        </>
+                      )}
+                    />
+                  </div>
+                </div>
+              )}
+            </SettingsToggle>
+          );
+        }}
+      />
+
+      <Controller
+        name="allowReschedulingPastBookings"
+        render={({ field: { value, onChange } }) => (
+          <SettingsToggle
+            labelClassName={classNames("text-sm")}
+            toggleSwitchAtTheEnd={true}
+            switchContainerClassName={classNames("border-subtle rounded-lg border py-6 px-4 sm:px-6")}
+            title={t("allow_rescheduling_past_events")}
+            {...reschedulingPastBookingsLocked}
+            description={
+              <LearnMoreLink
+                t={t}
+                i18nKey="allow_rescheduling_past_events_description"
+                href="https://cal.com/help/event-types/allow-rescheduling"
+              />
+            }
+            checked={value}
+            onCheckedChange={(e) => onChange(e)}
+          />
+        )}
+      />
+
+      <Controller
+        name="allowReschedulingCancelledBookings"
+        render={({ field: { onChange } }) => (
+          <SettingsToggle
+            labelClassName="text-sm"
+            toggleSwitchAtTheEnd={true}
+            switchContainerClassName="border-subtle rounded-lg border py-6 px-4 sm:px-6"
+            title={t("allow_rescheduling_cancelled_bookings")}
+            data-testid="allow-rescheduling-cancelled-bookings-toggle"
+            {...allowReschedulingCancelledBookingsLocked}
+            description={t("description_allow_rescheduling_cancelled_bookings")}
+            checked={allowReschedulingCancelledBookings}
+            onCheckedChange={(val) => {
+              setAllowReschedulingCancelledBookings(val);
+              onChange(val);
+            }}
+          />
+        )}
+      />
+    </div>
+  );
+};

--- a/apps/web/modules/event-types/components/tabs/privacy/EventPrivacyTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/privacy/EventPrivacyTab.tsx
@@ -12,7 +12,7 @@ import { extractHostTimezone } from "@calcom/lib/hashedLinksUtils";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
 import { Label, SettingsToggle } from "@calcom/ui/components/form";
-import { MultiplePrivateLinksController } from "@calcom/web/modules/event-types/components";
+import { MultiplePrivateLinksController } from "@calcom/web/modules/event-types/components/MultiplePrivateLinksController";
 import { TimezoneSelect as WebTimezoneSelect } from "@calcom/web/modules/timezone/components/TimezoneSelect";
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";

--- a/apps/web/modules/event-types/components/tabs/privacy/EventPrivacyWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/tabs/privacy/EventPrivacyWebWrapper.tsx
@@ -1,0 +1,13 @@
+import type { EventTypeSetupProps } from "@calcom/features/eventtypes/lib/types";
+import { EventPrivacyTab } from "./EventPrivacyTab";
+
+type EventPrivacyWebWrapperProps = {
+  eventType: EventTypeSetupProps["eventType"];
+  team: EventTypeSetupProps["team"];
+};
+
+const EventPrivacyWebWrapper = ({ eventType, team }: EventPrivacyWebWrapperProps) => {
+  return <EventPrivacyTab eventType={eventType} team={team} />;
+};
+
+export default EventPrivacyWebWrapper;

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1834,6 +1834,8 @@
   "event_limit_tab_description": "How often you can be booked",
   "event_advanced_tab_description": "Calendar settings & more...",
   "event_advanced_tab_title": "Advanced",
+  "event_privacy_tab_description": "Confirmation, cancellation & privacy",
+  "event_privacy_tab_title": "Privacy & Security",
   "event_payments_tab_description": "Set up payments for event",
   "event_setup_multiple_duration_error": "Event Setup: Multiple durations requires at least 1 option.",
   "event_setup_multiple_duration_default_error": "Event Setup: Please select a valid default duration.",

--- a/packages/features/eventtypes/lib/types.ts
+++ b/packages/features/eventtypes/lib/types.ts
@@ -451,6 +451,7 @@ export type TabMap = {
   availability: React.ReactNode;
   instant?: React.ReactNode;
   limits: React.ReactNode;
+  privacy: React.ReactNode;
   recurring: React.ReactNode;
   setup: React.ReactNode;
   team?: React.ReactNode;

--- a/packages/platform/atoms/event-types/hooks/useTabsNavigations.tsx
+++ b/packages/platform/atoms/event-types/hooks/useTabsNavigations.tsx
@@ -213,6 +213,13 @@ function getNavigation({
       "data-testid": "event_advanced_tab_title",
     },
     {
+      name: t("event_privacy_tab_title"),
+      href: `/event-types/${id}?tabName=privacy`,
+      icon: "lock",
+      info: t(`event_privacy_tab_description`),
+      "data-testid": "event_privacy_tab_title",
+    },
+    {
       name: t("apps"),
       href: `/event-types/${id}?tabName=apps`,
       icon: "grid-3x3",


### PR DESCRIPTION
## What does this PR do?

Splits the overloaded "Advanced" event type settings tab into two tabs:

- **Advanced** — Calendar settings, booking questions/form builder, booker layout, booking redirect, event colors, optimized slots, custom reply-to email, seats, email notifications
- **Privacy & Security** (new) — Requires confirmation, disable cancelling, disable rescheduling, booker email verification, hide calendar notes, hide calendar event details, hide organizer email, private links, timezone lock, allow rescheduling past/cancelled bookings

Requested by @PeerRich — [Devin session](https://app.devin.ai/sessions/7eac8e1fb9a444078fa1137b9765ac7e)

### Changes

- Created `EventPrivacyTab` and `EventPrivacyWebWrapper` in `apps/web/modules/event-types/components/tabs/privacy/`
- Removed moved settings and all related dead code (unused imports, state variables, locked field props) from `EventAdvancedTab`
- Registered the new tab in `EventType.tsx`, `EventTypeWebWrapper.tsx`, `useTabsNavigations.tsx`, and `TabMap` type
- Added i18n keys (`event_privacy_tab_title`, `event_privacy_tab_description`)
- Used direct imports (no barrel imports) per project conventions

## Visual Demo

No visual demo available — local testing could not complete login. **Manual visual verification is recommended.**

## ⚠️ Items for human review

1. **No automated tests**: The new `EventPrivacyTab` component has no test coverage.
2. **Type exports**: `EventAdvancedTabCustomClassNames` still exports types for settings that moved to Privacy tab (e.g. `requiresConfirmation`, `bookerEmailVerification`, `timezoneLock`). These are kept for backward compatibility but platform SDK consumers may need documentation about the tab split.
3. **Tab ordering**: The new "privacy" tab is inserted after "advanced" in the tabs array and navigation. Verify this ordering makes sense in the UI.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A — no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to any event type settings
2. Verify the "Advanced" tab still shows: calendar settings, booking questions, booker layout, redirect, colors, optimized slots, reply-to email, seats, email notifications
3. Verify the new "Privacy & Security" tab appears after Advanced with a lock icon
4. Verify Privacy tab shows: requires confirmation, disable cancelling, disable rescheduling, email verification, hide calendar notes, hide event details, hide organizer email, private links, timezone lock, allow rescheduling past/cancelled bookings
5. Test that all toggles/settings in both tabs save correctly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized (9 files, ~450 additions, ~340 deletions)