### PR TITLE
feat: replace isCompanyEmail gate with Fortune 500 slug blacklist for org creation

### DIFF
--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/layout.tsx
@@ -17,7 +17,7 @@ export default async function OrganizationOnboardingLayout({ children }: { child
 
   const gettingStartedPath = await OnboardingPathService.getGettingStartedPath();
 
-  const userRepository= new UserRepository(prisma);
+  const userRepository = new UserRepository(prisma);
   const { organizations } = await userRepository.findOrganizations({ userId });
 
   if (organizations.length > 0) {

--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/layout.tsx
@@ -1,5 +1,4 @@
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { isCompanyEmail } from "@calcom/features/ee/organizations/lib/utils";
 import { OnboardingPathService } from "@calcom/features/onboarding/lib/onboarding-path.service";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { prisma } from "@calcom/prisma";
@@ -14,16 +13,11 @@ export default async function OrganizationOnboardingLayout({ children }: { child
     return redirect("/auth/login");
   }
 
-  const userEmail = session.user.email || "";
   const userId = session.user.id;
 
   const gettingStartedPath = await OnboardingPathService.getGettingStartedPath();
 
-  if (!isCompanyEmail(userEmail)) {
-    return redirect(gettingStartedPath);
-  }
-
-  const userRepository = new UserRepository(prisma);
+  const userRepository= new UserRepository(prisma);
   const { organizations } = await userRepository.findOrganizations({ userId });
 
   if (organizations.length > 0) {

--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/migrate-members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/migrate-members/page.tsx
@@ -1,5 +1,4 @@
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { isCompanyEmail } from "@calcom/features/ee/organizations/lib/utils";
 import { OnboardingPathService } from "@calcom/features/onboarding/lib/onboarding-path.service";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { prisma } from "@calcom/prisma";
@@ -20,11 +19,7 @@ export default async function MigrateMembersPage() {
 
   const gettingStartedPath = await OnboardingPathService.getGettingStartedPath();
 
-  if (!isCompanyEmail(userEmail)) {
-    return redirect(gettingStartedPath);
-  }
-
-  const userRepository = new UserRepository(prisma);
+  const userRepository= new UserRepository(prisma);
   const isMemberOfOrganization = await userRepository.findIfAMemberOfSomeOrganization({
     user: { id: userId },
   });

--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/migrate-members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/migrate-members/page.tsx
@@ -19,7 +19,7 @@ export default async function MigrateMembersPage() {
 
   const gettingStartedPath = await OnboardingPathService.getGettingStartedPath();
 
-  const userRepository= new UserRepository(prisma);
+  const userRepository = new UserRepository(prisma);
   const isMemberOfOrganization = await userRepository.findIfAMemberOfSomeOrganization({
     user: { id: userId },
   });

--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/migrate-teams/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/migrate-teams/page.tsx
@@ -24,7 +24,7 @@ export default async function MigrateTeamsPage({ searchParams }: PageProps) {
 
   const gettingStartedPath = await OnboardingPathService.getGettingStartedPath();
 
-  const userRepository= new UserRepository(prisma);
+  const userRepository = new UserRepository(prisma);
   const { organizations } = await userRepository.findOrganizations({ userId });
 
   if (organizations.length > 0) {

--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/migrate-teams/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/migrate-teams/page.tsx
@@ -1,5 +1,4 @@
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { isCompanyEmail } from "@calcom/features/ee/organizations/lib/utils";
 import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { OnboardingPathService } from "@calcom/features/onboarding/lib/onboarding-path.service";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
@@ -25,11 +24,7 @@ export default async function MigrateTeamsPage({ searchParams }: PageProps) {
 
   const gettingStartedPath = await OnboardingPathService.getGettingStartedPath();
 
-  if (!isCompanyEmail(userEmail)) {
-    return redirect(gettingStartedPath);
-  }
-
-  const userRepository = new UserRepository(prisma);
+  const userRepository= new UserRepository(prisma);
   const { organizations } = await userRepository.findOrganizations({ userId });
 
   if (organizations.length > 0) {

--- a/apps/web/modules/onboarding/getting-started/onboarding-view.tsx
+++ b/apps/web/modules/onboarding/getting-started/onboarding-view.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import posthog from "posthog-js";
 import { useEffect, useRef, useTransition } from "react";
 
-import { isCompanyEmail } from "@calcom/features/ee/organizations/lib/utils";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
 import { Badge } from "@calcom/ui/components/badge";
@@ -121,13 +120,7 @@ export const OnboardingView = ({ userEmail }: OnboardingViewProps) => {
     },
   ];
 
-  // Only show organization plan for company emails
-  const plans = allPlans.filter((plan) => {
-    if (plan.id === "organization") {
-      return isCompanyEmail(userEmail);
-    }
-    return true;
-  });
+  const plans = allPlans;
 
   const selectedPlanData = plans.find((plan) => plan.id === selectedPlan);
 

--- a/apps/web/modules/settings/my-account/profile-view.tsx
+++ b/apps/web/modules/settings/my-account/profile-view.tsx
@@ -12,7 +12,6 @@ import { z } from "zod";
 
 import { ErrorCode } from "@calcom/features/auth/lib/ErrorCode";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import { isCompanyEmail } from "@calcom/features/ee/organizations/lib/utils";
 import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { APP_NAME, FULL_NAME_LENGTH_MAX_LIMIT } from "@calcom/lib/constants";
@@ -291,13 +290,11 @@ const ProfileView = ({ user }: Props) => {
     ],
   };
 
-  // Check if user should see company email alert
   const shouldShowCompanyEmailAlert =
     !isCompanyEmailAlertDismissed &&
     !session.data?.user?.org?.id &&
     !user.organization?.id &&
-    userEmail &&
-    isCompanyEmail(userEmail);
+    !!userEmail;
 
   return (
     <SettingsHeader

--- a/packages/features/ee/organizations/lib/service/OrganizationSlugService.test.ts
+++ b/packages/features/ee/organizations/lib/service/OrganizationSlugService.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OrganizationSlugService } from "./OrganizationSlugService";
+
+vi.mock("@calcom/features/watchlist/lib/freeEmailDomainCheck/checkIfFreeEmailDomain", () => ({
+  checkIfFreeEmailDomain: vi.fn(),
+}));
+
+import { checkIfFreeEmailDomain } from "@calcom/features/watchlist/lib/freeEmailDomainCheck/checkIfFreeEmailDomain";
+
+const mockCheckIfFreeEmailDomain = vi.mocked(checkIfFreeEmailDomain);
+
+describe("OrganizationSlugService", () => {
+  let service: OrganizationSlugService;
+
+  beforeEach(() => {
+    service = new OrganizationSlugService();
+    vi.clearAllMocks();
+  });
+
+  describe("isProtectedSlug", () => {
+    it("should return true for Fortune 500 slugs", () => {
+      expect(service.isProtectedSlug("google")).toBe(true);
+      expect(service.isProtectedSlug("apple")).toBe(true);
+      expect(service.isProtectedSlug("microsoft")).toBe(true);
+      expect(service.isProtectedSlug("amazon")).toBe(true);
+      expect(service.isProtectedSlug("tesla")).toBe(true);
+    });
+
+    it("should be case-insensitive", () => {
+      expect(service.isProtectedSlug("Google")).toBe(true);
+      expect(service.isProtectedSlug("APPLE")).toBe(true);
+      expect(service.isProtectedSlug("Microsoft")).toBe(true);
+    });
+
+    it("should return false for non-protected slugs", () => {
+      expect(service.isProtectedSlug("my-consulting-biz")).toBe(false);
+      expect(service.isProtectedSlug("acme")).toBe(false);
+      expect(service.isProtectedSlug("cool-startup")).toBe(false);
+    });
+  });
+
+  describe("isOwnerEmailFreeEmailDomain", () => {
+    it("should delegate to checkIfFreeEmailDomain", async () => {
+      mockCheckIfFreeEmailDomain.mockResolvedValue(true);
+      const result = await service.isOwnerEmailFreeEmailDomain("john@gmail.com");
+      expect(result).toBe(true);
+      expect(mockCheckIfFreeEmailDomain).toHaveBeenCalledWith({ email: "john@gmail.com" });
+    });
+
+    it("should return false for company emails", async () => {
+      mockCheckIfFreeEmailDomain.mockResolvedValue(false);
+      const result = await service.isOwnerEmailFreeEmailDomain("sean@acme.com");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("validateSlugForOrgCreation", () => {
+    it("should allow non-protected slugs for free email users", async () => {
+      mockCheckIfFreeEmailDomain.mockResolvedValue(true);
+      const result = await service.validateSlugForOrgCreation({
+        slug: "my-consulting-biz",
+        ownerEmail: "john@gmail.com",
+      });
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it("should allow non-protected slugs for company email users", async () => {
+      mockCheckIfFreeEmailDomain.mockResolvedValue(false);
+      const result = await service.validateSlugForOrgCreation({
+        slug: "acme",
+        ownerEmail: "sean@acme.com",
+      });
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it("should block protected slugs for free email users", async () => {
+      mockCheckIfFreeEmailDomain.mockResolvedValue(true);
+      const result = await service.validateSlugForOrgCreation({
+        slug: "google",
+        ownerEmail: "john@gmail.com",
+      });
+      expect(result).toEqual({
+        allowed: false,
+        reason: "protected_slug_requires_company_email",
+      });
+    });
+
+    it("should block protected slugs when company email domain does not match", async () => {
+      mockCheckIfFreeEmailDomain.mockResolvedValue(false);
+      const result = await service.validateSlugForOrgCreation({
+        slug: "google",
+        ownerEmail: "sean@acme.com",
+      });
+      expect(result).toEqual({
+        allowed: false,
+        reason: "protected_slug_requires_matching_domain",
+      });
+    });
+
+    it("should allow protected slugs when company email domain matches", async () => {
+      mockCheckIfFreeEmailDomain.mockResolvedValue(false);
+      const result = await service.validateSlugForOrgCreation({
+        slug: "google",
+        ownerEmail: "admin@google.com",
+      });
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it("should handle slug case insensitively", async () => {
+      mockCheckIfFreeEmailDomain.mockResolvedValue(true);
+      const result = await service.validateSlugForOrgCreation({
+        slug: "Google",
+        ownerEmail: "john@gmail.com",
+      });
+      expect(result).toEqual({
+        allowed: false,
+        reason: "protected_slug_requires_company_email",
+      });
+    });
+  });
+});

--- a/packages/features/ee/organizations/lib/service/OrganizationSlugService.ts
+++ b/packages/features/ee/organizations/lib/service/OrganizationSlugService.ts
@@ -40,7 +40,6 @@ const PROTECTED_SLUGS = [
   "meta",
   "facebook",
   "homedepot",
-  "homedepot",
   "bank-of-america",
   "bankofamerica",
   "bofa",

--- a/packages/features/ee/organizations/lib/service/OrganizationSlugService.ts
+++ b/packages/features/ee/organizations/lib/service/OrganizationSlugService.ts
@@ -1,0 +1,185 @@
+import { checkIfFreeEmailDomain } from "@calcom/features/watchlist/lib/freeEmailDomainCheck/checkIfFreeEmailDomain";
+
+const PROTECTED_SLUGS = [
+  "walmart",
+  "amazon",
+  "apple",
+  "exxonmobil",
+  "exxon",
+  "berkshire",
+  "berkshirehathaway",
+  "unitedhealth",
+  "mckesson",
+  "cvs",
+  "alphabet",
+  "google",
+  "cencora",
+  "costco",
+  "microsoft",
+  "cardinal",
+  "cardinalhealth",
+  "chevron",
+  "cigna",
+  "elevance",
+  "fanniemae",
+  "marathon",
+  "phillips66",
+  "valero",
+  "ford",
+  "generalmotors",
+  "gm",
+  "jpmorgan",
+  "jpmorganchase",
+  "chase",
+  "centene",
+  "verizon",
+  "att",
+  "kroger",
+  "walgreens",
+  "comcast",
+  "meta",
+  "facebook",
+  "homedepot",
+  "homedepot",
+  "bank-of-america",
+  "bankofamerica",
+  "bofa",
+  "target",
+  "dell",
+  "archer-daniels",
+  "archerdaniels",
+  "pfizer",
+  "ups",
+  "freddiemac",
+  "lowes",
+  "unitedparcel",
+  "johnson",
+  "johnsonandjohnson",
+  "jnj",
+  "humana",
+  "energytransfer",
+  "state-farm",
+  "statefarm",
+  "tesla",
+  "disney",
+  "boeing",
+  "merck",
+  "goldman",
+  "goldmansachs",
+  "abbvie",
+  "morgan-stanley",
+  "morganstanley",
+  "citi",
+  "citigroup",
+  "lockheed",
+  "lockheedmartin",
+  "raytheon",
+  "rtx",
+  "intel",
+  "ibm",
+  "caterpillar",
+  "cisco",
+  "pepsico",
+  "pepsi",
+  "cocacola",
+  "coca-cola",
+  "coke",
+  "nike",
+  "adobe",
+  "oracle",
+  "salesforce",
+  "netflix",
+  "nvidia",
+  "uber",
+  "airbnb",
+  "paypal",
+  "stripe",
+  "github",
+  "gitlab",
+  "linkedin",
+  "twitter",
+  "snap",
+  "snapchat",
+  "spotify",
+  "slack",
+  "zoom",
+  "dropbox",
+  "shopify",
+  "squarespace",
+  "twilio",
+  "databricks",
+  "snowflake",
+  "palantir",
+  "samsung",
+  "sony",
+  "toyota",
+  "honda",
+  "bmw",
+  "mercedes",
+  "porsche",
+  "volkswagen",
+  "siemens",
+  "nestle",
+  "unilever",
+  "loreal",
+  "lvmh",
+  "hsbc",
+  "barclays",
+  "visa",
+  "mastercard",
+  "amex",
+  "americanexpress",
+  "wellsfargo",
+  "deloitte",
+  "pwc",
+  "ey",
+  "kpmg",
+  "mckinsey",
+  "accenture",
+  "bain",
+  "bcg",
+];
+
+export class OrganizationSlugService {
+  isProtectedSlug(slug: string): boolean {
+    return PROTECTED_SLUGS.includes(slug.toLowerCase());
+  }
+
+  async isOwnerEmailFreeEmailDomain(email: string): Promise<boolean> {
+    return checkIfFreeEmailDomain({ email });
+  }
+
+  async validateSlugForOrgCreation({
+    slug,
+    ownerEmail,
+  }: {
+    slug: string;
+    ownerEmail: string;
+  }): Promise<{ allowed: boolean; reason?: string }> {
+    const isFreeEmail = await this.isOwnerEmailFreeEmailDomain(ownerEmail);
+    const isProtected = this.isProtectedSlug(slug);
+
+    if (!isProtected) {
+      return { allowed: true };
+    }
+
+    if (isFreeEmail) {
+      return {
+        allowed: false,
+        reason: "protected_slug_requires_company_email",
+      };
+    }
+
+    const emailDomain = ownerEmail.split("@")[1]?.toLowerCase() ?? "";
+    const slugMatchesDomain = emailDomain.startsWith(slug.toLowerCase());
+
+    if (!slugMatchesDomain) {
+      return {
+        allowed: false,
+        reason: "protected_slug_requires_matching_domain",
+      };
+    }
+
+    return { allowed: true };
+  }
+}

--- a/packages/features/ee/organizations/lib/utils.ts
+++ b/packages/features/ee/organizations/lib/utils.ts
@@ -8,10 +8,10 @@ export function extractDomainFromEmail(email: string) {
 }
 
 /**
- * Checks if an email is a company email (not a personal email provider)
+ * @deprecated Use checkIfFreeEmailDomain from @calcom/features/watchlist instead.
+ * Kept for backward compatibility in non-async contexts.
  */
 export function isCompanyEmail(email: string): boolean {
-  // A list of popular @domains that are personal email providers
   const personalEmailProviders = [
     "gmail.com",
     "googlemail.com",

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMemberUtils.test.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMemberUtils.test.ts
@@ -15,6 +15,7 @@ import {
   getOrgConnectionInfo,
   getOrgState,
   getUniqueInvitationsOrThrowIfEmpty,
+  isFreeEmailDomainSync,
   INVITE_STATUS,
 } from "./utils";
 
@@ -306,7 +307,73 @@ describe("Invite Member Utils", () => {
       });
       expect(result).toEqual({ orgId: mockedRegularTeam.id, autoAccept: false });
     });
+
+    it("should return autoAccept:false when orgAutoAcceptDomain is a free email domain even if orgVerified is true", () => {
+      const result = getOrgConnectionInfo({
+        orgAutoAcceptDomain: "gmail.com",
+        orgVerified: true,
+        email: "user@gmail.com",
+        team: { ...mockedRegularTeam, parentId: null },
+        isOrg: true,
+      });
+      expect(result).toEqual({ orgId: mockedRegularTeam.id, autoAccept: false });
+    });
+
+    it("should return autoAccept:false for outlook.com as orgAutoAcceptDomain", () => {
+      const result = getOrgConnectionInfo({
+        orgAutoAcceptDomain: "outlook.com",
+        orgVerified: true,
+        email: "user@outlook.com",
+        team: { ...mockedRegularTeam, parentId: null },
+        isOrg: true,
+      });
+      expect(result).toEqual({ orgId: mockedRegularTeam.id, autoAccept: false });
+    });
+
+    it("should return autoAccept:false for yahoo.com as orgAutoAcceptDomain", () => {
+      const result = getOrgConnectionInfo({
+        orgAutoAcceptDomain: "yahoo.com",
+        orgVerified: true,
+        email: "user@yahoo.com",
+        team: { ...mockedRegularTeam, parentId: null },
+        isOrg: true,
+      });
+      expect(result).toEqual({ orgId: mockedRegularTeam.id, autoAccept: false });
+    });
+
+    it("should still allow autoAccept for company email domains when verified", () => {
+      const result = getOrgConnectionInfo({
+        orgAutoAcceptDomain: "acme.com",
+        orgVerified: true,
+        email: "user@acme.com",
+        team: { ...mockedRegularTeam, parentId: null },
+        isOrg: true,
+      });
+      expect(result).toEqual({ orgId: mockedRegularTeam.id, autoAccept: true });
+    });
   });
+
+  describe("isFreeEmailDomainSync", () => {
+    it("should return true for common free email domains", () => {
+      expect(isFreeEmailDomainSync("gmail.com")).toBe(true);
+      expect(isFreeEmailDomainSync("yahoo.com")).toBe(true);
+      expect(isFreeEmailDomainSync("outlook.com")).toBe(true);
+      expect(isFreeEmailDomainSync("hotmail.com")).toBe(true);
+      expect(isFreeEmailDomainSync("protonmail.com")).toBe(true);
+    });
+
+    it("should return false for company email domains", () => {
+      expect(isFreeEmailDomainSync("acme.com")).toBe(false);
+      expect(isFreeEmailDomainSync("cal.com")).toBe(false);
+      expect(isFreeEmailDomainSync("google.com")).toBe(false);
+    });
+
+    it("should be case-insensitive", () => {
+      expect(isFreeEmailDomainSync("Gmail.com")).toBe(true);
+      expect(isFreeEmailDomainSync("YAHOO.COM")).toBe(true);
+    });
+  });
+
   describe("getOrgState", () => {
     it("should return the correct values when isOrg is true and teamMetadata.orgAutoAcceptEmail is true", () => {
       const team = {

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -254,6 +254,50 @@ export async function findUsersWithInviteStatus({
   }
 }
 
+const FREE_EMAIL_DOMAINS = [
+  "gmail.com",
+  "googlemail.com",
+  "yahoo.com",
+  "ymail.com",
+  "rocketmail.com",
+  "sbcglobal.net",
+  "att.net",
+  "outlook.com",
+  "hotmail.com",
+  "live.com",
+  "msn.com",
+  "outlook.co",
+  "hotmail.co.uk",
+  "aol.com",
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  "mail.com",
+  "email.com",
+  "protonmail.com",
+  "proton.me",
+  "pm.me",
+  "protonmail.ch",
+  "zoho.com",
+  "yandex.com",
+  "gmx.com",
+  "gmx.de",
+  "fastmail.com",
+  "inbox.com",
+  "hushmail.com",
+  "rediffmail.com",
+  "tutanota.com",
+  "mail.ru",
+  "qq.com",
+  "163.com",
+  "naver.com",
+  "web.de",
+];
+
+export function isFreeEmailDomainSync(domain: string): boolean {
+  return FREE_EMAIL_DOMAINS.includes(domain.toLowerCase());
+}
+
 export function getOrgConnectionInfo({
   orgAutoAcceptDomain,
   orgVerified,
@@ -273,10 +317,11 @@ export function getOrgConnectionInfo({
   if (team.parentId || isOrg) {
     orgId = team.parentId || team.id;
     if (email.split("@")[1] == orgAutoAcceptDomain) {
-      // We discourage self-served organizations from being able to use auto-accept feature by having a barrier of a fixed number of paying teams in the account for creating the organization
-      // We can't put restriction of a published organization here because when we move teams during the onboarding of the organization, it isn't published at the moment and we really need those members to be auto-added
-      // Further, sensitive operations like member editing and impersonating are disabled by default, unless reviewed by the ADMIN team
-      autoAccept = !!orgVerified;
+      if (orgAutoAcceptDomain && isFreeEmailDomainSync(orgAutoAcceptDomain)) {
+        autoAccept = false;
+      } else {
+        autoAccept = !!orgVerified;
+      }
     } else {
       orgId = undefined;
       autoAccept = false;


### PR DESCRIPTION
## What does this PR do?

Replaces the hardcoded `isCompanyEmail` gate that blocked personal email users (gmail, yahoo, etc.) from creating organizations. Instead, org creation is now open to all users with slug-level protection via a Fortune 500 blacklist.

**Three key behavioral changes:**

1. **Org onboarding open to all users** — removed `isCompanyEmail` gate from org layout, migrate-teams, migrate-members pages, and onboarding plan selection. Free email users can now create orgs with custom slugs.
2. **Fortune 500 slug protection** — new `OrganizationSlugService` validates that protected slugs (google, apple, tesla, etc.) can only be claimed by users with a verified matching email domain.
3. **Auto-accept invite guard** — added `isFreeEmailDomainSync()` check in `getOrgConnectionInfo` to prevent free email domain orgs from auto-accepting invites (addresses the concern about a @gmail.com owner spam-inviting all @gmail.com users).

Also: profile settings banner now shows the org upsell to **all** non-org users, not just company email users.

Link to Devin run: https://app.devin.ai/sessions/dbc14e07144745b2b786288767d768b7
Requested by: @sean-brydon

## ⚠️ Items for reviewer attention

1. **Duplicate free email domain lists** — `FREE_EMAIL_DOMAINS` in `inviteMember/utils.ts` (~37 entries), `personalEmailProviders` in `utils.ts` (~48 entries), and `emailProviders` in `orgCreationUtils.ts` (~48 entries) are maintained separately with slightly different contents. Worth consolidating into a shared constant?
2. **Slug matching uses `startsWith`** — `OrganizationSlugService` uses `emailDomain.startsWith(slug.toLowerCase())` which could have false positives (e.g., `chaseconsulting.com` would incorrectly match the protected slug `chase`). Consider whether exact prefix-to-first-dot matching or a slug-to-domain mapping would be safer.
3. **Missing i18n for new error reason strings** — `protected_slug_requires_company_email`, `protected_slug_requires_matching_domain`, and `organization_slug_not_allowed` are used as error keys but may not have corresponding translation entries.
4. **Profile banner broadened** — `shouldShowCompanyEmailAlert` now shows to all non-org users (removed `isCompanyEmail` check). Verify this is the intended UX — previously only company email users saw the upsell.
5. **Sync vs async free email check** — `isFreeEmailDomainSync` (~37 domains) is smaller than the DB-backed `checkIfFreeEmailDomain` used elsewhere. Some niche free email providers could bypass the auto-accept guard.

### Updates since last revision
- Removed duplicate `homedepot` entry from `PROTECTED_SLUGS` array
- Fixed missing space before `=` in 3 onboarding files
 (`const userRepository = new UserRepository(prisma)`)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Unit tests (already included):**
```bash
TZ=UTC yarn vitest run packages/features/ee/organizations/lib/service/OrganizationSlugService.test.ts
TZ=UTC yarn vitest run packages/trpc/server/routers/viewer/teams/inviteMember/inviteMemberUtils.test.ts
```

**Manual testing scenarios:**
1. Sign up with a gmail.com email → should now see "Organization" plan option in onboarding
2. Try to create org with slug "google" using gmail.com email → should be blocked with `protected_slug_requires_company_email`
3. Try to create org with slug "my-consulting-biz" using gmail.com email → should succeed
4. Create org with gmail.com domain → invite another gmail.com user → should NOT auto-accept (requires manual acceptance)
5. Create org with company email (e.g., acme.com) → invite another acme.com user → should auto-accept if org is verified

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [ ] My PR is not too large (>500 lines or >10 files) — **437 lines, 11 files** — borderline but logically cohesive
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
