### PR TITLE
fix: hide feature opt-in feedback dialog during impersonation

### DIFF
--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.test.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.test.ts
@@ -1,0 +1,100 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFeatureOptInBanner } from "./useFeatureOptInBanner";
+
+const mockUseSession = vi.fn();
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+}));
+
+vi.mock("@calcom/features/feature-opt-in/config", () => ({
+  getOptInFeatureConfig: vi.fn(() => ({
+    slug: "bookings-v3",
+    i18n: { title: "t", name: "n", description: "d" },
+    bannerImage: { src: "/img.png", width: 100, height: 100 },
+    policy: "permissive",
+    displayLocations: ["banner", "settings"],
+  })),
+  shouldDisplayFeatureAt: vi.fn(() => true),
+}));
+
+vi.mock("../lib/feature-opt-in-storage", () => ({
+  getFeatureOptInTimestamp: vi.fn(() => null),
+  isFeatureDismissed: vi.fn(() => false),
+  setFeatureDismissed: vi.fn(),
+  setFeatureOptedIn: vi.fn(),
+  isFeatureFeedbackShown: vi.fn(() => false),
+  setFeatureFeedbackShown: vi.fn(),
+}));
+
+const mockMutateAsync = vi.fn();
+const mockInvalidate = vi.fn();
+vi.mock("@calcom/trpc/react", () => ({
+  trpc: {
+    useUtils: vi.fn(() => ({
+      viewer: {
+        featureOptIn: {
+          checkFeatureOptInEligibility: { invalidate: mockInvalidate },
+          listForUser: { invalidate: mockInvalidate },
+        },
+      },
+    })),
+    viewer: {
+      featureOptIn: {
+        checkFeatureOptInEligibility: {
+          useQuery: vi.fn(() => ({
+            data: {
+              status: "can_opt_in",
+              canOptIn: true,
+              blockingReason: null,
+              userRoleContext: { isOrgAdmin: false, orgId: null, adminTeamIds: [], adminTeamNames: [] },
+            },
+            isLoading: false,
+          })),
+        },
+        setUserState: { useMutation: vi.fn(() => ({ mutateAsync: mockMutateAsync })) },
+        setTeamState: { useMutation: vi.fn(() => ({ mutateAsync: mockMutateAsync })) },
+        setOrganizationState: { useMutation: vi.fn(() => ({ mutateAsync: mockMutateAsync })) },
+        setUserAutoOptIn: { useMutation: vi.fn(() => ({ mutateAsync: mockMutateAsync })) },
+        setTeamAutoOptIn: { useMutation: vi.fn(() => ({ mutateAsync: mockMutateAsync })) },
+        setOrganizationAutoOptIn: { useMutation: vi.fn(() => ({ mutateAsync: mockMutateAsync })) },
+      },
+    },
+  },
+}));
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+
+describe("useFeatureOptInBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows banner for normal users when eligible", () => {
+    mockUseSession.mockReturnValue({ data: { user: {} } });
+
+    const { result } = renderHook(() => useFeatureOptInBanner("bookings-v3"));
+
+    expect(result.current.shouldShow).toBe(true);
+  });
+
+  it("hides banner when user is impersonated", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { impersonatedBy: { id: 999, email: "admin@cal.com" } } },
+    });
+
+    const { result } = renderHook(() => useFeatureOptInBanner("bookings-v3"));
+
+    expect(result.current.shouldShow).toBe(false);
+  });
+
+  it("hides banner when session is null", () => {
+    mockUseSession.mockReturnValue({ data: null });
+
+    const { result } = renderHook(() => useFeatureOptInBanner("bookings-v3"));
+
+    expect(result.current.shouldShow).toBe(true);
+  });
+});

--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.test.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.test.ts
@@ -80,18 +80,10 @@ describe("useFeatureOptInBanner", () => {
     expect(result.current.shouldShow).toBe(true);
   });
 
