### PR TITLE
feat: add UTM tracking to webhooks and API v2

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/repositories/bookings.repository.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/repositories/bookings.repository.ts
@@ -27,6 +27,7 @@ export class BookingsRepository_2024_08_13 {
         attendees: true,
         user: true,
         eventType: true,
+        tracking: true,
       },
     });
   }
@@ -46,6 +47,7 @@ export class BookingsRepository_2024_08_13 {
         },
         user: true,
         eventType: true,
+        tracking: true,
       },
     });
   }
@@ -103,6 +105,7 @@ export class BookingsRepository_2024_08_13 {
         attendees: true,
         user: true,
         eventType: true,
+        tracking: true,
       },
     });
   }
@@ -120,6 +123,7 @@ export class BookingsRepository_2024_08_13 {
         },
         user: true,
         eventType: true,
+        tracking: true,
       },
     });
   }
@@ -133,6 +137,7 @@ export class BookingsRepository_2024_08_13 {
         attendees: true,
         user: true,
         eventType: true,
+        tracking: true,
       },
     });
     if (!booking) {
@@ -159,6 +164,7 @@ export class BookingsRepository_2024_08_13 {
         },
         user: true,
         eventType: true,
+        tracking: true,
       },
     });
   }
@@ -180,6 +186,7 @@ export class BookingsRepository_2024_08_13 {
         attendees: true,
         user: true,
         eventType: true,
+        tracking: true,
       },
     });
   }

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/output.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/output.service.ts
@@ -83,6 +83,13 @@ type DatabaseBooking = Booking & {
   }[];
   user: DatabaseUser | null;
   createdAt: Date;
+  tracking?: {
+    utm_source: string | null;
+    utm_medium: string | null;
+    utm_campaign: string | null;
+    utm_term: string | null;
+    utm_content: string | null;
+  } | null;
 };
 
 type BookingWithUser = Booking & { user: DatabaseUser | null };
@@ -148,6 +155,15 @@ export class OutputBookingsService_2024_08_13 {
       icsUid: databaseBooking.iCalUID,
       rescheduledToUid,
       rescheduledByEmail,
+      tracking: databaseBooking.tracking
+        ? {
+            utmSource: databaseBooking.tracking.utm_source ?? undefined,
+            utmMedium: databaseBooking.tracking.utm_medium ?? undefined,
+            utmCampaign: databaseBooking.tracking.utm_campaign ?? undefined,
+            utmTerm: databaseBooking.tracking.utm_term ?? undefined,
+            utmContent: databaseBooking.tracking.utm_content ?? undefined,
+          }
+        : undefined,
     };
 
     const bookingTransformed = plainToClass(BookingOutput_2024_08_13, booking, { strategy: "excludeAll" });

