### PR TITLE
fix: pass onboarding false to team creation

### DIFF
--- a/apps/web/modules/onboarding/hooks/useCreateTeam.ts
+++ b/apps/web/modules/onboarding/hooks/useCreateTeam.ts
@@ -9,10 +9,11 @@ import { useOnboardingStore } from "../store/onboarding-store";
 type UseCreateTeamOptions = {
   redirectBasePath?: string;
   skipRedirectAfterInvite?: boolean;
+  isOnboarding?: boolean;
 };
 
 export function useCreateTeam(options: UseCreateTeamOptions = {}) {
-  const { redirectBasePath = "/onboarding/teams", skipRedirectAfterInvite = false } = options;
+  const { redirectBasePath = "/onboarding/teams", skipRedirectAfterInvite = false, isOnboarding = true } = options;
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const flags = useFlagMap();
@@ -42,7 +43,7 @@ export function useCreateTeam(options: UseCreateTeamOptions = {}) {
         slug: teamDetails.slug,
         bio: teamDetails.bio,
         logo: teamBrand.logo,
-        isOnboarding: true,
+        isOnboarding,
       });
 
       // If there's a checkout URL, redirect to Stripe payment

--- a/apps/web/modules/settings/teams/new/create-new-team-view.tsx
+++ b/apps/web/modules/settings/teams/new/create-new-team-view.tsx
@@ -28,7 +28,10 @@ export const CreateNewTeamView = ({ userEmail }: CreateNewTeamViewProps) => {
   const { t } = useLocale();
   const store = useOnboardingStore();
   const { teamDetails, teamBrand, setTeamDetails, setTeamBrand, resetOnboardingPreservingPlan } = store;
-  const { createTeam, isSubmitting } = useCreateTeam({ redirectBasePath: "/settings/teams/new" });
+  const { createTeam, isSubmitting } = useCreateTeam({
+    redirectBasePath: "/settings/teams/new",
+    isOnboarding: false
+  });
 
   const logoRef = useRef<HTMLInputElement>(null);
   const [teamName, setTeamName] = useState("");

--- a/apps/web/modules/settings/teams/new/invite/email/team-invite-email-view.tsx
+++ b/apps/web/modules/settings/teams/new/invite/email/team-invite-email-view.tsx
@@ -43,6 +43,7 @@ export const TeamInviteEmailView = ({ userEmail }: TeamInviteEmailViewProps) => 
   const { inviteMembers, isSubmitting } = useCreateTeam({
     redirectBasePath: "/settings/teams/new",
     skipRedirectAfterInvite: true,
+    isOnboarding: false,
   });
 
   // Read teamId from query params and store it (from payment callback or redirect)

--- a/apps/web/modules/settings/teams/new/invite/team-invite-view.tsx
+++ b/apps/web/modules/settings/teams/new/invite/team-invite-view.tsx
@@ -29,7 +29,10 @@ export const TeamInviteView = ({ userEmail }: TeamInviteViewProps) => {
 
   const store = useOnboardingStore();
   const { setTeamInvites, teamDetails, setTeamId, teamId, resetOnboardingPreservingPlan } = store;
-  const { isSubmitting } = useCreateTeam({ redirectBasePath: "/settings/teams/new" });
+  const { isSubmitting } = useCreateTeam({
+    redirectBasePath: "/settings/teams/new",
+    isOnboarding: false
+  });
   const [isCSVModalOpen, setIsCSVModalOpen] = React.useState(false);
 
   // Read teamId from query params and store it (from payment callback)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure teams created from Settings are not treated as onboarding flows by passing isOnboarding: false. This fixes incorrect flow handling and redirects for /settings/teams/new.

- **Bug Fixes**
  - Added isOnboarding option to useCreateTeam (default true) and used it to send false for Settings flows.
  - Updated CreateNewTeamView, TeamInviteView, and TeamInviteEmailView to pass isOnboarding: false.

<sup>Written for commit a60a0b9c40969c746ce84871b01de43e645de089. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

