### PR TITLE
feat(form-builder): format field labels to display human-readable names

### DIFF
--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -1012,12 +1012,13 @@ function VariantFields({
             ];
           const appUiFieldConfig =
             fieldTypeConfigVariants.fieldsMap[f.name as keyof typeof fieldTypeConfigVariants.fieldsMap];
+            
           return (
             <li className={classNames(!isSimpleVariant ? "p-4" : "")} key={f.name}>
               {!isSimpleVariant && (
                 <Label className="flex justify-between">
                   <span>{`Field ${index + 1}`}</span>
-                  <span className="text-muted">{f.name}</span>
+                  <span className="text-muted">{t(appUiFieldConfig?.defaultLabel || "")}</span>
                 </Label>
               )}
               <InputField


### PR DESCRIPTION
## What does this PR do?

This PR improves the Form Builder UI by displaying human-readable field labels instead of raw identifier keys. Previously, fields like firstName and lastName were rendered directly from their internal identifiers, which resulted in camelCase values appearing in the interface. This update formats those labels using translation/label formatting so they appear as readable text (e.g., First Name, Last Name) without changing internal field identifiers.
- Fixes #27856
- Fixes [CAL-7194](https://linear.app/calcom/issue/CAL-7194/improve-form-builder-field-labels-to-display-human-readable-names)

## Image Demo :

### before   
<img width="3018" height="1792" alt="image" src="https://github.com/user-attachments/assets/ad3af81c-87da-410b-ba80-2956be517f3d" />
### After 
<img width="3018" height="1802" alt="image" src="https://github.com/user-attachments/assets/3439efc4-6ca1-436d-8f01-3a55bb6f47f7" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Open any Event and click Edit.
- Navigate to the Advanced tab.
- Edit the Name field.
- Enable Split Full Name into First Name and Last Name.
- Verify field labels display as:
- First Name
- Last Name
- instead of firstName / lastName.

