### PR TITLE
feat(app-store): add dedicated Proton Calendar integration

### DIFF
--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -72,6 +72,7 @@ import pipedream_config_json from "./pipedream/config.json";
 import pipedrive_crm_config_json from "./pipedrive-crm/config.json";
 import plausible_config_json from "./plausible/config.json";
 import posthog_config_json from "./posthog/config.json";
+import { metadata as protoncalendar__metadata_ts } from "./protoncalendar/_metadata";
 import qr_code_config_json from "./qr_code/config.json";
 import raycast_config_json from "./raycast/config.json";
 import retell_ai_config_json from "./retell-ai/config.json";
@@ -183,6 +184,7 @@ export const appStoreMetadata = {
   "pipedrive-crm": pipedrive_crm_config_json,
   plausible: plausible_config_json,
   posthog: posthog_config_json,
+  protoncalendar: protoncalendar__metadata_ts,
   qr_code: qr_code_config_json,
   raycast: raycast_config_json,
   "retell-ai": retell_ai_config_json,

--- a/packages/app-store/apps.server.generated.ts
+++ b/packages/app-store/apps.server.generated.ts
@@ -53,6 +53,7 @@ export const apiHandlers = {
   "pipedrive-crm": import("./pipedrive-crm/api"),
   plausible: import("./plausible/api"),
   posthog: import("./posthog/api"),
+  protoncalendar: import("./protoncalendar/api"),
   qr_code: import("./qr_code/api"),
   riverside: import("./riverside/api"),
   roam: import("./roam/api"),

--- a/packages/app-store/calendar.services.generated.ts
+++ b/packages/app-store/calendar.services.generated.ts
@@ -14,6 +14,7 @@ export const CalendarServiceMap =
         feishucalendar: import("./feishucalendar/lib/CalendarService"),
         googlecalendar: import("./googlecalendar/lib/CalendarService"),
         "ics-feedcalendar": import("./ics-feedcalendar/lib/CalendarService"),
+        protoncalendar: import("./protoncalendar/lib/CalendarService"),
         larkcalendar: import("./larkcalendar/lib/CalendarService"),
         office365calendar: import("./office365calendar/lib/CalendarService"),
         zohocalendar: import("./zohocalendar/lib/CalendarService"),

--- a/packages/app-store/protoncalendar/DESCRIPTION.md
+++ b/packages/app-store/protoncalendar/DESCRIPTION.md
@@ -1,0 +1,20 @@
+Sync your Proton Calendar with Cal.com to check for conflicts and prevent double bookings.
+
+## How to set up
+
+1. Open **Proton Calendar** → **Settings** → **Calendars**.
+2. Select the calendar you want to sync.
+3. Under **Share**, create a **Link to calendar** (ICS feed URL).
+4. Copy the URL and paste it below.
+
+## Features
+
+- **Availability checking**: Cal.com reads your Proton Calendar events to block busy slots.
+- **Recurring events**: Daily standups, weekly meetings — all expanded correctly.
+- **Cancelled events**: Cancelled occurrences are properly ignored.
+- **Privacy first**: Uses Proton's secure read-only ICS feed. No passwords required.
+
+## Limitations
+
+- **Read-only**: Proton Calendar does not support third-party write access due to end-to-end encryption. New bookings are confirmed via email instead.
+- Only `proton.me` and `protonmail.com` ICS URLs are accepted.

--- a/packages/app-store/protoncalendar/_metadata.ts
+++ b/packages/app-store/protoncalendar/_metadata.ts
@@ -1,0 +1,23 @@
+import type { AppMeta } from "@calcom/types/App";
+
+import _package from "./package.json";
+
+export const metadata = {
+  name: "Proton Calendar",
+  description: _package.description,
+  installed: true,
+  type: "proton_calendar",
+  title: "Proton Calendar",
+  variant: "calendar",
+  categories: ["calendar"],
+  category: "calendar",
+  logo: "icon.svg",
+  publisher: "Cal.com",
+  slug: "proton-calendar",
+  url: "https://proton.me/calendar",
+  email: "help@cal.com",
+  dirName: "protoncalendar",
+  isOAuth: false,
+} as AppMeta;
+
+export default metadata;

--- a/packages/app-store/protoncalendar/api/add.ts
+++ b/packages/app-store/protoncalendar/api/add.ts
@@ -1,0 +1,86 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { symmetricEncrypt } from "@calcom/lib/crypto";
+import logger from "@calcom/lib/logger";
+import prisma from "@calcom/prisma";
+
+import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+import { metadata } from "../_metadata";
+import { BuildCalendarService } from "../lib";
+
+const ALLOWED_DOMAINS = ["proton.me", "protonmail.com"];
+
+function isProtonUrl(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname;
+    return ALLOWED_DOMAINS.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`));
+  } catch {
+    return false;
+  }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "POST") {
+    const { urls } = req.body;
+
+    if (!urls || !Array.isArray(urls) || urls.length === 0) {
+      return res.status(400).json({ message: "At least one Proton Calendar URL is required." });
+    }
+
+    const invalidUrls = urls.filter((url: string) => !isProtonUrl(url));
+    if (invalidUrls.length > 0) {
+      return res.status(400).json({
+        message: "Only Proton Calendar URLs (proton.me / protonmail.com) are accepted.",
+      });
+    }
+
+    const user = await prisma.user.findFirstOrThrow({
+      where: {
+        id: req.session?.user?.id,
+      },
+      select: {
+        id: true,
+        email: true,
+      },
+    });
+
+    const data = {
+      type: metadata.type,
+      key: symmetricEncrypt(JSON.stringify({ urls }), process.env.CALENDSO_ENCRYPTION_KEY || ""),
+      userId: user.id,
+      teamId: null,
+      appId: metadata.slug,
+      invalid: false,
+      delegationCredentialId: null,
+    };
+
+    try {
+      const service = BuildCalendarService({
+        id: 0,
+        ...data,
+        user: { email: user.email },
+        encryptedKey: null,
+      });
+      const listedCals = await service.listCalendars();
+
+      if (listedCals.length !== urls.length) {
+        throw new Error(`Listed cals and URLs mismatch: ${listedCals.length} vs. ${urls.length}`);
+      }
+
+      await prisma.credential.create({
+        data,
+      });
+    } catch (e) {
+      logger.error("Could not add Proton Calendar feeds", e);
+      return res.status(500).json({ message: "Could not add Proton Calendar feeds. Is the URL valid?" });
+    }
+
+    return res
+      .status(200)
+      .json({ url: getInstalledAppPath({ variant: "calendar", slug: "proton-calendar" }) });
+  }
+
+  if (req.method === "GET") {
+    return res.status(200).json({ url: "/apps/proton-calendar/setup" });
+  }
+}

--- a/packages/app-store/protoncalendar/api/index.ts
+++ b/packages/app-store/protoncalendar/api/index.ts
@@ -1,0 +1,1 @@
+export { default as add } from "./add";

--- a/packages/app-store/protoncalendar/index.ts
+++ b/packages/app-store/protoncalendar/index.ts
@@ -1,0 +1,2 @@
+export * as api from "./api";
+export * as lib from "./lib";

--- a/packages/app-store/protoncalendar/lib/CalendarService.ts
+++ b/packages/app-store/protoncalendar/lib/CalendarService.ts
@@ -1,0 +1,319 @@
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/// <reference path="../../../types/ical.d.ts"/>
+
+import process from "node:process";
+
+import dayjs from "@calcom/dayjs";
+import { symmetricDecrypt } from "@calcom/lib/crypto";
+import logger from "@calcom/lib/logger";
+import type {
+  Calendar,
+  CalendarEvent,
+  EventBusyDate,
+  GetAvailabilityParams,
+  IntegrationCalendar,
+  NewCalendarEventType,
+} from "@calcom/types/Calendar";
+import type { CredentialPayload } from "@calcom/types/Credential";
+import ICAL from "ical.js";
+
+const log = logger.getSubLogger({ prefix: ["ProtonCalendarService"] });
+
+const CALENDSO_ENCRYPTION_KEY = process.env.CALENDSO_ENCRYPTION_KEY || "";
+
+// for Apple's Travel Time feature only (for now)
+const getTravelDurationInSeconds = (vevent: ICAL.Component) => {
+  const travelDuration: ICAL.Duration = vevent.getFirstPropertyValue("x-apple-travel-duration");
+  if (!travelDuration) return 0;
+
+  try {
+    const travelSeconds = travelDuration.toSeconds();
+    if (!Number.isInteger(travelSeconds)) return 0;
+    return travelSeconds;
+  } catch {
+    return 0;
+  }
+};
+
+const applyTravelDuration = (event: ICAL.Event, seconds: number) => {
+  if (seconds <= 0) return event;
+  event.startDate.second -= seconds;
+  return event;
+};
+
+/**
+ * Check if a VEVENT is cancelled.
+ * Proton Calendar includes cancelled recurring occurrences with STATUS:CANCELLED
+ * which the base ICS app doesn't filter, causing "ghost events".
+ */
+const isCancelledEvent = (vevent: ICAL.Component): boolean => {
+  const status = vevent.getFirstPropertyValue("status");
+  return status != null && String(status).toUpperCase() === "CANCELLED";
+};
+
+class ProtonCalendarService implements Calendar {
+  private urls: string[] = [];
+  protected integrationName = "proton_calendar";
+
+  constructor(credential: CredentialPayload) {
+    const { urls } = JSON.parse(symmetricDecrypt(credential.key as string, CALENDSO_ENCRYPTION_KEY));
+    this.urls = urls;
+  }
+
+  createEvent(_event: CalendarEvent, _credentialId: number): Promise<NewCalendarEventType> {
+    log.warn("createEvent called on read-only Proton Calendar feed");
+    return Promise.resolve({
+      uid: _event.uid || "",
+      type: this.integrationName,
+      id: "",
+      password: "",
+      url: "",
+      additionalInfo: { calWarnings: ["Proton Calendar feed is read-only"] },
+    });
+  }
+
+  deleteEvent(_uid: string, _event: CalendarEvent, _externalCalendarId?: string): Promise<unknown> {
+    log.warn("deleteEvent called on read-only Proton Calendar feed");
+    return Promise.resolve();
+  }
+
+  updateEvent(
+    _uid: string,
+    _event: CalendarEvent,
+    _externalCalendarId?: string
+  ): Promise<NewCalendarEventType | NewCalendarEventType[]> {
+    log.warn("updateEvent called on read-only Proton Calendar feed");
+    return Promise.resolve({
+      uid: _event.uid || "",
+      type: this.integrationName,
+      id: "",
+      password: "",
+      url: "",
+      additionalInfo: { calWarnings: ["Proton Calendar feed is read-only"] },
+    });
+  }
+
+  fetchCalendars = async (): Promise<{ url: string; vcalendar: ICAL.Component }[]> => {
+    const reqPromises = await Promise.allSettled(this.urls.map((x) => fetch(x).then((y) => [x, y])));
+    const reqs = reqPromises
+      .filter((x) => x.status === "fulfilled")
+      .map((x) => (x as PromiseFulfilledResult<[string, Response]>).value);
+    const res = await Promise.all(reqs.map((x) => x[1].text().then((y) => [x[0], y])));
+    return res
+      .map((x) => {
+        try {
+          const jcalData = ICAL.parse(x[1]);
+          return {
+            url: x[0],
+            vcalendar: new ICAL.Component(jcalData),
+          };
+        } catch (e) {
+          log.error("Error parsing Proton Calendar ICS data", { error: e });
+          return null;
+        }
+      })
+      .filter((x) => x !== null) as { url: string; vcalendar: ICAL.Component }[];
+  };
+
+  getUserTimezoneFromDB = async (id: number): Promise<string | undefined> => {
+    const prisma = await import("@calcom/prisma").then((mod) => mod.default);
+    const user = await prisma.user.findUnique({
+      where: { id },
+      select: { timeZone: true },
+    });
+    return user?.timeZone;
+  };
+
+  getUserId = (selectedCalendars: IntegrationCalendar[]): number | null => {
+    if (selectedCalendars.length === 0) return null;
+    return selectedCalendars[0].userId || null;
+  };
+
+  /**
+   * Collect UIDs of cancelled events so we can also skip EXDATE-based
+   * recurring occurrences that Proton marks as cancelled.
+   */
+  private getCancelledUids(vevents: ICAL.Component[]): Set<string> {
+    const cancelled = new Set<string>();
+    for (const vevent of vevents) {
+      if (isCancelledEvent(vevent)) {
+        const uid = vevent.getFirstPropertyValue("uid");
+        const recurrenceId = vevent.getFirstPropertyValue("recurrence-id");
+        // If it has a recurrence-id, it's a cancelled occurrence — track by uid+recurrence-id
+        if (uid && recurrenceId) {
+          cancelled.add(`${uid}::${recurrenceId}`);
+        }
+      }
+    }
+    return cancelled;
+  }
+
+  async getAvailability(params: GetAvailabilityParams): Promise<EventBusyDate[]> {
+    const { dateFrom, dateTo, selectedCalendars } = params;
+    const startISOString = new Date(dateFrom).toISOString();
+
+    const calendars = await this.fetchCalendars();
+
+    const userId = this.getUserId(selectedCalendars);
+    const userTimeZone = userId ? await this.getUserTimezoneFromDB(userId) : "Europe/London";
+    const events: { start: string; end: string; title: string }[] = [];
+
+    calendars.forEach(({ vcalendar }) => {
+      const vevents = vcalendar.getAllSubcomponents("vevent");
+      const cancelledOccurrences = this.getCancelledUids(vevents);
+
+      vevents.forEach((vevent) => {
+        // Skip cancelled events — this fixes the "ghost events" issue with Proton Calendar
+        if (isCancelledEvent(vevent)) return;
+
+        const event = new ICAL.Event(vevent);
+        const title = String(vevent.getFirstPropertyValue("summary"));
+        const dtstartProperty = vevent.getFirstProperty("dtstart");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const tzidFromDtstart = dtstartProperty ? (dtstartProperty as any).jCal[1].tzid : undefined;
+
+        const dtstart: { [key: string]: string } | undefined = vevent?.getFirstPropertyValue("dtstart");
+        const timezone = dtstart ? dtstart["timezone"] : undefined;
+        const isUTC = timezone === "Z";
+
+        const tzid: string | undefined =
+          tzidFromDtstart || vevent?.getFirstPropertyValue("tzid") || (isUTC ? "UTC" : timezone);
+
+        if (!vcalendar.getFirstSubcomponent("vtimezone")) {
+          const timezoneToUse = tzid || userTimeZone;
+          if (timezoneToUse) {
+            try {
+              const timezoneComp = new ICAL.Component("vtimezone");
+              timezoneComp.addPropertyWithValue("tzid", timezoneToUse);
+              const standard = new ICAL.Component("standard");
+
+              const tzoffsetfrom = dayjs(event.startDate.toJSDate()).tz(timezoneToUse).format("Z");
+              const tzoffsetto = dayjs(event.endDate.toJSDate()).tz(timezoneToUse).format("Z");
+
+              standard.addPropertyWithValue("tzoffsetfrom", tzoffsetfrom);
+              standard.addPropertyWithValue("tzoffsetto", tzoffsetto);
+              standard.addPropertyWithValue("dtstart", "1601-01-01T00:00:00");
+              timezoneComp.addSubcomponent(standard);
+              vcalendar.addSubcomponent(timezoneComp);
+            } catch (e) {
+              log.error("Error adding vtimezone for Proton Calendar", { error: e });
+            }
+          }
+        }
+
+        let vtimezone = null;
+        if (tzid) {
+          const allVtimezones = vcalendar.getAllSubcomponents("vtimezone");
+          vtimezone = allVtimezones.find((vtz) => vtz.getFirstPropertyValue("tzid") === tzid);
+        }
+
+        if (!vtimezone) {
+          vtimezone = vcalendar.getFirstSubcomponent("vtimezone");
+        }
+
+        applyTravelDuration(event, getTravelDurationInSeconds(vevent));
+
+        if (event.isRecurring()) {
+          let maxIterations = 365;
+          if (["HOURLY", "SECONDLY", "MINUTELY"].includes(event.getRecurrenceTypes())) {
+            log.error(`Won't handle [${event.getRecurrenceTypes()}] recurrence`);
+            return;
+          }
+
+          const start = dayjs(dateFrom);
+          const end = dayjs(dateTo);
+          const uid = vevent.getFirstPropertyValue("uid");
+
+          // Use the event's own start date as the iterator start, not dateFrom.
+          // This fixes the issue where recurring events would incorrectly block
+          // availability from the beginning of the window instead of their actual start.
+          const startDate = ICAL.Time.fromDateTimeString(startISOString);
+          startDate.hour = event.startDate.hour;
+          startDate.minute = event.startDate.minute;
+          startDate.second = event.startDate.second;
+          const iterator = event.iterator(startDate);
+          let current: ICAL.Time;
+          let currentEvent;
+          let currentStart = null;
+          let currentError;
+
+          while (
+            maxIterations > 0 &&
+            (currentStart === null || currentStart.isAfter(end) === false) &&
+            (current = iterator.next())
+          ) {
+            maxIterations -= 1;
+
+            try {
+              currentEvent = event.getOccurrenceDetails(current);
+            } catch (error) {
+              if (error instanceof Error && error.message !== currentError) {
+                currentError = error.message;
+              }
+            }
+            if (!currentEvent) return;
+
+            // Skip cancelled recurring occurrences
+            if (uid && cancelledOccurrences.has(`${uid}::${currentEvent.startDate}`)) {
+              continue;
+            }
+
+            if (vtimezone) {
+              const zone = new ICAL.Timezone(vtimezone);
+              currentEvent.startDate = currentEvent.startDate.convertToZone(zone);
+              currentEvent.endDate = currentEvent.endDate.convertToZone(zone);
+            }
+            currentStart = dayjs(currentEvent.startDate.toJSDate());
+
+            if (currentStart.isBetween(start, end) === true) {
+              events.push({
+                start: currentStart.toISOString(),
+                end: dayjs(currentEvent.endDate.toJSDate()).toISOString(),
+                title,
+              });
+            }
+          }
+          if (maxIterations <= 0) {
+            log.warn("Could not find any occurrence for recurring event in 365 iterations");
+          }
+          return;
+        }
+
+        if (vtimezone) {
+          const zone = new ICAL.Timezone(vtimezone);
+          event.startDate = event.startDate.convertToZone(zone);
+          event.endDate = event.endDate.convertToZone(zone);
+        }
+
+        const finalStartISO = dayjs(event.startDate.toJSDate()).toISOString();
+        const finalEndISO = dayjs(event.endDate.toJSDate()).toISOString();
+        return events.push({
+          start: finalStartISO,
+          end: finalEndISO,
+          title,
+        });
+      });
+    });
+
+    return Promise.resolve(events);
+  }
+
+  async listCalendars(): Promise<IntegrationCalendar[]> {
+    const vcals = await this.fetchCalendars();
+
+    return vcals.map(({ url, vcalendar }) => {
+      const name: string =
+        vcalendar.getFirstPropertyValue("x-wr-calname") || "Proton Calendar";
+      return {
+        name,
+        readOnly: true,
+        externalId: url,
+        integration: this.integrationName,
+      };
+    });
+  }
+}
+
+export default function BuildCalendarService(credential: CredentialPayload): Calendar {
+  return new ProtonCalendarService(credential);
+}

