### PR TITLE
fix: show invite link settings modal when clicking edit invite link in team members view

### DIFF
--- a/apps/web/modules/ee/teams/views/team-members-view.tsx
+++ b/apps/web/modules/ee/teams/views/team-members-view.tsx
@@ -8,6 +8,7 @@ import type { RouterOutputs } from "@calcom/trpc/react";
 import type { MemberPermissions } from "@calcom/features/pbac/lib/team-member-permissions";
 
 import { MemberInvitationModalWithoutMembers } from "~/ee/teams/components/MemberInvitationModal";
+import InviteLinkSettingsModal from "~/ee/teams/components/InviteLinkSettingsModal";
 
 import MemberList from "../components/MemberList";
 
@@ -37,7 +38,7 @@ interface TeamMembersViewProps {
 export const TeamMembersView = ({ team, facetedTeamValues, permissions }: TeamMembersViewProps) => {
   const { t } = useLocale();
   const [showMemberInvitationModal, setShowMemberInvitationModal] = useState(false);
-  const [_showInviteLinkSettingsModal, setShowInviteLinkSettingsModal] = useState(false);
+  const [showInviteLinkSettingsModal, setShowInviteLinkSettingsModal] = useState(false);
 
   // Use PBAC permissions - server-side permission check should be done in parent component
   const canLoggedInUserSeeMembers = permissions?.canListMembers ?? false;
@@ -68,6 +69,18 @@ export const TeamMembersView = ({ team, facetedTeamValues, permissions }: TeamMe
             teamId={team.id}
             token={team.inviteToken?.token}
             onSettingsOpen={() => setShowInviteLinkSettingsModal(true)}
+          />
+        )}
+        {team?.inviteToken && (
+          <InviteLinkSettingsModal
+            isOpen={showInviteLinkSettingsModal}
+            teamId={team.id}
+            token={team.inviteToken.token}
+            expiresInDays={team.inviteToken.expiresInDays ?? undefined}
+            onExit={() => {
+              setShowInviteLinkSettingsModal(false);
+              setShowMemberInvitationModal(true);
+            }}
           />
         )}
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clicking “Edit invite link” in the Team Members view now opens the Invite Link Settings modal. The modal shows only when the team has an invite token, and closing it returns users to the invitation modal.

<sup>Written for commit 9f80de793f11065fa6fbfc0513a54b947b097a58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

