### PR TITLE
refactor: decouple @calcom/features from @calcom/trpc/server [2]

### DIFF
--- a/packages/features/ee/billing/service/proration/__tests__/MonthlyProrationService.integration-test.ts
+++ b/packages/features/ee/billing/service/proration/__tests__/MonthlyProrationService.integration-test.ts
@@ -1,11 +1,10 @@
+import { createMemberships } from "@calcom/features/ee/teams/lib/inviteMemberUtils";
 import { TeamService } from "@calcom/features/ee/teams/services/teamService";
 import type { IFeaturesRepository } from "@calcom/features/flags/features.repository.interface";
 import prisma from "@calcom/prisma";
 import type { Team, User } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
-import { createMemberships } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { buildMonthlyProrationMetadata } from "../../../lib/proration-utils";
 import type { IBillingProviderService } from "../../billingProvider/IBillingProviderService";
 import { SeatChangeTrackingService } from "../../seatTracking/SeatChangeTrackingService";
@@ -26,14 +25,10 @@ function getTestDates() {
 }
 
 const mockBillingService: IBillingProviderService = {
-  createInvoiceItem: vi
-    .fn()
-    .mockResolvedValue({ invoiceItemId: "ii_test_123" }),
+  createInvoiceItem: vi.fn().mockResolvedValue({ invoiceItemId: "ii_test_123" }),
   deleteInvoiceItem: vi.fn().mockResolvedValue(undefined),
   createInvoice: vi.fn().mockResolvedValue({ invoiceId: "in_test_123" }),
-  finalizeInvoice: vi
-    .fn()
-    .mockResolvedValue({ invoiceUrl: "https://invoice.stripe.com/test" }),
+  finalizeInvoice: vi.fn().mockResolvedValue({ invoiceUrl: "https://invoice.stripe.com/test" }),
   getSubscription: vi.fn().mockResolvedValue({
     items: [
       {
@@ -54,12 +49,8 @@ const mockBillingService: IBillingProviderService = {
   handleSubscriptionCancel: vi.fn().mockResolvedValue(undefined),
   handleSubscriptionCreation: vi.fn().mockResolvedValue(undefined),
   handleEndTrial: vi.fn().mockResolvedValue(undefined),
-  createCustomer: vi
-    .fn()
-    .mockResolvedValue({ stripeCustomerId: "cus_test_123" }),
-  createPaymentIntent: vi
-    .fn()
-    .mockResolvedValue({ id: "pi_test_123", client_secret: "secret_123" }),
+  createCustomer: vi.fn().mockResolvedValue({ stripeCustomerId: "cus_test_123" }),
+  createPaymentIntent: vi.fn().mockResolvedValue({ id: "pi_test_123", client_secret: "secret_123" }),
   createSubscriptionCheckout: vi.fn().mockResolvedValue({
     checkoutUrl: "https://checkout.test",
     sessionId: "cs_test_123",
@@ -158,10 +149,7 @@ describe("MonthlyProrationService Integration Tests", () => {
   });
 
   it("should process end-to-end proration for annual team with seat additions", async () => {
-    const prorationService = new MonthlyProrationService(
-      undefined,
-      mockBillingService
-    );
+    const prorationService = new MonthlyProrationService(undefined, mockBillingService);
     const timestamp = Date.now();
     const randomSuffix = Math.random().toString(36).substring(7);
 
@@ -231,17 +219,12 @@ describe("MonthlyProrationService Integration Tests", () => {
     });
 
     expect(seatChanges).toHaveLength(2);
-    expect(
-      seatChanges.every((sc) => sc.processedInProrationId === proration?.id)
-    ).toBe(true);
+    expect(seatChanges.every((sc) => sc.processedInProrationId === proration?.id)).toBe(true);
   });
 
   it("should create a $0 proration for team with no net change", async () => {
     const seatTracker = new SeatChangeTrackingService();
-    const prorationService = new MonthlyProrationService(
-      undefined,
-      mockBillingService
-    );
+    const prorationService = new MonthlyProrationService(undefined, mockBillingService);
 
     await seatTracker.logSeatAddition({
       teamId: testTeam.id,
@@ -344,21 +327,14 @@ describe("MonthlyProrationService Integration Tests", () => {
       monthKey,
     });
 
-    const filteredResults = results.filter((r) =>
-      [testTeam.id, testTeam2.id].includes(r.teamId)
-    );
+    const filteredResults = results.filter((r) => [testTeam.id, testTeam2.id].includes(r.teamId));
     expect(filteredResults).toHaveLength(2);
-    expect(filteredResults.every((r) => r.status === "INVOICE_CREATED")).toBe(
-      true
-    );
+    expect(filteredResults.every((r) => r.status === "INVOICE_CREATED")).toBe(true);
   });
 
   it("should handle payment success callback", async () => {
     const seatTracker = new SeatChangeTrackingService();
-    const prorationService = new MonthlyProrationService(
-      undefined,
-      mockBillingService
-    );
+    const prorationService = new MonthlyProrationService(undefined, mockBillingService);
 
     await seatTracker.logSeatAddition({
       teamId: testTeam.id,
@@ -387,10 +363,7 @@ describe("MonthlyProrationService Integration Tests", () => {
 
   it("should handle payment failure callback", async () => {
     const seatTracker = new SeatChangeTrackingService();
-    const prorationService = new MonthlyProrationService(
-      undefined,
-      mockBillingService
-    );
+    const prorationService = new MonthlyProrationService(undefined, mockBillingService);
 
     await seatTracker.logSeatAddition({
       teamId: testTeam.id,
@@ -422,10 +395,7 @@ describe("MonthlyProrationService Integration Tests", () => {
 
   it("should call handleSubscriptionUpdate when updating subscription quantity", async () => {
     const seatTracker = new SeatChangeTrackingService();
-    const prorationService = new MonthlyProrationService(
-      undefined,
-      mockBillingService
-    );
+    const prorationService = new MonthlyProrationService(undefined, mockBillingService);
 
     // Reset the mock to track calls
     vi.mocked(mockBillingService.handleSubscriptionUpdate).mockClear();
@@ -460,14 +430,9 @@ describe("MonthlyProrationService Integration Tests", () => {
     const seatTracker = new SeatChangeTrackingService();
     const failingBillingService = {
       ...mockBillingService,
-      handleSubscriptionUpdate: vi
-        .fn()
-        .mockRejectedValue(new Error("Subscription not found")),
+      handleSubscriptionUpdate: vi.fn().mockRejectedValue(new Error("Subscription not found")),
     };
-    const prorationService = new MonthlyProrationService(
-      undefined,
-      failingBillingService
-    );
+    const prorationService = new MonthlyProrationService(undefined, failingBillingService);
 
     await seatTracker.logSeatAddition({
       teamId: testTeam.id,
@@ -483,8 +448,8 @@ describe("MonthlyProrationService Integration Tests", () => {
     });
 
     // Should throw when trying to update subscription
-    await expect(
-      prorationService.handleProrationPaymentSuccess(proration!.id)
-    ).rejects.toThrow("Subscription not found");
+    await expect(prorationService.handleProrationPaymentSuccess(proration!.id)).rejects.toThrow(
+      "Subscription not found"
+    );
   });
 });

--- a/packages/features/ee/billing/service/proration/__tests__/MonthlyProrationService.integration-test.ts
+++ b/packages/features/ee/billing/service/proration/__tests__/MonthlyProrationService.integration-test.ts
@@ -5,6 +5,7 @@ import prisma from "@calcom/prisma";
 import type { Team, User } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import { buildMonthlyProrationMetadata } from "../../../lib/proration-utils";
 import type { IBillingProviderService } from "../../billingProvider/IBillingProviderService";
 import { SeatChangeTrackingService } from "../../seatTracking/SeatChangeTrackingService";
@@ -25,10 +26,14 @@ function getTestDates() {
 }
 
 const mockBillingService: IBillingProviderService = {
-  createInvoiceItem: vi.fn().mockResolvedValue({ invoiceItemId: "ii_test_123" }),
+  createInvoiceItem: vi
+    .fn()
+    .mockResolvedValue({ invoiceItemId: "ii_test_123" }),
   deleteInvoiceItem: vi.fn().mockResolvedValue(undefined),
   createInvoice: vi.fn().mockResolvedValue({ invoiceId: "in_test_123" }),
-  finalizeInvoice: vi.fn().mockResolvedValue({ invoiceUrl: "https://invoice.stripe.com/test" }),
+  finalizeInvoice: vi
+    .fn()
+    .mockResolvedValue({ invoiceUrl: "https://invoice.stripe.com/test" }),
   getSubscription: vi.fn().mockResolvedValue({
     items: [
       {
@@ -49,8 +54,12 @@ const mockBillingService: IBillingProviderService = {
   handleSubscriptionCancel: vi.fn().mockResolvedValue(undefined),
   handleSubscriptionCreation: vi.fn().mockResolvedValue(undefined),
   handleEndTrial: vi.fn().mockResolvedValue(undefined),
-  createCustomer: vi.fn().mockResolvedValue({ stripeCustomerId: "cus_test_123" }),
-  createPaymentIntent: vi.fn().mockResolvedValue({ id: "pi_test_123", client_secret: "secret_123" }),
+  createCustomer: vi
+    .fn()
+    .mockResolvedValue({ stripeCustomerId: "cus_test_123" }),
+  createPaymentIntent: vi
+    .fn()
+    .mockResolvedValue({ id: "pi_test_123", client_secret: "secret_123" }),
   createSubscriptionCheckout: vi.fn().mockResolvedValue({
     checkoutUrl: "https://checkout.test",
     sessionId: "cs_test_123",
@@ -149,7 +158,10 @@ describe("MonthlyProrationService Integration Tests", () => {
   });
 
   it("should process end-to-end proration for annual team with seat additions", async () => {
-    const prorationService = new MonthlyProrationService(undefined, mockBillingService);
+    const prorationService = new MonthlyProrationService(
+      undefined,
+      mockBillingService
+    );
     const timestamp = Date.now();
     const randomSuffix = Math.random().toString(36).substring(7);
 
@@ -219,12 +231,17 @@ describe("MonthlyProrationService Integration Tests", () => {
     });
 
     expect(seatChanges).toHaveLength(2);
-    expect(seatChanges.every((sc) => sc.processedInProrationId === proration?.id)).toBe(true);
+    expect(
+      seatChanges.every((sc) => sc.processedInProrationId === proration?.id)
+    ).toBe(true);
   });
 
   it("should create a $0 proration for team with no net change", async () => {
     const seatTracker = new SeatChangeTrackingService();
-    const prorationService = new MonthlyProrationService(undefined, mockBillingService);
+    const prorationService = new MonthlyProrationService(
+      undefined,
+      mockBillingService
+    );
 
     await seatTracker.logSeatAddition({
       teamId: testTeam.id,
@@ -327,14 +344,21 @@ describe("MonthlyProrationService Integration Tests", () => {
       monthKey,
     });
 
-    const filteredResults = results.filter((r) => [testTeam.id, testTeam2.id].includes(r.teamId));
+    const filteredResults = results.filter((r) =>
+      [testTeam.id, testTeam2.id].includes(r.teamId)
+    );
     expect(filteredResults).toHaveLength(2);
-    expect(filteredResults.every((r) => r.status === "INVOICE_CREATED")).toBe(true);
+    expect(filteredResults.every((r) => r.status === "INVOICE_CREATED")).toBe(
+      true
+    );
   });
 
   it("should handle payment success callback", async () => {
     const seatTracker = new SeatChangeTrackingService();
-    const prorationService = new MonthlyProrationService(undefined, mockBillingService);
+    const prorationService = new MonthlyProrationService(
+      undefined,
+      mockBillingService
+    );
 
     await seatTracker.logSeatAddition({
       teamId: testTeam.id,
@@ -363,7 +387,10 @@ describe("MonthlyProrationService Integration Tests", () => {
 
   it("should handle payment failure callback", async () => {
     const seatTracker = new SeatChangeTrackingService();
-    const prorationService = new MonthlyProrationService(undefined, mockBillingService);
+    const prorationService = new MonthlyProrationService(
+      undefined,
+      mockBillingService
+    );
 
     await seatTracker.logSeatAddition({
       teamId: testTeam.id,
@@ -395,7 +422,10 @@ describe("MonthlyProrationService Integration Tests", () => {
 
   it("should call handleSubscriptionUpdate when updating subscription quantity", async () => {
     const seatTracker = new SeatChangeTrackingService();
-    const prorationService = new MonthlyProrationService(undefined, mockBillingService);
+    const prorationService = new MonthlyProrationService(
+      undefined,
+      mockBillingService
+    );
 
     // Reset the mock to track calls
     vi.mocked(mockBillingService.handleSubscriptionUpdate).mockClear();
@@ -430,9 +460,14 @@ describe("MonthlyProrationService Integration Tests", () => {
     const seatTracker = new SeatChangeTrackingService();
     const failingBillingService = {
       ...mockBillingService,
-      handleSubscriptionUpdate: vi.fn().mockRejectedValue(new Error("Subscription not found")),
+      handleSubscriptionUpdate: vi
+        .fn()
+        .mockRejectedValue(new Error("Subscription not found")),
     };
-    const prorationService = new MonthlyProrationService(undefined, failingBillingService);
+    const prorationService = new MonthlyProrationService(
+      undefined,
+      failingBillingService
+    );
 
     await seatTracker.logSeatAddition({
       teamId: testTeam.id,
@@ -448,8 +483,8 @@ describe("MonthlyProrationService Integration Tests", () => {
     });
 
     // Should throw when trying to update subscription
-    await expect(prorationService.handleProrationPaymentSuccess(proration!.id)).rejects.toThrow(
-      "Subscription not found"
-    );
+    await expect(
+      prorationService.handleProrationPaymentSuccess(proration!.id)
+    ).rejects.toThrow("Subscription not found");
   });
 });

--- a/packages/features/ee/dsync/lib/handleGroupEvents.ts
+++ b/packages/features/ee/dsync/lib/handleGroupEvents.ts
@@ -158,24 +158,26 @@ const handleGroupEvents = async (event: DirectorySyncEvent, organizationId: numb
     // For existing users create membership for team and org if needed
     await prisma.membership.createMany({
       data: [
-        ...users.flatMap((user) => {
-          return [
-            {
-              createdAt: new Date(),
-              userId: user.id,
-              teamId: group.teamId,
-              role: MembershipRole.MEMBER,
-              accepted: true,
-            },
-            {
-              createdAt: new Date(),
-              userId: user.id,
-              teamId: organizationId,
-              role: MembershipRole.MEMBER,
-              accepted: true,
-            },
-          ];
-        }),
+        ...users
+          .map((user) => {
+            return [
+              {
+                createdAt: new Date(),
+                userId: user.id,
+                teamId: group.teamId,
+                role: MembershipRole.MEMBER,
+                accepted: true,
+              },
+              {
+                createdAt: new Date(),
+                userId: user.id,
+                teamId: organizationId,
+                role: MembershipRole.MEMBER,
+                accepted: true,
+              },
+            ];
+          })
+          .flat(),
       ],
       skipDuplicates: true,
     });

--- a/packages/features/ee/dsync/lib/handleGroupEvents.ts
+++ b/packages/features/ee/dsync/lib/handleGroupEvents.ts
@@ -1,5 +1,9 @@
 import type { DirectorySyncEvent, Group } from "@boxyhq/saml-jackson";
-
+import {
+  getTeamOrThrow,
+  sendExistingUserTeamInviteEmails,
+  sendSignupToOrganizationEmail,
+} from "@calcom/features/ee/teams/lib/inviteMemberUtils";
 import { addNewMembersToEventTypes } from "@calcom/features/ee/teams/lib/queries";
 import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import logger from "@calcom/lib/logger";
@@ -7,12 +11,6 @@ import { safeStringify } from "@calcom/lib/safeStringify";
 import { getTranslation } from "@calcom/lib/server/i18n";
 import prisma from "@calcom/prisma";
 import { IdentityProvider, MembershipRole } from "@calcom/prisma/enums";
-import {
-  getTeamOrThrow,
-  sendSignupToOrganizationEmail,
-  sendExistingUserTeamInviteEmails,
-} from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
-
 import createUsersAndConnectToOrg from "./users/createUsersAndConnectToOrg";
 
 const handleGroupEvents = async (event: DirectorySyncEvent, organizationId: number) => {
@@ -160,26 +158,24 @@ const handleGroupEvents = async (event: DirectorySyncEvent, organizationId: numb
     // For existing users create membership for team and org if needed
     await prisma.membership.createMany({
       data: [
-        ...users
-          .map((user) => {
-            return [
-              {
-                createdAt: new Date(),
-                userId: user.id,
-                teamId: group.teamId,
-                role: MembershipRole.MEMBER,
-                accepted: true,
-              },
-              {
-                createdAt: new Date(),
-                userId: user.id,
-                teamId: organizationId,
-                role: MembershipRole.MEMBER,
-                accepted: true,
-              },
-            ];
-          })
-          .flat(),
+        ...users.flatMap((user) => {
+          return [
+            {
+              createdAt: new Date(),
+              userId: user.id,
+              teamId: group.teamId,
+              role: MembershipRole.MEMBER,
+              accepted: true,
+            },
+            {
+              createdAt: new Date(),
+              userId: user.id,
+              teamId: organizationId,
+              role: MembershipRole.MEMBER,
+              accepted: true,
+            },
+          ];
+        }),
       ],
       skipDuplicates: true,
     });

--- a/packages/features/ee/dsync/lib/handleUserEvents.test.ts
+++ b/packages/features/ee/dsync/lib/handleUserEvents.test.ts
@@ -21,7 +21,7 @@ vi.mock("@calcom/lib/server/i18n", () => ({
   getTranslation: vi.fn().mockResolvedValue((key: string) => key),
 }));
 
-vi.mock("@calcom/trpc/server/routers/viewer/teams/inviteMember/utils", () => ({
+vi.mock("@calcom/features/ee/teams/lib/inviteMemberUtils", () => ({
   getTeamOrThrow: vi.fn(),
   sendExistingUserTeamInviteEmails: vi.fn(),
   sendSignupToOrganizationEmail: vi.fn(),
@@ -112,7 +112,7 @@ describe("handleUserEvents", () => {
       slug: organizationSlug,
     });
 
-    const { getTeamOrThrow } = await import("@calcom/trpc/server/routers/viewer/teams/inviteMember/utils");
+    const { getTeamOrThrow } = await import("@calcom/features/ee/teams/lib/inviteMemberUtils");
     vi.mocked(getTeamOrThrow).mockResolvedValue({
       id: organizationId,
       name: organizationName,
@@ -299,7 +299,7 @@ describe("handleUserEvents", () => {
 
       const inviteExistingUserToOrg = (await import("./users/inviteExistingUserToOrg")).default;
       const sendExistingUserTeamInviteEmails = (
-        await import("@calcom/trpc/server/routers/viewer/teams/inviteMember/utils")
+        await import("@calcom/features/ee/teams/lib/inviteMemberUtils")
       ).sendExistingUserTeamInviteEmails;
 
       await handleUserEvents(event, organizationId);
@@ -419,7 +419,7 @@ describe("handleUserEvents", () => {
         },
       };
 
-      const { getTeamOrThrow } = await import("@calcom/trpc/server/routers/viewer/teams/inviteMember/utils");
+      const { getTeamOrThrow } = await import("@calcom/features/ee/teams/lib/inviteMemberUtils");
       vi.mocked(getTeamOrThrow).mockResolvedValue(
         null as unknown as Awaited<ReturnType<typeof getTeamOrThrow>>
       );

--- a/packages/features/ee/dsync/lib/handleUserEvents.ts
+++ b/packages/features/ee/dsync/lib/handleUserEvents.ts
@@ -1,17 +1,17 @@
 import type { DirectorySyncEvent, User } from "@boxyhq/saml-jackson";
-
 import removeUserFromOrg from "@calcom/features/ee/dsync/lib/removeUserFromOrg";
+import type { UserWithMembership } from "@calcom/features/ee/teams/lib/inviteMemberUtils";
+import {
+  getTeamOrThrow,
+  sendExistingUserTeamInviteEmails,
+  sendSignupToOrganizationEmail,
+} from "@calcom/features/ee/teams/lib/inviteMemberUtils";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { getTranslation } from "@calcom/lib/server/i18n";
 import prisma from "@calcom/prisma";
 import { IdentityProvider } from "@calcom/prisma/enums";
-import { getTeamOrThrow } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
-import type { UserWithMembership } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
-import { sendExistingUserTeamInviteEmails } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
-import { sendSignupToOrganizationEmail } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
-
 import { assignValueToUserInOrgBulk } from "./assignValueToUser";
 import getAttributesFromScimPayload from "./getAttributesFromScimPayload";
 import createUsersAndConnectToOrg from "./users/createUsersAndConnectToOrg";

--- a/packages/features/ee/dsync/lib/inviteExistingUserToOrg.ts
+++ b/packages/features/ee/dsync/lib/inviteExistingUserToOrg.ts
@@ -1,9 +1,8 @@
-import type { TFunction } from "i18next";
-
+import type { UserWithMembership } from "@calcom/features/ee/teams/lib/inviteMemberUtils";
+import { sendExistingUserTeamInviteEmails } from "@calcom/features/ee/teams/lib/inviteMemberUtils";
 import { createAProfileForAnExistingUser } from "@calcom/features/profile/lib/createAProfileForAnExistingUser";
 import prisma from "@calcom/prisma";
-import { sendExistingUserTeamInviteEmails } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
-import type { UserWithMembership } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
+import type { TFunction } from "i18next";
 
 /**
  * This should only be used in a dsync context

--- a/packages/features/ee/dsync/lib/users/inviteExistingUserToOrg.ts
+++ b/packages/features/ee/dsync/lib/users/inviteExistingUserToOrg.ts
@@ -1,8 +1,7 @@
-import type { TFunction } from "i18next";
-
+import type { UserWithMembership } from "@calcom/features/ee/teams/lib/inviteMemberUtils";
 import { createAProfileForAnExistingUser } from "@calcom/features/profile/lib/createAProfileForAnExistingUser";
 import prisma from "@calcom/prisma";
-import type { UserWithMembership } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/utils";
+import type { TFunction } from "i18next";
 
 /**
  * This should only be used in a dsync context

--- a/packages/features/ee/teams/lib/inviteMemberUtils.ts
+++ b/packages/features/ee/teams/lib/inviteMemberUtils.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from "node:crypto";
 import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
 import { sendTeamInviteEmail } from "@calcom/emails/organization-email-service";
+import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
+import { SeatChangeTrackingService } from "@calcom/features/ee/billing/service/seatTracking/SeatChangeTrackingService";
 import { OnboardingPathService } from "@calcom/features/onboarding/lib/onboarding-path.service";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { ErrorCode } from "@calcom/lib/errorCodes";
@@ -14,7 +16,7 @@ import type {
   UserPassword,
   User as UserType,
 } from "@calcom/prisma/client";
-import type { MembershipRole } from "@calcom/prisma/enums";
+import { Prisma, MembershipRole } from "@calcom/prisma/enums";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 import type { TFunction } from "i18next";
 
@@ -212,3 +214,86 @@ export const sendExistingUserTeamInviteEmails = async ({
 
   await sendEmails(sendEmailsPromises);
 };
+
+export async function createMemberships({
+  teamId,
+  language,
+  invitees,
+  parentId,
+  accepted,
+}: {
+  teamId: number;
+  language: string;
+  invitees: (UserWithMembership & {
+    newRole: MembershipRole;
+    needToCreateOrgMembership: boolean | null;
+  })[];
+  parentId: number | null;
+  accepted: boolean;
+}) {
+  log.debug("Creating memberships for", safeStringify({ teamId, language, invitees, parentId, accepted }));
+  try {
+    await prisma.membership.createMany({
+      data: invitees.flatMap((invitee) => {
+        const organizationRole = parentId
+          ? invitee?.teams?.find((membership) => membership.teamId === parentId)?.role
+          : undefined;
+        const data = [];
+        const createdAt = new Date();
+        // membership for the team
+        data.push({
+          createdAt,
+          teamId,
+          userId: invitee.id,
+          accepted,
+          role: checkAdminOrOwner(organizationRole) ? organizationRole : invitee.newRole,
+        });
+
+        // membership for the org
+        if (parentId && invitee.needToCreateOrgMembership) {
+          data.push({
+            createdAt,
+            accepted,
+            teamId: parentId,
+            userId: invitee.id,
+            role: MembershipRole.MEMBER,
+          });
+        }
+        return data;
+      }),
+    });
+
+    const seatTracker = new SeatChangeTrackingService();
+    const teamSeatAdditions = parentId ? 0 : invitees.length;
+    const organizationSeatAdditions = parentId
+      ? invitees.filter((invitee) => invitee.needToCreateOrgMembership).length
+      : 0;
+
+    const trackingPromises: Promise<void>[] = [];
+    if (teamSeatAdditions > 0) {
+      trackingPromises.push(
+        seatTracker.logSeatAddition({
+          teamId,
+          seatCount: teamSeatAdditions,
+        })
+      );
+    }
+
+    if (parentId && organizationSeatAdditions > 0) {
+      trackingPromises.push(
+        seatTracker.logSeatAddition({
+          teamId: parentId,
+          seatCount: organizationSeatAdditions,
+        })
+      );
+    }
+
+    await Promise.all(trackingPromises);
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError) {
+      logger.error("Failed to create memberships", teamId);
+    } else {
+      throw e;
+    }
+  }
+}

--- a/packages/features/ee/teams/lib/inviteMemberUtils.ts
+++ b/packages/features/ee/teams/lib/inviteMemberUtils.ts
@@ -1,0 +1,214 @@
+import { randomBytes } from "node:crypto";
+import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
+import { sendTeamInviteEmail } from "@calcom/emails/organization-email-service";
+import { OnboardingPathService } from "@calcom/features/onboarding/lib/onboarding-path.service";
+import { WEBAPP_URL } from "@calcom/lib/constants";
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
+import logger from "@calcom/lib/logger";
+import { safeStringify } from "@calcom/lib/safeStringify";
+import { prisma } from "@calcom/prisma";
+import type {
+  Membership,
+  Profile as ProfileType,
+  UserPassword,
+  User as UserType,
+} from "@calcom/prisma/client";
+import type { MembershipRole } from "@calcom/prisma/enums";
+import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
+import type { TFunction } from "i18next";
+
+const log = logger.getSubLogger({ prefix: ["inviteMember.utils"] });
+
+const isEmail = (str: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(str);
+
+export type Invitee = Pick<
+  UserType,
+  "id" | "email" | "username" | "identityProvider" | "completedOnboarding"
+>;
+
+export type UserWithMembership = Invitee & {
+  teams?: Pick<Membership, "userId" | "teamId" | "accepted" | "role">[];
+  profiles: ProfileType[];
+  password: UserPassword | null;
+};
+
+type InvitableExistingUser = UserWithMembership & {
+  newRole: MembershipRole;
+};
+
+type InvitableExistingUserWithProfile = InvitableExistingUser & {
+  profile: {
+    username: string;
+  } | null;
+};
+
+export async function getTeamOrThrow(teamId: number) {
+  const team = await prisma.team.findUnique({
+    where: {
+      id: teamId,
+    },
+    include: {
+      organizationSettings: true,
+      parent: {
+        include: {
+          organizationSettings: true,
+        },
+      },
+    },
+  });
+
+  if (!team) throw new ErrorWithCode(ErrorCode.NotFound, "Team not found");
+
+  return { ...team, metadata: teamMetadataSchema.parse(team.metadata) };
+}
+
+const createVerificationToken = async (identifier: string, teamId: number) => {
+  const token = randomBytes(32).toString("hex");
+  return prisma.verificationToken.create({
+    data: {
+      identifier,
+      token,
+      expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // +1 week
+      team: {
+        connect: {
+          id: teamId,
+        },
+      },
+    },
+  });
+};
+
+export async function sendSignupToOrganizationEmail({
+  usernameOrEmail,
+  team,
+  translation,
+  inviterName,
+  teamId,
+  isOrg,
+}: {
+  usernameOrEmail: string;
+  team: { name: string; parent: { name: string } | null };
+  translation: TFunction;
+  inviterName: string;
+  teamId: number;
+  isOrg: boolean;
+}) {
+  try {
+    const verificationToken = await createVerificationToken(usernameOrEmail, teamId);
+    const gettingStartedPath = await OnboardingPathService.getGettingStartedPathWhenInvited();
+    await sendTeamInviteEmail({
+      language: translation,
+      from: inviterName || `${team.name}'s admin`,
+      to: usernameOrEmail,
+      teamName: team.name,
+      joinLink: `${WEBAPP_URL}/signup?token=${verificationToken.token}&callbackUrl=${gettingStartedPath}`,
+      isCalcomMember: false,
+      isOrg: isOrg,
+      parentTeamName: team?.parent?.name,
+      isAutoJoin: false,
+      isExistingUserMovedToOrg: false,
+      prevLink: null,
+      newLink: null,
+    });
+  } catch (error) {
+    logger.error(
+      "Failed to send signup to organization email",
+      safeStringify({
+        usernameOrEmail,
+        orgId: teamId,
+      }),
+      error
+    );
+  }
+}
+
+export const sendEmails = async (emailPromises: Promise<void>[]) => {
+  const sentEmails = await Promise.allSettled(emailPromises);
+  sentEmails.forEach((sentEmail) => {
+    if (sentEmail.status === "rejected") {
+      logger.error("Could not send email to user. Reason:", sentEmail.reason);
+    }
+  });
+};
+
+export const sendExistingUserTeamInviteEmails = async ({
+  existingUsersWithMemberships,
+  language,
+  currentUserTeamName,
+  currentUserName,
+  currentUserParentTeamName,
+  isOrg,
+  teamId,
+  isAutoJoin,
+  orgSlug,
+}: {
+  language: TFunction;
+  isAutoJoin: boolean;
+  existingUsersWithMemberships: Omit<InvitableExistingUserWithProfile, "canBeInvited" | "newRole">[];
+  currentUserTeamName?: string;
+  currentUserParentTeamName: string | undefined;
+  currentUserName?: string | null;
+  isOrg: boolean;
+  teamId: number;
+  orgSlug: string | null;
+}) => {
+  const sendEmailsPromises = existingUsersWithMemberships.map(async (user) => {
+    let sendTo = user.email;
+    if (!isEmail(user.email)) {
+      sendTo = user.email;
+    }
+
+    log.debug("Sending team invite email to", safeStringify({ user, currentUserName, currentUserTeamName }));
+
+    if (!currentUserTeamName) {
+      throw new ErrorWithCode(ErrorCode.InternalServerError, "The team doesn't have a name");
+    }
+
+    if (currentUserTeamName) {
+      const inviteTeamOptions = {
+        joinLink: `${WEBAPP_URL}/auth/login?callbackUrl=/settings/teams`,
+        isCalcomMember: true,
+      };
+      /**
+       * Here we want to redirect to a different place if onboarding has been completed or not. This prevents the flash of going to teams -> Then to onboarding - also show a different email template.
+       * This only changes if the user is a CAL user and has not completed onboarding and has no password
+       */
+      if (!user.completedOnboarding && !user.password?.hash && user.identityProvider === "CAL") {
+        const verificationToken = await createVerificationToken(user.email, teamId);
+
+        const gettingStartedPath = await OnboardingPathService.getGettingStartedPathWhenInvited();
+        inviteTeamOptions.joinLink = `${WEBAPP_URL}/signup?token=${verificationToken.token}&callbackUrl=${gettingStartedPath}`;
+        inviteTeamOptions.isCalcomMember = false;
+      } else if (!isAutoJoin) {
+        let verificationToken = await prisma.verificationToken.findFirst({
+          where: {
+            identifier: user.email,
+            teamId: teamId,
+          },
+        });
+
+        if (!verificationToken) {
+          verificationToken = await createVerificationToken(user.email, teamId);
+        }
+        inviteTeamOptions.joinLink = `${WEBAPP_URL}/teams?token=${verificationToken.token}&autoAccept=true`;
+      }
+
+      return sendTeamInviteEmail({
+        language,
+        isAutoJoin,
+        from: currentUserName ?? `${currentUserTeamName}'s admin`,
+        to: sendTo,
+        teamName: currentUserTeamName,
+        ...inviteTeamOptions,
+        isOrg: isOrg,
+        parentTeamName: currentUserParentTeamName,
+        isExistingUserMovedToOrg: true,
+        prevLink: `${getOrgFullOrigin("")}/${user.username || ""}`,
+        newLink: user.profile ? `${getOrgFullOrigin(orgSlug ?? "")}/${user.profile.username}` : null,
+      });
+    }
+  });
+
+  await sendEmails(sendEmailsPromises);
+};

--- a/packages/features/ee/teams/lib/inviteMemberUtils.ts
+++ b/packages/features/ee/teams/lib/inviteMemberUtils.ts
@@ -16,7 +16,7 @@ import type {
   UserPassword,
   User as UserType,
 } from "@calcom/prisma/client";
-import { Prisma, MembershipRole } from "@calcom/prisma/enums";
+import { MembershipRole, Prisma } from "@calcom/prisma/enums";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 import type { TFunction } from "i18next";
 

--- a/packages/features/ee/teams/lib/inviteMemberUtils.ts
+++ b/packages/features/ee/teams/lib/inviteMemberUtils.ts
@@ -117,7 +117,6 @@ export async function sendSignupToOrganizationEmail({
     logger.error(
       "Failed to send signup to organization email",
       safeStringify({
-        usernameOrEmail,
         orgId: teamId,
       }),
       error
@@ -161,7 +160,7 @@ export const sendExistingUserTeamInviteEmails = async ({
       sendTo = user.email;
     }
 
-    log.debug("Sending team invite email to", safeStringify({ user, currentUserName, currentUserTeamName }));
+    log.debug("Sending team invite email to", safeStringify({ userId: user.id, currentUserTeamName }));
 
     if (!currentUserTeamName) {
       throw new ErrorWithCode(ErrorCode.InternalServerError, "The team doesn't have a name");

--- a/packages/features/ee/teams/lib/inviteMemberUtils.ts
+++ b/packages/features/ee/teams/lib/inviteMemberUtils.ts
@@ -14,7 +14,8 @@ import type {
   UserPassword,
   User as UserType,
 } from "@calcom/prisma/client";
-import { MembershipRole, Prisma } from "@calcom/prisma/enums";
+import { Prisma } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 import { TRPCError } from "@trpc/server";
 import type { TFunction } from "i18next";

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -1,43 +1,37 @@
-import { randomBytes } from "node:crypto";
-import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
-import { sendTeamInviteEmail } from "@calcom/emails/organization-email-service";
 import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
 import { SeatChangeTrackingService } from "@calcom/features/ee/billing/service/seatTracking/SeatChangeTrackingService";
 import { getParsedTeam } from "@calcom/features/ee/teams/lib/getParsedTeam";
+import {
+  type UserWithMembership,
+  getTeamOrThrow,
+  sendEmails,
+  sendExistingUserTeamInviteEmails,
+  sendSignupToOrganizationEmail,
+} from "@calcom/features/ee/teams/lib/inviteMemberUtils";
 import { updateNewTeamMemberEventTypes } from "@calcom/features/ee/teams/lib/queries";
-import { OnboardingPathService } from "@calcom/features/onboarding/lib/onboarding-path.service";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { createAProfileForAnExistingUser } from "@calcom/features/profile/lib/createAProfileForAnExistingUser";
 import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { DEFAULT_SCHEDULE, getAvailabilityFromSchedule } from "@calcom/lib/availability";
-import { ENABLE_PROFILE_SWITCHER, WEBAPP_URL } from "@calcom/lib/constants";
+import { ENABLE_PROFILE_SWITCHER } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { getTranslation } from "@calcom/lib/server/i18n";
 import slugify from "@calcom/lib/slugify";
 import { prisma } from "@calcom/prisma";
-import type { Membership, OrganizationSettings, Profile as ProfileType, Team } from "@calcom/prisma/client";
-import { Prisma, type UserPassword, type User as UserType } from "@calcom/prisma/client";
+import type { OrganizationSettings, Team } from "@calcom/prisma/client";
+import { Prisma } from "@calcom/prisma/client";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { MembershipRole } from "@calcom/prisma/enums";
-import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 import { TRPCError } from "@trpc/server";
-import type { TFunction } from "i18next";
 import { isEmail } from "../util";
 import type { TeamWithParent } from "./types";
 
-const log = logger.getSubLogger({ prefix: ["inviteMember.utils"] });
-export type Invitee = Pick<
-  UserType,
-  "id" | "email" | "username" | "identityProvider" | "completedOnboarding"
->;
+export type { Invitee, UserWithMembership } from "@calcom/features/ee/teams/lib/inviteMemberUtils";
+export { getTeamOrThrow, sendEmails, sendExistingUserTeamInviteEmails, sendSignupToOrganizationEmail } from "@calcom/features/ee/teams/lib/inviteMemberUtils";
 
-export type UserWithMembership = Invitee & {
-  teams?: Pick<Membership, "userId" | "teamId" | "accepted" | "role">[];
-  profiles: ProfileType[];
-  password: UserPassword | null;
-};
+const log = logger.getSubLogger({ prefix: ["inviteMember.utils"] });
 
 export type Invitation = {
   usernameOrEmail: string;
@@ -86,30 +80,6 @@ export function checkInputEmailIsValid(email: string) {
       code: "BAD_REQUEST",
       message: `Invite failed because ${email} is not a valid email address`,
     });
-}
-
-export async function getTeamOrThrow(teamId: number) {
-  const team = await prisma.team.findUnique({
-    where: {
-      id: teamId,
-    },
-    include: {
-      organizationSettings: true,
-      parent: {
-        include: {
-          organizationSettings: true,
-        },
-      },
-    },
-  });
-
-  if (!team)
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: `Team not found`,
-    });
-
-  return { ...team, metadata: teamMetadataSchema.parse(team.metadata) };
 }
 
 export async function getUniqueInvitationsOrThrowIfEmpty(invitations: Invitation[]) {
@@ -507,67 +477,6 @@ export async function createMemberships({
   }
 }
 
-const createVerificationToken = async (identifier: string, teamId: number) => {
-  const token = randomBytes(32).toString("hex");
-  return prisma.verificationToken.create({
-    data: {
-      identifier,
-      token,
-      expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // +1 week
-      team: {
-        connect: {
-          id: teamId,
-        },
-      },
-    },
-  });
-};
-
-export async function sendSignupToOrganizationEmail({
-  usernameOrEmail,
-  team,
-  translation,
-  inviterName,
-  teamId,
-  isOrg,
-}: {
-  usernameOrEmail: string;
-  team: { name: string; parent: { name: string } | null };
-  translation: TFunction;
-  inviterName: string;
-  teamId: number;
-  isOrg: boolean;
-}) {
-  try {
-    const verificationToken = await createVerificationToken(usernameOrEmail, teamId);
-    const gettingStartedPath = await OnboardingPathService.getGettingStartedPathWhenInvited();
-    await sendTeamInviteEmail({
-      language: translation,
-      from: inviterName || `${team.name}'s admin`,
-      to: usernameOrEmail,
-      teamName: team.name,
-      joinLink: `${WEBAPP_URL}/signup?token=${verificationToken.token}&callbackUrl=${gettingStartedPath}`,
-      isCalcomMember: false,
-      isOrg: isOrg,
-      parentTeamName: team?.parent?.name,
-      isAutoJoin: false,
-      isExistingUserMovedToOrg: false,
-      // For a new user there is no prev and new links.
-      prevLink: null,
-      newLink: null,
-    });
-  } catch (error) {
-    logger.error(
-      "Failed to send signup to organization email",
-      safeStringify({
-        usernameOrEmail,
-        orgId: teamId,
-      }),
-      error
-    );
-  }
-}
-
 type TeamAndOrganizationSettings = Team & {
   organizationSettings?: OrganizationSettings | null;
 };
@@ -697,100 +606,6 @@ export const groupUsersByJoinability = ({
   }
 
   return [usersToAutoJoin, regularUsers];
-};
-
-export const sendEmails = async (emailPromises: Promise<void>[]) => {
-  const sentEmails = await Promise.allSettled(emailPromises);
-  sentEmails.forEach((sentEmail) => {
-    if (sentEmail.status === "rejected") {
-      logger.error("Could not send email to user. Reason:", sentEmail.reason);
-    }
-  });
-};
-
-export const sendExistingUserTeamInviteEmails = async ({
-  existingUsersWithMemberships,
-  language,
-  currentUserTeamName,
-  currentUserName,
-  currentUserParentTeamName,
-  isOrg,
-  teamId,
-  isAutoJoin,
-  orgSlug,
-}: {
-  language: TFunction;
-  isAutoJoin: boolean;
-  existingUsersWithMemberships: Omit<InvitableExistingUserWithProfile, "canBeInvited" | "newRole">[];
-  currentUserTeamName?: string;
-  currentUserParentTeamName: string | undefined;
-  currentUserName?: string | null;
-  isOrg: boolean;
-  teamId: number;
-  orgSlug: string | null;
-}) => {
-  const sendEmailsPromises = existingUsersWithMemberships.map(async (user) => {
-    let sendTo = user.email;
-    if (!isEmail(user.email)) {
-      sendTo = user.email;
-    }
-
-    log.debug("Sending team invite email to", safeStringify({ user, currentUserName, currentUserTeamName }));
-
-    if (!currentUserTeamName) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "The team doesn't have a name",
-      });
-    }
-
-    // inform user of membership by email
-    if (currentUserTeamName) {
-      const inviteTeamOptions = {
-        joinLink: `${WEBAPP_URL}/auth/login?callbackUrl=/settings/teams`,
-        isCalcomMember: true,
-      };
-      /**
-       * Here we want to redirect to a different place if onboarding has been completed or not. This prevents the flash of going to teams -> Then to onboarding - also show a different email template.
-       * This only changes if the user is a CAL user and has not completed onboarding and has no password
-       */
-      if (!user.completedOnboarding && !user.password?.hash && user.identityProvider === "CAL") {
-        const verificationToken = await createVerificationToken(user.email, teamId);
-
-        const gettingStartedPath = await OnboardingPathService.getGettingStartedPathWhenInvited();
-        inviteTeamOptions.joinLink = `${WEBAPP_URL}/signup?token=${verificationToken.token}&callbackUrl=${gettingStartedPath}`;
-        inviteTeamOptions.isCalcomMember = false;
-      } else if (!isAutoJoin) {
-        let verificationToken = await prisma.verificationToken.findFirst({
-          where: {
-            identifier: user.email,
-            teamId: teamId,
-          },
-        });
-
-        if (!verificationToken) {
-          verificationToken = await createVerificationToken(user.email, teamId);
-        }
-        inviteTeamOptions.joinLink = `${WEBAPP_URL}/teams?token=${verificationToken.token}&autoAccept=true`;
-      }
-
-      return sendTeamInviteEmail({
-        language,
-        isAutoJoin,
-        from: currentUserName ?? `${currentUserTeamName}'s admin`,
-        to: sendTo,
-        teamName: currentUserTeamName,
-        ...inviteTeamOptions,
-        isOrg: isOrg,
-        parentTeamName: currentUserParentTeamName,
-        isExistingUserMovedToOrg: true,
-        prevLink: `${getOrgFullOrigin("")}/${user.username || ""}`,
-        newLink: user.profile ? `${getOrgFullOrigin(orgSlug ?? "")}/${user.profile.username}` : null,
-      });
-    }
-  });
-
-  await sendEmails(sendEmailsPromises);
 };
 
 export async function handleExistingUsersInvites({

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -1,8 +1,7 @@
-import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
-import { SeatChangeTrackingService } from "@calcom/features/ee/billing/service/seatTracking/SeatChangeTrackingService";
 import { getParsedTeam } from "@calcom/features/ee/teams/lib/getParsedTeam";
 import {
   type UserWithMembership,
+  createMemberships,
   getTeamOrThrow,
   sendEmails,
   sendExistingUserTeamInviteEmails,
@@ -21,7 +20,6 @@ import { getTranslation } from "@calcom/lib/server/i18n";
 import slugify from "@calcom/lib/slugify";
 import { prisma } from "@calcom/prisma";
 import type { OrganizationSettings, Team } from "@calcom/prisma/client";
-import { Prisma } from "@calcom/prisma/client";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { MembershipRole } from "@calcom/prisma/enums";
 import { TRPCError } from "@trpc/server";
@@ -29,7 +27,13 @@ import { isEmail } from "../util";
 import type { TeamWithParent } from "./types";
 
 export type { Invitee, UserWithMembership } from "@calcom/features/ee/teams/lib/inviteMemberUtils";
-export { getTeamOrThrow, sendEmails, sendExistingUserTeamInviteEmails, sendSignupToOrganizationEmail } from "@calcom/features/ee/teams/lib/inviteMemberUtils";
+export {
+  createMemberships,
+  getTeamOrThrow,
+  sendEmails,
+  sendExistingUserTeamInviteEmails,
+  sendSignupToOrganizationEmail,
+} from "@calcom/features/ee/teams/lib/inviteMemberUtils";
 
 const log = logger.getSubLogger({ prefix: ["inviteMember.utils"] });
 
@@ -393,88 +397,6 @@ export async function createNewUsersConnectToOrgIfExists({
   }
 
   return createdUsers;
-}
-
-export async function createMemberships({
-  teamId,
-  language,
-  invitees,
-  parentId,
-  accepted,
-}: {
-  teamId: number;
-  language: string;
-  invitees: (InvitableExistingUser & {
-    needToCreateOrgMembership: boolean | null;
-  })[];
-  parentId: number | null;
-  accepted: boolean;
-}) {
-  log.debug("Creating memberships for", safeStringify({ teamId, language, invitees, parentId, accepted }));
-  try {
-    await prisma.membership.createMany({
-      data: invitees.flatMap((invitee) => {
-        const organizationRole = parentId
-          ? invitee?.teams?.find((membership) => membership.teamId === parentId)?.role
-          : undefined;
-        const data = [];
-        const createdAt = new Date();
-        // membership for the team
-        data.push({
-          createdAt,
-          teamId,
-          userId: invitee.id,
-          accepted,
-          role: checkAdminOrOwner(organizationRole) ? organizationRole : invitee.newRole,
-        });
-
-        // membership for the org
-        if (parentId && invitee.needToCreateOrgMembership) {
-          data.push({
-            createdAt,
-            accepted,
-            teamId: parentId,
-            userId: invitee.id,
-            role: MembershipRole.MEMBER,
-          });
-        }
-        return data;
-      }),
-    });
-
-    const seatTracker = new SeatChangeTrackingService();
-    const teamSeatAdditions = parentId ? 0 : invitees.length;
-    const organizationSeatAdditions = parentId
-      ? invitees.filter((invitee) => invitee.needToCreateOrgMembership).length
-      : 0;
-
-    const trackingPromises: Promise<void>[] = [];
-    if (teamSeatAdditions > 0) {
-      trackingPromises.push(
-        seatTracker.logSeatAddition({
-          teamId,
-          seatCount: teamSeatAdditions,
-        })
-      );
-    }
-
-    if (parentId && organizationSeatAdditions > 0) {
-      trackingPromises.push(
-        seatTracker.logSeatAddition({
-          teamId: parentId,
-          seatCount: organizationSeatAdditions,
-        })
-      );
-    }
-
-    await Promise.all(trackingPromises);
-  } catch (e) {
-    if (e instanceof Prisma.PrismaClientKnownRequestError) {
-      logger.error("Failed to create memberships", teamId);
-    } else {
-      throw e;
-    }
-  }
 }
 
 type TeamAndOrganizationSettings = Team & {

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -1,11 +1,11 @@
 import { getParsedTeam } from "@calcom/features/ee/teams/lib/getParsedTeam";
 import {
-  type UserWithMembership,
   createMemberships,
   getTeamOrThrow,
   sendEmails,
   sendExistingUserTeamInviteEmails,
   sendSignupToOrganizationEmail,
+  type UserWithMembership,
 } from "@calcom/features/ee/teams/lib/inviteMemberUtils";
 import { updateNewTeamMemberEventTypes } from "@calcom/features/ee/teams/lib/queries";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -1,3 +1,4 @@
+import { SeatChangeTrackingService } from "@calcom/features/ee/billing/service/seatTracking/SeatChangeTrackingService";
 import { getParsedTeam } from "@calcom/features/ee/teams/lib/getParsedTeam";
 import {
   createMemberships,


### PR DESCRIPTION
## What does this PR do?

Extracts 5 team-invite utilities (`getTeamOrThrow`, `sendSignupToOrganizationEmail`, `sendExistingUserTeamInviteEmails`, `sendEmails`, and shared types) from `@calcom/trpc` into `@calcom/features/ee/teams/lib/inviteMemberUtils`, removing all 4 `@calcom/trpc` imports from the `@calcom/features` dsync module.

### Why this matters

- **Enforces package boundaries**: `@calcom/features` no longer imports from `@calcom/trpc`, eliminating a reverse dependency that violated the intended `features → trpc` direction
- **Centralizes invite logic in the domain layer**: Team-invite utilities now live in `features/ee/teams` where they naturally belong, making them reusable by dsync and other consumers without pulling in the full trpc router

No runtime behavior change. The trpc utils file re-exports from the new location for full backward compatibility.

**Note for reviewer**: The extracted code intentionally still uses `TRPCError` from `@trpc/server` to maintain exact parity with the original. This is a known trade-off for pure relocation vs. full decoupling. I will address this in a separate PR later.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
