### PR TITLE
fix(caldav): start RRULE iterator from event start date

### DIFF
--- a/packages/lib/CalendarService.test.ts
+++ b/packages/lib/CalendarService.test.ts
@@ -1,5 +1,5 @@
 import { createEvent as createIcsEvent } from "ics";
-import { createCalendarObject, updateCalendarObject } from "tsdav";
+import { createCalendarObject, updateCalendarObject, fetchCalendarObjects } from "tsdav";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("ics", () => ({
@@ -16,15 +16,16 @@ vi.mock("tsdav", () => ({
   getBasicAuthHeaders: vi.fn().mockReturnValue({}),
 }));
 
-vi.mock("@calcom/lib/logger", () => ({
-  default: {
-    getSubLogger: () => ({
-      debug: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-    }),
-  },
-}));
+vi.mock("@calcom/lib/logger", () => {
+  const mockFn = vi.fn();
+  return {
+    default: {
+      getSubLogger: () => ({ debug: mockFn, error: mockFn, warn: mockFn }),
+      error: mockFn,
+      warn: mockFn,
+    },
+  };
+});
 
 vi.mock("@calcom/lib/crypto", () => ({
   symmetricDecrypt: vi.fn().mockImplementation((text) => {
@@ -38,6 +39,10 @@ vi.mock("@calcom/lib/crypto", () => ({
 vi.mock("./CalEventParser", () => ({
   getLocation: vi.fn().mockReturnValue("Test Location"),
   getRichDescription: vi.fn().mockReturnValue("Test Description"),
+}));
+
+vi.mock("@calcom/lib/sanitizeCalendarObject", () => ({
+  default: vi.fn().mockImplementation((obj) => obj.data),
 }));
 
 import type { CalendarServiceEvent } from "@calcom/types/Calendar";
@@ -746,5 +751,227 @@ describe("CalendarService - SCHEDULE-AGENT injection", () => {
 
       await expect(service.createEvent(event, 1)).rejects.toThrow();
     });
+  });
+});
+
+/**
+ * Regression tests for RRULE expansion in getAvailability()
+ *
+ * Bug: The iterator was started from the query date instead of the event's start date,
+ * causing FREQ=WEEKLY events to appear on the wrong weekday.
+ *
+ * Fixes: https://github.com/calcom/cal.com/issues/5749
+ */
+describe("CalendarService - RRULE expansion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Main regression test: FREQ=WEEKLY without BYDAY
+   *
+   * Event: Weekly on Tuesday (Jan 13, 2026)
+   * Query: Feb 16-18, 2026 (Mon-Wed)
+   *
+   * Bug: Found Monday Feb 16 (query start date with event time)
+   * Fixed: Finds Tuesday Feb 17 (correct weekday from RRULE)
+   */
+  it("should expand FREQ=WEEKLY to correct weekday when query starts on different day", async () => {
+    const service = new TestCalendarService();
+
+    // Weekly event starting Tuesday Jan 13, 2026 at 09:00-17:00 Europe/Amsterdam
+    const weeklyTuesdayEvent = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:Europe/Amsterdam
+BEGIN:STANDARD
+TZOFFSETTO:+0100
+TZOFFSETFROM:+0200
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+BEGIN:DAYLIGHT
+TZOFFSETTO:+0200
+TZOFFSETFROM:+0100
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:test-weekly-tuesday
+SUMMARY:Weekly Tuesday Meeting
+RRULE:FREQ=WEEKLY
+DTSTART;TZID=Europe/Amsterdam:20260113T090000
+DTEND;TZID=Europe/Amsterdam:20260113T170000
+END:VEVENT
+END:VCALENDAR`;
+
+    vi.mocked(fetchCalendarObjects).mockResolvedValue([
+      {
+        url: "https://caldav.example.com/calendar/test.ics",
+        etag: '"etag123"',
+        data: weeklyTuesdayEvent,
+      },
+    ]);
+
+    // Query Mon Feb 16 to Wed Feb 18 - should find Tue Feb 17
+    const result = await service.getAvailability({
+      dateFrom: "2026-02-16",
+      dateTo: "2026-02-18",
+      selectedCalendars: [
+        {
+          externalId: "https://caldav.example.com/calendar/",
+          integration: "caldav",
+          credentialId: 1,
+        },
+      ],
+    });
+
+    expect(result.length).toBe(1);
+
+    const eventStart = new Date(result[0].start);
+    expect(eventStart.getUTCDay()).toBe(2); // Tuesday
+    expect(eventStart.getUTCDate()).toBe(17); // Feb 17, not Feb 16
+  });
+
+  /**
+   * Regression test: FREQ=WEEKLY;INTERVAL=2 (bi-weekly)
+   *
+   * Event: Bi-weekly on Monday starting Jan 12, 2026
+   * Occurrences: Jan 12, Jan 26, Feb 9, Feb 23...
+   * Query: Feb 16-24, 2026
+   *
+   * Bug: Found Feb 16 (query start)
+   * Fixed: Finds Feb 23 (correct bi-weekly occurrence)
+   */
+  it("should expand FREQ=WEEKLY;INTERVAL=2 to correct bi-weekly occurrence", async () => {
+    const service = new TestCalendarService();
+
+    const biweeklyEvent = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:test-biweekly
+SUMMARY:Bi-weekly Meeting
+RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO
+DTSTART:20260112T140000Z
+DTEND:20260112T150000Z
+END:VEVENT
+END:VCALENDAR`;
+
+    vi.mocked(fetchCalendarObjects).mockResolvedValue([
+      {
+        url: "https://caldav.example.com/calendar/test.ics",
+        etag: '"etag123"',
+        data: biweeklyEvent,
+      },
+    ]);
+
+    // Query Feb 16-24 - bi-weekly from Jan 12 hits Feb 23, not Feb 16
+    const result = await service.getAvailability({
+      dateFrom: "2026-02-16",
+      dateTo: "2026-02-24",
+      selectedCalendars: [
+        {
+          externalId: "https://caldav.example.com/calendar/",
+          integration: "caldav",
+          credentialId: 1,
+        },
+      ],
+    });
+
+    expect(result.length).toBe(1);
+
+    const eventStart = new Date(result[0].start);
+    expect(eventStart.getUTCDate()).toBe(23); // Feb 23, not Feb 16
+  });
+
+  /**
+   * Regression test: FREQ=MONTHLY
+   *
+   * Event: Monthly on the 15th
+   * Query: Feb 10-20, 2026
+   *
+   * Bug: Found Feb 10 (query start)
+   * Fixed: Finds Feb 15 (correct day of month)
+   */
+  it("should expand FREQ=MONTHLY to correct day of month", async () => {
+    const service = new TestCalendarService();
+
+    const monthlyEvent = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:test-monthly
+SUMMARY:Monthly Review
+RRULE:FREQ=MONTHLY
+DTSTART:20260115T100000Z
+DTEND:20260115T110000Z
+END:VEVENT
+END:VCALENDAR`;
+
+    vi.mocked(fetchCalendarObjects).mockResolvedValue([
+      {
+        url: "https://caldav.example.com/calendar/test.ics",
+        etag: '"etag123"',
+        data: monthlyEvent,
+      },
+    ]);
+
+    // Query Feb 10-20 - monthly on 15th should find Feb 15
+    const result = await service.getAvailability({
+      dateFrom: "2026-02-10",
+      dateTo: "2026-02-20",
+      selectedCalendars: [
+        {
+          externalId: "https://caldav.example.com/calendar/",
+          integration: "caldav",
+          credentialId: 1,
+        },
+      ],
+    });
+
+    expect(result.length).toBe(1);
+
+    const eventStart = new Date(result[0].start);
+    expect(eventStart.getUTCDate()).toBe(15); // Feb 15, not Feb 10
+  });
+
+  it("should include long-running daily recurrences when query window is years later", async () => {
+    const service = new TestCalendarService();
+
+    const dailyEvent = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:test-daily-long-running
+SUMMARY:Daily Standup
+RRULE:FREQ=DAILY
+DTSTART:20200101T090000Z
+DTEND:20200101T093000Z
+END:VEVENT
+END:VCALENDAR`;
+
+    vi.mocked(fetchCalendarObjects).mockResolvedValue([
+      {
+        url: "https://caldav.example.com/calendar/test.ics",
+        etag: '"etag123"',
+        data: dailyEvent,
+      },
+    ]);
+
+    const result = await service.getAvailability({
+      dateFrom: "2026-02-17T00:00:00Z",
+      dateTo: "2026-02-17T23:59:59Z",
+      selectedCalendars: [
+        {
+          externalId: "https://caldav.example.com/calendar/",
+          integration: "caldav",
+          credentialId: 1,
+        },
+      ],
+    });
+
+    expect(result.length).toBe(1);
+
+    const eventStart = new Date(result[0].start);
+    expect(eventStart.toISOString()).toBe("2026-02-17T09:00:00.000Z");
   });
 });

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -40,6 +40,10 @@ const DEFAULT_CALENDAR_TYPE = "caldav";
 
 const CALENDSO_ENCRYPTION_KEY = process.env.CALENDSO_ENCRYPTION_KEY || "";
 
+// Some feeds expose unbounded RRULEs; cap expansion to prevent pathological loops
+// while still allowing multi-year daily recurrences to reach the requested window.
+const MAX_RECURRENCE_ITERATIONS = 50_000;
+
 type FetchObjectsWithOptionalExpandOptionsType = {
   selectedCalendars: IntegrationCalendar[];
   startISOString: string;
@@ -737,19 +741,19 @@ export default abstract class BaseCalendarService implements Calendar {
         applyTravelDuration(event, getTravelDurationInSeconds(vevent, this.log));
 
         if (event.isRecurring()) {
-          let maxIterations = 365;
-          if (["HOURLY", "SECONDLY", "MINUTELY"].includes(event.getRecurrenceTypes())) {
-            logger.warn(`Won't handle [${event.getRecurrenceTypes()}] recurrence`);
+          const recurrenceType = event.getRecurrenceTypes();
+          if (["HOURLY", "SECONDLY", "MINUTELY"].includes(recurrenceType)) {
+            logger.warn(`Won't handle [${recurrenceType}] recurrence`);
             return;
           }
 
           const start = dayjs(dateFrom);
           const end = dayjs(dateTo);
-          const startDate = ICAL.Time.fromDateTimeString(startISOString);
-          startDate.hour = event.startDate.hour;
-          startDate.minute = event.startDate.minute;
-          startDate.second = event.startDate.second;
-          const iterator = event.iterator(startDate);
+          const eventStart = dayjs(event.startDate.toJSDate());
+          const daysUntilQueryEnd = Math.max(0, end.diff(eventStart, "day"));
+          let maxIterations = Math.min(MAX_RECURRENCE_ITERATIONS, Math.max(365, daysUntilQueryEnd + 365));
+          // Start iterator from actual event start to preserve weekday/monthday alignment
+          const iterator = event.iterator(event.startDate);
           let current: ICAL.Time;
           let currentEvent: ReturnType<typeof event.getOccurrenceDetails> | undefined;
           let currentStart: ReturnType<typeof dayjs> | null = null;


### PR DESCRIPTION
## What does this PR do?

The iterator was started from the query date with the event's time, causing FREQ=WEEKLY/MONTHLY events to expand on wrong days when the query range started on a different weekday/day than the original event.

Fixes #5749
   
## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

@emrysal @alishaz-polymath

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix RRULE expansion by starting iteration from the event’s start date so weekly/monthly recurrences land on the right day, even when the query window starts on a different day. Also adds a dynamic recurrence cap (up to 50k) so long‑running daily events are included. Fixes #5749.

- **Bug Fixes**
  - Start the `ICAL` iterator from `event.startDate` in `getAvailability()`, ensuring FREQ=WEEKLY/MONTHLY (incl. INTERVAL=2) expand on the correct days.
  - Replace the fixed 365-day cap with a dynamic limit (min 365, up to 50k) based on event start to query end; add regression tests for weekly (no BYDAY), bi-weekly, monthly, and long-running daily recurrences.

<sup>Written for commit fde8b47e54134f14e370fcc957c853dfad3045be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

