### PR TITLE
chore: Broken styles for save & delete button on medium devices

### DIFF
--- a/apps/web/modules/shell/Shell.tsx
+++ b/apps/web/modules/shell/Shell.tsx
@@ -42,13 +42,18 @@ const Layout = (props: LayoutProps) => {
       <DynamicModals />
 
       <div className="flex min-h-screen flex-col">
-        {banners && !props.isPlatformUser && <BannerContainer banners={banners} />}
+        {banners && !props.isPlatformUser && (
+          <BannerContainer banners={banners} />
+        )}
 
         <div className="flex flex-1" data-testid="dashboard-shell">
           {props.SidebarContainer ? (
             cloneElement(props.SidebarContainer, { bannersHeight })
           ) : (
-            <SideBarContainer isPlatformUser={props.isPlatformUser} bannersHeight={bannersHeight} />
+            <SideBarContainer
+              isPlatformUser={props.isPlatformUser}
+              bannersHeight={bannersHeight}
+            />
           )}
           <div className="flex w-0 flex-1 flex-col">
             <MainContainer {...props} />
@@ -59,7 +64,10 @@ const Layout = (props: LayoutProps) => {
   );
 };
 
-type DrawerState = [isOpen: boolean, setDrawerOpen: Dispatch<SetStateAction<boolean>>];
+type DrawerState = [
+  isOpen: boolean,
+  setDrawerOpen: Dispatch<SetStateAction<boolean>>
+];
 
 export type LayoutProps = {
   centered?: boolean;
@@ -88,9 +96,16 @@ export type LayoutProps = {
   smallHeading?: boolean;
   isPlatformUser?: boolean;
   disableSticky?: boolean;
+  topAlignedHeading?: boolean;
 };
 
-const KBarWrapper = ({ children, withKBar = false }: { withKBar: boolean; children: React.ReactNode }) =>
+const KBarWrapper = ({
+  children,
+  withKBar = false,
+}: {
+  withKBar: boolean;
+  children: React.ReactNode;
+}) =>
   withKBar ? (
     <KBarRoot>
       {children}
@@ -140,17 +155,22 @@ export function ShellMain(props: LayoutProps) {
         <div
           style={headerStyle}
           className={classNames(
-            "bg-default mb-0 flex items-center md:mb-6 md:mt-0",
+            "bg-default mb-0 flex md:mb-6 md:mt-0",
             props.smallHeading ? "lg:mb-7" : "lg:mb-8",
-            !props.disableSticky && "sticky top-0 z-10 md:fixed md:w-[calc(100%-3.5rem)] md:pt-3 md:pb-2 md:px-5 md:left-14 lg:left-56 lg:w-[calc(100%-14rem)]"
-          )}>
+            props.topAlignedHeading ? "items-start" : "items-center",
+            !props.disableSticky &&
+              "sticky top-0 z-10 md:fixed md:w-[calc(100%-3.5rem)] md:pt-3 md:pb-2 md:px-5 md:left-14 lg:left-56 lg:w-[calc(100%-14rem)]"
+          )}
+        >
           {!!props.backPath && (
             <Button
               variant="icon"
               size="sm"
               color="minimal"
               onClick={() =>
-                typeof props.backPath === "string" ? router.push(props.backPath as string) : router.back()
+                typeof props.backPath === "string"
+                  ? router.push(props.backPath as string)
+                  : router.back()
               }
               StartIcon="arrow-left"
               aria-label="Go Back"
@@ -160,22 +180,45 @@ export function ShellMain(props: LayoutProps) {
           )}
           {props.heading && (
             <header
-              className={classNames(props.large && "py-8", "flex w-full max-w-full items-center truncate")}>
-              {props.HeadingLeftIcon && <div className="ltr:mr-4">{props.HeadingLeftIcon}</div>}
+              className={classNames(
+                props.large && "py-8",
+                "flex w-full max-w-full truncate",
+                props.topAlignedHeading ? "items-start" : "items-center"
+              )}
+            >
+              {props.HeadingLeftIcon && (
+                <div className="ltr:mr-4">{props.HeadingLeftIcon}</div>
+              )}
               <div
-                className={classNames("w-full truncate ltr:mr-4 rtl:ml-4 md:block", props.headerClassName)}>
+                className={classNames(
+                  "w-full truncate ltr:mr-4 rtl:ml-4 md:block",
+                  props.headerClassName
+                )}
+              >
                 {props.heading && (
                   <h3
                     className={classNames(
                       "font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 hidden truncate text-lg font-semibold tracking-wide sm:text-xl md:block xl:max-w-full",
                       props.smallHeading ? "text-base" : "text-xl"
-                    )}>
-                    {!isLocaleReady ? <SkeletonText invisible /> : props.heading}
+                    )}
+                  >
+                    {!isLocaleReady ? (
+                      <SkeletonText invisible />
+                    ) : (
+                      props.heading
+                    )}
                   </h3>
                 )}
                 {props.subtitle && (
-                  <p className="text-default hidden text-sm md:block" data-testid="subtitle">
-                    {!isLocaleReady ? <SkeletonText invisible /> : props.subtitle}
+                  <p
+                    className="text-default hidden text-sm md:block"
+                    data-testid="subtitle"
+                  >
+                    {!isLocaleReady ? (
+                      <SkeletonText invisible />
+                    ) : (
+                      props.subtitle
+                    )}
                   </p>
                 )}
               </div>
@@ -187,7 +230,8 @@ export function ShellMain(props: LayoutProps) {
                       ? "relative"
                       : "pwa:bottom-[max(7rem,_calc(5rem_+_env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0",
                     "shrink-0 [-webkit-app-region:no-drag] md:relative md:bottom-auto md:right-auto"
-                  )}>
+                  )}
+                >
                   {isLocaleReady && props.CTA}
                 </div>
               )}