--- a/packages/features/bookings/lib/getWebhookPayloadForBooking.ts
+++ b/packages/features/bookings/lib/getWebhookPayloadForBooking.ts
@@ -1,9 +1,12 @@
 import type { EventPayloadType, EventTypeInfo } from "@calcom/features/webhooks/lib/sendPayload";
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
+import type { Tracking } from "./handleNewBooking/types";
+
 export const getWebhookPayloadForBooking = ({
   booking,
   evt,
+  tracking,
 }: {
   booking: {
     eventType: {
@@ -20,6 +23,7 @@ export const getWebhookPayloadForBooking = ({
     userId: number | null;
   };
   evt: CalendarEvent;
+  tracking?: Tracking;
 }) => {
   const eventTypeInfo: EventTypeInfo = {
     eventTitle: booking.eventType?.title,
@@ -34,6 +38,11 @@ export const getWebhookPayloadForBooking = ({
     ...evt,
     ...eventTypeInfo,
     bookingId: booking.id,
+    ...(tracking?.utm_source && { utmSource: tracking.utm_source }),
+    ...(tracking?.utm_medium && { utmMedium: tracking.utm_medium }),
+    ...(tracking?.utm_campaign && { utmCampaign: tracking.utm_campaign }),
+    ...(tracking?.utm_term && { utmTerm: tracking.utm_term }),
+    ...(tracking?.utm_content && { utmContent: tracking.utm_content }),
   };
 
   return payload;

--- a/packages/features/bookings/lib/getWebhookPayloadForBooking.ts
+++ b/packages/features/bookings/lib/getWebhookPayloadForBooking.ts
@@ -1,6 +1,5 @@
 import type { EventPayloadType, EventTypeInfo } from "@calcom/features/webhooks/lib/sendPayload";
 import type { CalendarEvent } from "@calcom/types/Calendar";
-
 import type { Tracking } from "./handleNewBooking/types";
 
 export const getWebhookPayloadForBooking = ({

--- a/packages/features/bookings/lib/handleConfirmation.ts
+++ b/packages/features/bookings/lib/handleConfirmation.ts
@@ -570,6 +570,17 @@ export async function handleConfirmation(args: {
       length: eventType?.length,
     };
 
+    const trackingData = await prisma.tracking.findUnique({
+      where: { bookingId },
+      select: {
+        utm_source: true,
+        utm_medium: true,
+        utm_campaign: true,
+        utm_term: true,
+        utm_content: true,
+      },
+    });
+
     const payload: EventPayloadType = {
       ...evt,
       ...eventTypeInfo,
@@ -579,6 +590,11 @@ export async function handleConfirmation(args: {
       smsReminderNumber: booking.smsReminderNumber || undefined,
       metadata: meetingUrl ? { videoCallUrl: meetingUrl } : {},
       ...(platformClientParams ? platformClientParams : {}),
+      ...(trackingData?.utm_source && { utmSource: trackingData.utm_source }),
+      ...(trackingData?.utm_medium && { utmMedium: trackingData.utm_medium }),
+      ...(trackingData?.utm_campaign && { utmCampaign: trackingData.utm_campaign }),
+      ...(trackingData?.utm_term && { utmTerm: trackingData.utm_term }),
+      ...(trackingData?.utm_content && { utmContent: trackingData.utm_content }),
     };
 
     const promises = subscribersBookingCreated.map((sub) =>

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -2517,6 +2517,11 @@ async function handler(
     rescheduledBy: reqBody.rescheduledBy,
     location: webhookLocation,
     ...(assignmentReason ? { assignmentReason: [assignmentReason] } : {}),
+    ...(reqBody.tracking?.utm_source && { utmSource: reqBody.tracking.utm_source }),
+    ...(reqBody.tracking?.utm_medium && { utmMedium: reqBody.tracking.utm_medium }),
+    ...(reqBody.tracking?.utm_campaign && { utmCampaign: reqBody.tracking.utm_campaign }),
+    ...(reqBody.tracking?.utm_term && { utmTerm: reqBody.tracking.utm_term }),
+    ...(reqBody.tracking?.utm_content && { utmContent: reqBody.tracking.utm_content }),
   };
 
   if (bookingRequiresPayment) {

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -102,6 +102,11 @@ export type EventPayloadType = Omit<CalendarEvent, "assignmentReason"> &
       | { reasonEnum: string; reasonString: string }[]
       | { category: string; details?: string | null }
       | null;
+    utmSource?: string;
+    utmMedium?: string;
+    utmCampaign?: string;
+    utmTerm?: string;
+    utmContent?: string;
   };
 
 export type WebhookPayloadType =

--- a/packages/platform/types/bookings/2024-08-13/outputs/booking.output.ts
+++ b/packages/platform/types/bookings/2024-08-13/outputs/booking.output.ts
@@ -4,17 +4,16 @@ import {
   IsArray,
   IsBoolean,
   IsDateString,
+  IsEmail,
   IsEnum,
   IsInt,
   IsObject,
   IsOptional,
   IsString,
-  IsEmail,
   IsTimeZone,
   IsUrl,
   ValidateNested,
 } from "class-validator";
-
 import type { BookingLanguageType } from "../inputs/language";
 import { BookingLanguage } from "../inputs/language";
 
@@ -100,7 +99,11 @@ class BookingHost {
   @Expose()
   email!: string;
 
-  @ApiProperty({ type: String, example: "jane100@example.com", description: "Clean email for display purposes" })
+  @ApiProperty({
+    type: String,
+    example: "jane100@example.com",
+    description: "Clean email for display purposes",
+  })
   @IsString()
   @Expose()
   displayEmail!: string;
@@ -126,6 +129,38 @@ class EventType {
   @IsString()
   @Expose()
   slug!: string;
+}
+
+class BookingTracking {
+  @ApiPropertyOptional({ type: String, example: "google" })
+  @IsString()
+  @IsOptional()
+  @Expose()
+  utmSource?: string;
+
+  @ApiPropertyOptional({ type: String, example: "cpc" })
+  @IsString()
+  @IsOptional()
+  @Expose()
+  utmMedium?: string;
+
+  @ApiPropertyOptional({ type: String, example: "spring_sale" })
+  @IsString()
+  @IsOptional()
+  @Expose()
+  utmCampaign?: string;
+
+  @ApiPropertyOptional({ type: String, example: "scheduling" })
+  @IsString()
+  @IsOptional()
+  @Expose()
+  utmTerm?: string;
+
+  @ApiPropertyOptional({ type: String, example: "header_cta" })
+  @IsString()
+  @IsOptional()
+  @Expose()
+  utmContent?: string;
 }
 
 class BaseBookingOutput_2024_08_13 {
@@ -285,6 +320,16 @@ class BaseBookingOutput_2024_08_13 {
   @IsOptional()
   @Expose()
   icsUid?: string;
+
+  @ApiPropertyOptional({
+    type: BookingTracking,
+    description: "UTM tracking parameters captured during booking.",
+  })
+  @ValidateNested()
+  @Type(() => BookingTracking)
+  @IsOptional()
+  @Expose()
+  tracking?: BookingTracking;
 }
 
 export class BookingOutput_2024_08_13 extends BaseBookingOutput_2024_08_13 {
@@ -406,7 +451,11 @@ class ReassignedToDto {
   @Expose()
   email!: string;
 
-  @ApiProperty({ type: String, example: "john.doe@example.com", description: "Clean email for display purposes" })
+  @ApiProperty({
+    type: String,
+    example: "john.doe@example.com",
+    description: "Clean email for display purposes",
+  })
   @IsString()
   @Expose()
   displayEmail!: string;


### PR DESCRIPTION
## Summary
- Add UTM tracking fields (`utmSource`, `utmMedium`, `utmCampaign`, `utmTerm`, `utmContent`) to webhook payloads
- Add `tracking` object to API v2 booking responses
- UTM data is now exposed in `BOOKING_CREATED` webhooks and GET booking endpoints

## Test plan
- [ ] Create a booking with UTM parameters via the booker UI
- [ ] Verify webhook payload contains UTM fields
- [ ] Fetch booking via API v2 and verify tracking object is present
- [ ] Verify existing bookings without tracking return `tracking: undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)