### PR TITLE
fix: skip onboarding redirect for team owners creating additional teams

### DIFF
--- a/apps/web/app/(use-page-wrapper)/onboarding/getting-started/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/getting-started/page.tsx
@@ -25,10 +25,17 @@ const ServerPage = async () => {
     return redirect("/auth/login");
   }
 
-  // If user has any team membership (pending or accepted), redirect them directly to personal onboarding
-  // This handles the case where users sign up with an invite token (membership is auto-accepted)
+  // If user has any team membership (pending or accepted), check their role.
+  // Invited members (MEMBER role) skip team onboarding and go directly to personal settings.
+  // Team owners are redirected to the main app since they've already gone through team creation.
   const hasTeamMembership = await MembershipRepository.hasAnyTeamMembershipByUserId({ userId: session.user.id });
   if (hasTeamMembership) {
+    const isTeamOwner = await MembershipRepository.hasAcceptedOwnerTeamMembership({
+      userId: session.user.id,
+    });
+    if (isTeamOwner) {
+      return redirect("/event-types");
+    }
     return redirect("/onboarding/personal/settings");
   }
 

--- a/packages/features/auth/lib/onboardingUtils.test.ts
+++ b/packages/features/auth/lib/onboardingUtils.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFindById = vi.fn();
+const mockCheckIfFeatureIsEnabledGlobally = vi.fn();
+
+vi.mock("@calcom/features/flags/features.repository", () => {
+  return {
+    FeaturesRepository: class {
+      checkIfFeatureIsEnabledGlobally = mockCheckIfFeatureIsEnabledGlobally;
+    },
+  };
+});
+
+vi.mock("@calcom/features/membership/repositories/MembershipRepository", () => ({
+  MembershipRepository: {
+    hasAnyTeamMembershipByUserId: vi.fn(),
+    hasAcceptedOwnerTeamMembership: vi.fn(),
+  },
+}));
+
+vi.mock("@calcom/features/profile/repositories/ProfileRepository", () => ({
+  ProfileRepository: {
+    findFirstForUserId: vi.fn(),
+  },
+}));
+
+vi.mock("@calcom/features/users/repositories/UserRepository", () => {
+  return {
+    UserRepository: class {
+      findById = mockFindById;
+    },
+  };
+});
+
+vi.mock("@calcom/prisma", () => ({
+  prisma: {},
+}));
+
+import { MembershipRepository } from "@calcom/features/membership/repositories/MembershipRepository";
+
+import { checkOnboardingRedirect } from "./onboardingUtils";
+
+function createMockUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    completedOnboarding: false,
+    createdDate: new Date("2024-01-01"),
+    emailVerified: new Date(),
+    identityProvider: "CAL",
+    ...overrides,
+  };
+}
+
+describe("checkOnboardingRedirect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when user is not found", async () => {
+    mockFindById.mockResolvedValue(null);
+
+    const result = await checkOnboardingRedirect(1);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when user has completedOnboarding=true", async () => {
+    mockFindById.mockResolvedValue(createMockUser({ completedOnboarding: true }));
+
+    const result = await checkOnboardingRedirect(1, { organizationId: null });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when user belongs to an organization", async () => {
+    mockFindById.mockResolvedValue(createMockUser());
+
+    const result = await checkOnboardingRedirect(1, { organizationId: 100 });
+    expect(result).toBeNull();
+  });
+
+  it("redirects invited member (non-owner) to personal settings when onboarding-v3 is enabled", async () => {
+    mockFindById.mockResolvedValue(createMockUser());
+    mockCheckIfFeatureIsEnabledGlobally.mockResolvedValue(true);
+    vi.mocked(MembershipRepository.hasAnyTeamMembershipByUserId).mockResolvedValue(true);
+    vi.mocked(MembershipRepository.hasAcceptedOwnerTeamMembership).mockResolvedValue(false);
+
+    const result = await checkOnboardingRedirect(1, { organizationId: null });
+    expect(result).toBe("/onboarding/personal/settings");
+  });
+
+  it("returns null for team OWNER even when completedOnboarding is false", async () => {
+    mockFindById.mockResolvedValue(createMockUser());
+    mockCheckIfFeatureIsEnabledGlobally.mockResolvedValue(true);
+    vi.mocked(MembershipRepository.hasAnyTeamMembershipByUserId).mockResolvedValue(true);
+    vi.mocked(MembershipRepository.hasAcceptedOwnerTeamMembership).mockResolvedValue(true);
+
+    const result = await checkOnboardingRedirect(1, { organizationId: null });
+    expect(result).toBeNull();
+  });
+
+  it("redirects to getting-started when no team membership and onboarding-v3 enabled", async () => {
+    mockFindById.mockResolvedValue(createMockUser());
+    mockCheckIfFeatureIsEnabledGlobally.mockResolvedValue(true);
+    vi.mocked(MembershipRepository.hasAnyTeamMembershipByUserId).mockResolvedValue(false);
+
+    const result = await checkOnboardingRedirect(1, { organizationId: null });
+    expect(result).toBe("/onboarding/getting-started");
+  });
+
+  it("redirects to getting-started (legacy) when onboarding-v3 is disabled", async () => {
+    mockFindById.mockResolvedValue(createMockUser());
+    mockCheckIfFeatureIsEnabledGlobally.mockResolvedValue(false);
+    vi.mocked(MembershipRepository.hasAnyTeamMembershipByUserId).mockResolvedValue(false);
+
+    const result = await checkOnboardingRedirect(1, { organizationId: null });
+    expect(result).toBe("/getting-started");
+  });
+
+  it("does not check owner membership when user has no team membership", async () => {
+    mockFindById.mockResolvedValue(createMockUser());
+    mockCheckIfFeatureIsEnabledGlobally.mockResolvedValue(true);
+    vi.mocked(MembershipRepository.hasAnyTeamMembershipByUserId).mockResolvedValue(false);
+
+    await checkOnboardingRedirect(1, { organizationId: null });
+    expect(MembershipRepository.hasAcceptedOwnerTeamMembership).not.toHaveBeenCalled();
+  });
+});

