### PR TITLE
fix: update data-table hook imports missed in #27833 refactor

### DIFF
--- a/apps/web/modules/insights/components/routing/WrongAssignmentReportsDashboard.tsx
+++ b/apps/web/modules/insights/components/routing/WrongAssignmentReportsDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useDataTable, useFilterValue, ZSingleSelectFilterValue } from "@calcom/features/data-table";
+import { ZSingleSelectFilterValue } from "@calcom/features/data-table";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { WrongAssignmentReportStatus } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
@@ -30,6 +30,8 @@ import {
 import { useWrongAssignmentFacetedUniqueValues } from "@calcom/web/modules/insights/hooks/useWrongAssignmentFacetedUniqueValues";
 import { createColumnHelper, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
 import { useCallback, useMemo, useState } from "react";
+import { useDataTable } from "~/data-table/hooks/useDataTable";
+import { useFilterValue } from "~/data-table/hooks/useFilterValue";
 import { OrgTeamsFilter } from "../filters/OrgTeamsFilter";
 
 type TabType = "pending" | "handled";

--- a/apps/web/modules/insights/views/insights-wrong-routing-view.tsx
+++ b/apps/web/modules/insights/views/insights-wrong-routing-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DataTableProvider } from "@calcom/features/data-table/DataTableProvider";
+import { DataTableProvider } from "~/data-table/DataTableProvider";
 import { useSegments } from "~/data-table/hooks/useSegments";
 import { WrongAssignmentReportsDashboard } from "@calcom/web/modules/insights/components/routing";
 


### PR DESCRIPTION
## Summary
- Fix broken import of `useDataTable` and `useFilterValue` from `@calcom/features/data-table` in `WrongAssignmentReportsDashboard.tsx`
- These hooks were moved to `~/data-table/hooks/` in #27833 but this file was missed, causing a build error

## Test plan
- [ ] Verify `yarn build` passes without the "Export useFilterValue doesn't exist" error
- [ ] Verify the Wrong Assignment Reports dashboard renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)