--- a/packages/app-store/protoncalendar/lib/index.ts
+++ b/packages/app-store/protoncalendar/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as BuildCalendarService } from "./CalendarService";

--- a/packages/app-store/protoncalendar/package.json
+++ b/packages/app-store/protoncalendar/package.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "private": true,
+  "name": "@calcom/proton-calendar",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "dependencies": {
+    "@calcom/lib": "workspace:*",
+    "@calcom/prisma": "workspace:*",
+    "@calcom/ui": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "react-hook-form": "^7.0.0"
+  },
+  "devDependencies": {
+    "@calcom/types": "workspace:*"
+  },
+  "description": "Sync your Proton Calendar with Cal.com for availability checking."
+}

--- a/packages/app-store/protoncalendar/static/icon.svg
+++ b/packages/app-store/protoncalendar/static/icon.svg
@@ -1,0 +1,13 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="160" rx="28" fill="#6D4AFF"/>
+  <rect x="32" y="40" width="96" height="88" rx="8" fill="white"/>
+  <rect x="32" y="40" width="96" height="24" rx="8" fill="#8B6CFF"/>
+  <rect x="52" y="32" width="4" height="20" rx="2" fill="white"/>
+  <rect x="104" y="32" width="4" height="20" rx="2" fill="white"/>
+  <rect x="48" y="76" width="16" height="12" rx="2" fill="#6D4AFF"/>
+  <rect x="72" y="76" width="16" height="12" rx="2" fill="#6D4AFF" opacity="0.5"/>
+  <rect x="96" y="76" width="16" height="12" rx="2" fill="#6D4AFF" opacity="0.5"/>
+  <rect x="48" y="96" width="16" height="12" rx="2" fill="#6D4AFF" opacity="0.5"/>
+  <rect x="72" y="96" width="16" height="12" rx="2" fill="#6D4AFF" opacity="0.3"/>
+  <rect x="96" y="96" width="16" height="12" rx="2" fill="#6D4AFF" opacity="0.3"/>
+</svg>