-  it("hides banner when user is impersonated", () => {
+  it("still shows banner when user is impersonated", () => {
     mockUseSession.mockReturnValue({
       data: { user: { impersonatedBy: { id: 999, email: "admin@cal.com" } } },
     });
-
-    const { result } = renderHook(() => useFeatureOptInBanner("bookings-v3"));
-
-    expect(result.current.shouldShow).toBe(false);
-  });
-
-  it("hides banner when session is null", () => {
-    mockUseSession.mockReturnValue({ data: null });
 
     const { result } = renderHook(() => useFeatureOptInBanner("bookings-v3"));
 

--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
@@ -3,6 +3,7 @@
 import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
 import { getOptInFeatureConfig, shouldDisplayFeatureAt } from "@calcom/features/feature-opt-in/config";
 import { trpc } from "@calcom/trpc/react";
+import { useSession } from "next-auth/react";
 import posthog from "posthog-js";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -59,6 +60,8 @@ function isFeatureOptedIn(featureId: string): boolean {
 }
 
 function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
+  const { data: session } = useSession();
+  const isImpersonating = !!session?.user?.impersonatedBy;
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isDismissed, setIsDismissed] = useState(() => isFeatureDismissed(featureId));
   const [isOptedIn, setIsOptedIn] = useState(() => isFeatureOptedIn(featureId));
@@ -161,6 +164,7 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
   );
 
   const shouldShow = useMemo(() => {
+    if (isImpersonating) return false;
     if (isDismissed) return false;
     if (isOptedIn) return false;
     if (!featureConfig) return false;
@@ -169,7 +173,14 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
     if (eligibilityQuery.isLoading) return false;
     if (!eligibilityQuery.data) return false;
     return eligibilityQuery.data.status === "can_opt_in";
-  }, [isDismissed, isOptedIn, featureConfig, eligibilityQuery.isLoading, eligibilityQuery.data]);
+  }, [
+    isImpersonating,
+    isDismissed,
+    isOptedIn,
+    featureConfig,
+    eligibilityQuery.isLoading,
+    eligibilityQuery.data,
+  ]);
 
   useEffect(() => {
     if (shouldShow && !hasBannerShownBeenTracked.current) {

--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
@@ -3,7 +3,6 @@
 import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
 import { getOptInFeatureConfig, shouldDisplayFeatureAt } from "@calcom/features/feature-opt-in/config";
 import { trpc } from "@calcom/trpc/react";
-import { useSession } from "next-auth/react";
 import posthog from "posthog-js";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -60,8 +59,6 @@ function isFeatureOptedIn(featureId: string): boolean {
 }
 
 function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
-  const { data: session } = useSession();
-  const isImpersonating = !!session?.user?.impersonatedBy;
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isDismissed, setIsDismissed] = useState(() => isFeatureDismissed(featureId));
   const [isOptedIn, setIsOptedIn] = useState(() => isFeatureOptedIn(featureId));
@@ -164,7 +161,6 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
   );
 
   const shouldShow = useMemo(() => {
-    if (isImpersonating) return false;
     if (isDismissed) return false;
     if (isOptedIn) return false;
     if (!featureConfig) return false;
@@ -173,14 +169,7 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
     if (eligibilityQuery.isLoading) return false;
     if (!eligibilityQuery.data) return false;
     return eligibilityQuery.data.status === "can_opt_in";
-  }, [
-    isImpersonating,
-    isDismissed,
-    isOptedIn,
-    featureConfig,
-    eligibilityQuery.isLoading,
-    eligibilityQuery.data,
-  ]);
+  }, [isDismissed, isOptedIn, featureConfig, eligibilityQuery.isLoading, eligibilityQuery.data]);
 
   useEffect(() => {
     if (shouldShow && !hasBannerShownBeenTracked.current) {

--- a/apps/web/modules/feature-opt-in/hooks/useOptInFeedback.test.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useOptInFeedback.test.ts
@@ -8,6 +8,13 @@ vi.mock("next-auth/react", () => ({
   useSession: () => mockUseSession(),
 }));
 
+const mockEnv = vi.hoisted(() => ({ isENVDev: false }));
+vi.mock("@calcom/lib/env", () => ({
+  get isENVDev() {
+    return mockEnv.isENVDev;
+  },
+}));
+
 vi.mock("../lib/feature-opt-in-storage", () => ({
   getFeatureOptInTimestamp: vi.fn(() => Date.now() - 10 * 24 * 60 * 60 * 1000),
   isFeatureFeedbackShown: vi.fn(() => false),
@@ -48,7 +55,8 @@ describe("useOptInFeedback", () => {
     expect(result.current.showFeedbackDialog).toBe(true);
   });
 
-  it("does not show feedback dialog when user is impersonated", () => {
+  it("does not show feedback dialog when user is impersonated in production", () => {
+    mockEnv.isENVDev = false;
     mockUseSession.mockReturnValue({
       data: { user: { impersonatedBy: { id: 999, email: "admin@cal.com" } } },
     });
@@ -60,6 +68,21 @@ describe("useOptInFeedback", () => {
     });
 
     expect(result.current.showFeedbackDialog).toBe(false);
+  });
+
+  it("shows feedback dialog when user is impersonated in development", () => {
+    mockEnv.isENVDev = true;
+    mockUseSession.mockReturnValue({
+      data: { user: { impersonatedBy: { id: 999, email: "admin@cal.com" } } },
+    });
+
+    const { result } = renderHook(() => useOptInFeedback("bookings-v3", featureConfig));
+
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+
+    expect(result.current.showFeedbackDialog).toBe(true);
   });
 
   it("shows feedback dialog when session has no impersonation", () => {

--- a/apps/web/modules/feature-opt-in/hooks/useOptInFeedback.test.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useOptInFeedback.test.ts
@@ -1,0 +1,76 @@
+import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useOptInFeedback } from "./useOptInFeedback";
+
+const mockUseSession = vi.fn();
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+}));
+
+vi.mock("../lib/feature-opt-in-storage", () => ({
+  getFeatureOptInTimestamp: vi.fn(() => Date.now() - 10 * 24 * 60 * 60 * 1000),
+  isFeatureFeedbackShown: vi.fn(() => false),
+  setFeatureFeedbackShown: vi.fn(),
+}));
+
+const featureConfig: OptInFeatureConfig = {
+  slug: "bookings-v3" as OptInFeatureConfig["slug"],
+  i18n: { title: "t", name: "n", description: "d" },
+  bannerImage: { src: "/img.png", width: 100, height: 100 },
+  policy: "permissive",
+  formbricks: {
+    waitAfterDays: 0,
+    surveyId: "survey-1",
+    questions: { ratingQuestionId: "q1", commentQuestionId: "q2" },
+  },
+};
+
+describe("useOptInFeedback", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockUseSession.mockReturnValue({ data: { user: {} } });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("shows feedback dialog for normal users after delay", () => {
+    const { result } = renderHook(() => useOptInFeedback("bookings-v3", featureConfig));
+    expect(result.current.showFeedbackDialog).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+
+    expect(result.current.showFeedbackDialog).toBe(true);
+  });
+
+  it("does not show feedback dialog when user is impersonated", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { impersonatedBy: { id: 999, email: "admin@cal.com" } } },
+    });
+
+    const { result } = renderHook(() => useOptInFeedback("bookings-v3", featureConfig));
+
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+
+    expect(result.current.showFeedbackDialog).toBe(false);
+  });
+
+  it("shows feedback dialog when session has no impersonation", () => {
+    mockUseSession.mockReturnValue({ data: { user: { name: "Test" } } });
+
+    const { result } = renderHook(() => useOptInFeedback("bookings-v3", featureConfig));
+
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+
+    expect(result.current.showFeedbackDialog).toBe(true);
+  });
+});

--- a/apps/web/modules/feature-opt-in/hooks/useOptInFeedback.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useOptInFeedback.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
+import { useSession } from "next-auth/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getFeatureOptInTimestamp,
@@ -31,10 +32,9 @@ export interface OptInFeedbackState {
  * Hook to manage feedback dialog display after a user opts into a feature.
  * Shows a custom feedback dialog after a configurable delay (waitAfterDays).
  */
-function useOptInFeedback(
-  featureId: string,
-  featureConfig: OptInFeatureConfig | null
-): OptInFeedbackState {
+function useOptInFeedback(featureId: string, featureConfig: OptInFeatureConfig | null): OptInFeedbackState {
+  const { data: session } = useSession();
+  const isImpersonating = !!session?.user?.impersonatedBy;
   const [showFeedbackDialog, setShowFeedbackDialog] = useState(false);
   const hasTriggeredRef = useRef(false);
 
@@ -44,6 +44,7 @@ function useOptInFeedback(
   }, [featureId]);
 
   useEffect(() => {
+    if (isImpersonating) return;
     if (!featureConfig?.formbricks) return;
 
     // Don't trigger if already triggered this session
@@ -77,7 +78,7 @@ function useOptInFeedback(
     // Show after page load delay to let the page finish loading
     const timer = setTimeout(triggerFeedback, PAGE_LOAD_DELAY_MS);
     return () => clearTimeout(timer);
-  }, [featureId, featureConfig]);
+  }, [featureId, featureConfig, isImpersonating]);
 
   const feedbackDialogProps = featureConfig?.formbricks?.surveyId
     ? {

--- a/apps/web/modules/feature-opt-in/hooks/useOptInFeedback.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useOptInFeedback.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
+import { isENVDev } from "@calcom/lib/env";
 import { useSession } from "next-auth/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -44,7 +45,7 @@ function useOptInFeedback(featureId: string, featureConfig: OptInFeatureConfig |
   }, [featureId]);
 
   useEffect(() => {
-    if (isImpersonating) return;
+    if (isImpersonating && !isENVDev) return;
     if (!featureConfig?.formbricks) return;
 
     // Don't trigger if already triggered this session


### PR DESCRIPTION
## What does this PR do?

Hides the post-opt-in feedback dialog when the current session has `impersonatedBy` set (i.e., an admin is impersonating a user). This follows the same pattern used by `TimezoneChangeDialog` to prevent impersonating admins from accidentally submitting feedback on behalf of a user.

The opt-in **banner** intentionally remains visible during impersonation — only the feedback form is suppressed. In **development mode**, the feedback form is still shown even during impersonation to aid testing.

**Changes:**
- `useOptInFeedback`: checks `session.user.impersonatedBy` and `isENVDev` — skips the feedback trigger effect only when impersonating in production (`if (isImpersonating && !isENVDev) return`)
- Unit tests added for both `useOptInFeedback` (feedback hidden during impersonation in prod, shown in dev) and `useFeatureOptInBanner` (banner still visible during impersonation)

### Updates since last revision
- Reverted the impersonation check from `useFeatureOptInBanner` per reviewer feedback — the banner should remain visible during impersonation; only the feedback dialog should be hidden.
- Updated banner test to assert `shouldShow` is `true` during impersonation.
- Added development mode exception: feedback form remains visible during impersonation when `NODE_ENV === "development"` (via `isENVDev` from `@calcom/lib/env`).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Production behavior:** Log in as an admin and impersonate a user → navigate to a page with the feature opt-in banner → verify the banner **still appears** but the feedback dialog does **not** appear for opted-in users
2. **Development behavior:** Run `yarn dev` locally → impersonate a user → verify the feedback dialog **does** appear (since `NODE_ENV=development`)
3. Stop impersonating → feedback should appear as normal in both environments

## Human Review Checklist

- [ ] `useOptInFeedback` now calls `useSession()`. Since it's invoked inside `useFeatureOptInBanner`, this adds one `useSession()` call per banner render. This is fine (same provider, same cached value), but worth confirming the reviewer is comfortable with it.
- [ ] `isENVDev` is imported from `@calcom/lib/env` and is a build-time constant (`process.env.NODE_ENV === "development"`). It's not included in the `useEffect` dependency array since it cannot change at runtime — verify this is acceptable.
- [ ] The early return `if (isImpersonating && !isENVDev) return;` means no feedback side effects run during production impersonation, but they **do** run in development. Confirm this matches the intended behavior.

---

[Link to Devin run](https://app.devin.ai/sessions/eb9022a7e0ef46699caa3b01597a5b1e) | Requested by @sean-brydon