### PR TITLE
fix(form-builder): correct value of selection box behavior in Edit of new Added Question dialog

### DIFF
--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -593,6 +593,7 @@ function FieldEditDialog({
     //resolver: zodResolver(fieldSchema),
   });
   const formFieldType = fieldForm.getValues("type");
+  
 
   useEffect(() => {
     if (!formFieldType) {
@@ -614,6 +615,7 @@ function FieldEditDialog({
   const variantsConfig = fieldForm.watch("variantsConfig");
 
   const fieldTypes = Object.values(fieldTypesConfigMap);
+
 
   return (
     <Dialog open={dialog.isOpen} onOpenChange={onOpenChange} modal={false}>
@@ -645,7 +647,8 @@ function FieldEditDialog({
                 }
                 fieldForm.setValue("type", value, { shouldDirty: true });
               }}
-              value={dialog.data ? getLocationFieldType(dialog.data) : fieldTypesConfigMap[formFieldType]}
+              value={fieldTypesConfigMap[formFieldType]}
+              // value="Hello World"
               options={fieldTypes.filter((f) => !f.systemOnly)}
               label={t("input_type")}
             />

--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -433,7 +433,7 @@ function Options({
   label = "Options",
   value,
 
-  onChange = () => {},
+  onChange = () => { },
   className = "",
   readOnly = false,
   showPrice = false,
@@ -593,7 +593,6 @@ function FieldEditDialog({
     //resolver: zodResolver(fieldSchema),
   });
   const formFieldType = fieldForm.getValues("type");
-  
 
   useEffect(() => {
     if (!formFieldType) {
@@ -615,7 +614,6 @@ function FieldEditDialog({
   const variantsConfig = fieldForm.watch("variantsConfig");
 
   const fieldTypes = Object.values(fieldTypesConfigMap);
-
 
   return (
     <Dialog open={dialog.isOpen} onOpenChange={onOpenChange} modal={false}>
@@ -1010,11 +1008,11 @@ function VariantFields({
           const rhfVariantFieldPrefix = `variantsConfig.variants.${variantName}.fields.${index}` as const;
           const fieldTypeConfigVariants =
             fieldTypeConfigVariantsConfig.variants[
-              variantName as keyof typeof fieldTypeConfigVariantsConfig.variants
+            variantName as keyof typeof fieldTypeConfigVariantsConfig.variants
             ];
           const appUiFieldConfig =
             fieldTypeConfigVariants.fieldsMap[f.name as keyof typeof fieldTypeConfigVariants.fieldsMap];
-            
+
           return (
             <li className={classNames(!isSimpleVariant ? "p-4" : "")} key={f.name}>
               {!isSimpleVariant && (

--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -648,7 +648,6 @@ function FieldEditDialog({
                 fieldForm.setValue("type", value, { shouldDirty: true });
               }}
               value={fieldTypesConfigMap[formFieldType]}
-              // value="Hello World"
               options={fieldTypes.filter((f) => !f.systemOnly)}
               label={t("input_type")}
             />


### PR DESCRIPTION
## What does this PR do?

Inside Event Edit → Advanced → Add Question → Edit Question , changing the values from the selection dropdown did not update the displayed value correctly. When users selected a different option, the UI continued showing the previous value because the onChange handler and the rendered value were referencing different sources.

- Fixes #27889
- Fixes [CAL-7200](https://linear.app/calcom/issue/CAL-7200/input-type-selection-not-updating-correctly-in-add-question-advanced)


#### Video Demo (Before):

https://github.com/user-attachments/assets/7e768a9d-c4ee-4311-adfe-0d77cac1dc8b

#### Video Demo (After):

https://github.com/user-attachments/assets/ad436797-8229-4e2e-89fb-cb999be7db4c


- UI behavior fix only.
- No backend or data structure changes.

## Mandatory Tasks 

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.






