### PR TITLE
feat: add UTM parameter data to insights bookings CSV download

### DIFF
--- a/packages/features/insights/services/InsightsBookingBaseService.ts
+++ b/packages/features/insights/services/InsightsBookingBaseService.ts
@@ -588,6 +588,11 @@ export class InsightsBookingBaseService {
             bookingFields: true,
           },
         },
+        utm_source: true,
+        utm_medium: true,
+        utm_campaign: true,
+        utm_term: true,
+        utm_content: true,
       },
     });
 

--- a/packages/features/insights/services/InsightsBookingBaseService.ts
+++ b/packages/features/insights/services/InsightsBookingBaseService.ts
@@ -588,11 +588,15 @@ export class InsightsBookingBaseService {
             bookingFields: true,
           },
         },
-        utm_source: true,
-        utm_medium: true,
-        utm_campaign: true,
-        utm_term: true,
-        utm_content: true,
+        tracking: {
+          select: {
+            utm_source: true,
+            utm_medium: true,
+            utm_campaign: true,
+            utm_term: true,
+            utm_content: true,
+          },
+        },
       },
     });
 

--- a/packages/features/insights/services/__tests__/__snapshots__/csvDataTransformer.test.ts.snap
+++ b/packages/features/insights/services/__tests__/__snapshots__/csvDataTransformer.test.ts.snap
@@ -251,6 +251,11 @@ exports[`csvDataTransformer > transformBookingsForCsv > snapshot: complete trans
     "uid": "booking-1",
     "userEmail": "sales@company.com",
     "userUsername": "sales",
+    "utm_campaign": "spring-sale",
+    "utm_content": "banner-ad",
+    "utm_medium": "cpc",
+    "utm_source": "google",
+    "utm_term": "scheduling",
   },
   {
     "Budget": null,
@@ -286,6 +291,11 @@ exports[`csvDataTransformer > transformBookingsForCsv > snapshot: complete trans
     "uid": "booking-2",
     "userEmail": "trainer@company.com",
     "userUsername": "trainer",
+    "utm_campaign": "",
+    "utm_content": "",
+    "utm_medium": "",
+    "utm_source": "",
+    "utm_term": "",
   },
   {
     "Budget": null,
@@ -321,6 +331,11 @@ exports[`csvDataTransformer > transformBookingsForCsv > snapshot: complete trans
     "uid": null,
     "userEmail": "user@company.com",
     "userUsername": "user",
+    "utm_campaign": "",
+    "utm_content": "",
+    "utm_medium": "",
+    "utm_source": "",
+    "utm_term": "",
   },
 ]
 `;

--- a/packages/features/insights/services/__tests__/csvDataTransformer.test.ts
+++ b/packages/features/insights/services/__tests__/csvDataTransformer.test.ts
@@ -9,6 +9,7 @@ import {
   processBookingsForCsv,
   formatCsvRow,
   transformBookingsForCsv,
+  getUtmDataForBooking,
   type BookingWithAttendees,
   type BookingTimeStatusData,
 } from "../csvDataTransformer";
@@ -212,6 +213,11 @@ describe("csvDataTransformer", () => {
       seatsReferences: [],
       responses: {},
       eventType: { bookingFields: [] },
+      utm_source: null,
+      utm_medium: null,
+      utm_campaign: null,
+      utm_term: null,
+      utm_content: null,
       ...overrides,
     });
 
@@ -365,6 +371,11 @@ describe("csvDataTransformer", () => {
           seatsReferences: [],
           responses: {},
           eventType: { bookingFields: [] },
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_term: null,
+          utm_content: null,
         },
         {
           uid: "booking-2",
@@ -377,6 +388,11 @@ describe("csvDataTransformer", () => {
           seatsReferences: [],
           responses: {},
           eventType: { bookingFields: [] },
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_term: null,
+          utm_content: null,
         },
       ];
 
@@ -397,6 +413,11 @@ describe("csvDataTransformer", () => {
           eventType: {
             bookingFields: [{ name: "company", type: "text", label: "Company" }],
           },
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_term: null,
+          utm_content: null,
         },
         {
           uid: "booking-2",
@@ -407,6 +428,11 @@ describe("csvDataTransformer", () => {
           eventType: {
             bookingFields: [{ name: "department", type: "text", label: "Department" }],
           },
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_term: null,
+          utm_content: null,
         },
       ];
 
@@ -438,6 +464,11 @@ describe("csvDataTransformer", () => {
               { name: "customPhone", type: "phone", label: "Contact Phone" },
             ],
           },
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_term: null,
+          utm_content: null,
         },
         {
           uid: "seated-booking",
@@ -456,6 +487,11 @@ describe("csvDataTransformer", () => {
               { name: "dietaryRestrictions", type: "text", label: "Dietary Restrictions" },
             ],
           },
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_term: null,
+          utm_content: null,
         },
       ];
 
@@ -689,6 +725,11 @@ describe("csvDataTransformer", () => {
               { name: "timeline", type: "text", label: "Timeline" },
             ],
           },
+          utm_source: "google",
+          utm_medium: "cpc",
+          utm_campaign: "spring-sale",
+          utm_term: "scheduling",
+          utm_content: "banner-ad",
         },
         {
           uid: "booking-2",
@@ -707,6 +748,11 @@ describe("csvDataTransformer", () => {
               { name: "emergencyContact", type: "phone", label: "Emergency Contact" },
             ],
           },
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_term: null,
+          utm_content: null,
         },
       ];
 
@@ -753,12 +799,159 @@ describe("csvDataTransformer", () => {
           seatsReferences: [],
           responses: {},
           eventType: { bookingFields: [] },
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_term: null,
+          utm_content: null,
         },
       ];
 
       const result = transformBookingsForCsv(csvData, bookings, "UTC");
 
       expect(result).toHaveLength(0);
+    });
+
+    it("should include UTM data in transformed rows", () => {
+      const csvData: BookingTimeStatusData[] = [
+        {
+          id: 1,
+          uid: "booking-with-utm",
+          title: "UTM Test",
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          timeStatus: "completed",
+          eventTypeId: 1,
+          eventLength: 30,
+          startTime: new Date("2024-01-01T10:00:00Z"),
+          endTime: new Date("2024-01-01T10:30:00Z"),
+          paid: false,
+          userEmail: "test@test.com",
+          userUsername: "test",
+          rating: null,
+          ratingFeedback: null,
+          noShowHost: false,
+        },
+        {
+          id: 2,
+          uid: "booking-no-utm",
+          title: "No UTM",
+          createdAt: new Date("2024-01-02T00:00:00Z"),
+          timeStatus: "completed",
+          eventTypeId: 1,
+          eventLength: 30,
+          startTime: new Date("2024-01-02T10:00:00Z"),
+          endTime: new Date("2024-01-02T10:30:00Z"),
+          paid: false,
+          userEmail: "test@test.com",
+          userUsername: "test",
+          rating: null,
+          ratingFeedback: null,
+          noShowHost: false,
+        },
+      ];
+
+      const bookings: BookingWithAttendees[] = [
+        {
+          uid: "booking-with-utm",
+          eventTypeId: 1,
+          attendees: [{ name: "A", email: "a@test.com", phoneNumber: null, noShow: false }],
+          seatsReferences: [],
+          responses: {},
+          eventType: { bookingFields: [] },
+          utm_source: "google",
+          utm_medium: "cpc",
+          utm_campaign: "spring-sale",
+          utm_term: "scheduling",
+          utm_content: "banner-ad",
+        },
+        {
+          uid: "booking-no-utm",
+          eventTypeId: 1,
+          attendees: [{ name: "B", email: "b@test.com", phoneNumber: null, noShow: false }],
+          seatsReferences: [],
+          responses: {},
+          eventType: { bookingFields: [] },
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_term: null,
+          utm_content: null,
+        },
+      ];
+
+      const result = transformBookingsForCsv(csvData, bookings, "UTC");
+
+      expect(result[0].utm_source).toBe("google");
+      expect(result[0].utm_medium).toBe("cpc");
+      expect(result[0].utm_campaign).toBe("spring-sale");
+      expect(result[0].utm_term).toBe("scheduling");
+      expect(result[0].utm_content).toBe("banner-ad");
+
+      expect(result[1].utm_source).toBe("");
+      expect(result[1].utm_medium).toBe("");
+      expect(result[1].utm_campaign).toBe("");
+      expect(result[1].utm_term).toBe("");
+      expect(result[1].utm_content).toBe("");
+    });
+  });
+
+  describe("getUtmDataForBooking", () => {
+    it("should return UTM data from booking", () => {
+      const booking: BookingWithAttendees = {
+        uid: "test",
+        eventTypeId: 1,
+        attendees: [],
+        seatsReferences: [],
+        responses: {},
+        eventType: null,
+        utm_source: "google",
+        utm_medium: "cpc",
+        utm_campaign: "spring-sale",
+        utm_term: "scheduling",
+        utm_content: "banner-ad",
+      };
+
+      expect(getUtmDataForBooking(booking)).toEqual({
+        utm_source: "google",
+        utm_medium: "cpc",
+        utm_campaign: "spring-sale",
+        utm_term: "scheduling",
+        utm_content: "banner-ad",
+      });
+    });
+
+    it("should return empty strings for null UTM values", () => {
+      const booking: BookingWithAttendees = {
+        uid: "test",
+        eventTypeId: 1,
+        attendees: [],
+        seatsReferences: [],
+        responses: {},
+        eventType: null,
+        utm_source: null,
+        utm_medium: null,
+        utm_campaign: null,
+        utm_term: null,
+        utm_content: null,
+      };
+
+      expect(getUtmDataForBooking(booking)).toEqual({
+        utm_source: "",
+        utm_medium: "",
+        utm_campaign: "",
+        utm_term: "",
+        utm_content: "",
+      });
+    });
+
+    it("should return empty strings for undefined booking", () => {
+      expect(getUtmDataForBooking(undefined)).toEqual({
+        utm_source: "",
+        utm_medium: "",
+        utm_campaign: "",
+        utm_term: "",
+        utm_content: "",
+      });
     });
   });
 });