--- a/packages/features/auth/lib/onboardingUtils.ts
+++ b/packages/features/auth/lib/onboardingUtils.ts
@@ -69,6 +69,14 @@ export async function checkOnboardingRedirect(
   const hasTeamMembership = await MembershipRepository.hasAnyTeamMembershipByUserId({ userId });
 
   if (hasTeamMembership && onboardingV3Enabled) {
+    // If user is an accepted OWNER of any team, they have already gone through
+    // team creation and should not be forced back into onboarding.
+    // This prevents team owners from being stuck in an onboarding loop when
+    // they try to access the main app or create additional teams.
+    const isTeamOwner = await MembershipRepository.hasAcceptedOwnerTeamMembership({ userId });
+    if (isTeamOwner) {
+      return null;
+    }
     return "/onboarding/personal/settings";
   }
 

--- a/packages/features/membership/repositories/MembershipRepository.ts
+++ b/packages/features/membership/repositories/MembershipRepository.ts
@@ -613,4 +613,26 @@ export class MembershipRepository {
     });
     return !!membership;
   }
+
+  /**
+   * Checks if a user is an accepted OWNER of any team (non-organization).
+   * Used during onboarding to distinguish users who created a team themselves
+   * from users who were merely invited to a team.
+   */
+  static async hasAcceptedOwnerTeamMembership({ userId }: { userId: number }): Promise<boolean> {
+    const membership = await prisma.membership.findFirst({
+      where: {
+        userId,
+        role: MembershipRole.OWNER,
+        accepted: true,
+        team: {
+          isOrganization: false,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+    return !!membership;
+  }
 }


### PR DESCRIPTION
## What does this PR do?

When an existing user who already owns a team creates a second team and completes Stripe checkout, they were incorrectly redirected to `/onboarding/personal/settings` instead of proceeding to the team onboard-members page. This happened because `checkOnboardingRedirect` and the getting-started page checked for **any** team membership without distinguishing between team **owners** (who created the team) and team **members** (who were invited).

This PR adds an ownership check so that accepted team owners skip the onboarding redirect entirely.

### Changes

1. **`MembershipRepository.ts`** — Added `hasAcceptedOwnerTeamMembership()` static method that checks if a user is an accepted OWNER of any non-organization team.
2. **`onboardingUtils.ts`** — Inside the `hasTeamMembership && onboardingV3Enabled` branch, checks owner status before redirecting. Owners get `null` (no redirect), invited members still go to `/onboarding/personal/settings`.
3. **`getting-started/page.tsx`** — Same distinction: owners redirect to `/event-types`, invited members still redirect to `/onboarding/personal/settings`.
4. **`onboardingUtils.test.ts`** — 8 unit tests covering all redirect paths including the new owner-skip behavior.

### ⚠️ Items for reviewer attention

- **Different redirect targets**: `onboardingUtils.ts` returns `null` (no redirect) for owners, while `getting-started/page.tsx` redirects owners to `/event-types`. Is `/event-types` the right fallback destination here, or should it match?
- **Root cause vs. symptom**: The underlying issue may be that `completedOnboarding` is never set to `true` after team creation via Stripe checkout. This fix is defensive — it prevents the redirect loop — but doesn't address why the flag stays false.
- **Extra DB query**: `hasAcceptedOwnerTeamMembership` adds one more query on the redirect-check path (only when user already has a team membership).

Link to Devin run: https://app.devin.ai/sessions/3f9809a7036c4178b7a9a0b7c36b4e2e
Requested by: @sean-brydon

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a user with an existing team (user must be OWNER)
2. Ensure `completedOnboarding` is `false` for this user
3. Create a second team and complete Stripe checkout
4. Verify user is NOT redirected to `/onboarding/personal/settings`
5. Verify invited team members (MEMBER role) still get redirected to `/onboarding/personal/settings`

Run unit tests:
```bash
TZ=UTC yarn vitest run packages/features/auth/lib/onboardingUtils.test.ts
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings