### PR TITLE
fix: pass both bookingLimits and durationLimits to getStartEndDateforLimitCheck

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -681,12 +681,13 @@ export class UserAvailabilityService {
     const { bookingLimits, durationLimits } = await this.parseLimits(eventType);
 
     let busyTimesFromLimitsBookings: EventBusyDetails[] = [];
-    if (!initialData?.busyTimesFromLimitsBookings && eventType) {
+    if (!initialData?.busyTimesFromLimitsBookings && eventType && (bookingLimits || durationLimits)) {
       const busyTimesService = getBusyTimesService();
       const { limitDateFrom, limitDateTo } = busyTimesService.getStartEndDateforLimitCheck(
         dateFrom.toISOString(),
         dateTo.toISOString(),
-        bookingLimits || durationLimits
+        bookingLimits,
+        durationLimits
       );
 
       // For team events with booking/duration limits, fetch bookings for all team members

--- a/packages/features/availability/lib/getUserAvailabilityIncludingBusyTimesFromLimits.test.ts
+++ b/packages/features/availability/lib/getUserAvailabilityIncludingBusyTimesFromLimits.test.ts
@@ -1,7 +1,7 @@
 import dayjs from "@calcom/dayjs";
 import type { EventBusyDetails } from "@calcom/types/Calendar";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { GetUserAvailabilityInitialData } from "./getUserAvailability";
+import type { EventType, GetUserAvailabilityInitialData } from "./getUserAvailability";
 import { UserAvailabilityService } from "./getUserAvailability";
 
 vi.mock("@calcom/features/di/containers/BusyTimes", () => ({
@@ -32,24 +32,34 @@ const mockBusyTimesService = {
   getBusyTimes: vi.fn().mockResolvedValue([]),
 };
 
-const mockDependencies = {
+const mockDependencies: ConstructorParameters<typeof UserAvailabilityService>[0] = {
   oooRepo: {
     findUserOOODays: vi.fn().mockResolvedValue([]),
-  } as never,
-  bookingRepo: {} as never,
+  },
+  bookingRepo: {
+    findAcceptedBookingByEventTypeId: vi.fn().mockResolvedValue([]),
+  },
   redisClient: {
     get: vi.fn().mockResolvedValue(null),
     set: vi.fn(),
-  } as never,
+  },
   eventTypeRepo: {
     findByIdForUserAvailability: vi.fn().mockResolvedValue(null),
-  } as never,
+    findForSlots: vi.fn().mockResolvedValue(null),
+  },
   holidayRepo: {
     findUserSettingsSelect: vi.fn().mockResolvedValue(null),
-  } as never,
+  },
 };
 
-const createMockUser = (overrides?: Partial<NonNullable<GetUserAvailabilityInitialData["user"]>>) => ({
+const DATE_FROM = "2025-01-06T00:00:00Z";
+const DATE_TO = "2025-01-10T23:59:59Z";
+const DATE_FROM_ISO = "2025-01-06T00:00:00.000Z";
+const DATE_TO_ISO = "2025-01-10T23:59:59.000Z";
+
+const createMockUser = (
+  overrides?: Partial<NonNullable<GetUserAvailabilityInitialData["user"]>>
+): NonNullable<GetUserAvailabilityInitialData["user"]> => ({
   id: 1,
   username: "testuser",
   email: "test@example.com",
@@ -91,10 +101,8 @@ const createMockUser = (overrides?: Partial<NonNullable<GetUserAvailabilityIniti
   ...overrides,
 });
 
-const createMockEventType = (overrides?: Record<string, unknown>) => ({
+const createMockEventType = (overrides?: Partial<NonNullable<EventType>>): NonNullable<EventType> => ({
   id: 100,
-  slug: "test-event",
-  title: "Test Event",
   length: 30,
   seatsPerTimeSlot: null,
   timeZone: null,
@@ -108,12 +116,13 @@ const createMockEventType = (overrides?: Record<string, unknown>) => ({
   team: null,
   parent: null,
   schedulingType: null,
+  assignAllTeamMembers: false,
   ...overrides,
 });
 
 const createParams = (overrides?: Record<string, unknown>) => ({
-  dateFrom: dayjs("2025-01-06T00:00:00Z"),
-  dateTo: dayjs("2025-01-10T23:59:59Z"),
+  dateFrom: dayjs(DATE_FROM),
+  dateTo: dayjs(DATE_TO),
   returnDateOverrides: false,
   ...overrides,
 });
@@ -139,7 +148,7 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
 
     const result = await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
       user,
-      eventType: eventType as never,
+      eventType,
       busyTimesFromLimitsBookings: existingBusyTimes,
     });
 
@@ -148,67 +157,86 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
     expect(result.busy).toBeDefined();
   });
 
-  it("fetches busy times from limits when eventType has booking limits and no initialData busyTimesFromLimitsBookings", async () => {
+  it("fetches busy times when eventType has booking limits", async () => {
     const user = createMockUser();
     const eventType = createMockEventType({ bookingLimits: { PER_DAY: 3 } });
 
     await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams({ eventTypeId: 100 }), {
       user,
-      eventType: eventType as never,
+      eventType,
     });
 
     expect(mockBusyTimesService.getStartEndDateforLimitCheck).toHaveBeenCalledWith(
-      "2025-01-06T00:00:00.000Z",
-      "2025-01-10T23:59:59.000Z",
-      expect.objectContaining({ PER_DAY: 3 })
+      DATE_FROM_ISO,
+      DATE_TO_ISO,
+      { PER_DAY: 3 },
+      null
     );
     expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
       expect.objectContaining({
-        userIds: [user.id],
+        userIds: [1],
         eventTypeId: 100,
-        bookingLimits: expect.objectContaining({ PER_DAY: 3 }),
+        bookingLimits: { PER_DAY: 3 },
+        durationLimits: null,
       })
     );
   });
 
-  it("fetches busy times from limits when eventType has duration limits", async () => {
+  it("fetches busy times when eventType has duration limits", async () => {
     const user = createMockUser();
     const eventType = createMockEventType({ durationLimits: { PER_WEEK: 120 } });
 
     await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
       user,
-      eventType: eventType as never,
+      eventType,
     });
 
     expect(mockBusyTimesService.getStartEndDateforLimitCheck).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      expect.objectContaining({ PER_WEEK: 120 })
+      DATE_FROM_ISO,
+      DATE_TO_ISO,
+      null,
+      { PER_WEEK: 120 }
     );
     expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
       expect.objectContaining({
-        userIds: [user.id],
-        durationLimits: expect.objectContaining({ PER_WEEK: 120 }),
+        userIds: [1],
+        bookingLimits: null,
+        durationLimits: { PER_WEEK: 120 },
       })
     );
   });
 
-  it("still calls getBusyTimesForLimitChecks when eventType exists but has no limits", async () => {
+  it("passes both bookingLimits and durationLimits separately to getStartEndDateforLimitCheck", async () => {
+    const user = createMockUser();
+    const eventType = createMockEventType({
+      bookingLimits: { PER_DAY: 3 },
+      durationLimits: { PER_WEEK: 120 },
+    });
+
+    await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
+      user,
+      eventType,
+    });
+
+    expect(mockBusyTimesService.getStartEndDateforLimitCheck).toHaveBeenCalledWith(
+      DATE_FROM_ISO,
+      DATE_TO_ISO,
+      { PER_DAY: 3 },
+      { PER_WEEK: 120 }
+    );
+  });
+
+  it("skips fetching limit busy times when eventType has no limits", async () => {
     const user = createMockUser();
     const eventType = createMockEventType();
 
     await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
       user,
-      eventType: eventType as never,
+      eventType,
     });
 
-    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
-      expect.objectContaining({
-        bookingLimits: null,
-        durationLimits: null,
-        eventTypeId: 100,
-      })
-    );
+    expect(mockBusyTimesService.getStartEndDateforLimitCheck).not.toHaveBeenCalled();
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).not.toHaveBeenCalled();
   });
 
   it("skips fetching limit busy times when no eventType exists", async () => {
@@ -225,12 +253,16 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
     const user = createMockUser();
     const eventType = createMockEventType({
       bookingLimits: { PER_DAY: 5 },
-      hosts: [{ user: { id: 1 } }, { user: { id: 2 } }, { user: { id: 3 } }],
+      hosts: [
+        { user: { id: 1, email: "host1@test.com" }, schedule: null },
+        { user: { id: 2, email: "host2@test.com" }, schedule: null },
+        { user: { id: 3, email: "host3@test.com" }, schedule: null },
+      ],
     });
 
     await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
       user,
-      eventType: eventType as never,
+      eventType,
     });
 
     expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
