### PR TITLE
chore: Update CODEOWNERS for Shell.tsx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 /apps/web/lib/core/**/* @calcom/Foundation
 /apps/web/lib/booking.ts @calcom/Foundation
 /apps/web/lib/handleOrgRedirect.ts @calcom/Foundation
+/apps/web/modules/shell/Shell.tsx @calcom/Foundation
 /apps/web/proxy.ts @calcom/Foundation
 /deploy/**/* @calcom/Foundation
 /packages/app-store/applecalendar/**/* @calcom/Foundation


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds /apps/web/modules/shell/Shell.tsx to CODEOWNERS so @calcom/Foundation is auto-assigned for changes. This clarifies ownership and ensures review requests on Shell updates.

<sup>Written for commit 3cef08d146509b79b0e6fa46da3c5d30da043ba3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

