### PR TITLE
fix: use randomString() for booking UIDs in slots E2E tests

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
@@ -468,7 +468,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking and slot should not be available at that time", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${crypto.randomUUID()}`,
+        uid: `booking-uid-${randomString()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -515,7 +515,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${crypto.randomUUID()}`,
+        uid: `booking-uid-${randomString()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -598,7 +598,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid in range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${crypto.randomUUID()}`,
+        uid: `booking-uid-${randomString()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
@@ -515,7 +515,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-seated-${seatedEventTypeId}`,
+        uid: `booking-uid-seated-0415-${seatedEventTypeId}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -598,7 +598,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid in range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-seated-range-${seatedEventTypeId}`,
+        uid: `booking-uid-seated-range-0415-${seatedEventTypeId}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
@@ -515,7 +515,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${seatedEventTypeId}`,
+        uid: `booking-uid-seated-${seatedEventTypeId}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -598,7 +598,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid in range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${seatedEventTypeId}`,
+        uid: `booking-uid-seated-range-${seatedEventTypeId}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
@@ -468,7 +468,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking and slot should not be available at that time", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${eventTypeId}`,
+        uid: `booking-uid-${crypto.randomUUID()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -515,7 +515,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-seated-0415-${seatedEventTypeId}`,
+        uid: `booking-uid-${crypto.randomUUID()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -598,7 +598,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid in range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-seated-range-0415-${seatedEventTypeId}`,
+        uid: `booking-uid-${crypto.randomUUID()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
@@ -832,7 +832,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${seatedEventType.id}`,
+        uid: `booking-uid-seated-${seatedEventType.id}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -961,7 +961,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid and return range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${seatedEventType.id}`,
+        uid: `booking-uid-seated-range-${seatedEventType.id}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
@@ -832,7 +832,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-seated-${seatedEventType.id}`,
+        uid: `booking-uid-seated-0904-${seatedEventType.id}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -961,7 +961,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid and return range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-seated-range-${seatedEventType.id}`,
+        uid: `booking-uid-seated-range-0904-${seatedEventType.id}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
@@ -787,7 +787,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking and slot should not be available at that time", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${crypto.randomUUID()}`,
+        uid: `booking-uid-${randomString()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -832,7 +832,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${crypto.randomUUID()}`,
+        uid: `booking-uid-${randomString()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -961,7 +961,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid and return range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${crypto.randomUUID()}`,
+        uid: `booking-uid-${randomString()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
@@ -787,7 +787,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking and slot should not be available at that time", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${eventTypeId}`,
+        uid: `booking-uid-${crypto.randomUUID()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -832,7 +832,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-seated-0904-${seatedEventType.id}`,
+        uid: `booking-uid-${crypto.randomUUID()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -961,7 +961,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid and return range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-seated-range-0904-${seatedEventType.id}`,
+        uid: `booking-uid-${crypto.randomUUID()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",


### PR DESCRIPTION
## What does this PR do?

Fixes flaky E2E tests in the API v2 slots controllers that have been causing failures across many PRs (e.g. [this CI run](https://github.com/calcom/cal.com/actions/runs/21839903743/job/63021523152?pr=26852)).

In both `slots-2024-04-15` and `slots-2024-09-04` test files, booking tests used deterministic UIDs derived from event type IDs (e.g. `booking-uid-${seatedEventTypeId}`). This caused two kinds of collisions:

1. Within a file: two seated-event tests used the identical UID. If the first test failed before cleanup, the second hit a `Unique constraint failed on the fields: (uid)` error.
2. Across files: both test files ran in the same CI shard against the same database, so if auto-incremented event type IDs happened to match, UIDs collided across files too.

The fix replaces all hardcoded booking UIDs with `randomString()` (from `test/utils/randomString`), making collisions practically impossible regardless of test ordering, parallelism, or cleanup failures.

Note: the `afterAll` hooks already call `deleteAllBookings` which handles cleanup of any stragglers from failed runs across test suites.

### Updates since last revision

- Switched from `crypto.randomUUID()` to `randomString()` per request.
- Ensured the non-seated booking test in each file also uses a random UID (not `eventTypeId`-derived).
- No new dependencies or imports were needed; `randomString` is already imported in both files.

### Files changed

- `apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts` (3 UIDs)
- `apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts` (3 UIDs)

## Visual Demo (For contributors especially)

N/A — test-only change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A — test-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This is a test-fix-only PR. Verify by checking that the `E2E API v2` CI job passes consistently — specifically the booking/slot tests in both `slots-2024-04-15` (shard 2/4) and `slots-2024-09-04` suites:
- `should do a booking and slot should not be available at that time`
- `should do a booking for seated event and slot should show attendees count and bookingUid`
- `should do a booking for seated event and slot should show attendees count and bookingUid in range format`

Optional local verification (use UTC to avoid TZ flake):
- `TZ=UTC yarn test apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts`
- `TZ=UTC yarn test apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts`

## Human Review Checklist

- [ ] Confirm `randomString()` length/format is acceptable for Booking.uid (DB constraints) and doesn’t break any downstream logic expecting a UUID-like format. If desired, increase entropy via `randomString(length)`.
- [ ] Verify all relevant tests compare against `booking.uid` variables (not literals) — current assertions should be unaffected.
- [ ] Double-check there are no remaining deterministic `booking-uid-${...}` patterns in these two files.
- [ ] Consider spot-checking other E2E spec files for similar deterministic UID usage that could benefit from the same change.

Link to Devin run: https://app.devin.ai/sessions/db88139ee8854058a79c452adf73942c  
Requested by: @anikdhabal