@@ -249,7 +281,7 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
 
     await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
       user,
-      eventType: eventType as never,
+      eventType,
     });
 
     expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
@@ -263,7 +295,9 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
     const user = createMockUser();
     const fetchedEventType = createMockEventType({ bookingLimits: { PER_DAY: 1 } });
 
-    mockDependencies.eventTypeRepo.findByIdForUserAvailability.mockResolvedValueOnce(fetchedEventType);
+    vi.mocked(mockDependencies.eventTypeRepo.findByIdForUserAvailability).mockResolvedValueOnce(
+      fetchedEventType
+    );
 
     await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams({ eventTypeId: 100 }), {
       user,
@@ -273,7 +307,7 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
     expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
       expect.objectContaining({
         eventTypeId: 100,
-        bookingLimits: expect.objectContaining({ PER_DAY: 1 }),
+        bookingLimits: { PER_DAY: 1 },
       })
     );
   });
@@ -292,11 +326,11 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
 
     mockBusyTimesService.getBusyTimesForLimitChecks.mockResolvedValueOnce(fetchedBusyTimes);
 
-    const getUserAvailabilitySpy = vi.spyOn(service, "_getUserAvailability" as never);
+    const getUserAvailabilitySpy = vi.spyOn(service, "_getUserAvailability" as keyof typeof service);
 
     await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
       user,
