### PR TITLE
fix: 27868-multiple-taost-rendering fixed

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -642,7 +642,7 @@ export const InfiniteEventTypeList = ({
                                     variant="icon"
                                     StartIcon="link"
                                     onClick={() => {
-                                      showToast(t("link_copied"), "success");
+                                      showToast(t("link_copied"), "success", { id: "link-copied" });
                                       copyToClipboard(calLink);
                                     }}
                                   />
@@ -655,7 +655,7 @@ export const InfiniteEventTypeList = ({
                                       variant="icon"
                                       StartIcon="venetian-mask"
                                       onClick={() => {
-                                        showToast(t("private_link_copied"), "success");
+                                        showToast(t("private_link_copied"), "success", { id: "private-link-copied" });
                                         copyToClipboard(placeholderHashedLink);
                                         setPrivateLinkCopyIndices((prev) => {
                                           const prevIndex = prev[type.slug] ?? 0;
@@ -771,7 +771,7 @@ export const InfiniteEventTypeList = ({
                                   data-testid={`event-type-duplicate-${type.id}`}
                                   onClick={() => {
                                     navigator.clipboard.writeText(calLink);
-                                    showToast(t("link_copied"), "success");
+                                    showToast(t("link_copied"), "success", { id: "link-copied" });
                                   }}
                                   StartIcon="clipboard"
                                   className="w-full rounded-none text-left">
@@ -793,8 +793,8 @@ export const InfiniteEventTypeList = ({
                                       }),
                                       url: calLink,
                                     })
-                                    .then(() => showToast(t("link_shared"), "success"))
-                                    .catch(() => showToast(t("failed"), "error"));
+                                    .then(() => showToast(t("link_shared"), "success", { id: "link-shared" }))
+                                    .catch(() => showToast(t("failed"), "error", { id: "link-share-failed" }));
                                 }}
                                 StartIcon="upload"
                                 className="w-full rounded-none">


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where triggering the same toast-producing action repeatedly (e.g., clicking "Copy Link" multiple times) caused duplicate toasts to stack on top of each other. 

By adding a unique `id` to the [showToast](cci:1://file:///c:/Users/YASHVI%20SAINI/Desktop/opensource/cal.com/packages/ui/components/toast/showToast.tsx:76:0-100:1) calls for copy and share actions, the toast notification now updates (upserts) the existing one instead of spawning a new instance. This reduces visual clutter and provides a better user experience.

- Fixes #27868
- Fixes CAL-7196

## Visual Demo (For contributors especially)

| Before | After |
| :---: | :---: |
| *(Multiple toasts stacking)* | *(Single toast updating)* |
| <!-- Add screenshot/video here --> | <!-- Add screenshot/video here --> |
<img width="1412" height="940" alt="Screenshot 2026-02-11 195947" src="https://github.com/user-attachments/assets/a102f23e-1c32-4554-a539-18d1cce33ae4" />
<img width="1134" height="930" alt="Screenshot 2026-02-11 204219" src="https://github.com/user-attachments/assets/d931ec60-a5cb-4992-89ad-bae5f0b0de61" />


## Mandatory Tasks 


- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - (Documentation change not required)
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to the **Event Types** page.
2. Find an event type and click the **Copy Link** icon (chain link) multiple times rapidly.
   - **Expected**: A single "Link copied" toast appears and stays on screen (timer resets), without stacking.
3. (Optional) Enable "Private Link" for an event type and click the **Copy Private Link** icon multiple times.
   - **Expected**: Single "Private link copied" toast.
4. (Optional) On mobile view, click the **Share** option in the dropdown menu.
   - **Expected**: Verify single toast behavior for share actions.

