### PR TITLE
feat: min seats + admin UI for org creation

### DIFF
--- a/apps/web/modules/ee/organizations/lib/onboardingStore.ts
+++ b/apps/web/modules/ee/organizations/lib/onboardingStore.ts
@@ -6,13 +6,15 @@ import { persist, StorageValue } from "zustand/middleware";
 
 import { WEBAPP_URL, IS_TEAM_BILLING_ENABLED_CLIENT } from "@calcom/lib/constants";
 import { localStorage } from "@calcom/lib/webstorage";
-import { BillingPeriod, UserPermissionRole } from "@calcom/prisma/enums";
+import { BillingMode, BillingPeriod, UserPermissionRole } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 
 interface OnboardingAdminStoreState {
   billingPeriod?: BillingPeriod;
+  billingMode?: BillingMode;
   pricePerSeat?: number | null;
   seats?: number | null;
+  minSeats?: number | null;
   orgOwnerEmail?: string;
 }
 
@@ -31,8 +33,10 @@ interface OnboardingUserStoreState {
 interface OnboardingStoreState extends OnboardingAdminStoreState, OnboardingUserStoreState {
   // Actions for admin state
   setBillingPeriod: (billingPeriod: BillingPeriod) => void;
+  setBillingMode: (billingMode: BillingMode) => void;
   setPricePerSeat: (price: number | null) => void;
   setSeats: (seats: number | null) => void;
+  setMinSeats: (minSeats: number | null) => void;
   setOrgOwnerEmail: (email: string) => void;
 
   // Actions for user state
@@ -65,6 +69,8 @@ const initialState: OnboardingAdminStoreState & OnboardingUserStoreState = {
   seats: null,
   pricePerSeat: null,
   billingPeriod: undefined,
+  billingMode: undefined,
+  minSeats: null,
   onboardingId: null,
   invitedMembers: [],
   teams: [],
@@ -77,8 +83,10 @@ export const useOnboardingStore = create<OnboardingStoreState>()(
 
       // Admin actions
       setBillingPeriod: (billingPeriod) => set({ billingPeriod }),
+      setBillingMode: (billingMode) => set({ billingMode }),
       setPricePerSeat: (pricePerSeat) => set({ pricePerSeat }),
       setSeats: (seats) => set({ seats }),
+      setMinSeats: (minSeats) => set({ minSeats }),
       setOrgOwnerEmail: (orgOwnerEmail) => set({ orgOwnerEmail }),
 
       // User actions

--- a/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
@@ -166,8 +166,10 @@ const handler = async (data: SWHMap["invoice.paid"]["data"]) => {
       subscriptionEnd: subscriptionEnd ?? undefined,
       subscriptionTrialEnd: subscriptionTrialEnd ?? undefined,
       billingPeriod,
+      billingMode: organizationOnboarding.billingMode,
       pricePerSeat,
       paidSeats,
+      minSeats: organizationOnboarding.minSeats,
     });
 
     logger.debug(`Marking onboarding as complete for organization ${organization.id}`);

--- a/packages/features/ee/billing/repository/billing/IBillingRepository.ts
+++ b/packages/features/ee/billing/repository/billing/IBillingRepository.ts
@@ -31,7 +31,9 @@ export interface IBillingRepositoryUpdateArgs {
   subscriptionEnd?: Date | null;
   subscriptionTrialEnd?: Date | null;
   billingPeriod?: "MONTHLY" | "ANNUALLY" | null;
+  billingMode?: "SEATS" | "ACTIVE_USERS";
   pricePerSeat?: number | null;
+  minSeats?: number | null;
 }
 
 export interface IBillingRepository {
@@ -56,6 +58,8 @@ export interface IBillingRepositoryCreateArgs {
   subscriptionTrialEnd?: Date;
   subscriptionEnd?: Date;
   billingPeriod?: "MONTHLY" | "ANNUALLY";
+  billingMode?: "SEATS" | "ACTIVE_USERS";
   pricePerSeat?: number;
   paidSeats?: number;
+  minSeats?: number | null;
 }

--- a/packages/features/ee/billing/service/billingPeriod/BillingPeriodService.ts
+++ b/packages/features/ee/billing/service/billingPeriod/BillingPeriodService.ts
@@ -18,6 +18,7 @@ export interface BillingPeriodInfo {
   trialEnd: Date | null;
   isInTrial: boolean;
   pricePerSeat: number | null;
+  minSeats: number | null;
   isOrganization: boolean;
 }
 
@@ -100,6 +101,7 @@ export class BillingPeriodService {
             subscriptionTrialEnd: true,
             pricePerSeat: true,
             paidSeats: true,
+            minSeats: true,
             subscriptionId: true,
           },
         },
@@ -113,6 +115,7 @@ export class BillingPeriodService {
             subscriptionTrialEnd: true,
             pricePerSeat: true,
             paidSeats: true,
+            minSeats: true,
             subscriptionId: true,
           },
         },
@@ -133,6 +136,7 @@ export class BillingPeriodService {
         trialEnd: null,
         isInTrial: false,
         pricePerSeat: null,
+        minSeats: null,
         isOrganization,
       };
     }
@@ -167,6 +171,7 @@ export class BillingPeriodService {
             trialEnd: billing.subscriptionTrialEnd,
             isInTrial,
             pricePerSeat: billing.pricePerSeat,
+            minSeats: billing.minSeats,
             isOrganization,
           };
         }
