### PR TITLE
feat: re-render bookings page after feature opt-in without full refresh

### DIFF
--- a/apps/web/modules/bookings/views/bookings-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-view.tsx
@@ -6,8 +6,8 @@ import FeatureOptInBannerWrapper from "~/feature-opt-in/components/FeatureOptInB
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
 import dynamic from "next/dynamic";
-import { usePathname } from "next/navigation";
-import { useMemo } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useCallback, useMemo } from "react";
 import { useFeatureOptInBanner } from "../../feature-opt-in/hooks/useFeatureOptInBanner";
 import { BookingListContainer } from "../components/BookingListContainer";
 import { useActiveFiltersValidator } from "../hooks/useActiveFiltersValidator";
@@ -78,7 +78,11 @@ export default function Bookings(props: BookingsProps) {
 
 function BookingsContent({ status, permissions, bookingsV3Enabled, bookingAuditEnabled }: BookingsProps) {
   const [view] = useBookingsView({ bookingsV3Enabled });
-  const optInBanner = useFeatureOptInBanner("bookings-v3");
+  const router = useRouter();
+  const handleOptInSuccess = useCallback(() => {
+    router.refresh();
+  }, [router]);
+  const optInBanner = useFeatureOptInBanner("bookings-v3", { onOptInSuccess: handleOptInSuccess });
 
   return (
     <div className={classNames(view === "calendar" && "-mb-8")}>

--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.test.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.test.ts
@@ -89,4 +89,17 @@ describe("useFeatureOptInBanner", () => {
 
     expect(result.current.shouldShow).toBe(true);
   });
+
+  it("calls onOptInSuccess callback when markOptedIn is invoked", () => {
+    mockUseSession.mockReturnValue({ data: { user: {} } });
+    const onOptInSuccess = vi.fn();
+
+    const { result } = renderHook(() =>
+      useFeatureOptInBanner("bookings-v3", { onOptInSuccess })
+    );
+
+    result.current.markOptedIn();
+
+    expect(onOptInSuccess).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.test.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.test.ts
@@ -75,7 +75,9 @@ describe("useFeatureOptInBanner", () => {
   it("shows banner for normal users when eligible", () => {
     mockUseSession.mockReturnValue({ data: { user: {} } });
 
-    const { result } = renderHook(() => useFeatureOptInBanner("bookings-v3"));
+    const { result } = renderHook(() =>
+      useFeatureOptInBanner("bookings-v3", { onOptInSuccess: vi.fn() })
+    );
 
     expect(result.current.shouldShow).toBe(true);
   });
@@ -85,7 +87,9 @@ describe("useFeatureOptInBanner", () => {
       data: { user: { impersonatedBy: { id: 999, email: "admin@cal.com" } } },
     });
 
-    const { result } = renderHook(() => useFeatureOptInBanner("bookings-v3"));
+    const { result } = renderHook(() =>
+      useFeatureOptInBanner("bookings-v3", { onOptInSuccess: vi.fn() })
+    );
 
     expect(result.current.shouldShow).toBe(true);
   });

--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
@@ -58,7 +58,14 @@ function isFeatureOptedIn(featureId: string): boolean {
   return getFeatureOptInTimestamp(featureId) !== null;
 }
 
-function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
+type UseFeatureOptInBannerOptions = {
+  onOptInSuccess?: () => void;
+};
+
+function useFeatureOptInBanner(
+  featureId: string,
+  options?: UseFeatureOptInBannerOptions
+): UseFeatureOptInBannerResult {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isDismissed, setIsDismissed] = useState(() => isFeatureDismissed(featureId));
   const [isOptedIn, setIsOptedIn] = useState(() => isFeatureOptedIn(featureId));
@@ -135,7 +142,8 @@ function useFeatureOptInBanner(featureId: string): UseFeatureOptInBannerResult {
   const markOptedIn = useCallback(() => {
     setFeatureOptedIn(featureId);
     setIsOptedIn(true);
-  }, [featureId]);
+    options?.onOptInSuccess?.();
+  }, [featureId, options?.onOptInSuccess]);
 
   const openDialog = useCallback(() => {
     posthog.capture("feature_opt_in_banner_try_it_clicked", {

--- a/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
+++ b/apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.ts
@@ -59,12 +59,12 @@ function isFeatureOptedIn(featureId: string): boolean {
 }
 
 type UseFeatureOptInBannerOptions = {
-  onOptInSuccess?: () => void;
+  onOptInSuccess: () => void;
 };
 
 function useFeatureOptInBanner(
   featureId: string,
-  options?: UseFeatureOptInBannerOptions
+  options: UseFeatureOptInBannerOptions
 ): UseFeatureOptInBannerResult {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isDismissed, setIsDismissed] = useState(() => isFeatureDismissed(featureId));
@@ -142,8 +142,8 @@ function useFeatureOptInBanner(
   const markOptedIn = useCallback(() => {
     setFeatureOptedIn(featureId);
     setIsOptedIn(true);
-    options?.onOptInSuccess?.();
-  }, [featureId, options?.onOptInSuccess]);
+    options.onOptInSuccess();
+  }, [featureId, options.onOptInSuccess]);
 
   const openDialog = useCallback(() => {
     posthog.capture("feature_opt_in_banner_try_it_clicked", {


### PR DESCRIPTION
## What does this PR do?

After a user opts into a feature via the `useFeatureOptInBanner()` banner on `/bookings`, the page now re-renders to apply the feature immediately — without a full browser reload.

**Problem:** `bookingsV3Enabled` is computed server-side in the page component and passed as a prop. When a user opts in via the banner, only the banner's local state updates (hiding it), but the server-computed prop remains stale until a manual page refresh.

**Solution:** Adds a **required** `onOptInSuccess` callback to `useFeatureOptInBanner()`. In the bookings view, this callback calls `router.refresh()` — the idiomatic Next.js App Router method that re-runs the server component and streams updated props to the client without losing client-side state.

This pattern is already established in the codebase (e.g., `PbacOptInModal`, `RoleSheet`).

### Updates since last revision

- Changed `onOptInSuccess` from optional to **required** per reviewer feedback, ensuring every consumer explicitly handles the post-opt-in behavior.
- Updated all existing tests to pass `onOptInSuccess`.

## Demo


https://github.com/user-attachments/assets/323885a9-5efa-4064-83a7-83fd9c7259bc



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to `/bookings` as a user eligible for the `bookings-v3` feature opt-in banner.
2. Click the banner and complete the opt-in flow.
3. After opt-in succeeds, the page should re-render and reflect the `bookings-v3` feature (e.g., calendar view toggle becomes available) **without** a full browser reload.
4. Verify client-side state (scroll position, active filters) is preserved after the refresh.

Unit test: `TZ=UTC yarn test apps/web/modules/feature-opt-in/hooks/useFeatureOptInBanner.test.ts`

## Human Review Checklist

- [ ] Confirm that making `onOptInSuccess` required (rather than optional) is the desired contract — every future consumer of `useFeatureOptInBanner` must provide this callback
- [ ] Consider whether other pages consuming `useFeatureOptInBanner` should also wire up `onOptInSuccess` with `router.refresh()`

---

Link to Devin run: https://app.devin.ai/sessions/8ab178f5789541b2ba241659860a09b0
Requested by: @eunjae-lee