### PR TITLE
fix: use randomString() for booking uid in slots e2e tests to avoid unique constraint flake

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
@@ -515,7 +515,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${seatedEventTypeId}`,
+        uid: `booking-uid-${randomString()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -598,7 +598,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid in range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${seatedEventTypeId}`,
+        uid: `booking-uid-${randomString()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
@@ -832,7 +832,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${seatedEventType.id}`,
+        uid: `booking-uid-${randomString()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",
@@ -961,7 +961,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     it("should do a booking for seated event and slot should show attendees count and bookingUid and return range format", async () => {
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
-        uid: `booking-uid-${seatedEventType.id}`,
+        uid: `booking-uid-${randomString()}`,
         title: "booking title",
         startTime,
         endTime: "2050-09-05T12:00:00.000Z",


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky test caused by hardcoded booking UIDs in seated event slot e2e tests. The tests used `booking-uid-${seatedEventTypeId}` as the UID, which is deterministic and causes `Unique constraint failed on the fields: (uid)` errors when prior test data isn't fully cleaned up.

Replaces the deterministic ID with `randomString()` (already imported and used elsewhere in both files) to guarantee uniqueness across runs.

**Affected tests:**
- `slots-2024-04-15/controllers/slots.controller.e2e-spec.ts` — 2 occurrences
- `slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts` — 2 occurrences

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the affected e2e test suites multiple times in succession — the seated event booking tests should no longer fail with unique constraint errors:

```
yarn test -- src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
yarn test -- src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
```

## Human Review Checklist

- [ ] Verify `randomString()` is already imported in both test files (no new dependencies)
- [ ] Verify downstream assertions using `booking.uid` (e.g., `bookingUid: booking.uid`) still work since they read the value back from the created object

---

> Link to Devin run: https://app.devin.ai/sessions/2741867580d6485c94097e64d3b3b175
> Requested by: @alishaz-polymath