-      eventType: eventType as never,
+      eventType,
     });
 
     expect(getUserAvailabilitySpy).toHaveBeenCalledWith(
@@ -313,7 +347,7 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
 
     await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
       user,
-      eventType: eventType as never,
+      eventType,
       rescheduleUid: "reschedule-uid-123",
     });
 

--- a/packages/features/availability/lib/getUserAvailabilityIncludingBusyTimesFromLimits.test.ts
+++ b/packages/features/availability/lib/getUserAvailabilityIncludingBusyTimesFromLimits.test.ts
@@ -1,0 +1,326 @@
+import dayjs from "@calcom/dayjs";
+import type { EventBusyDetails } from "@calcom/types/Calendar";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GetUserAvailabilityInitialData } from "./getUserAvailability";
+import { UserAvailabilityService } from "./getUserAvailability";
+
+vi.mock("@calcom/features/di/containers/BusyTimes", () => ({
+  getBusyTimesService: vi.fn(() => mockBusyTimesService),
+}));
+
+vi.mock("@calcom/features/busyTimes/lib/getBusyTimesFromLimits", () => ({
+  getBusyTimesFromLimits: vi.fn().mockResolvedValue([]),
+  getBusyTimesFromTeamLimits: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@calcom/app-store/_utils/getCalendar", () => ({
+  getCalendar: vi.fn(),
+}));
+
+vi.mock("@calcom/lib/holidays", () => ({
+  getHolidayService: vi.fn(() => ({
+    getHolidayDatesInRange: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+const mockBusyTimesService = {
+  getStartEndDateforLimitCheck: vi.fn().mockReturnValue({
+    limitDateFrom: dayjs("2025-01-01T00:00:00Z"),
+    limitDateTo: dayjs("2025-01-31T23:59:59Z"),
+  }),
+  getBusyTimesForLimitChecks: vi.fn().mockResolvedValue([]),
+  getBusyTimes: vi.fn().mockResolvedValue([]),
+};
+
+const mockDependencies = {
+  oooRepo: {
+    findUserOOODays: vi.fn().mockResolvedValue([]),
+  } as never,
+  bookingRepo: {} as never,
+  redisClient: {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn(),
+  } as never,
+  eventTypeRepo: {
+    findByIdForUserAvailability: vi.fn().mockResolvedValue(null),
+  } as never,
+  holidayRepo: {
+    findUserSettingsSelect: vi.fn().mockResolvedValue(null),
+  } as never,
+};
+
+const createMockUser = (overrides?: Partial<NonNullable<GetUserAvailabilityInitialData["user"]>>) => ({
+  id: 1,
+  username: "testuser",
+  email: "test@example.com",
+  bufferTime: 0,
+  timeZone: "UTC",
+  availability: [
+    {
+      id: 1,
+      userId: 1,
+      eventTypeId: null,
+      scheduleId: 1,
+      days: [1, 2, 3, 4, 5],
+      startTime: new Date("1970-01-01T09:00:00Z"),
+      endTime: new Date("1970-01-01T17:00:00Z"),
+      date: null,
+    },
+  ],
+  timeFormat: 12,
+  defaultScheduleId: 1,
+  isPlatformManaged: false,
+  schedules: [
+    {
+      id: 1,
+      availability: [
+        {
+          days: [1, 2, 3, 4, 5],
+          startTime: new Date("1970-01-01T09:00:00Z"),
+          endTime: new Date("1970-01-01T17:00:00Z"),
+          date: null,
+        },
+      ],
+      timeZone: "UTC",
+    },
+  ],
+  credentials: [],
+  allSelectedCalendars: [],
+  userLevelSelectedCalendars: [],
+  travelSchedules: [],
+  ...overrides,
+});
+
+const createMockEventType = (overrides?: Record<string, unknown>) => ({
+  id: 100,
+  slug: "test-event",
+  title: "Test Event",
+  length: 30,
+  seatsPerTimeSlot: null,
+  timeZone: null,
+  schedule: null,
+  availability: [],
+  hosts: [],
+  bookingLimits: null,
+  durationLimits: null,
+  metadata: null,
+  useEventLevelSelectedCalendars: false,
+  team: null,
+  parent: null,
+  schedulingType: null,
+  ...overrides,
+});
+
+const createParams = (overrides?: Record<string, unknown>) => ({
+  dateFrom: dayjs("2025-01-06T00:00:00Z"),
+  dateTo: dayjs("2025-01-10T23:59:59Z"),
+  returnDateOverrides: false,
+  ...overrides,
+});
+
+describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimits", () => {
+  let service: UserAvailabilityService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new UserAvailabilityService(mockDependencies);
+  });
+
+  it("skips fetching limit busy times when busyTimesFromLimitsBookings is already in initialData", async () => {
+    const user = createMockUser();
+    const eventType = createMockEventType({ bookingLimits: { PER_DAY: 3 } });
+    const existingBusyTimes: EventBusyDetails[] = [
+      {
+        start: "2025-01-06T10:00:00Z",
+        end: "2025-01-06T23:59:59Z",
+        source: "Event Booking Limit",
+      },
+    ];
+
+    const result = await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
+      user,
+      eventType: eventType as never,
+      busyTimesFromLimitsBookings: existingBusyTimes,
+    });
+
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).not.toHaveBeenCalled();
+    expect(result).toBeDefined();
+    expect(result.busy).toBeDefined();
+  });
+
+  it("fetches busy times from limits when eventType has booking limits and no initialData busyTimesFromLimitsBookings", async () => {
+    const user = createMockUser();
+    const eventType = createMockEventType({ bookingLimits: { PER_DAY: 3 } });
+
+    await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams({ eventTypeId: 100 }), {
+      user,
+      eventType: eventType as never,
+    });
+
+    expect(mockBusyTimesService.getStartEndDateforLimitCheck).toHaveBeenCalledWith(
+      "2025-01-06T00:00:00.000Z",
+      "2025-01-10T23:59:59.000Z",
+      expect.objectContaining({ PER_DAY: 3 })
+    );
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userIds: [user.id],
+        eventTypeId: 100,
+        bookingLimits: expect.objectContaining({ PER_DAY: 3 }),
+      })
+    );
+  });
+
+  it("fetches busy times from limits when eventType has duration limits", async () => {
+    const user = createMockUser();
+    const eventType = createMockEventType({ durationLimits: { PER_WEEK: 120 } });
+
+    await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
+      user,
+      eventType: eventType as never,
+    });
+
+    expect(mockBusyTimesService.getStartEndDateforLimitCheck).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ PER_WEEK: 120 })
+    );
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userIds: [user.id],
+        durationLimits: expect.objectContaining({ PER_WEEK: 120 }),
+      })
+    );
+  });
+
+  it("still calls getBusyTimesForLimitChecks when eventType exists but has no limits", async () => {
+    const user = createMockUser();
+    const eventType = createMockEventType();
+
+    await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
+      user,
+      eventType: eventType as never,
+    });
+
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bookingLimits: null,
+        durationLimits: null,
+        eventTypeId: 100,
+      })
+    );
+  });
+
+  it("skips fetching limit busy times when no eventType exists", async () => {
+    const user = createMockUser();
+
+    await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
+      user,
+    });
+
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).not.toHaveBeenCalled();
+  });
+
+  it("uses host user IDs for team events with booking limits", async () => {
+    const user = createMockUser();
+    const eventType = createMockEventType({
+      bookingLimits: { PER_DAY: 5 },
+      hosts: [{ user: { id: 1 } }, { user: { id: 2 } }, { user: { id: 3 } }],
+    });
+
+    await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
+      user,
+      eventType: eventType as never,
+    });
+
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userIds: [1, 2, 3],
+      })
+    );
+  });
+
+  it("uses only the user ID for solo events with booking limits", async () => {
+    const user = createMockUser({ id: 42 });
+    const eventType = createMockEventType({
+      bookingLimits: { PER_DAY: 2 },
+      hosts: [],
+    });
+
+    await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
+      user,
+      eventType: eventType as never,
+    });
+
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userIds: [42],
+      })
+    );
+  });
+
+  it("fetches eventType by eventTypeId when not provided in initialData", async () => {
+    const user = createMockUser();
+    const fetchedEventType = createMockEventType({ bookingLimits: { PER_DAY: 1 } });
+
+    mockDependencies.eventTypeRepo.findByIdForUserAvailability.mockResolvedValueOnce(fetchedEventType);
+
+    await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams({ eventTypeId: 100 }), {
+      user,
+    });
+
+    expect(mockDependencies.eventTypeRepo.findByIdForUserAvailability).toHaveBeenCalledWith({ id: 100 });
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventTypeId: 100,
+        bookingLimits: expect.objectContaining({ PER_DAY: 1 }),
+      })
+    );
+  });
+
+  it("passes fetched busyTimesFromLimitsBookings to _getUserAvailability", async () => {
+    const user = createMockUser();
+    const eventType = createMockEventType({ bookingLimits: { PER_DAY: 3 } });
+    const fetchedBusyTimes: EventBusyDetails[] = [
+      {
+        start: "2025-01-06T09:00:00Z",
+        end: "2025-01-06T10:00:00Z",
+        source: "eventType-100-booking-1",
+        title: "Test Booking",
+      },
+    ];
+
+    mockBusyTimesService.getBusyTimesForLimitChecks.mockResolvedValueOnce(fetchedBusyTimes);
+
+    const getUserAvailabilitySpy = vi.spyOn(service, "_getUserAvailability" as never);
+
+    await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
+      user,
+      eventType: eventType as never,
+    });
+
+    expect(getUserAvailabilitySpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        busyTimesFromLimitsBookings: fetchedBusyTimes,
+      })
+    );
+  });
+
+  it("passes rescheduleUid to getBusyTimesForLimitChecks when provided", async () => {
+    const user = createMockUser();
+    const eventType = createMockEventType({ bookingLimits: { PER_DAY: 3 } });
+
+    await service.getUserAvailabilityIncludingBusyTimesFromLimits(createParams(), {
+      user,
+      eventType: eventType as never,
+      rescheduleUid: "reschedule-uid-123",
+    });
+
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rescheduleUid: "reschedule-uid-123",
+      })
+    );
+  });
+});

