### PR TITLE
fix: remove unsupported GOOGLE_MEET from team conferencing endpoint enums

### DIFF
--- a/apps/api/v2/src/modules/organizations/conferencing/organizations-conferencing.controller.ts
+++ b/apps/api/v2/src/modules/organizations/conferencing/organizations-conferencing.controller.ts
@@ -45,7 +45,7 @@ import { plainToInstance } from "class-transformer";
 import { Request } from "express";
 import { stringify } from "querystring";
 
-import { GOOGLE_MEET, ZOOM, SUCCESS_STATUS, OFFICE_365_VIDEO, CAL_VIDEO } from "@calcom/platform-constants";
+import { ZOOM, SUCCESS_STATUS, OFFICE_365_VIDEO, CAL_VIDEO } from "@calcom/platform-constants";
 
 export type OAuthCallbackState = {
   accessToken: string;
@@ -73,7 +73,7 @@ export class OrganizationsConferencingController {
   @ApiParam({
     name: "app",
     description: "Conferencing application type",
-    enum: [GOOGLE_MEET],
+    enum: [ZOOM, OFFICE_365_VIDEO],
     required: true,
   })
   @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
@@ -82,10 +82,8 @@ export class OrganizationsConferencingController {
   @ApiOperation({
     summary: "Connect your conferencing application to a team",
     description:
-      "Note: Google Meet is currently not supported for team-level connections. " +
-      "Connecting Google Meet to a team requires a Google Calendar to be connected to that team first, " +
-      "but there is currently no way to connect Google Calendar at the team level. " +
-      "Only OAuth-based conferencing apps (Zoom, Office365 Video) can be connected to teams at the moment.",
+      "Google Meet is not supported for team-level connections because it requires a Google Calendar " +
+      "to be connected to the team first, which is not yet available.",
   })
   async connectTeamApp(
     @GetUser() user: UserWithProfile,
@@ -169,13 +167,13 @@ export class OrganizationsConferencingController {
   @ApiOperation({
     summary: "Set team default conferencing application",
     description:
-      "Note: Google Meet cannot currently be set as a team default because it requires a Google Calendar " +
-      "connection at the team level, which is not yet supported.",
+      "Google Meet is not supported for team-level connections because it requires a Google Calendar " +
+      "to be connected to the team first, which is not yet available.",
   })
   @ApiParam({
     name: "app",
     description: "Conferencing application type",
-    enum: [GOOGLE_MEET, ZOOM, OFFICE_365_VIDEO, CAL_VIDEO],
+    enum: [ZOOM, OFFICE_365_VIDEO, CAL_VIDEO],
     required: true,
   })
   async setTeamDefaultApp(
@@ -199,7 +197,7 @@ export class OrganizationsConferencingController {
   @ApiParam({
     name: "app",
     description: "Conferencing application type",
-    enum: [GOOGLE_MEET, ZOOM, OFFICE_365_VIDEO, CAL_VIDEO],
+    enum: [ZOOM, OFFICE_365_VIDEO, CAL_VIDEO],
     required: true,
   })
   async getTeamDefaultApp(
@@ -221,12 +219,13 @@ export class OrganizationsConferencingController {
   @ApiOperation({
     summary: "Disconnect team conferencing application",
     description:
-      "Note: Google Meet is currently not supported for team-level connections, so there would be nothing to disconnect for it.",
+      "Google Meet is not supported for team-level connections because it requires a Google Calendar " +
+      "to be connected to the team first, which is not yet available.",
   })
   @ApiParam({
     name: "app",
     description: "Conferencing application type",
-    enum: [GOOGLE_MEET, ZOOM, OFFICE_365_VIDEO],
+    enum: [ZOOM, OFFICE_365_VIDEO],
     required: true,
   })
   async disconnectTeamApp(

--- a/apps/api/v2/src/modules/organizations/conferencing/organizations-conferencing.controller.ts
+++ b/apps/api/v2/src/modules/organizations/conferencing/organizations-conferencing.controller.ts
@@ -79,7 +79,14 @@ export class OrganizationsConferencingController {
   @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
   @Post("/teams/:teamId/conferencing/:app/connect")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "Connect your conferencing application to a team" })
+  @ApiOperation({
+    summary: "Connect your conferencing application to a team",
+    description:
+      "Note: Google Meet is currently not supported for team-level connections. " +
+      "Connecting Google Meet to a team requires a Google Calendar to be connected to that team first, " +
+      "but there is currently no way to connect Google Calendar at the team level. " +
+      "Only OAuth-based conferencing apps (Zoom, Office365 Video) can be connected to teams at the moment.",
+  })
   async connectTeamApp(
     @GetUser() user: UserWithProfile,
     @Param("teamId", ParseIntPipe) teamId: number,
@@ -159,7 +166,12 @@ export class OrganizationsConferencingController {
   @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
   @Post("/teams/:teamId/conferencing/:app/default")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "Set team default conferencing application" })
+  @ApiOperation({
+    summary: "Set team default conferencing application",
+    description:
+      "Note: Google Meet cannot currently be set as a team default because it requires a Google Calendar " +
+      "connection at the team level, which is not yet supported.",
+  })
   @ApiParam({
     name: "app",
     description: "Conferencing application type",
@@ -206,7 +218,11 @@ export class OrganizationsConferencingController {
   @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
   @Delete("/teams/:teamId/conferencing/:app/disconnect")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "Disconnect team conferencing application" })
+  @ApiOperation({
+    summary: "Disconnect team conferencing application",
+    description:
+      "Note: Google Meet is currently not supported for team-level connections, so there would be nothing to disconnect for it.",
+  })
   @ApiParam({
     name: "app",
     description: "Conferencing application type",

--- a/apps/api/v2/src/modules/organizations/conferencing/organizations-conferencing.controller.ts
+++ b/apps/api/v2/src/modules/organizations/conferencing/organizations-conferencing.controller.ts
@@ -72,8 +72,7 @@ export class OrganizationsConferencingController {
   @PlatformPlan("ESSENTIALS")
   @ApiParam({
     name: "app",
-    description: "Conferencing application type",
-    enum: [ZOOM, OFFICE_365_VIDEO],
+    description: "Conferencing application type. Currently no apps are supported via this non-OAuth endpoint.",
     required: true,
   })
   @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
@@ -82,8 +81,9 @@ export class OrganizationsConferencingController {
   @ApiOperation({
     summary: "Connect your conferencing application to a team",
     description:
-      "Google Meet is not supported for team-level connections because it requires a Google Calendar " +
-      "to be connected to the team first, which is not yet available.",
+      "This endpoint is for non-OAuth conferencing apps. Currently no apps are supported: " +
+      "Google Meet requires a Google Calendar to be connected to the team first, which is not yet available. " +
+      "For OAuth-based apps (Zoom, Office365 Video), use the OAuth auth-url endpoint instead.",
   })
   async connectTeamApp(
     @GetUser() user: UserWithProfile,


### PR DESCRIPTION
## What does this PR do?

Removes `GOOGLE_MEET` from the `@ApiParam` enums on team conferencing endpoints and adds `description` fields explaining the limitation.

**Background**: Connecting Google Meet to a team (`POST /teams/:teamId/conferencing/google-meet/connect`) requires a Google Calendar credential to exist for that team. However, there is currently no API endpoint or UI flow to connect Google Calendar at the team level — the existing calendar connect endpoints (`GET /v2/calendars/:calendar/connect`) are user-level only, and `doesAppSupportTeamInstall()` explicitly excludes calendar apps from team install. This made the Google Meet team connect endpoint effectively unusable.

### Changes

1. **Removed `GOOGLE_MEET` from `@ApiParam` enums** on set-default, get-default, and disconnect endpoints so Swagger no longer advertises a broken option
2. **Removed the `enum` property entirely from the connect endpoint's `@ApiParam`** — this endpoint is for non-OAuth apps only, and since Google Meet (the only non-OAuth conferencing app) can't work at the team level, there are currently no valid values to advertise. Zoom and Office365 Video use the separate OAuth auth-url endpoint.
3. **Added `description` fields** to `@ApiOperation` decorators on connect, set-default, and disconnect endpoints explaining why Google Meet is unsupported and directing users to the correct OAuth endpoints
4. **Removed unused `GOOGLE_MEET` import** from platform-constants

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A — changes are to OpenAPI descriptions only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — the endpoint was already non-functional for Google Meet.

## How should this be tested?

1. Check the generated Swagger UI for the `Orgs / Teams / Conferencing` endpoints
2. Confirm `google-meet` no longer appears in the enum dropdowns for set-default, get-default, or disconnect
3. Confirm the connect endpoint no longer has an enum constraint (since no non-OAuth apps are currently supported)
4. Confirm the `description` fields appear on the connect, set-default, and disconnect endpoints

## Human Review Checklist

- [ ] The connect endpoint (`POST /teams/:teamId/conferencing/:app/connect`) now has **no enum values** in its `@ApiParam`. Its handler (`connectTeamNonOauthApps`) still only has a case for `GOOGLE_MEET` internally (which throws at runtime due to missing Google Calendar). Verify this is acceptable — alternatively, consider whether this endpoint should be formally deprecated since it currently has no usable apps.
- [ ] Confirm this enum removal is acceptable as a non-breaking change given that Google Meet team connections always failed at runtime anyway
- [ ] Check if the OpenAPI JSON (`swagger/documentation.json`) needs to be regenerated after these decorator changes

Link to Devin run: https://app.devin.ai/sessions/e0a8703af7594135937f7f2102ce6abd
Requested by: @Ryukemeister