### PR TITLE
fix: adjusted zoho Token expiry time to miliseconds.

### DIFF
--- a/packages/app-store/zohocrm/lib/CrmService.ts
+++ b/packages/app-store/zohocrm/lib/CrmService.ts
@@ -236,7 +236,7 @@ class ZohoCrmCrmService implements CRM {
         );
         if (!zohoCrmTokenInfo.data.error) {
           // set expiry date as offset from current time.
-          zohoCrmTokenInfo.data.expiryDate = Math.round(Date.now() + 60 * 60);
+          zohoCrmTokenInfo.data.expiryDate = Math.round(Date.now() + 60 * 60 * 1000);
 
           await prisma.credential.update({
             where: {


### PR DESCRIPTION
## What does this PR do?

The Date.now() method returns time in epoch miliseconds, adding 60 * 60 = 3.6seconds leads to a bug that results in expiring the access token in 3.6 seconds, although it been valid. It creates unnecessary api calls to the zoho servers before most the api calls.

No functional changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Zoho CRM token expiry by correctly adding one hour (in milliseconds) to the current time when setting expiryDate. Prevents tokens expiring after ~3.6 seconds and reduces unnecessary Zoho API calls.

<sup>Written for commit ecd562b7f7945cd665c4332a8a2f7b59d303d345. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

