### PR TITLE
chore: Use IF NOT EXISTS for index of App_RoutingForms_FormResponse

### DIFF
--- a/packages/prisma/migrations/20260126173100_add_form_response_formid_createdat_index/migration.sql
+++ b/packages/prisma/migrations/20260126173100_add_form_response_formid_createdat_index/migration.sql
@@ -1,2 +1,2 @@
 -- CreateIndex
-CREATE INDEX "App_RoutingForms_FormResponse_formId_createdAt_idx" ON "App_RoutingForms_FormResponse"("formId", "createdAt");
+CREATE INDEX IF NOT EXISTS "App_RoutingForms_FormResponse_formId_createdAt_idx" ON "App_RoutingForms_FormResponse"("formId", "createdAt");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use CREATE INDEX IF NOT EXISTS for App_RoutingForms_FormResponse(formId, createdAt) to avoid errors if the index already exists. This makes the migration safe to rerun and reduces deployment friction.

<sup>Written for commit f4863e69a65158211cbfb3ab885f160d0fe7ed8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