@@ -199,6 +204,7 @@ export class BillingPeriodService {
           trialEnd: billing.subscriptionTrialEnd,
           isInTrial,
           pricePerSeat: pricePerSeat ?? null,
+          minSeats: billing.minSeats,
           isOrganization,
         };
       } catch (error) {
@@ -217,6 +223,7 @@ export class BillingPeriodService {
       trialEnd: billing.subscriptionTrialEnd,
       isInTrial,
       pricePerSeat: billing.pricePerSeat,
+      minSeats: billing.minSeats,
       isOrganization,
     };
   }

--- a/packages/features/ee/billing/service/billingPeriod/__tests__/BillingPeriodService.test.ts
+++ b/packages/features/ee/billing/service/billingPeriod/__tests__/BillingPeriodService.test.ts
@@ -293,6 +293,7 @@ describe("BillingPeriodService", () => {
         trialEnd: null,
         isInTrial: false,
         pricePerSeat: 10000,
+        minSeats: undefined,
         isOrganization: false,
       });
     });
@@ -340,6 +341,7 @@ describe("BillingPeriodService", () => {
         trialEnd: null,
         isInTrial: false,
         pricePerSeat: null,
+        minSeats: null,
         isOrganization: false,
       });
     });

--- a/packages/features/ee/billing/service/seatBillingStrategy/SeatBillingStrategyFactory.ts
+++ b/packages/features/ee/billing/service/seatBillingStrategy/SeatBillingStrategyFactory.ts
@@ -46,6 +46,7 @@ export class SeatBillingStrategyFactory {
       activeUserBillingService: deps.activeUserBillingService,
       billingProviderService: deps.billingProviderService,
       teamBillingDataRepository: deps.teamBillingDataRepository,
+      billingPeriodService: deps.billingPeriodService,
     });
   }
 

--- a/packages/features/ee/billing/service/seatBillingStrategy/__tests__/SeatBillingStrategyFactory.test.ts
+++ b/packages/features/ee/billing/service/seatBillingStrategy/__tests__/SeatBillingStrategyFactory.test.ts
@@ -75,6 +75,7 @@ const baseBillingInfo: BillingPeriodInfo = {
   trialEnd: null,
   isInTrial: false,
   pricePerSeat: 1500,
+  minSeats: null,
   isOrganization: false,
 };
 

--- a/packages/features/ee/organizations/lib/OrganizationPaymentService.ts
+++ b/packages/features/ee/organizations/lib/OrganizationPaymentService.ts
@@ -9,7 +9,7 @@ import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { prisma } from "@calcom/prisma";
 import type { OrganizationOnboarding } from "@calcom/prisma/client";
-import { UserPermissionRole, type BillingPeriod } from "@calcom/prisma/enums";
+import { UserPermissionRole, type BillingMode, type BillingPeriod } from "@calcom/prisma/enums";
 import { userMetadata } from "@calcom/prisma/zod-utils";
 
 import { OrganizationPermissionService } from "./OrganizationPermissionService";
