### PR TITLE
feat: enable requires-confirmation with seats; per-seat confirmation for BookingSeat

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.e2e-spec.ts
@@ -1053,7 +1053,7 @@ describe("Event types Endpoints", () => {
         .expect(400);
     });
 
-    it("should return an error when creating an event type with seats enabled and confirmationPolicy enabled", async () => {
+    it("should allow creating an event type with seats enabled and confirmationPolicy enabled", async () => {
       const body: CreateEventTypeInput_2024_06_14 = {
         title: "Coding class 4",
         slug: "coding-class-4",
@@ -1071,12 +1071,17 @@ describe("Event types Endpoints", () => {
         },
       };
 
-      await request(app.getHttpServer())
+      const response = await request(app.getHttpServer())
         .post("/api/v2/event-types")
         .set("Authorization", `Bearer ${apiKeyString}`)
         .set(CAL_API_VERSION_HEADER, VERSION_2024_06_14)
         .send(body)
-        .expect(400);
+        .expect(201);
+
+      expect(response.body.data).toMatchObject({
+        seats: body.seats,
+        confirmationPolicy: body.confirmationPolicy,
+      });
     });
 
     it("should return an error when trying to enable seats for an event type with confirmationPolicy enabled", async () => {
@@ -1176,7 +1181,7 @@ describe("Event types Endpoints", () => {
         .expect(400);
     });
 
-    it("should return an error when creating an event type with confirmationPolicy enabled and seats enabled", async () => {
+    it("should allow creating an event type with confirmationPolicy enabled and seats enabled", async () => {
       const body: CreateEventTypeInput_2024_06_14 = {
         title: "Coding class 7",
         slug: "coding-class-7",
@@ -1194,15 +1199,20 @@ describe("Event types Endpoints", () => {
         },
       };
 
-      await request(app.getHttpServer())
+      const response = await request(app.getHttpServer())
         .post("/api/v2/event-types")
         .set("Authorization", `Bearer ${apiKeyString}`)
         .set(CAL_API_VERSION_HEADER, VERSION_2024_06_14)
         .send(body)
-        .expect(400);
+        .expect(201);
+
+      expect(response.body.data).toMatchObject({
+        seats: body.seats,
+        confirmationPolicy: body.confirmationPolicy,
+      });
     });
 
-    it("should return an error when trying to enable confirmationPolicy for an event type with seats enabled", async () => {
+    it("should allow enabling confirmationPolicy for an event type with seats enabled", async () => {
       const body: CreateEventTypeInput_2024_06_14 = {
         title: "Coding class 8",
         slug: "coding-class-8",
@@ -1244,7 +1254,7 @@ describe("Event types Endpoints", () => {
             blockUnconfirmedBookingsInBooker: false,
           },
         })
-        .expect(400);
+        .expect(200);
     });
 
     it("should update event type", async () => {

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/input-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/input-event-types.service.ts
@@ -455,9 +455,7 @@ export class InputEventTypesService_2024_06_14 {
     const requiresConfirmationFinal =
       requiresConfirmation !== undefined ? requiresConfirmation : requiresConfirmationDb;
     this.validateSeatsSingleLocationRule(seatsEnabledFinal, locationsFinal);
-    this.validateSeatsRequiresConfirmationFalseRule(seatsEnabledFinal, requiresConfirmationFinal);
     this.validateMultipleLocationsSeatsDisabledRule(locationsFinal, seatsEnabledFinal);
-    this.validateRequiresConfirmationSeatsDisabledRule(requiresConfirmationFinal, seatsEnabledFinal);
 
     if (eventName) {
       await this.validateCustomEventNameInput(eventName);
@@ -491,28 +489,12 @@ export class InputEventTypesService_2024_06_14 {
     return [...knownLocations];
   }
 
-  validateSeatsRequiresConfirmationFalseRule(seatsEnabled: boolean, requiresConfirmation: boolean) {
-    if (seatsEnabled && requiresConfirmation) {
-      throw new BadRequestException(
-        "Seats Validation failed: Seats are enabled but requiresConfirmation is true."
-      );
-    }
-  }
-
   validateMultipleLocationsSeatsDisabledRule(
     locations: ReturnType<typeof this.transformLocations>,
     seatsEnabled: boolean
   ) {
     if (locations.length > 1 && seatsEnabled) {
       throw new BadRequestException("Locations Validation failed: Multiple locations but seats are enabled.");
-    }
-  }
-
-  validateRequiresConfirmationSeatsDisabledRule(requiresConfirmation: boolean, seatsEnabled: boolean) {
-    if (requiresConfirmation && seatsEnabled) {
-      throw new BadRequestException(
-        "RequiresConfirmation Validation failed: Seats are enabled but requiresConfirmation is true."
-      );
     }
   }
 

--- a/apps/web/components/booking/AcceptBookingButton.tsx
+++ b/apps/web/components/booking/AcceptBookingButton.tsx
@@ -10,6 +10,7 @@ interface AcceptBookingButtonProps {
   isRecurring?: boolean;
   isTabRecurring?: boolean;
   isTabUnconfirmed?: boolean;
+  seatReferenceUid?: string;
   size?: "sm" | "base" | "lg";
   color?: "primary" | "secondary" | "minimal" | "destructive";
   className?: string;
@@ -22,6 +23,7 @@ export function AcceptBookingButton({
   isRecurring = false,
   isTabRecurring = false,
   isTabUnconfirmed = false,
+  seatReferenceUid,
   size = "base",
   color = "primary",
   className,
@@ -41,7 +43,7 @@ export function AcceptBookingButton({
       color={color}
       size={size}
       className={className}
-      onClick={() => bookingConfirm({ bookingId, confirmed: true, recurringEventId })}
+      onClick={() => bookingConfirm({ bookingId, confirmed: true, recurringEventId, seatReferenceUid })}
       disabled={isPending}
       data-booking-uid={bookingUid}
       data-testid="confirm">

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -186,7 +186,7 @@ function BookingListItem(booking: BookingItemProps) {
   const isAttendee = !!userSeat;
 
   const pendingSeats = booking.seatsReferences.filter(
-    (seat) => seat.status === BookingStatus.PENDING
+    (seat) => seat.status?.toLowerCase() === "pending"
   );
 
   const paymentAppData = getPaymentAppData(booking.eventType);

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -185,6 +185,10 @@ function BookingListItem(booking: BookingItemProps) {
 
   const isAttendee = !!userSeat;
 
+  const pendingSeats = booking.seatsReferences.filter(
+    (seat) => seat.status === BookingStatus.PENDING
+  );
+
   const paymentAppData = getPaymentAppData(booking.eventType);
 
   const location = booking.location as ReturnType<typeof getEventLocationValue>;
@@ -555,6 +559,13 @@ function BookingListItem(booking: BookingItemProps) {
           booking.assignmentReasonSortedByCreatedAt.length > 0 ? () => setIsOpenRoutingTraceSheet(true) : undefined
         }
       />
+      {pendingSeats.length > 0 && (
+        <PendingSeatsSection
+          pendingSeats={pendingSeats}
+          bookingId={booking.id}
+          bookingUid={booking.uid}
+        />
+      )}
       {isBookingFromRoutingForm && (
         <WrongAssignmentDialog
           isOpenDialog={isOpenWrongAssignmentDialog}
@@ -565,6 +576,53 @@ function BookingListItem(booking: BookingItemProps) {
     </div>
   );
 }
+
+const PendingSeatsSection = ({
+  pendingSeats,
+  bookingId,
+  bookingUid,
+}: {
+  pendingSeats: { referenceUid: string; status: string; attendee: { email: string; name: string | null } | null }[];
+  bookingId: number;
+  bookingUid: string;
+}) => {
+  const { t } = useLocale();
+
+  return (
+    <div className="border-subtle border-t px-6 py-3">
+      <div className="text-emphasis mb-2 text-xs font-semibold uppercase">{t("pending_seats")}</div>
+      <div className="space-y-2">
+        {pendingSeats.map((seat) => (
+          <div key={seat.referenceUid} className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Icon name="user" className="text-subtle h-4 w-4" />
+              <span className="text-default text-sm">
+                {seat.attendee?.name || seat.attendee?.email || t("unknown_attendee")}
+              </span>
+              {seat.attendee?.name && seat.attendee?.email && (
+                <span className="text-subtle text-xs">{seat.attendee.email}</span>
+              )}
+            </div>
+            <div className="flex space-x-2 rtl:space-x-reverse">
+              <RejectBookingButton
+                bookingId={bookingId}
+                bookingUid={bookingUid}
+                seatReferenceUid={seat.referenceUid}
+                size="sm"
+              />
+              <AcceptBookingButton
+                bookingId={bookingId}
+                bookingUid={bookingUid}
+                seatReferenceUid={seat.referenceUid}
+                size="sm"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 const BookingItemBadges = ({
   booking,

--- a/apps/web/components/booking/RejectBookingButton.tsx
+++ b/apps/web/components/booking/RejectBookingButton.tsx
@@ -11,6 +11,7 @@ interface RejectBookingButtonProps {
   isRecurring?: boolean;
   isTabRecurring?: boolean;
   isTabUnconfirmed?: boolean;
+  seatReferenceUid?: string;
   size?: "sm" | "base" | "lg";
   color?: "primary" | "secondary" | "minimal" | "destructive";
   className?: string;
@@ -23,6 +24,7 @@ export function RejectBookingButton({
   isRecurring = false,
   isTabRecurring = false,
   isTabUnconfirmed = false,
+  seatReferenceUid,
   size = "base",
   color = "secondary",
   className,
@@ -43,7 +45,7 @@ export function RejectBookingButton({
       <RejectionReasonDialog
         isOpenDialog={rejectionDialogIsOpen}
         setIsOpenDialog={setRejectionDialogIsOpen}
-        onConfirm={(reason) => bookingConfirm({ bookingId, confirmed: false, recurringEventId, reason })}
+        onConfirm={(reason) => bookingConfirm({ bookingId, confirmed: false, recurringEventId, reason, seatReferenceUid })}
         isPending={isPending}
       />
 

--- a/apps/web/components/booking/hooks/useBookingConfirmation.tsx
+++ b/apps/web/components/booking/hooks/useBookingConfirmation.tsx
@@ -44,18 +44,24 @@ export function useBookingConfirmation(options: UseBookingConfirmationOptions = 
   });
 
   const bookingConfirm = ({ bookingId, confirmed, recurringEventId, reason, seatReferenceUid }: BookingConfirmParams) => {
-    let body: Record<string, unknown> = {
+    const body: {
+      bookingId: number;
+      confirmed: boolean;
+      reason: string;
+      recurringEventId?: string;
+      seatReferenceUid?: string;
+    } = {
       bookingId,
       confirmed,
       reason: reason || "",
     };
 
     if ((isTabRecurring || isTabUnconfirmed) && isRecurring && recurringEventId) {
-      body = Object.assign({}, body, { recurringEventId });
+      body.recurringEventId = recurringEventId;
     }
 
     if (seatReferenceUid) {
-      body = Object.assign({}, body, { seatReferenceUid });
+      body.seatReferenceUid = seatReferenceUid;
     }
 
     mutation.mutate(body);

--- a/apps/web/components/booking/hooks/useBookingConfirmation.tsx
+++ b/apps/web/components/booking/hooks/useBookingConfirmation.tsx
@@ -16,6 +16,7 @@ interface BookingConfirmParams {
   confirmed: boolean;
   recurringEventId?: string | null;
   reason?: string;
+  seatReferenceUid?: string;
 }
 
 export function useBookingConfirmation(options: UseBookingConfirmationOptions = {}) {
@@ -43,18 +44,18 @@ export function useBookingConfirmation(options: UseBookingConfirmationOptions = 
   });
 
   const bookingConfirm = ({ bookingId, confirmed, recurringEventId, reason }: BookingConfirmParams) => {
-    let body = {
+    let body: Record<string, unknown> = {
       bookingId,
       confirmed,
       reason: reason || "",
     };
 
-    /**
-     * Only pass down the recurring event id when we need to confirm the entire series, which happens in
-     * the "Recurring" tab and "Unconfirmed" tab, to support confirming discretionally in the "Recurring" tab.
-     */
     if ((isTabRecurring || isTabUnconfirmed) && isRecurring && recurringEventId) {
       body = Object.assign({}, body, { recurringEventId });
+    }
+
+    if (seatReferenceUid) {
+      body = Object.assign({}, body, { seatReferenceUid });
     }
 
     mutation.mutate(body);

--- a/apps/web/components/booking/hooks/useBookingConfirmation.tsx
+++ b/apps/web/components/booking/hooks/useBookingConfirmation.tsx
@@ -43,7 +43,7 @@ export function useBookingConfirmation(options: UseBookingConfirmationOptions = 
     },
   });
 
-  const bookingConfirm = ({ bookingId, confirmed, recurringEventId, reason }: BookingConfirmParams) => {
+  const bookingConfirm = ({ bookingId, confirmed, recurringEventId, reason, seatReferenceUid }: BookingConfirmParams) => {
     let body: Record<string, unknown> = {
       bookingId,
       confirmed,

--- a/apps/web/modules/event-types/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/EventAdvancedTab.tsx
@@ -678,7 +678,6 @@ export const EventAdvancedTab = ({
       </div>
       <RequiresConfirmationController
         eventType={eventType}
-        seatsEnabled={seatsEnabled}
         metadata={formMethods.getValues("metadata")}
         requiresConfirmation={requiresConfirmation}
         requiresConfirmationWillBlockSlot={formMethods.getValues("requiresConfirmationWillBlockSlot")}
@@ -1082,11 +1081,8 @@ export const EventAdvancedTab = ({
                       : undefined
               }
               onCheckedChange={(e) => {
-                // Enabling seats will disable guests and requiring confirmation until fully supported
                 if (e) {
                   toggleGuests(false);
-                  formMethods.setValue("requiresConfirmation", false, { shouldDirty: true });
-                  setRequiresConfirmation(false);
                   formMethods.setValue("metadata.multipleDuration", undefined, { shouldDirty: true });
                   formMethods.setValue("seatsPerTimeSlot", eventType.seatsPerTimeSlot ?? 2, {
                     shouldDirty: true,

--- a/apps/web/modules/event-types/components/tabs/advanced/RequiresConfirmationController.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/RequiresConfirmationController.tsx
@@ -36,7 +36,6 @@ type RequiresConfirmationControllerProps = {
   requiresConfirmation: boolean;
   requiresConfirmationWillBlockSlot: boolean;
   onRequiresConfirmation: Dispatch<SetStateAction<boolean>>;
-  seatsEnabled: boolean;
   eventType: EventTypeSetup;
   customClassNames?: RequiresConfirmationCustomClassNames;
 };
@@ -46,7 +45,6 @@ export default function RequiresConfirmationController({
   eventType,
   requiresConfirmation,
   onRequiresConfirmation,
-  seatsEnabled,
   customClassNames,
 }: RequiresConfirmationControllerProps) {
   const { t } = useLocale();
@@ -97,8 +95,7 @@ export default function RequiresConfirmationController({
               descriptionClassName={customClassNames?.description}
               title={t("requires_confirmation")}
               data-testid="requires-confirmation"
-              disabled={seatsEnabled || requiresConfirmationLockedProps.disabled}
-              tooltip={seatsEnabled ? t("seat_options_doesnt_support_confirmation") : undefined}
+              disabled={requiresConfirmationLockedProps.disabled}
               description={
                 <LearnMoreLink
                   t={t}

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -4629,5 +4629,7 @@
   "last_6_months": "Last 6 months",
   "last_12_months": "Last 12 months",
   "calendar_events_disabled_video_limitation": "When calendar events are disabled, meeting links cannot be generated for apps whose link generation is tied to calendar event creation, for example, Google Meet and Microsoft Teams. Other video apps like Cal Video will continue to work.",
+  "pending_seats": "Pending seats",
+  "unknown_attendee": "Unknown attendee",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/companion/components/event-type-detail/tabs/AdvancedTab.tsx
+++ b/companion/components/event-type-detail/tabs/AdvancedTab.tsx
@@ -145,13 +145,6 @@ export function AdvancedTab(props: AdvancedTabProps) {
           learnMoreUrl="https://cal.com/help/event-types/how-to-requires"
           value={props.requiresConfirmation}
           onValueChange={(value) => {
-            if (value && props.seatsEnabled) {
-              Alert.alert(
-                "Disable 'Offer seats' first",
-                "You need to:\n1. Disable 'Offer seats' and Save\n2. Then enable 'Requires confirmation' and Save again"
-              );
-              return;
-            }
             props.setRequiresConfirmation(value);
           }}
         />
@@ -251,13 +244,6 @@ export function AdvancedTab(props: AdvancedTabProps) {
           description="Offer seats for booking. This automatically disables guest & opt-in bookings."
           value={props.seatsEnabled}
           onValueChange={(value) => {
-            if (value && props.requiresConfirmation) {
-              Alert.alert(
-                "Disable 'Requires confirmation' first",
-                "You need to:\n1. Disable 'Requires confirmation' and Save\n2. Then enable 'Offer seats' and Save again"
-              );
-              return;
-            }
             props.setSeatsEnabled(value);
           }}
           learnMoreUrl="https://cal.com/help/event-types/offer-seats"

--- a/packages/features/CalendarEventBuilder.ts
+++ b/packages/features/CalendarEventBuilder.ts
@@ -46,7 +46,7 @@ async function _buildPersonFromAttendee(
   attendee: Pick<Attendee, "locale" | "name" | "timeZone" | "email" | "phoneNumber"> & {
     bookingSeat: Pick<
       BookingSeat,
-      "id" | "referenceUid" | "bookingId" | "metadata" | "data" | "attendeeId"
+      "id" | "referenceUid" | "bookingId" | "metadata" | "data" | "attendeeId" | "status"
     > | null;
   }
 ) {

--- a/packages/features/bookings/lib/handleNewBooking/createBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking/createBooking.ts
@@ -242,7 +242,8 @@ function buildNewBookingData(params: CreateBookingParams) {
     endTime: dayjs.utc(evt.endTime).toDate(),
     description: evt.seatsPerTimeSlot ? null : evt.additionalNotes,
     customInputs: isPrismaObjOrUndefined(evt.customInputs),
-    status: eventType.isConfirmedByDefault ? BookingStatus.ACCEPTED : BookingStatus.PENDING,
+    status:
+      evt.seatsPerTimeSlot || eventType.isConfirmedByDefault ? BookingStatus.ACCEPTED : BookingStatus.PENDING,
     oneTimePassword: evt.oneTimePassword,
     location: evt.location,
     eventType: eventTypeRel,

--- a/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
+++ b/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
@@ -25,6 +25,7 @@ export type AddSeatInput = {
   bookingId: number;
   bookingStatus: BookingStatus;
   seatsPerTimeSlot: number;
+  requiresConfirmation?: boolean;
   attendee: {
     email: string;
     phoneNumber?: string;
@@ -103,6 +104,7 @@ export async function addSeatToBooking(input: AddSeatInput, prismaClient: Prisma
                 booking: {
                   connect: { id: input.bookingId },
                 },
+                status: input.requiresConfirmation ? BookingStatus.PENDING : BookingStatus.ACCEPTED,
               },
             },
           },
@@ -169,6 +171,7 @@ const createNewSeat = async (
     bookingId: seatedBooking.id,
     bookingStatus: seatedBooking.status,
     seatsPerTimeSlot: eventType.seatsPerTimeSlot ?? 0,
+    requiresConfirmation: eventType.requiresConfirmation,
     attendee: {
       email: inviteeToAdd.email,
       phoneNumber: inviteeToAdd.phoneNumber,

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -2043,6 +2043,7 @@ async function handler(
                 id: currentAttendee?.id,
               },
             },
+            status: isConfirmedByDefault ? BookingStatus.ACCEPTED : BookingStatus.PENDING,
           },
         });
         evt.attendeeSeatId = uniqueAttendeeId;

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -228,6 +228,7 @@ const selectStatementToGetBookingForCalEventBuilder = {
           attendeeId: true,
           data: true,
           metadata: true,
+          status: true,
         },
       },
     },

--- a/packages/prisma/migrations/20260212212406_add_status_to_booking_seat/migration.sql
+++ b/packages/prisma/migrations/20260212212406_add_status_to_booking_seat/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."BookingSeat" ADD COLUMN     "status" "public"."BookingStatus" NOT NULL DEFAULT 'accepted';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1692,15 +1692,16 @@ enum WorkflowMethods {
 }
 
 model BookingSeat {
-  id           Int      @id @default(autoincrement())
-  referenceUid String   @unique
+  id           Int           @id @default(autoincrement())
+  referenceUid String        @unique
   bookingId    Int
-  booking      Booking  @relation(fields: [bookingId], references: [id], onDelete: Cascade)
-  attendeeId   Int      @unique
-  attendee     Attendee @relation(fields: [attendeeId], references: [id], onDelete: Cascade)
+  booking      Booking       @relation(fields: [bookingId], references: [id], onDelete: Cascade)
+  attendeeId   Int           @unique
+  attendee     Attendee      @relation(fields: [attendeeId], references: [id], onDelete: Cascade)
   /// @zod.import(["import { bookingSeatDataSchema } from '../../zod-utils'"]).custom.use(bookingSeatDataSchema)
   data         Json?
   metadata     Json?
+  status       BookingStatus @default(ACCEPTED)
 
   @@index([bookingId])
   @@index([attendeeId])
@@ -3044,7 +3045,7 @@ model TeamBilling {
   subscriptionEnd      DateTime?
 
   billingPeriod     BillingPeriod?
-  billingMode       BillingMode    @default(SEATS)
+  billingMode       BillingMode        @default(SEATS)
   pricePerSeat      Int?
   paidSeats         Int?
   monthlyProrations MonthlyProration[]
@@ -3073,7 +3074,7 @@ model OrganizationBilling {
   subscriptionEnd      DateTime?
 
   billingPeriod     BillingPeriod?
-  billingMode       BillingMode    @default(SEATS)
+  billingMode       BillingMode        @default(SEATS)
   pricePerSeat      Int?
   paidSeats         Int?
   monthlyProrations MonthlyProration[]

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -380,6 +380,7 @@ export const bookingConfirmPatchBodySchema = z.object({
   reason: z.string().optional(),
   emailsEnabled: z.boolean().default(true),
   platformClientParams: PlatformClientParamsSchema.optional(),
+  seatReferenceUid: z.string().optional(),
 });
 
 export const bookingCancelSchema = z.object({


### PR DESCRIPTION
## What does this PR do?

Enables the "Requires confirmation" feature to work with seated events. Previously, these two features were mutually exclusive. Now hosts can require confirmation for seated events and confirm/reject individual seat requests from the bookings page.

**Key changes:**
- Added `status` field to `BookingSeat` model to track per-seat confirmation status
- Removed API validation rules that blocked seats + requiresConfirmation combination
- Removed UI restrictions in web app and companion app
- Parent booking stays `ACCEPTED` for seated events; individual seats track their own `PENDING`/`ACCEPTED`/`REJECTED` status
- Extended confirm handler to support per-seat confirmation via `seatReferenceUid` parameter
- Added per-seat confirm/reject UI (`PendingSeatsSection`) on the bookings page showing each pending attendee with Accept/Reject buttons
- Updated bookings query to include seat status and attendee name
- Updated "Unconfirmed" tab filter to surface bookings with pending seats

Link to Devin run: https://app.devin.ai/sessions/39ca226d3ca84a278ea4ac469c74d753
Requested by: @PeerRich

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create an event type with seats enabled (e.g., 4 seats per time slot)
2. Enable "Requires confirmation" on the same event type — this should now be allowed
3. Have multiple attendees book seats on the same time slot
4. Go to `/bookings` → "Unconfirmed" tab — the booking should appear with a "Pending seats" section listing each attendee with their name/email
5. Click Accept/Reject on individual seats and verify the seat status updates
6. Verify that confirming/rejecting one seat does not affect other seats on the same booking

## ⚠️ Important items for human review

1. **Per-seat confirmation returns early without sending emails or calendar events** — The new seat confirmation path in `confirm.handler.ts` (line ~260) returns `{ message, status }` early without sending confirmation emails or creating calendar events. The `onSuccess` handler in `useBookingConfirmation` checks `data?.status === BookingStatus.REJECTED` which may not match since the confirm handler returns the raw enum string. Verify this interaction works correctly.

2. **Parent booking always ACCEPTED for seated events** — In `createBooking.ts`, seated events now always get `BookingStatus.ACCEPTED` regardless of `requiresConfirmation`. Verify no downstream logic relies on checking `booking.status` to determine if confirmation is needed for the overall booking.

3. **Seat status case mismatch** — The Kysely query returns lowercase DB enum values (`"pending"`) while `BookingStatus.PENDING` is uppercase. The `BookingListItem` uses `.toLowerCase() === "pending"` as a workaround. The `get.handler.ts` unconfirmed filter uses the lowercase `"pending"` string directly. This inconsistency should be verified.

4. **No unit tests for `PendingSeatsSection` component** — The new UI component for per-seat confirmation lacks dedicated test coverage.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings