### PR TITLE
fix(app-store): preserve existing enabled state during seed

### DIFF
--- a/scripts/seed-app-store.ts
+++ b/scripts/seed-app-store.ts
@@ -50,7 +50,7 @@ async function createApp(
     });
 
     // Only enable apps if they have valid keys (or don't require keys)
-    const enabled = shouldEnableApp(dirName, keys as Prisma.JsonValue);
+    const enabled = keys !== undefined ? shouldEnableApp(dirName, keys as Prisma.JsonValue) : foundApp?.enabled ?? shouldEnableApp(dirName);
     const data = { slug, dirName, categories, keys, enabled };
 
     if (!foundApp) {

--- a/scripts/seed-app-store.ts
+++ b/scripts/seed-app-store.ts
@@ -50,8 +50,15 @@ async function createApp(
     });
 
     // Only enable apps if they have valid keys (or don't require keys)
-    const enabled = keys !== undefined ? shouldEnableApp(dirName, keys as Prisma.JsonValue) : foundApp?.enabled ?? shouldEnableApp(dirName);
-    const data = { slug, dirName, categories, keys, enabled };
+    const keysToValidate = (keys ?? foundApp?.keys) as Prisma.JsonValue | undefined;
+    const enabled = shouldEnableApp(dirName, keysToValidate);
+    const data = {
+      slug,
+      dirName,
+      categories,
+      ...(keys !== undefined && { keys }),
+      enabled,
+    };
 
     if (!foundApp) {
       await prisma.app.create({


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where apps (e.g. Google Calendar / Google Meet) were being unintentionally disabled during Docker restarts or database reseeding.

- Fixes #27465
- Fixes CAL-7161

## Problem

When `scripts/seed-app-store.ts` runs, it recalculates the `enabled` flag for every app using `shouldEnableApp`.
On subsequent runs, if keys were `undefined` or validation logic behaved differently, the app's `enabled` field could be set to false , even if it was previously configured and working correctly.

The main issue I found is this loop in `scripts/seed-app-store.ts`

```
for (const [, app] of Object.entries(appStoreMetadata)) {
    if (app.isTemplate && process.argv[2] !== "seed-templates") {
      continue;
    }

    const validatedCategories = app.categories.filter(
      (category): category is AppCategories => category in AppCategories
    );

    await createApp(
      app.slug,
      app.dirName ?? app.slug,
      validatedCategories,
      app.type,
      undefined,   // keys are passed as undefined
      app.isTemplate
    );
  }
}
```
This loop overrides the apps `enabled` flag to be `false`

This caused integrations to appear randomly disabled on self-hosted Docker instances after restart.

## Solution

Preserve the existing enabled state if no new keys are provided.

##  What Was Tested

- Tested locally using Docker self-host setup.
- Configured Google Calendar integration with valid OAuth credentials.
- Verified `enabled = true` in the database.
- Restarted containers multiple times.
- Confirmed that `enabled` no longer flips to `false`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs).  (N/A)
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Reproduction (Before Fix)

- Self-host using Docker.
- Configure Google Calendar integration.
- Confirm enabled = true in DB.
- Restart Docker (docker compose restart calcom).
- Observe that enabled becomes false.

### Verification (After Fix)

- Apply this PR.
- Configure Google Calendar integration.
- Restart Docker.

Confirm:
- `enabled` remains `true`
- Integration remains visible and usable.

### Environment Variables
Ensure relevant integration credentials are set (e.g. Google OAuth keys) when testing validation logic.

## Expected Behavior

- Seeding should not disable existing apps.
- `enabled` state should only change when explicitly revalidated with new keys.




<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
