### PR TITLE
fix: prevent duplicate toast stacking by using message as default id

### DIFF
--- a/packages/ui/components/toast/showToast.tsx
+++ b/packages/ui/components/toast/showToast.tsx
@@ -80,6 +80,10 @@ export function showToast(
   options: number | ExternalToast = TOAST_VISIBLE_DURATION
 ) {
   const _options: ExternalToast = typeof options === "number" ? { duration: options } : options;
+
+  // Use message as default ID to prevent duplicate toasts with same content
+  if (!_options.id) _options.id = message;
+
   if (!_options.duration) _options.duration = TOAST_VISIBLE_DURATION;
   if (!_options.position) _options.position = "bottom-center";
 


### PR DESCRIPTION
Fixes #27868.

This PR implements a global fix in the showToast utility by using the toast message as the default id. This ensures that identical toasts (e.g., from multiple clicks on a 'Copy' button) refresh the existing toast rather than stacking vertically, improving UX across the app.