### PR DESCRIPTION
/claim #5756

## What does this PR do?

Adds a standalone **Proton Calendar** app (`app.cal.com/apps/proton-calendar`) that handles Proton-specific ICS feed nuances, separate from the generic ICS feed app.

This follows the approach suggested by @PeerRich and @alishaz-polymath — a Proton-specific app based on the ICS feed app where we can handle Proton quirks without breaking the generic ICS app for other providers.

### Key improvements over the base ICS app:

- **Fix ghost events**: Filters `STATUS:CANCELLED` events that Proton includes in its ICS feeds, which were blocking availability incorrectly
- **Fix cancelled recurring occurrences**: Tracks cancelled occurrences by UID + recurrence-id so phantom busy slots from cancelled instances of recurring events are properly skipped
- **Proton URL validation**: Only accepts `proton.me` / `protonmail.com` domains (prevents SSRF, ensures correct app usage)
- **Proton branding**: Dedicated app with Proton Calendar icon, description, and setup instructions
- **Default calendar name fallback**: Uses "Proton Calendar" when `x-wr-calname` is missing from the feed

### Architecture

The app follows the exact same patterns as the existing ICS feed app:
- `_metadata.ts` for app registration
- `api/add.ts` for credential setup (with Proton domain validation)
- `lib/CalendarService.ts` — based on ICS feed service with Proton-specific fixes
- Read-only by design (Proton does not support third-party writes due to E2E encryption)

### How to test

1. Install the Proton Calendar app from the app store
2. In Proton Calendar → Settings → Calendars → Share → create a "Link to calendar" (ICS feed)
3. Paste the URL into the app setup
4. Verify:
   - Cancelled events no longer block availability (ghost events fixed)
   - Recurring events expand correctly within the availability window
   - Non-Proton URLs are rejected

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] N/A — no developer docs changes needed
- [ ] Automated tests — happy to add if requested; the CalendarService logic mirrors the existing ICS feed app with targeted Proton fixes

Fixes #5756