### PR TITLE
fix: add isCompanyEmail check to organization upgrade path

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/organizations/new/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/new/page.tsx
@@ -1,7 +1,11 @@
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { isCompanyEmail } from "@calcom/features/ee/organizations/lib/utils";
+import { UserPermissionRole } from "@calcom/prisma/enums";
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 import { _generateMetadata } from "app/_utils";
-
+import { cookies, headers } from "next/headers";
+import { redirect } from "next/navigation";
 import LicenseRequired from "~/ee/common/components/LicenseRequired";
-
 import LegacyPage, { LayoutWrapper } from "~/ee/organizations/new/create-new-view";
 
 export const generateMetadata = async () =>
@@ -14,6 +18,19 @@ export const generateMetadata = async () =>
   );
 
 const ServerPage = async () => {
+  const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
+
+  if (!session?.user?.id) {
+    return redirect("/auth/login");
+  }
+
+  const isAdmin = session.user.role === UserPermissionRole.ADMIN;
+  const userEmail = session.user.email || "";
+
+  if (!isAdmin && !isCompanyEmail(userEmail)) {
+    return redirect("/settings/my-account/profile");
+  }
+
   return (
     <LayoutWrapper>
       <LicenseRequired>

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3637,6 +3637,8 @@
   "you_cannot_create_an_organization_as_you_are_already_part_of_an_organization": "You cannot create an organization as you are already a part of an organization",
   "you_need_to_complete_user_onboarding_before_creating_an_organization": "You need to complete user onboarding before creating an organization",
   "use_company_email_to_create_an_organization": "Use company email to create an organization",
+  "update_email_organization_description": "To create an organization, you need a company email address. Please update your email in your profile settings.",
+  "update_email_address": "Update email address",
   "you_cannot_create_a_platform_organization_as_you_are_already_part_of_a_team": "You cannot create a platform organization as you are already a part of a team",
   "you_need_to_have_minimum_published_teams": "You need to have minimum published teams",
   "you_are_part_of_this_organization_already": "You are part of this organization already",

--- a/packages/features/ee/organizations/lib/utils.test.ts
+++ b/packages/features/ee/organizations/lib/utils.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { extractDomainFromEmail, isCompanyEmail } from "./utils";
+
+describe("utils", () => {
+  describe("isCompanyEmail", () => {
+    it("should return false for gmail.com email", () => {
+      expect(isCompanyEmail("user@gmail.com")).toBe(false);
+    });
+
+    it("should return false for yahoo.com email", () => {
+      expect(isCompanyEmail("user@yahoo.com")).toBe(false);
+    });
+
+    it("should return false for outlook.com email", () => {
+      expect(isCompanyEmail("user@outlook.com")).toBe(false);
+    });
+
+    it("should return false for hotmail.com email", () => {
+      expect(isCompanyEmail("user@hotmail.com")).toBe(false);
+    });
+
+    it("should return false for protonmail.com email", () => {
+      expect(isCompanyEmail("user@protonmail.com")).toBe(false);
+    });
+
+    it("should return false for icloud.com email", () => {
+      expect(isCompanyEmail("user@icloud.com")).toBe(false);
+    });
+
+    it("should return true for company email", () => {
+      expect(isCompanyEmail("user@acme.com")).toBe(true);
+    });
+
+    it("should return true for cal.com email", () => {
+      expect(isCompanyEmail("user@cal.com")).toBe(true);
+    });
+
+    it("should return false for email without @", () => {
+      expect(isCompanyEmail("invalidemail")).toBe(false);
+    });
+
+    it("should return false for empty email", () => {
+      expect(isCompanyEmail("")).toBe(false);
+    });
+
+    it("should return false for all popular personal email providers", () => {
+      const personalProviders = [
+        "gmail.com",
+        "googlemail.com",
+        "yahoo.com",
+        "ymail.com",
+        "rocketmail.com",
+        "sbcglobal.net",
+        "att.net",
+        "outlook.com",
+        "hotmail.com",
+        "live.com",
+        "msn.com",
+        "outlook.co",
+        "hotmail.co.uk",
+        "aol.com",
+        "icloud.com",
+        "me.com",
+        "mac.com",
+        "mail.com",
+        "email.com",
+        "protonmail.com",
+        "proton.me",
+        "zoho.com",
+        "yandex.com",
+        "gmx.com",
+        "fastmail.com",
+        "tutanota.com",
+        "mail.ru",
+        "qq.com",
+      ];
+
+      for (const provider of personalProviders) {
+        expect(isCompanyEmail(`user@${provider}`)).toBe(false);
+      }
+    });
+
+    it("should return true for various company domains", () => {
+      const companyDomains = [
+        "acme.com",
+        "techcorp.io",
+        "business.co",
+        "startup.ai",
+        "enterprise.net",
+        "cal.com",
+      ];
+
+      for (const domain of companyDomains) {
+        expect(isCompanyEmail(`user@${domain}`)).toBe(true);
+      }
+    });
+
+    it("should be case-insensitive for domain matching", () => {
+      expect(isCompanyEmail("user@GMAIL.COM")).toBe(false);
+      expect(isCompanyEmail("user@Gmail.Com")).toBe(false);
+    });
+  });
+
+  describe("extractDomainFromEmail", () => {
+    it("should extract domain from a standard email", () => {
+      expect(extractDomainFromEmail("user@acme.com")).toBe("acme");
+    });
+
+    it("should return empty string for invalid input", () => {
+      expect(extractDomainFromEmail("invalid")).toBe("");
+    });
+
+    it("should return empty string for empty input", () => {
+      expect(extractDomainFromEmail("")).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Users with personal email addresses (e.g., Gmail) could enter the organization creation flow at `/settings/organizations/new` (linked from team list cards, gated features modal, etc.), fill out the entire form, and only hit a "need company email" error at checkout — with no way to fix it inline. Worse, after changing their email in profile settings and returning, the Zustand-persisted store still used the old cached Gmail address, effectively locking them out.

This PR adds `isCompanyEmail` validation at the **start** of the upgrade path, matching what the newer `/onboarding/organization/` flow already does.

### Changes

1. **Server-side guard in `page.tsx`**: Non-admin users with personal emails are redirected to `/settings/my-account/profile` before the page renders.
2. **Client-side guard in `CreateANewOrganizationForm`**: Shows a warning Alert with a link to update their email, as a defense-in-depth fallback.
3. **Stale email fix**: For non-admin users, always uses the current session email (`session.data.user.email`) instead of the potentially stale Zustand-cached `orgOwnerEmail`. This fixes the "changed email in settings but onboarding still uses Gmail" scenario.
4. **New i18n keys**: `update_email_organization_description` and `update_email_address`.
5. **Unit tests** for `isCompanyEmail` and `extractDomainFromEmail` utilities.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Log in as a non-admin user with a **personal email** (e.g., `user@gmail.com`).
2. Navigate to `/settings/organizations/new` directly → should be redirected to `/settings/my-account/profile`.
3. If somehow the form renders (e.g., client-side nav), a warning alert should appear instead of the form, with a button linking to profile settings.
4. Log in as a non-admin user with a **company email** (e.g., `user@acme.com`) → org creation form should render normally.
5. Log in as an **admin** user with any email → form should render normally (admins are exempt).
6. Test the stale-email scenario: start org creation with a Gmail, change email to a company domain in settings, return → form should use the new email.

## Important review items

- [ ] **Redirect destination**: Server-side guard redirects to `/settings/my-account/profile` silently — is a toast/query-param needed to explain the redirect?
- [ ] **`effectiveOrgOwnerEmail` logic** (line 58): Non-admins always get session email; admins fall back to store then session. Verify this is correct for admin handover flows.
- [ ] **Sub-pages**: The guard is only on the entry page (`/settings/organizations/new`). Subsequent pages (`/about`, `/add-teams`, etc.) don't have this check — is that acceptable since users can't reach them without passing the first page?

---

Link to Devin run: https://app.devin.ai/sessions/2abb44e3f29c4f6c9125d7ad9343a9e0
Requested by: @sean-brydon