--- a/packages/features/availability/lib/getUserAvailabilityIncludingBusyTimesFromLimits.test.ts
+++ b/packages/features/availability/lib/getUserAvailabilityIncludingBusyTimesFromLimits.test.ts
@@ -56,6 +56,8 @@ const DATE_FROM = "2025-01-06T00:00:00Z";
 const DATE_TO = "2025-01-10T23:59:59Z";
 const DATE_FROM_ISO = "2025-01-06T00:00:00.000Z";
 const DATE_TO_ISO = "2025-01-10T23:59:59.000Z";
+const LIMIT_DATE_FROM_FORMATTED = "2025-01-01T00:00:00+00:00";
+const LIMIT_DATE_TO_FORMATTED = "2025-01-31T23:59:59+00:00";
 
 const createMockUser = (
   overrides?: Partial<NonNullable<GetUserAvailabilityInitialData["user"]>>
@@ -172,14 +174,15 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
       { PER_DAY: 3 },
       null
     );
-    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userIds: [1],
-        eventTypeId: 100,
-        bookingLimits: { PER_DAY: 3 },
-        durationLimits: null,
-      })
-    );
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith({
+      userIds: [1],
+      eventTypeId: 100,
+      startDate: LIMIT_DATE_FROM_FORMATTED,
+      endDate: LIMIT_DATE_TO_FORMATTED,
+      rescheduleUid: undefined,
+      bookingLimits: { PER_DAY: 3 },
+      durationLimits: null,
+    });
   });
 
   it("fetches busy times when eventType has duration limits", async () => {
@@ -197,13 +200,15 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
       null,
       { PER_WEEK: 120 }
     );
-    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userIds: [1],
-        bookingLimits: null,
-        durationLimits: { PER_WEEK: 120 },
-      })
-    );
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith({
+      userIds: [1],
+      eventTypeId: 100,
+      startDate: LIMIT_DATE_FROM_FORMATTED,
+      endDate: LIMIT_DATE_TO_FORMATTED,
+      rescheduleUid: undefined,
+      bookingLimits: null,
+      durationLimits: { PER_WEEK: 120 },
+    });
   });
 
   it("passes both bookingLimits and durationLimits separately to getStartEndDateforLimitCheck", async () => {
@@ -265,11 +270,15 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
       eventType,
     });
 