@@ -31,8 +31,10 @@ type CreateOnboardingInput = {
   slug: string;
   orgOwnerEmail: string;
   billingPeriod?: BillingPeriod;
+  billingMode?: BillingMode;
   seats?: number | null;
   pricePerSeat?: number | null;
+  minSeats?: number | null;
   createdByUserId: number;
   logo?: string | null;
   bio?: string | null;
@@ -193,8 +195,10 @@ export class OrganizationPaymentService {
       slug: input.slug,
       orgOwnerEmail: input.orgOwnerEmail,
       billingPeriod: config.billingPeriod,
+      billingMode: input.billingMode,
       seats: config.seats,
       pricePerSeat: config.pricePerSeat,
+      minSeats: input.minSeats ?? null,
       createdById: input.createdByUserId,
       logo: input.logo ?? null,
       bio: input.bio ?? null,

--- a/packages/features/ee/organizations/lib/service/onboarding/BaseOnboardingService.ts
+++ b/packages/features/ee/organizations/lib/service/onboarding/BaseOnboardingService.ts
@@ -130,6 +130,8 @@ export abstract class BaseOnboardingService implements IOrganizationOnboardingSe
       seats: input.seats,
       pricePerSeat: input.pricePerSeat,
       billingPeriod: input.billingPeriod,
+      billingMode: input.billingMode,
+      minSeats: input.minSeats,
       createdByUserId: this.user.id,
       logo: processedAssets.logo ?? null,
       bio: input.bio ?? null,

--- a/packages/features/ee/organizations/lib/service/onboarding/types.ts
+++ b/packages/features/ee/organizations/lib/service/onboarding/types.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from "@calcom/prisma/client";
-import type { BillingPeriod, CreationSource } from "@calcom/prisma/enums";
+import type { BillingMode, BillingPeriod, CreationSource } from "@calcom/prisma/enums";
 
 export type TeamInput = {
   id: number;
@@ -23,6 +23,8 @@ export type CreateOnboardingIntentInput = {
   seats?: number | null;
   pricePerSeat?: number | null;
   billingPeriod?: BillingPeriod;
+  billingMode?: BillingMode;
+  minSeats?: number | null;
   isPlatform: boolean;
   creationSource: CreationSource;
   logo?: string | null;

--- a/packages/features/organizations/repositories/OrganizationOnboardingRepository.ts
+++ b/packages/features/organizations/repositories/OrganizationOnboardingRepository.ts
@@ -1,7 +1,7 @@
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { prisma } from "@calcom/prisma";
-import type { BillingPeriod } from "@calcom/prisma/enums";
+import type { BillingMode, BillingPeriod } from "@calcom/prisma/enums";
 
 type OnboardingId = string;
 
@@ -9,8 +9,10 @@ export type CreateOrganizationOnboardingInput = {
   createdById: number;
   organizationId?: number | null;
   billingPeriod: BillingPeriod;
+  billingMode?: BillingMode;
   pricePerSeat: number;
   seats: number;
+  minSeats?: number | null;
   orgOwnerEmail: string;
   name: string;
   slug: string;
@@ -33,11 +35,12 @@ export class OrganizationOnboardingRepository {
     logger.debug("Creating organization onboarding", safeStringify(data));
 
     return await prisma.organizationOnboarding.create({
-      // HEKOP
       data: {
         billingPeriod: data.billingPeriod,
+        billingMode: data.billingMode,
         pricePerSeat: data.pricePerSeat,
         seats: data.seats,
+        minSeats: data.minSeats ?? null,
         orgOwnerEmail: data.orgOwnerEmail,
         name: data.name,
         slug: data.slug,

--- a/packages/prisma/migrations/20260212000000_add_billing_mode_min_seats/migration.sql
+++ b/packages/prisma/migrations/20260212000000_add_billing_mode_min_seats/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "OrganizationOnboarding" ADD COLUMN "billingMode" "BillingMode" NOT NULL DEFAULT 'SEATS';
+ALTER TABLE "OrganizationOnboarding" ADD COLUMN "minSeats" INTEGER;
+
+-- AlterTable
+ALTER TABLE "TeamBilling" ADD COLUMN "minSeats" INTEGER;
+
+-- AlterTable
+ALTER TABLE "OrganizationBilling" ADD COLUMN "minSeats" INTEGER;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2627,8 +2627,10 @@ model OrganizationOnboarding {
   organization   Team? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   billingPeriod BillingPeriod
+  billingMode   BillingMode   @default(SEATS)
   pricePerSeat  Float
   seats         Int
+  minSeats      Int?
 
   isPlatform Boolean @default(false)
 
@@ -3047,6 +3049,7 @@ model TeamBilling {
   billingMode       BillingMode    @default(SEATS)
   pricePerSeat      Int?
   paidSeats         Int?
+  minSeats          Int?
   monthlyProrations MonthlyProration[]
   seatChangeLogs    SeatChangeLog[]
 
@@ -3076,6 +3079,7 @@ model OrganizationBilling {
   billingMode       BillingMode    @default(SEATS)
   pricePerSeat      Int?
   paidSeats         Int?
+  minSeats          Int?
   monthlyProrations MonthlyProration[]
   seatChangeLogs    SeatChangeLog[]
 

--- a/packages/trpc/server/routers/viewer/organizations/create.schema.ts
+++ b/packages/trpc/server/routers/viewer/organizations/create.schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { emailSchema } from "@calcom/lib/emailSchema";
 import slugify from "@calcom/lib/slugify";
-import { CreationSource } from "@calcom/prisma/enums";
+import { BillingMode, CreationSource } from "@calcom/prisma/enums";
 
 export enum BillingPeriod {
   MONTHLY = "MONTHLY",
@@ -18,6 +18,8 @@ export const ZCreateInputSchema = z.object({
   pricePerSeat: z.number().optional(),
   isPlatform: z.boolean().default(false),
   billingPeriod: z.nativeEnum(BillingPeriod).default(BillingPeriod.MONTHLY).optional(),
+  billingMode: z.nativeEnum(BillingMode).default(BillingMode.SEATS).optional(),
+  minSeats: z.number().int().positive().optional(),
   creationSource: z.nativeEnum(CreationSource),
 });
 

--- a/packages/trpc/server/routers/viewer/organizations/intentToCreateOrg.schema.ts
+++ b/packages/trpc/server/routers/viewer/organizations/intentToCreateOrg.schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { emailSchema } from "@calcom/lib/emailSchema";
 import slugify from "@calcom/lib/slugify";
-import { BillingPeriod, CreationSource } from "@calcom/prisma/enums";
+import { BillingMode, BillingPeriod, CreationSource } from "@calcom/prisma/enums";
 import { orgOnboardingInvitedMembersSchema, orgOnboardingTeamsSchema } from "@calcom/prisma/zod-utils";
 
 export const ZIntentToCreateOrgInputSchema = z.object({
@@ -14,6 +14,8 @@ export const ZIntentToCreateOrgInputSchema = z.object({
   pricePerSeat: z.number().nullish(),
   isPlatform: z.boolean().default(false),
   billingPeriod: z.nativeEnum(BillingPeriod).default(BillingPeriod.MONTHLY),
+  billingMode: z.nativeEnum(BillingMode).default(BillingMode.SEATS),
+  minSeats: z.number().int().positive().nullish(),
   creationSource: z.nativeEnum(CreationSource),
   // Brand fields
   logo: z.string().nullish(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds “min seats” support for Active User billing and an admin-only billing configuration in org creation. This wires billingMode and minSeats through onboarding, billing, and APIs, and enforces a seat floor when invoicing.

- **New Features**
  - Admin UI in Create Organization: choose Billing Mode (Seats or Active Users) and optional Min Seats.
  - Persist billingMode and minSeats in OrganizationOnboarding, TeamBilling, and OrganizationBilling; webhook writes them on invoice paid.
  - ActiveUserBillingStrategy bills max(active users, minSeats); factory and tests updated.
  - TRPC schemas, onboarding store, and BillingPeriodService now include minSeats.

- **Migration**
  - Run database migrations.
  - Defaults keep existing behavior (billingMode=SEATS; minSeats unset).

<sup>Written for commit c1ceda808659ed5f6a222641f409b1ea7cd4b84b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