@@ -200,7 +244,11 @@ export function ShellMain(props: LayoutProps) {
         <div className="hidden md:block md:h-14" aria-hidden="true" />
       )}
       {props.afterHeading && <>{props.afterHeading}</>}
-      <div className={classNames(props.flexChildrenContainer && "flex flex-1 flex-col")}>
+      <div
+        className={classNames(
+          props.flexChildrenContainer && "flex flex-1 flex-col"
+        )}
+      >
         {props.children}
       </div>
     </>
@@ -221,7 +269,11 @@ function MainContainer({
       {TopNavContainerProp}
       <div className="max-w-full p-2 sm:py-4 lg:px-6">
         <ErrorBoundary>
-          {!props.withoutMain ? <ShellMain {...props}>{props.children}</ShellMain> : props.children}
+          {!props.withoutMain ? (
+            <ShellMain {...props}>{props.children}</ShellMain>
+          ) : (
+            props.children
+          )}
         </ErrorBoundary>
         {/* show bottom navigation for md and smaller (tablet and phones) on pages where back button doesn't exist */}
         {!props.backPath ? MobileNavigationContainerProp : null}

--- a/apps/web/modules/shell/Shell.tsx
+++ b/apps/web/modules/shell/Shell.tsx
@@ -185,7 +185,7 @@ export function ShellMain(props: LayoutProps) {
                   className={classNames(
                     props.backPath
                       ? "relative"
-                      : "pwa:bottom-[max(7rem,calc(5rem+env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0",
+                      : "pwa:bottom-[max(7rem,_calc(5rem_+_env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0",
                     "shrink-0 [-webkit-app-region:no-drag] md:relative md:bottom-auto md:right-auto"
                   )}>
                   {isLocaleReady && props.CTA}

--- a/apps/web/modules/shell/Shell.tsx
+++ b/apps/web/modules/shell/Shell.tsx
@@ -142,7 +142,7 @@ export function ShellMain(props: LayoutProps) {
           className={classNames(
             "bg-default mb-0 flex items-center md:mb-6 md:mt-0",
             props.smallHeading ? "lg:mb-7" : "lg:mb-8",
-            !props.disableSticky && "sticky top-0 z-10 md:fixed md:w-[calc(100%-3.5rem)] md:pt-3 md:pb-2 md:pl-5 md:pr-5 md:left-14 lg:left-56 lg:w-[calc(100%-14rem)]"
+            !props.disableSticky && "sticky top-0 z-10 md:fixed md:w-[calc(100%-3.5rem)] md:pt-3 md:pb-2 md:px-5 md:left-14 lg:left-56 lg:w-[calc(100%-14rem)]"
           )}>
           {!!props.backPath && (
             <Button

--- a/apps/web/modules/shell/Shell.tsx
+++ b/apps/web/modules/shell/Shell.tsx
@@ -142,7 +142,7 @@ export function ShellMain(props: LayoutProps) {
           className={classNames(
             "bg-default mb-0 flex items-center md:mb-6 md:mt-0",
             props.smallHeading ? "lg:mb-7" : "lg:mb-8",
-            !props.disableSticky && "sticky top-0 z-10 md:fixed md:w-[calc(100%-3.5rem)] md:pt-3 md:pb-2 md:pl-5 md:left-14 lg:left-56 lg:w-[calc(100%-14rem)]"
+            !props.disableSticky && "sticky top-0 z-10 md:fixed md:w-[calc(100%-3.5rem)] md:pt-3 md:pb-2 md:pl-5 md:pr-5 md:left-14 lg:left-56 lg:w-[calc(100%-14rem)]"
           )}>
           {!!props.backPath && (
             <Button
@@ -185,7 +185,7 @@ export function ShellMain(props: LayoutProps) {
                   className={classNames(
                     props.backPath
                       ? "relative"
-                      : "pwa:bottom-[max(7rem,_calc(5rem_+_env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0",
+                      : "pwa:bottom-[max(7rem,calc(5rem+env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0",
                     "shrink-0 [-webkit-app-region:no-drag] md:relative md:bottom-auto md:right-auto"
                   )}>
                   {isLocaleReady && props.CTA}

--- a/apps/web/modules/shell/Shell.tsx
+++ b/apps/web/modules/shell/Shell.tsx
@@ -42,18 +42,13 @@ const Layout = (props: LayoutProps) => {
       <DynamicModals />
 
       <div className="flex min-h-screen flex-col">
-        {banners && !props.isPlatformUser && (
-          <BannerContainer banners={banners} />
-        )}
+        {banners && !props.isPlatformUser && <BannerContainer banners={banners} />}
 
         <div className="flex flex-1" data-testid="dashboard-shell">
           {props.SidebarContainer ? (
             cloneElement(props.SidebarContainer, { bannersHeight })
           ) : (
-            <SideBarContainer
-              isPlatformUser={props.isPlatformUser}
-              bannersHeight={bannersHeight}
-            />
+            <SideBarContainer isPlatformUser={props.isPlatformUser} bannersHeight={bannersHeight} />
           )}
           <div className="flex w-0 flex-1 flex-col">
             <MainContainer {...props} />
@@ -64,10 +59,7 @@ const Layout = (props: LayoutProps) => {
   );
 };
 
-type DrawerState = [
-  isOpen: boolean,
-  setDrawerOpen: Dispatch<SetStateAction<boolean>>
-];
+type DrawerState = [isOpen: boolean, setDrawerOpen: Dispatch<SetStateAction<boolean>>];
 
 export type LayoutProps = {
   centered?: boolean;
@@ -96,16 +88,9 @@ export type LayoutProps = {
   smallHeading?: boolean;
   isPlatformUser?: boolean;
   disableSticky?: boolean;
-  topAlignedHeading?: boolean;
 };
 
-const KBarWrapper = ({
-  children,
-  withKBar = false,
-}: {
-  withKBar: boolean;
-  children: React.ReactNode;
-}) =>
+const KBarWrapper = ({ children, withKBar = false }: { withKBar: boolean; children: React.ReactNode }) =>
   withKBar ? (
     <KBarRoot>
       {children}
@@ -155,24 +140,17 @@ export function ShellMain(props: LayoutProps) {
         <div
           style={headerStyle}
           className={classNames(
-            "bg-default mb-0 flex md:mb-6 md:mt-0",
+            "bg-default mb-0 flex items-center md:mb-6 md:mt-0",
             props.smallHeading ? "lg:mb-7" : "lg:mb-8",
             !props.disableSticky && "sticky top-0 z-10 md:fixed md:w-[calc(100%-3.5rem)] md:pt-3 md:pb-2 md:px-5 md:left-14 lg:left-56 lg:w-[calc(100%-14rem)]"
           )}>
-            props.topAlignedHeading ? "items-start" : "items-center",
-            !props.disableSticky &&
-              "sticky top-0 z-10 md:fixed md:w-[calc(100%-3.5rem)] md:pt-3 md:pb-2 md:px-5 md:left-14 lg:left-56 lg:w-[calc(100%-14rem)]"
-          )}
-        >
           {!!props.backPath && (
             <Button
               variant="icon"
               size="sm"
               color="minimal"
               onClick={() =>
-                typeof props.backPath === "string"
-                  ? router.push(props.backPath as string)
-                  : router.back()
+                typeof props.backPath === "string" ? router.push(props.backPath as string) : router.back()
               }
               StartIcon="arrow-left"
               aria-label="Go Back"
@@ -182,45 +160,22 @@ export function ShellMain(props: LayoutProps) {
           )}
           {props.heading && (
             <header
-              className={classNames(
-                props.large && "py-8",
-                "flex w-full max-w-full truncate",
-                props.topAlignedHeading ? "items-start" : "items-center"
-              )}
-            >
-              {props.HeadingLeftIcon && (
-                <div className="ltr:mr-4">{props.HeadingLeftIcon}</div>
-              )}
+              className={classNames(props.large && "py-8", "flex w-full max-w-full items-center truncate")}>
+              {props.HeadingLeftIcon && <div className="ltr:mr-4">{props.HeadingLeftIcon}</div>}
               <div
-                className={classNames(
-                  "w-full truncate ltr:mr-4 rtl:ml-4 md:block",
-                  props.headerClassName
-                )}
-              >
+                className={classNames("w-full truncate ltr:mr-4 rtl:ml-4 md:block", props.headerClassName)}>
                 {props.heading && (
                   <h3
                     className={classNames(
                       "font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 hidden truncate text-lg font-semibold tracking-wide sm:text-xl md:block xl:max-w-full",
                       props.smallHeading ? "text-base" : "text-xl"
-                    )}
-                  >
-                    {!isLocaleReady ? (
-                      <SkeletonText invisible />
-                    ) : (
-                      props.heading
-                    )}
+                    )}>
+                    {!isLocaleReady ? <SkeletonText invisible /> : props.heading}
                   </h3>
                 )}
                 {props.subtitle && (
-                  <p
-                    className="text-default hidden text-sm md:block"
-                    data-testid="subtitle"
-                  >
-                    {!isLocaleReady ? (
-                      <SkeletonText invisible />
-                    ) : (
-                      props.subtitle
-                    )}
+                  <p className="text-default hidden text-sm md:block" data-testid="subtitle">
+                    {!isLocaleReady ? <SkeletonText invisible /> : props.subtitle}
                   </p>
                 )}
               </div>
@@ -232,8 +187,7 @@ export function ShellMain(props: LayoutProps) {
                       ? "relative"
                       : "pwa:bottom-[max(7rem,_calc(5rem_+_env(safe-area-inset-bottom)))] fixed bottom-20 z-40 ltr:right-4 rtl:left-4 md:z-auto md:ltr:right-0 md:rtl:left-0",
                     "shrink-0 [-webkit-app-region:no-drag] md:relative md:bottom-auto md:right-auto"
-                  )}
-                >
+                  )}>
                   {isLocaleReady && props.CTA}
                 </div>
               )}
@@ -246,11 +200,7 @@ export function ShellMain(props: LayoutProps) {
         <div className="hidden md:block md:h-14" aria-hidden="true" />
       )}
       {props.afterHeading && <>{props.afterHeading}</>}
-      <div
-        className={classNames(
-          props.flexChildrenContainer && "flex flex-1 flex-col"
-        )}
-      >
+      <div className={classNames(props.flexChildrenContainer && "flex flex-1 flex-col")}>
         {props.children}
       </div>
     </>
@@ -271,11 +221,7 @@ function MainContainer({
       {TopNavContainerProp}
       <div className="max-w-full p-2 sm:py-4 lg:px-6">
         <ErrorBoundary>
-          {!props.withoutMain ? (
-            <ShellMain {...props}>{props.children}</ShellMain>
-          ) : (
-            props.children
-          )}
+          {!props.withoutMain ? <ShellMain {...props}>{props.children}</ShellMain> : props.children}
         </ErrorBoundary>
         {/* show bottom navigation for md and smaller (tablet and phones) on pages where back button doesn't exist */}
         {!props.backPath ? MobileNavigationContainerProp : null}

--- a/packages/platform/atoms/availability/AvailabilitySettings.tsx
+++ b/packages/platform/atoms/availability/AvailabilitySettings.tsx
@@ -497,7 +497,7 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
               <>
                 <VerticalDivider className="hidden sm:inline" />
                 <DeleteDialogButton
-                  buttonClassName={cn("hidden me-2 sm:inline", customClassNames?.deleteButtonClassname)}
+                  buttonClassName={cn("hidden sm:inline", customClassNames?.deleteButtonClassname)}
                   disabled={schedule.isLastSchedule}
                   isPending={isDeleting}
                   handleDelete={handleDelete}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Save button style was crashing at the right end of the website for web view & md devices as shown below.
- Delete button wasn't in the center of the 2 separators as shown below.

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):

Before:

[4e87b22a-859d-4d47-a88a-24f7b057313f.webm](https://github.com/user-attachments/assets/b08ddddb-f628-43af-91a5-001f8c540c4f)

After:

[b2d5c9a6-9487-42b7-afb3-2071fff393af.webm](https://github.com/user-attachments/assets/c600effe-dca6-4f3b-bd70-0d0e5dfe9680)

- Demonstrate how to reproduce the issue, the behavior before and after the change.

 Simply spin the app & head to /availability/id route & you have the issue visible on the right end of the website.

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] [N/A]. I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

Fix 1: Save Button Right Padding (Shell.tsx)
- What was changed: Added md:pr-5 to the header container for right padding

How to test:

Navigate to availability page that has a header with a Save button.
Resize your browser to viewport widths between 768px and 1024px (medium breakpoint where md: applies)

Expected behavior:
The Save button should have visible spacing from the right edge of the screen
The button should NOT touch or be cut off at the right edge
Left and right padding should appear balanced

--------------------------------------------------------------------------------------------------------

Fix 2: Delete Button Centering (AvailabilitySettings.tsx)

 - What was changed: Removed me-2 margin class from the delete button

How to test:
Navigate to availability page that has a header with a Delete button.
Resize to a tablet/medium size (640px+) to see the desktop layout
Look at the header area with: Set as default | Delete button | Save

Expected behavior:
The delete button (trash icon) should be perfectly centered between the two vertical divider lines ("|")
All three elements should have consistent, even spacing
No visual misalignment or off-center appearance
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
