### PR TITLE
fix: Trimmed License Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,38 +731,6 @@ Currently Vercel Pro Plan is required to be able to Deploy this application with
 
 See the [roadmap project](https://cal.com/roadmap) for a list of proposed features (and known issues). You can change the view to see planned tagged releases.
 
-<!-- LICENSE -->
-
-## License
-
-Cal.com, Inc. is a commercial open source company, which means some parts of this open source repository require a commercial license. The concept is called "Open Core" where the core technology (99%) is fully open source, licensed under [AGPLv3](https://opensource.org/license/agpl-v3) and the last 1% is covered under a commercial license (["/ee" Enterprise Edition](https://github.com/calcom/cal.com/tree/main/packages/features/ee)) which we believe is entirely relevant for larger organisations that require enterprise features. Enterprise features are built by the core engineering team of Cal.com, Inc. which is hired in full-time. Find their compensation on https://cal.com/open.
-
-> [!NOTE]
-> Our philosophy is simple, all "Singleplayer APIs" are open-source under AGPLv3. All commercial "Multiplayer APIs" are under a commercial license.
-
-|                                   | AGPLv3 | EE  |
-| --------------------------------- | ------ | --- |
-| Self-host for commercial purposes | ✅     | ✅  |
-| Clone privately                   | ✅     | ✅  |
-| Fork publicly                     | ✅     | ✅  |
-| Requires CLA                      | ✅     | ✅  |
-|  Official Support                 | ❌     | ✅  |
-| Derivative work privately         | ❌     | ✅  |
-|  SSO                              | ❌     | ✅  |
-| Admin Panel                       | ❌     | ✅  |
-| Impersonation                     | ❌     | ✅  |
-| Managed Event Types               | ❌     | ✅  |
-| Organizations                     | ❌     | ✅  |
-| Payments                          | ❌     | ✅  |
-| Platform                          | ❌     | ✅  |
-| Teams                             | ❌     | ✅  |
-| Users                             | ❌     | ✅  |
-| Video                             | ❌     | ✅  |
-| Workflows                         | ❌     | ✅  |
-
-> [!TIP]
-> We work closely with the community and always invite feedback about what should be open and what is fine to be commercial. This list is not set and stone and we have moved things from commercial to open in the past. Please open a [discussion](https://github.com/calcom/cal.com/discussions) if you feel like something is wrong.
-
 ## Repo Activity
 
 <img width="100%" src="https://repobeats.axiom.co/api/embed/6bfca2f20f39738048b6e70ca205efde46352c3d.svg" />
@@ -987,11 +955,18 @@ An example of good readme is [atoms readme](https://github.com/calcom/cal.com/bl
 1. Follow semantic versioning when using changesets.
 2. Mark breaking changes using `❗️Breaking change`
 
-<!-- LICENSE -->
-
 ## License
 
-Distributed under the [AGPLv3 License](https://github.com/calcom/cal.com/blob/main/LICENSE). See `LICENSE` for more information.
+Cal.com uses an open-core model: the core is open-source under [AGPLv3](https://opensource.org/license/agpl-v3), with optional [Enterprise Edition](https://github.com/calcom/cal.com/tree/main/packages/features/ee) features available under a commercial license. See the [LICENSE](https://github.com/calcom/cal.com/blob/main/LICENSE) file for details.
+
+| Feature | AGPLv3 | EE |
+| - | - | - |
+| Self-host for commercial purposes | ✅ | ✅ |
+| Clone privately | ✅ | ✅ |
+| Fork publicly | ✅ | ✅ |
+| Requires CLA | ✅ | ✅ |
+| Official support | ❌ | ✅ |
+| SSO, Admin Panel, Teams, Organizations | ❌ | ✅ |
 
 <!-- ACKNOWLEDGEMENTS -->
 

--- a/README.md
+++ b/README.md
@@ -731,6 +731,38 @@ Currently Vercel Pro Plan is required to be able to Deploy this application with
 
 See the [roadmap project](https://cal.com/roadmap) for a list of proposed features (and known issues). You can change the view to see planned tagged releases.
 
+<!-- LICENSE -->
+
+## License
+
+Cal.com, Inc. is a commercial open source company, which means some parts of this open source repository require a commercial license. The concept is called "Open Core" where the core technology (99%) is fully open source, licensed under [AGPLv3](https://opensource.org/license/agpl-v3) and the last 1% is covered under a commercial license (["/ee" Enterprise Edition](https://github.com/calcom/cal.com/tree/main/packages/features/ee)) which we believe is entirely relevant for larger organisations that require enterprise features. Enterprise features are built by the core engineering team of Cal.com, Inc. which is hired in full-time. Find their compensation on https://cal.com/open.
+
+> [!NOTE]
+> Our philosophy is simple, all "Singleplayer APIs" are open-source under AGPLv3. All commercial "Multiplayer APIs" are under a commercial license.
+
+|                                   | AGPLv3 | EE  |
+| --------------------------------- | ------ | --- |
+| Self-host for commercial purposes | ✅     | ✅  |
+| Clone privately                   | ✅     | ✅  |
+| Fork publicly                     | ✅     | ✅  |
+| Requires CLA                      | ✅     | ✅  |
+|  Official Support                 | ❌     | ✅  |
+| Derivative work privately         | ❌     | ✅  |
+|  SSO                              | ❌     | ✅  |
+| Admin Panel                       | ❌     | ✅  |
+| Impersonation                     | ❌     | ✅  |
+| Managed Event Types               | ❌     | ✅  |
+| Organizations                     | ❌     | ✅  |
+| Payments                          | ❌     | ✅  |
+| Platform                          | ❌     | ✅  |
+| Teams                             | ❌     | ✅  |
+| Users                             | ❌     | ✅  |
+| Video                             | ❌     | ✅  |
+| Workflows                         | ❌     | ✅  |
+
+> [!TIP]
+> We work closely with the community and always invite feedback about what should be open and what is fine to be commercial. This list is not set and stone and we have moved things from commercial to open in the past. Please open a [discussion](https://github.com/calcom/cal.com/discussions) if you feel like something is wrong.
+
 ## Repo Activity
 
 <img width="100%" src="https://repobeats.axiom.co/api/embed/6bfca2f20f39738048b6e70ca205efde46352c3d.svg" />
@@ -954,22 +986,6 @@ An example of good readme is [atoms readme](https://github.com/calcom/cal.com/bl
 
 1. Follow semantic versioning when using changesets.
 2. Mark breaking changes using `❗️Breaking change`
-
-## License
-
-Cal.com, Inc. is a commercial open source company, which means some parts of this open source repository require a commercial license. The concept is called "Open Core" where the core technology (99%) is fully open source, licensed under [AGPLv3](https://opensource.org/license/agpl-v3) and the last 1% is covered under a commercial license (["/ee" Enterprise Edition](https://github.com/calcom/cal.com/tree/main/packages/features/ee)) which we believe is entirely relevant for larger organisations that require enterprise features. Enterprise features are built by the core engineering team of Cal.com, Inc. which is hired in full-time. Find their compensation on https://cal.com/open.
-
-> [!NOTE]
-> Our philosophy is simple, all "Singleplayer APIs" are open-source under AGPLv3. All commercial "Multiplayer APIs" are under a commercial license.
-
-| Feature | AGPLv3 | EE |
-| - | - | - |
-| Self-host for commercial purposes | ✅ | ✅ |
-| Clone privately | ✅ | ✅ |
-| Fork publicly | ✅ | ✅ |
-| Requires CLA | ✅ | ✅ |
-| Official support | ❌ | ✅ |
-| SSO, Admin Panel, Teams, Organizations | ❌ | ✅ |
 
 <!-- ACKNOWLEDGEMENTS -->
 

--- a/README.md
+++ b/README.md
@@ -957,7 +957,10 @@ An example of good readme is [atoms readme](https://github.com/calcom/cal.com/bl
 
 ## License
 
-Cal.com uses an open-core model: the core is open-source under [AGPLv3](https://opensource.org/license/agpl-v3), with optional [Enterprise Edition](https://github.com/calcom/cal.com/tree/main/packages/features/ee) features available under a commercial license. See the [LICENSE](https://github.com/calcom/cal.com/blob/main/LICENSE) file for details.
+Cal.com, Inc. is a commercial open source company, which means some parts of this open source repository require a commercial license. The concept is called "Open Core" where the core technology (99%) is fully open source, licensed under [AGPLv3](https://opensource.org/license/agpl-v3) and the last 1% is covered under a commercial license (["/ee" Enterprise Edition](https://github.com/calcom/cal.com/tree/main/packages/features/ee)) which we believe is entirely relevant for larger organisations that require enterprise features. Enterprise features are built by the core engineering team of Cal.com, Inc. which is hired in full-time. Find their compensation on https://cal.com/open.
+
+> [!NOTE]
+> Our philosophy is simple, all "Singleplayer APIs" are open-source under AGPLv3. All commercial "Multiplayer APIs" are under a commercial license.
 
 | Feature | AGPLv3 | EE |
 | - | - | - |


### PR DESCRIPTION
Improves README file by removing unwanted data and Aligning Properly.

The Older README file has a duplicate license section causing confusion, also the section contained unwanted rows which I've trimmed to make it concise .

- Fixes #27874

- **EARLIER**
       
<img width="1082" height="660" alt="Screenshot from 2026-02-12 21-59-56" src="https://github.com/user-attachments/assets/54d90547-9f0a-4f95-b91a-5e79d1afac3d" />

- **UPDATED**
      
<img width="1216" height="492" alt="Screenshot from 2026-02-12 21-59-04" src="https://github.com/user-attachments/assets/17cab70e-ff84-4c23-93a4-f3642bb0d79f" />

## Mandatory Tasks (DO NOT REMOVE)

- [ *] I have self-reviewed the code 
- [* ] N/A
- [ *] I confirm automated tests are in place that prove my fix is effective or that my feature works.