-    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userIds: [1, 2, 3],
-      })
-    );
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith({
+      userIds: [1, 2, 3],
+      eventTypeId: 100,
+      startDate: LIMIT_DATE_FROM_FORMATTED,
+      endDate: LIMIT_DATE_TO_FORMATTED,
+      rescheduleUid: undefined,
+      bookingLimits: { PER_DAY: 5 },
+      durationLimits: null,
+    });
   });
 
   it("uses only the user ID for solo events with booking limits", async () => {
@@ -284,11 +293,15 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
       eventType,
     });
 
-    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userIds: [42],
-      })
-    );
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith({
+      userIds: [42],
+      eventTypeId: 100,
+      startDate: LIMIT_DATE_FROM_FORMATTED,
+      endDate: LIMIT_DATE_TO_FORMATTED,
+      rescheduleUid: undefined,
+      bookingLimits: { PER_DAY: 2 },
+      durationLimits: null,
+    });
   });
 
   it("fetches eventType by eventTypeId when not provided in initialData", async () => {
@@ -304,12 +317,15 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
     });
 
     expect(mockDependencies.eventTypeRepo.findByIdForUserAvailability).toHaveBeenCalledWith({ id: 100 });
-    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
-      expect.objectContaining({
-        eventTypeId: 100,
-        bookingLimits: { PER_DAY: 1 },
-      })
-    );
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith({
+      userIds: [1],
+      eventTypeId: 100,
+      startDate: LIMIT_DATE_FROM_FORMATTED,
+      endDate: LIMIT_DATE_TO_FORMATTED,
+      rescheduleUid: undefined,
+      bookingLimits: { PER_DAY: 1 },
+      durationLimits: null,
+    });
   });
 
   it("passes fetched busyTimesFromLimitsBookings to _getUserAvailability", async () => {
@@ -334,10 +350,12 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
     });
 
     expect(getUserAvailabilitySpy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
+      createParams(),
+      {
+        user,
+        eventType,
         busyTimesFromLimitsBookings: fetchedBusyTimes,
-      })
+      }
     );
   });
 
