### PR TITLE
fix: exclude test files from CODEOWNERS foundation approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,3 +37,7 @@
 /packages/trpc/server/routers/viewer/bookings/get.handler.ts @calcom/Foundation
 /packages/trpc/server/routers/viewer/slots/**/* @calcom/Foundation
 /packages/ui/**/* @calcom/Consumer @calcom/Foundation
+
+# Exclude test files from requiring foundation/consumer approval
+**/*.spec.*
+**/*.e2e.*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,3 +41,4 @@
 # Exclude test files from requiring foundation/consumer approval
 **/*.spec.*
 **/*.e2e.*
+**/*.test.*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,3 +42,4 @@
 **/*.spec.*
 **/*.e2e.*
 **/*.test.*
+**/*.integration-test.*


### PR DESCRIPTION
## What does this PR do?

PRs that only modify test files currently require Foundation team approval because those files fall under CODEOWNERS-covered directories (e.g. `packages/features/bookings/lib/**/*`). This adds override patterns at the end of CODEOWNERS to remove code ownership from test files, so they no longer trigger approval requirements.

In GitHub CODEOWNERS, later rules take precedence. Patterns with no owners assigned effectively clear ownership for matching files.

The following test file patterns are excluded:
- `**/*.spec.*`
- `**/*.e2e.*`
- `**/*.test.*`
- `**/*.integration-test.*`

## How should this be tested?

1. Open a PR that only touches test files (`.spec.*`, `.e2e.*`, `.test.*`, or `.integration-test.*`) under a Foundation-owned path (e.g. `packages/features/bookings/lib/`)
2. Verify that the PR no longer lists `@calcom/Foundation` or `@calcom/Consumer` as required reviewers

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — CODEOWNERS changes are validated by GitHub at PR time.

## Human Review Checklist

- [ ] Verify that removing **all** code ownership (not just Foundation) from test files is the desired behavior — these patterns also clear `@calcom/Consumer` ownership if a test file falls under a Consumer-owned path (e.g. `packages/ui/**/*`)
- [ ] Confirm the glob patterns (`**/*.spec.*`, `**/*.e2e.*`, `**/*.test.*`, `**/*.integration-test.*`) match the intended file naming conventions used across the repo
- [ ] Consider whether test infrastructure files (fixtures, utilities) should remain under code ownership — these patterns only match files with the listed suffixes in their name, not entire test directories

---

Link to Devin run: https://app.devin.ai/sessions/84166a44e2204df290f844112fa52a29
Requested by: @hariombalhara