### PR TITLE
fix: maintain uid parameter in BookingDetailsSheet URL

### DIFF
--- a/apps/web/modules/bookings/store/bookingDetailsSheetStore.tsx
+++ b/apps/web/modules/bookings/store/bookingDetailsSheetStore.tsx
@@ -185,11 +185,8 @@ function useBiDirectionalSyncBetweenStoreAndUrl({ store }: { store: BookingDetai
 
   // Sync Store → URL
   useEffect(() => {
-    // We can't sync from Store to URL if URL hasn't first been synced to Store
-    // This is to prevent override of any user configuration provided by URL query params. Think about page being refreshed
-    if (!isSyncedFromUrlToStoreRef.current) return;
-
     const unsubscribe = store.subscribe((state) => {
+      if (!isSyncedFromUrlToStoreRef.current) return;
       if (state.selectedBookingUid !== selectedBookingUidFromUrl) {
         setSelectedBookingUidToUrl(state.selectedBookingUid);
       }

--- a/apps/web/playwright/bookings-list.e2e.ts
+++ b/apps/web/playwright/bookings-list.e2e.ts
@@ -770,36 +770,48 @@ test.describe("Bookings", () => {
     bookings,
     prisma,
   }) => {
+    const existingFlag = await prisma.feature.findUnique({ where: { slug: "bookings-v3" } });
     await prisma.feature.upsert({
       where: { slug: "bookings-v3" },
       update: { enabled: true },
       create: { slug: "bookings-v3", enabled: true, type: "OPERATIONAL" },
     });
 
-    const user = await users.create();
+    try {
+      const user = await users.create();
 
-    const bookingFixture = await createBooking({
-      title: "Test booking for uid param",
-      bookingsFixture: bookings,
-      relativeDate: 3,
-      organizer: user,
-      organizerEventType: user.eventTypes[0],
-      attendees: [{ name: "Attendee", email: "attendee@example.com", timeZone: "Europe/Berlin" }],
-    });
+      const bookingFixture = await createBooking({
+        title: "Test booking for uid param",
+        bookingsFixture: bookings,
+        relativeDate: 3,
+        organizer: user,
+        organizerEventType: user.eventTypes[0],
+        attendees: [{ name: "Attendee", email: "attendee@example.com", timeZone: "Europe/Berlin" }],
+      });
 
-    await user.apiLogin();
-    const bookingsGetResponse = page.waitForResponse((response) =>
-      /\/api\/trpc\/bookings\/get.*/.test(response.url())
-    );
-    await page.goto("/bookings/upcoming", { waitUntil: "domcontentloaded" });
-    await bookingsGetResponse;
+      await user.apiLogin();
+      const bookingsGetResponse = page.waitForResponse((response) =>
+        /\/api\/trpc\/bookings\/get.*/.test(response.url())
+      );
+      await page.goto("/bookings/upcoming", { waitUntil: "domcontentloaded" });
+      await bookingsGetResponse;
 
-    const bookingItem = page.locator(`[data-booking-uid="${bookingFixture.uid}"]`);
-    await expect(bookingItem).toBeVisible();
+      const bookingItem = page.locator(`[data-booking-uid="${bookingFixture.uid}"]`);
+      await expect(bookingItem).toBeVisible();
 
-    await bookingItem.locator('[role="button"]').first().click();
+      await bookingItem.locator('[role="button"]').first().click();
 
-    await expect(page).toHaveURL(new RegExp(`[?&]uid=${bookingFixture.uid}(&|$)`));
+      await expect(page).toHaveURL(new RegExp(`[?&]uid=${bookingFixture.uid}(&|$)`));
+    } finally {
+      if (existingFlag) {
+        await prisma.feature.update({
+          where: { slug: "bookings-v3" },
+          data: { enabled: existingFlag.enabled },
+        });
+      } else {
+        await prisma.feature.deleteMany({ where: { slug: "bookings-v3" } });
+      }
+    }
   });
 });
 

--- a/apps/web/playwright/bookings-list.e2e.ts
+++ b/apps/web/playwright/bookings-list.e2e.ts
@@ -799,12 +799,7 @@ test.describe("Bookings", () => {
 
     await bookingItem.locator('[role="button"]').first().click();
 
-    await expect
-      .poll(() => {
-        const url = new URL(page.url());
-        return url.searchParams.get("uid");
-      })
-      .toBe(bookingFixture.uid);
+    await expect(page).toHaveURL(new RegExp(`[?&]uid=${bookingFixture.uid}(&|$)`));
   });
 });
 

--- a/apps/web/playwright/bookings-list.e2e.ts
+++ b/apps/web/playwright/bookings-list.e2e.ts
@@ -763,6 +763,49 @@ test.describe("Bookings", () => {
         .toBe(1);
     });
   });