--- a/packages/features/insights/services/__tests__/csvDataTransformer.test.ts
+++ b/packages/features/insights/services/__tests__/csvDataTransformer.test.ts
@@ -213,11 +213,7 @@ describe("csvDataTransformer", () => {
       seatsReferences: [],
       responses: {},
       eventType: { bookingFields: [] },
-      utm_source: null,
-      utm_medium: null,
-      utm_campaign: null,
-      utm_term: null,
-      utm_content: null,
+      tracking: null,
       ...overrides,
     });
 
@@ -371,11 +367,7 @@ describe("csvDataTransformer", () => {
           seatsReferences: [],
           responses: {},
           eventType: { bookingFields: [] },
-          utm_source: null,
-          utm_medium: null,
-          utm_campaign: null,
-          utm_term: null,
-          utm_content: null,
+          tracking: null,
         },
         {
           uid: "booking-2",
@@ -388,11 +380,7 @@ describe("csvDataTransformer", () => {
           seatsReferences: [],
           responses: {},
           eventType: { bookingFields: [] },
-          utm_source: null,
-          utm_medium: null,
-          utm_campaign: null,
-          utm_term: null,
-          utm_content: null,
+          tracking: null,
         },
       ];
 
@@ -413,11 +401,7 @@ describe("csvDataTransformer", () => {
           eventType: {
             bookingFields: [{ name: "company", type: "text", label: "Company" }],
           },
-          utm_source: null,
-          utm_medium: null,
-          utm_campaign: null,
-          utm_term: null,
-          utm_content: null,
+          tracking: null,
         },
         {
           uid: "booking-2",
@@ -428,11 +412,7 @@ describe("csvDataTransformer", () => {
           eventType: {
             bookingFields: [{ name: "department", type: "text", label: "Department" }],
           },
-          utm_source: null,
-          utm_medium: null,
-          utm_campaign: null,
-          utm_term: null,
-          utm_content: null,
+          tracking: null,
         },
       ];
 
@@ -464,11 +444,7 @@ describe("csvDataTransformer", () => {
               { name: "customPhone", type: "phone", label: "Contact Phone" },
             ],
           },
-          utm_source: null,
-          utm_medium: null,
-          utm_campaign: null,
-          utm_term: null,
-          utm_content: null,
+          tracking: null,
         },
         {
           uid: "seated-booking",
@@ -487,11 +463,7 @@ describe("csvDataTransformer", () => {
               { name: "dietaryRestrictions", type: "text", label: "Dietary Restrictions" },
             ],
           },
-          utm_source: null,
-          utm_medium: null,
-          utm_campaign: null,
-          utm_term: null,
-          utm_content: null,
+          tracking: null,
         },
       ];
 
@@ -725,11 +697,13 @@ describe("csvDataTransformer", () => {
               { name: "timeline", type: "text", label: "Timeline" },
             ],
           },
-          utm_source: "google",
-          utm_medium: "cpc",
-          utm_campaign: "spring-sale",
-          utm_term: "scheduling",
-          utm_content: "banner-ad",
+          tracking: {
+            utm_source: "google",
+            utm_medium: "cpc",
+            utm_campaign: "spring-sale",
+            utm_term: "scheduling",
+            utm_content: "banner-ad",
+          },
         },
         {
           uid: "booking-2",
@@ -748,11 +722,7 @@ describe("csvDataTransformer", () => {
               { name: "emergencyContact", type: "phone", label: "Emergency Contact" },
             ],
           },
-          utm_source: null,
-          utm_medium: null,
-          utm_campaign: null,
-          utm_term: null,
-          utm_content: null,
+          tracking: null,
         },
       ];
 
