### PR TITLE
chore(deps): resolve fast-xml-parser to 5.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
     "min-document": "2.19.1",
     "tar": "7.5.7",
     "lodash": "4.17.23",
-    "lodash-es": "4.17.23"
+    "lodash-es": "4.17.23",
+    "@lingo.dev/_compiler/fast-xml-parser": "5.3.4"
   },
   "packageExtensions": {
     "ink@3.2.0": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22683,14 +22683,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.3.2":
-  version: 5.3.2
-  resolution: "fast-xml-parser@npm:5.3.2"
+"fast-xml-parser@npm:5.3.4":
+  version: 5.3.4
+  resolution: "fast-xml-parser@npm:5.3.4"
   dependencies:
     strnum: "npm:^2.1.0"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10/8157045ebb1709696729f75c5a1d31e1224df73d51300dadd2468224b9ffdc3197615712affee4578889534ed47d6344545765a0d63b3151749dd427b68b70da
+  checksum: 10/0d7e6872fed7c3065641400d43cdf24c03177f05c343bfb31df53b79f0900b085c103f647852d0b00693125aa3f0e9d8b8cfc4273b168d4da0308f857dafe830
   languageName: node
   linkType: hard
 
@@ -36293,9 +36293,9 @@ __metadata:
   linkType: hard
 
 "strnum@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "strnum@npm:1.0.5"
-  checksum: 10/d3117975db8372d4d7b2c07601ed2f65bf21cc48d741f37a8617b76370d228f2ec26336e53791ebc3638264d23ca54e6c241f57f8c69bd4941c63c79440525ca
+  version: 1.1.2
+  resolution: "strnum@npm:1.1.2"
+  checksum: 10/ccd6297a1fdaf0fc8ea0ea904acdae76878d49a4b0d98a70155df4bc081fd88eac5ec99fb150f3d1d1af065c1898d38420705259ba6c39aa850c671bcd54e35d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

Resolves `fast-xml-parser` to latest patch version for `@lingo.dev/_compiler`.

### Changes

| Package | From | To | Scope |
|---------|------|----|-------|
| `fast-xml-parser` | 5.3.2 | 5.3.4 | `@lingo.dev/_compiler` |

### Notes

- Patch version update
- Transitive dependency via `@lingo.dev/_compiler` (used by lingo.dev SDK)
- Scoped resolution to avoid affecting `@aws-sdk/core` which uses 4.4.1

## How should this be tested?

1. `yarn install` completes without errors
2. CI/CD pipeline validates build

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a documentation
change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.