@@ -351,10 +369,14 @@ describe("UserAvailabilityService.getUserAvailabilityIncludingBusyTimesFromLimit
       rescheduleUid: "reschedule-uid-123",
     });
 
-    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rescheduleUid: "reschedule-uid-123",
-      })
-    );
+    expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith({
+      userIds: [1],
+      eventTypeId: 100,
+      startDate: LIMIT_DATE_FROM_FORMATTED,
+      endDate: LIMIT_DATE_TO_FORMATTED,
+      rescheduleUid: "reschedule-uid-123",
+      bookingLimits: { PER_DAY: 3 },
+      durationLimits: null,
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `getUserAvailabilityIncludingBusyTimesFromLimits` and adds unit tests, as requested in [PR #27088 review comment](https://github.com/calcom/cal.com/pull/27088#discussion_r2797993125).

### Bug fix

`getStartEndDateforLimitCheck` accepts both `bookingLimits` and `durationLimits` as separate parameters, but was being called with `bookingLimits || durationLimits` — a whole-object OR that loses date range expansion when both limits exist with different period keys (e.g. `bookingLimits = { PER_DAY: 3 }` and `durationLimits = { PER_WEEK: 120 }`). Fixed to pass both separately.

Also added a guard `(bookingLimits || durationLimits)` to skip calling `getStartEndDateforLimitCheck` and `getBusyTimesForLimitChecks` entirely when the eventType has no limits, avoiding unnecessary overhead.

### Test coverage (11 tests)

- **InitialData passthrough**: Skips fetching when `busyTimesFromLimitsBookings` already provided
- **Booking limits**: Fetches limit busy times when `bookingLimits` is set
- **Duration limits**: Fetches limit busy times when `durationLimits` is set
- **Both limits**: Verifies both `bookingLimits` and `durationLimits` are passed separately to `getStartEndDateforLimitCheck`
- **No limits on eventType**: Verifies limit fetching is skipped when eventType has no limits
- **No eventType**: Skips limit fetching entirely
- **Team events**: Uses all host user IDs for limit checks
- **Solo events**: Uses only the current user's ID
- **EventType resolution**: Fetches eventType via `eventTypeId` when not in `initialData`
- **Data forwarding**: Verifies fetched busy times are passed to `_getUserAvailability`
- **Reschedule support**: Passes `rescheduleUid` through to the service

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — test-only change + minor bug fix.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

```bash
TZ=UTC yarn vitest run packages/features/availability/lib/getUserAvailabilityIncludingBusyTimesFromLimits.test.ts
```

All 11 tests should pass.

## Human Review Checklist

- [ ] Verify the guard `(bookingLimits || durationLimits)` correctly handles `parseLimits` returning `null` for both — confirm no edge case where limits are present but parsed as falsy.
- [ ] The same `bookingLimits || durationLimits` pattern exists in `_getBusyTimesFromTeamLimits` (line 263-266) — consider whether that should also be fixed in a follow-up.
- [ ] Consider whether a test for the edge case where `eventTypeId` is provided but `getEventType` returns `null` (not found in DB) is needed.

**Link to Devin run**: https://app.devin.ai/sessions/1526e25f088b4a66a24a036a4c90e976
**Requested by**: @hariombalhara
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
