### PR TITLE
fix: few flaky api v2 e2e tests

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
@@ -468,7 +468,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking and slot should not be available at that time", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${randomString()}`,
+        uid: `booking-uid-${eventTypeId}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -515,7 +515,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${randomString()}`,
+        uid: `booking-uid-${seatedEventTypeId}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -549,7 +549,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
       });
 
       bookingSeatsRepositoryFixture.create({
-        referenceUid: "100",
+        referenceUid: randomString(),
         data: {},
         booking: {
           connect: {
@@ -598,7 +598,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid in range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${randomString()}`,
+        uid: `booking-uid-${seatedEventTypeId}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -632,7 +632,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
       });
 
       bookingSeatsRepositoryFixture.create({
-        referenceUid: "100",
+        referenceUid: randomString(),
         data: {},
         booking: {
           connect: {

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
@@ -787,7 +787,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking and slot should not be available at that time", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${randomString()}`,
+        uid: `booking-uid-${eventTypeId}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -832,7 +832,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${randomString()}`,
+        uid: `booking-uid-${seatedEventType.id}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -866,7 +866,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
       });
 
       bookingSeatsRepositoryFixture.create({
-        referenceUid: "100",
+        referenceUid: randomString(),
         data: {},
         booking: {
           connect: {
@@ -961,7 +961,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid and return range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${randomString()}`,
+        uid: `booking-uid-${seatedEventType.id}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -995,7 +995,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
       });
 
       bookingSeatsRepositoryFixture.create({
-        referenceUid: "100",
+        referenceUid: randomString(),
         data: {},
         booking: {
           connect: {


### PR DESCRIPTION
## What does this PR do?

Failed suites:

0*m FAIL /src/modules/slots/slots-2024-09-04/controllers/e2e/**muser-event-type-slots.controller.e2e-spec.ts

**m ? Slots 2024-09-04 Endpoints User event type slots should do a booking for seated event and slot should show attendees count and bookingUid and return range format

**m ? Slots 2024-09-04 Endpoints User event type slots variable length should reserve a slot with slot duration for variable event type length

0*m FAIL /src/modules/slots/slots-2024-04-***5/controllers/**mslots.controller.e2e-spec.ts

**m ? Slots 2024-04-***5 Endpoints Individual user slots should do a booking for seated event and slot should show attendees count and bookingUid

**m ? Slots 2024-04-***5 Endpoints Individual user slots should do a booking for seated event and slot should show attendees count and bookingUid in range format