+
+  test("clicking a booking item adds uid param to URL when bookings-v3 is enabled", async ({
+    page,
+    users,
+    bookings,
+    prisma,
+  }) => {
+    await prisma.feature.upsert({
+      where: { slug: "bookings-v3" },
+      update: { enabled: true },
+      create: { slug: "bookings-v3", enabled: true, type: "OPERATIONAL" },
+    });
+
+    const user = await users.create();
+
+    const bookingFixture = await createBooking({
+      title: "Test booking for uid param",
+      bookingsFixture: bookings,
+      relativeDate: 3,
+      organizer: user,
+      organizerEventType: user.eventTypes[0],
+      attendees: [{ name: "Attendee", email: "attendee@example.com", timeZone: "Europe/Berlin" }],
+    });
+
+    await user.apiLogin();
+    const bookingsGetResponse = page.waitForResponse((response) =>
+      /\/api\/trpc\/bookings\/get.*/.test(response.url())
+    );
+    await page.goto("/bookings/upcoming", { waitUntil: "domcontentloaded" });
+    await bookingsGetResponse;
+
+    const bookingItem = page.locator(`[data-booking-uid="${bookingFixture.uid}"]`);
+    await expect(bookingItem).toBeVisible();
+
+    await bookingItem.locator('[role="button"]').first().click();
+
+    await expect
+      .poll(() => {
+        const url = new URL(page.url());
+        return url.searchParams.get("uid");
+      })
+      .toBe(bookingFixture.uid);
+  });
 });
 
 async function createBooking({


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where the `&uid=` query parameter stopped appearing in the URL when clicking a booking in the v3 bookings view. This was introduced in commit `a7fd7890a7` which refactored the URL sync into `useBiDirectionalSyncBetweenStoreAndUrl` and added an `isSyncedFromUrlToStoreRef` guard.

**Root cause:** The guard `if (!isSyncedFromUrlToStoreRef.current) return` was placed at the **effect level**, causing the entire effect (including the `store.subscribe()` call) to be skipped on initial render when the ref is `false`. After the URL→Store effect sets the ref to `true`, the Store→URL effect never re-runs because its dependencies haven't changed. Result: the Zustand subscription that pushes `selectedBookingUid` changes to the URL is **never created**.

**Fix:** Move the guard from the effect level to **inside** the subscription callback. This ensures the subscription is always created, while still preventing premature URL overwrites during URL→Store sync on page refresh.

Also adds an E2E test that enables the `bookings-v3` feature flag, clicks a booking item, and asserts the `uid` query parameter appears in the URL. The test properly saves and restores the feature flag state via `try/finally` to avoid cross-test side effects.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Enable the `bookings-v3` feature flag
2. Navigate to `/bookings/upcoming`
3. Click on any booking item
4. Verify the URL updates to include `?uid=<booking-uid>`
5. Verify the booking detail sheet opens

The E2E test (`bookings-list.e2e.ts`, grep for "clicking a booking item adds uid param") covers this flow automatically.

## Human Review Checklist

- [ ] Verify the moved guard (`if (!isSyncedFromUrlToStoreRef.current) return` now inside the subscribe callback) is logically equivalent — it still prevents Store→URL sync before URL→Store sync completes, but no longer blocks subscription creation
- [ ] The `useEffect` dependency array does not include `setSelectedBookingUidToUrl` / `setActiveSegmentToUrl` — this is pre-existing and unchanged, but worth noting

---

Link to Devin run: https://app.devin.ai/sessions/e312e09588404fe08637a73cf99c9486
Requested by: @eunjae-lee