@@ -799,11 +769,7 @@ describe("csvDataTransformer", () => {
           seatsReferences: [],
           responses: {},
           eventType: { bookingFields: [] },
-          utm_source: null,
-          utm_medium: null,
-          utm_campaign: null,
-          utm_term: null,
-          utm_content: null,
+          tracking: null,
         },
       ];
 
@@ -858,11 +824,13 @@ describe("csvDataTransformer", () => {
           seatsReferences: [],
           responses: {},
           eventType: { bookingFields: [] },
-          utm_source: "google",
-          utm_medium: "cpc",
-          utm_campaign: "spring-sale",
-          utm_term: "scheduling",
-          utm_content: "banner-ad",
+          tracking: {
+            utm_source: "google",
+            utm_medium: "cpc",
+            utm_campaign: "spring-sale",
+            utm_term: "scheduling",
+            utm_content: "banner-ad",
+          },
         },
         {
           uid: "booking-no-utm",
@@ -871,11 +839,7 @@ describe("csvDataTransformer", () => {
           seatsReferences: [],
           responses: {},
           eventType: { bookingFields: [] },
-          utm_source: null,
-          utm_medium: null,
-          utm_campaign: null,
-          utm_term: null,
-          utm_content: null,
+          tracking: null,
         },
       ];
 
@@ -904,11 +868,13 @@ describe("csvDataTransformer", () => {
         seatsReferences: [],
         responses: {},
         eventType: null,
-        utm_source: "google",
-        utm_medium: "cpc",
-        utm_campaign: "spring-sale",
-        utm_term: "scheduling",
-        utm_content: "banner-ad",
+        tracking: {
+          utm_source: "google",
+          utm_medium: "cpc",
+          utm_campaign: "spring-sale",
+          utm_term: "scheduling",
+          utm_content: "banner-ad",
+        },
       };
 
       expect(getUtmDataForBooking(booking)).toEqual({
@@ -928,11 +894,7 @@ describe("csvDataTransformer", () => {
         seatsReferences: [],
         responses: {},
         eventType: null,
-        utm_source: null,
-        utm_medium: null,
-        utm_campaign: null,
-        utm_term: null,
-        utm_content: null,
+        tracking: null,
       };
 
       expect(getUtmDataForBooking(booking)).toEqual({

--- a/packages/features/insights/services/csvDataTransformer.ts
+++ b/packages/features/insights/services/csvDataTransformer.ts
@@ -44,6 +44,11 @@ export type BookingWithAttendees = {
   eventType: {
     bookingFields: unknown;
   } | null;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  utm_term: string | null;
+  utm_content: string | null;
 };
 
 export type ProcessedBookingData = {
@@ -279,6 +284,18 @@ export function formatCsvRow(
   return result;
 }
 
+export function getUtmDataForBooking(
+  booking: BookingWithAttendees | undefined
+): Record<string, string> {
+  return {
+    utm_source: booking?.utm_source || "",
+    utm_medium: booking?.utm_medium || "",
+    utm_campaign: booking?.utm_campaign || "",
+    utm_term: booking?.utm_term || "",
+    utm_content: booking?.utm_content || "",
+  };
+}
+
 export function transformBookingsForCsv(
   csvData: BookingTimeStatusData[],
   bookings: BookingWithAttendees[],
@@ -286,14 +303,21 @@ export function transformBookingsForCsv(
 ): Record<string, unknown>[] {
   const { bookingMap, maxAttendees, allBookingQuestionLabels } = processBookingsForCsv(bookings);
 
+  const bookingsByUid = new Map(bookings.map((b) => [b.uid, b]));
+
   return csvData.map((bookingTimeStatus) => {
     const processedData = bookingTimeStatus.uid ? bookingMap.get(bookingTimeStatus.uid) : null;
-    return formatCsvRow(
+    const booking = bookingTimeStatus.uid ? bookingsByUid.get(bookingTimeStatus.uid) : undefined;
+    const row = formatCsvRow(
       bookingTimeStatus,
       processedData || null,
       maxAttendees,
       allBookingQuestionLabels,
       timeZone
     );
+    return {
+      ...row,
+      ...getUtmDataForBooking(booking),
+    };
   });
 }

--- a/packages/features/insights/services/csvDataTransformer.ts
+++ b/packages/features/insights/services/csvDataTransformer.ts
@@ -44,11 +44,13 @@ export type BookingWithAttendees = {
   eventType: {
     bookingFields: unknown;
   } | null;
-  utm_source: string | null;
-  utm_medium: string | null;
-  utm_campaign: string | null;
-  utm_term: string | null;
-  utm_content: string | null;
+  tracking: {
+    utm_source: string | null;
+    utm_medium: string | null;
+    utm_campaign: string | null;
+    utm_term: string | null;
+    utm_content: string | null;
+  } | null;
 };
 
 export type ProcessedBookingData = {
@@ -288,11 +290,11 @@ export function getUtmDataForBooking(
   booking: BookingWithAttendees | undefined
 ): Record<string, string> {
   return {
-    utm_source: booking?.utm_source || "",
-    utm_medium: booking?.utm_medium || "",
-    utm_campaign: booking?.utm_campaign || "",
-    utm_term: booking?.utm_term || "",
-    utm_content: booking?.utm_content || "",
+    utm_source: booking?.tracking?.utm_source || "",
+    utm_medium: booking?.tracking?.utm_medium || "",
+    utm_campaign: booking?.tracking?.utm_campaign || "",
+    utm_term: booking?.tracking?.utm_term || "",
+    utm_content: booking?.tracking?.utm_content || "",
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds UTM parameter data (`utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`) to the CSV download from `/insights` bookings, matching the format already used in the `/insights/routing` CSV download.

Previously, the bookings CSV export did not include any UTM tracking data. UTM data is stored on the `Tracking` model (one-to-one relation with `Booking` via `@@unique([bookingId])`). The routing form responses CSV already includes UTM columns (see `routing-events.ts` lines 191-195), so this change brings parity.

**Changes:**
- Extended the `BookingWithAttendees` type to include the `tracking` relation (nullable, since not all bookings have tracking data)
- Added the `tracking` relation with UTM fields to the Prisma `select` in `getCsvData`
- Added `getUtmDataForBooking` helper to extract UTM data via `booking.tracking`, with empty-string defaults for null values (matching routing CSV behavior)
- UTM columns appear at the end of each CSV row
- Added unit tests for `getUtmDataForBooking` and UTM inclusion in `transformBookingsForCsv`, updated existing test fixtures and snapshots

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create bookings that have UTM parameters (book via a URL with `?utm_source=test&utm_medium=email` etc.)
2. Go to `/insights`, select a date range covering those bookings
3. Click Download → As CSV
4. Open the CSV and confirm `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content` columns are present with correct values
5. Compare with the routing CSV download from `/insights/routing` to verify the format matches

## Human Review Checklist

- [ ] Verify the `tracking` relation JOIN in `getCsvData` doesn't significantly impact query performance for large exports
- [ ] Confirm empty-string default for missing UTM values (matching routing CSV) vs. null is the desired behavior
- [ ] Check that the additional `bookingsByUid` Map construction in `transformBookingsForCsv` is acceptable (iterates bookings array once more per batch of up to 100)

---

> **Link to Devin run:** https://app.devin.ai/sessions/9683a4a30f3344f7a52a2954eb9119e7
> **Requested by:** @CarinaWolli