### PR TITLE
fix: resolve signup watchlist review issues and auto-unlock on SIGNUP entry removal

### DIFF
--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -317,7 +317,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
     );
   }
 
-  if (!checkoutSessionId) {
+  if (!checkoutSessionId && !token) {
     sendEmailVerification({
       email,
       language: await getLocaleFromRequest(buildLegacyRequest(await headers(), await cookies())),

--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -12,8 +12,8 @@ import {
   validateAndGetCorrectedUsernameForTeam,
 } from "@calcom/features/auth/signup/utils/token";
 import { validateAndGetCorrectedUsernameAndEmail } from "@calcom/features/auth/signup/utils/validateUsername";
-import { getBillingProviderService } from "@calcom/features/ee/billing/di/containers/Billing";
 import { getFeatureRepository } from "@calcom/features/di/containers/FeatureRepository";
+import { getBillingProviderService } from "@calcom/features/ee/billing/di/containers/Billing";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { GlobalWatchlistRepository } from "@calcom/features/watchlist/lib/repository/GlobalWatchlistRepository";
 import { sentrySpan } from "@calcom/features/watchlist/lib/telemetry";
@@ -287,15 +287,6 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
     if (process.env.AVATARAPI_USERNAME && process.env.AVATARAPI_PASSWORD) {
       await prefillAvatar({ email });
     }
-    // Only send verification email for non-premium usernames
-    // Premium usernames will get a magic link after payment in paymentCallback
-    if (!checkoutSessionId) {
-      sendEmailVerification({
-        email,
-        language: await getLocaleFromRequest(buildLegacyRequest(await headers(), await cookies())),
-        username: username || "",
-      });
-    }
   }
 
   const featureRepository = getFeatureRepository();
@@ -324,6 +315,14 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
       { message: "Created user", stripeCustomerId: customer.stripeCustomerId, accountUnderReview: true },
       { status: 201 }
     );
+  }
+
+  if (!checkoutSessionId) {
+    sendEmailVerification({
+      email,
+      language: await getLocaleFromRequest(buildLegacyRequest(await headers(), await cookies())),
+      username: username || "",
+    });
   }
 
   if (checkoutSessionId) {

--- a/packages/features/di/watchlist/containers/watchlist.ts
+++ b/packages/features/di/watchlist/containers/watchlist.ts
@@ -1,5 +1,3 @@
-import { createContainer } from "@evyweb/ioctopus";
-
 import { PrismaBookingReportRepository } from "@calcom/features/bookingReport/repositories/PrismaBookingReportRepository";
 import { moduleLoader as prismaModuleLoader } from "@calcom/features/di/modules/Prisma";
 import { moduleLoader as loggerModuleLoader } from "@calcom/features/di/shared/services/logger.service";
@@ -11,8 +9,10 @@ import {
   createWatchlistFeature,
   type WatchlistFeature,
 } from "@calcom/features/watchlist/lib/facade/WatchlistFeature";
-import type { IGlobalWatchlistRepository } from "@calcom/features/watchlist/lib/interface/IWatchlistRepositories";
-import type { IOrganizationWatchlistRepository } from "@calcom/features/watchlist/lib/interface/IWatchlistRepositories";
+import type {
+  IGlobalWatchlistRepository,
+  IOrganizationWatchlistRepository,
+} from "@calcom/features/watchlist/lib/interface/IWatchlistRepositories";
 import { WatchlistRepository } from "@calcom/features/watchlist/lib/repository/WatchlistRepository";
 import { AdminWatchlistOperationsService } from "@calcom/features/watchlist/lib/service/AdminWatchlistOperationsService";
 import { AdminWatchlistQueryService } from "@calcom/features/watchlist/lib/service/AdminWatchlistQueryService";
@@ -23,9 +23,9 @@ import { OrganizationWatchlistQueryService } from "@calcom/features/watchlist/li
 import type { WatchlistAuditService } from "@calcom/features/watchlist/lib/service/WatchlistAuditService";
 import type { WatchlistService } from "@calcom/features/watchlist/lib/service/WatchlistService";
 import { prisma } from "@calcom/prisma";
-
-import { WATCHLIST_DI_TOKENS } from "../Watchlist.tokens";
+import { createContainer } from "@evyweb/ioctopus";
 import { watchlistModule } from "../modules/Watchlist.module";
+import { WATCHLIST_DI_TOKENS } from "../Watchlist.tokens";
 
 export const watchlistContainer = createContainer();
 
@@ -77,10 +77,12 @@ export async function getWatchlistFeature(): Promise<WatchlistFeature> {
 export function getAdminWatchlistOperationsService(): AdminWatchlistOperationsService {
   const watchlistRepo = new WatchlistRepository(prisma);
   const bookingReportRepo = new PrismaBookingReportRepository(prisma);
+  const userRepo = new UserRepository(prisma);
 
   return new AdminWatchlistOperationsService({
     watchlistRepo,
     bookingReportRepo,
+    userRepo,
   });
 }
 

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1436,4 +1436,24 @@ export class UserRepository {
       data: { locked: true },
     });
   }
+
+  async unlockByEmail({
+    email,
+  }: {
+    email: string;
+  }): Promise<{ email: string; username: string | null } | null> {
+    const user = await this.prismaClient.user.findFirst({
+      where: { email, locked: true },
+      select: { id: true, email: true, username: true },
+    });
+
+    if (!user) return null;
+
+    await this.prismaClient.user.update({
+      where: { id: user.id },
+      data: { locked: false },
+    });
+
+    return { email: user.email, username: user.username };
+  }
 }

--- a/packages/features/watchlist/lib/repository/GlobalWatchlistRepository.test.ts
+++ b/packages/features/watchlist/lib/repository/GlobalWatchlistRepository.test.ts
@@ -1,0 +1,99 @@
+import type { PrismaClient } from "@calcom/prisma/client";
+import { WatchlistAction, WatchlistSource, WatchlistType } from "@calcom/prisma/enums";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type DeepMockProxy, mockDeep, mockReset } from "vitest-mock-extended";
+import { GlobalWatchlistRepository } from "./GlobalWatchlistRepository";
+
+describe("GlobalWatchlistRepository", () => {
+  let prismaMock: DeepMockProxy<PrismaClient>;
+  let repo: GlobalWatchlistRepository;
+
+  beforeEach(() => {
+    prismaMock = mockDeep<PrismaClient>();
+    repo = new GlobalWatchlistRepository(prismaMock);
+    mockReset(prismaMock);
+  });
+
+  describe("deleteEntry", () => {
+    it("should await the prisma delete call", async () => {
+      const entryId = "test-entry-id";
+      prismaMock.watchlist.delete.mockResolvedValue({} as never);
+
+      await repo.deleteEntry(entryId);
+
+      expect(prismaMock.watchlist.delete).toHaveBeenCalledWith({
+        where: { id: entryId },
+      });
+    });
+
+    it("should propagate errors from prisma delete", async () => {
+      const entryId = "test-entry-id";
+      prismaMock.watchlist.delete.mockRejectedValue(new Error("Record not found"));
+
+      await expect(repo.deleteEntry(entryId)).rejects.toThrow("Record not found");
+    });
+  });
+
+  describe("createEntry", () => {
+    it("should use provided source instead of defaulting to MANUAL", async () => {
+      const mockEntry = {
+        id: "new-id",
+        type: WatchlistType.EMAIL,
+        value: "test@example.com",
+        description: "Auto-added during signup review",
+        isGlobal: true,
+        organizationId: null,
+        action: WatchlistAction.BLOCK,
+        source: WatchlistSource.SIGNUP,
+        lastUpdatedAt: new Date(),
+      };
+      prismaMock.watchlist.create.mockResolvedValue(mockEntry as never);
+
+      const result = await repo.createEntry({
+        type: WatchlistType.EMAIL,
+        value: "test@example.com",
+        action: WatchlistAction.BLOCK,
+        source: WatchlistSource.SIGNUP,
+        description: "Auto-added during signup review",
+      });
+
+      expect(prismaMock.watchlist.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            source: WatchlistSource.SIGNUP,
+          }),
+        })
+      );
+      expect(result.source).toBe(WatchlistSource.SIGNUP);
+    });
+
+    it("should default to MANUAL when source is not provided", async () => {
+      const mockEntry = {
+        id: "new-id",
+        type: WatchlistType.EMAIL,
+        value: "test@example.com",
+        description: null,
+        isGlobal: true,
+        organizationId: null,
+        action: WatchlistAction.BLOCK,
+        source: WatchlistSource.MANUAL,
+        lastUpdatedAt: new Date(),
+      };
+      prismaMock.watchlist.create.mockResolvedValue(mockEntry as never);
+
+      await repo.createEntry({
+        type: WatchlistType.EMAIL,
+        value: "test@example.com",
+        action: WatchlistAction.BLOCK,
+      });
+
+      expect(prismaMock.watchlist.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            source: WatchlistSource.MANUAL,
+          }),
+        })
+      );
+    });
+  });
+});

--- a/packages/features/watchlist/lib/repository/GlobalWatchlistRepository.ts
+++ b/packages/features/watchlist/lib/repository/GlobalWatchlistRepository.ts
@@ -1,6 +1,5 @@
 import type { PrismaClient, Watchlist } from "@calcom/prisma/client";
-import { WatchlistAction, WatchlistType, WatchlistSource } from "@calcom/prisma/enums";
-
+import { WatchlistAction, WatchlistSource, WatchlistType } from "@calcom/prisma/enums";
 import type { IGlobalWatchlistRepository } from "../interface/IWatchlistRepositories";
 
 /**
@@ -164,7 +163,7 @@ export class GlobalWatchlistRepository implements IGlobalWatchlistRepository {
   }
 
   async deleteEntry(id: string): Promise<void> {
-    this.prisma.watchlist.delete({
+    await this.prisma.watchlist.delete({
       where: { id },
     });
   }

--- a/packages/features/watchlist/lib/repository/WatchlistRepository.ts
+++ b/packages/features/watchlist/lib/repository/WatchlistRepository.ts
@@ -1,13 +1,12 @@
 import type { PrismaClient } from "@calcom/prisma";
 import { WatchlistAction, WatchlistSource } from "@calcom/prisma/enums";
-
 import type {
-  IWatchlistRepository,
-  CreateWatchlistInput,
   CheckWatchlistInput,
-  WatchlistEntry,
+  CreateWatchlistInput,
   FindAllEntriesInput,
+  IWatchlistRepository,
   WatchlistAuditEntry,
+  WatchlistEntry,
 } from "./IWatchlistRepository";
 
 export class WatchlistRepository implements IWatchlistRepository {
@@ -238,6 +237,9 @@ export class WatchlistRepository implements IWatchlistRepository {
       id: string;
       isGlobal: boolean;
       organizationId: number | null;
+      source: WatchlistSource;
+      type: WatchlistEntry["type"];
+      value: string;
     }>
   > {
     return this.prismaClient.watchlist.findMany({
@@ -246,6 +248,9 @@ export class WatchlistRepository implements IWatchlistRepository {
         id: true,
         isGlobal: true,
         organizationId: true,
+        source: true,
+        type: true,
+        value: true,
       },
     });
   }

--- a/packages/features/watchlist/lib/service/AdminWatchlistOperationsService.test.ts
+++ b/packages/features/watchlist/lib/service/AdminWatchlistOperationsService.test.ts
@@ -1,0 +1,221 @@
+import { WatchlistAction, WatchlistSource, WatchlistType } from "@calcom/prisma/enums";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AdminWatchlistOperationsService } from "./AdminWatchlistOperationsService";
+
+vi.mock("@calcom/features/auth/lib/verifyEmail", () => ({
+  sendEmailVerification: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { sendEmailVerification } from "@calcom/features/auth/lib/verifyEmail";
+
+function createMockWatchlistRepo() {
+  return {
+    findEntryWithAuditAndReports: vi.fn(),
+    deleteEntry: vi.fn().mockResolvedValue(undefined),
+    findEntriesByIds: vi.fn().mockResolvedValue([]),
+    bulkDeleteEntries: vi.fn().mockResolvedValue({ deleted: 0 }),
+    createEntry: vi.fn(),
+    createEntryIfNotExists: vi.fn(),
+    checkExists: vi.fn(),
+    findAllEntriesWithLatestAudit: vi.fn(),
+    createEntryFromReport: vi.fn(),
+    findOrgAndGlobalEntries: vi.fn(),
+  };
+}
+
+function createMockBookingReportRepo() {
+  return {
+    findPendingSystemReportsByEmail: vi.fn(),
+    findPendingSystemReportsByDomain: vi.fn(),
+    bulkLinkGlobalWatchlistWithSystemStatus: vi.fn(),
+    dismissSystemReportsByEmail: vi.fn(),
+  };
+}
+
+function createMockUserRepo() {
+  return {
+    unlockByEmail: vi.fn().mockResolvedValue(null),
+  };
+}
+
+function makeEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "entry-1",
+    type: WatchlistType.EMAIL,
+    value: "test@example.com",
+    action: WatchlistAction.BLOCK,
+    description: null,
+    organizationId: null,
+    isGlobal: true,
+    source: WatchlistSource.SIGNUP,
+    lastUpdatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("AdminWatchlistOperationsService", () => {
+  let service: AdminWatchlistOperationsService;
+  let mockWatchlistRepo: ReturnType<typeof createMockWatchlistRepo>;
+  let mockBookingReportRepo: ReturnType<typeof createMockBookingReportRepo>;
+  let mockUserRepo: ReturnType<typeof createMockUserRepo>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWatchlistRepo = createMockWatchlistRepo();
+    mockBookingReportRepo = createMockBookingReportRepo();
+    mockUserRepo = createMockUserRepo();
+
+    service = new AdminWatchlistOperationsService({
+      watchlistRepo: mockWatchlistRepo as never,
+      bookingReportRepo: mockBookingReportRepo as never,
+      userRepo: mockUserRepo as never,
+    });
+  });
+
+  describe("deleteWatchlistEntry - auto-unlock", () => {
+    test("should unlock user and send verification email when deleting SIGNUP email entry", async () => {
+      const entry = makeEntry({ source: WatchlistSource.SIGNUP, type: WatchlistType.EMAIL });
+      mockWatchlistRepo.findEntryWithAuditAndReports.mockResolvedValue({ entry, auditHistory: [] });
+      mockUserRepo.unlockByEmail.mockResolvedValue({ email: "test@example.com", username: "testuser" });
+
+      await service.deleteWatchlistEntry({ entryId: "entry-1", userId: 1 });
+
+      expect(mockWatchlistRepo.deleteEntry).toHaveBeenCalledWith("entry-1", 1);
+      expect(mockUserRepo.unlockByEmail).toHaveBeenCalledWith({ email: "test@example.com" });
+      expect(sendEmailVerification).toHaveBeenCalledWith({
+        email: "test@example.com",
+        username: "testuser",
+      });
+    });
+
+    test("should not unlock user when deleting MANUAL source entry", async () => {
+      const entry = makeEntry({ source: WatchlistSource.MANUAL, type: WatchlistType.EMAIL });
+      mockWatchlistRepo.findEntryWithAuditAndReports.mockResolvedValue({ entry, auditHistory: [] });
+
+      await service.deleteWatchlistEntry({ entryId: "entry-1", userId: 1 });
+
+      expect(mockWatchlistRepo.deleteEntry).toHaveBeenCalledWith("entry-1", 1);
+      expect(mockUserRepo.unlockByEmail).not.toHaveBeenCalled();
+      expect(sendEmailVerification).not.toHaveBeenCalled();
+    });
+
+    test("should not unlock user when deleting SIGNUP domain entry", async () => {
+      const entry = makeEntry({
+        source: WatchlistSource.SIGNUP,
+        type: WatchlistType.DOMAIN,
+        value: "example.com",
+      });
+      mockWatchlistRepo.findEntryWithAuditAndReports.mockResolvedValue({ entry, auditHistory: [] });
+
+      await service.deleteWatchlistEntry({ entryId: "entry-1", userId: 1 });
+
+      expect(mockUserRepo.unlockByEmail).not.toHaveBeenCalled();
+    });
+
+    test("should not send verification email when user is not locked", async () => {
+      const entry = makeEntry({ source: WatchlistSource.SIGNUP, type: WatchlistType.EMAIL });
+      mockWatchlistRepo.findEntryWithAuditAndReports.mockResolvedValue({ entry, auditHistory: [] });
+      mockUserRepo.unlockByEmail.mockResolvedValue(null);
+
+      await service.deleteWatchlistEntry({ entryId: "entry-1", userId: 1 });
+
+      expect(mockUserRepo.unlockByEmail).toHaveBeenCalledWith({ email: "test@example.com" });
+      expect(sendEmailVerification).not.toHaveBeenCalled();
+    });
+
+    test("should not throw if unlock fails", async () => {
+      const entry = makeEntry({ source: WatchlistSource.SIGNUP, type: WatchlistType.EMAIL });
+      mockWatchlistRepo.findEntryWithAuditAndReports.mockResolvedValue({ entry, auditHistory: [] });
+      mockUserRepo.unlockByEmail.mockRejectedValue(new Error("db error"));
+
+      const result = await service.deleteWatchlistEntry({ entryId: "entry-1", userId: 1 });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("bulkDeleteWatchlistEntries - auto-unlock", () => {
+    test("should unlock users for SIGNUP email entries in bulk delete", async () => {
+      const entries = [
+        {
+          id: "e1",
+          isGlobal: true,
+          organizationId: null,
+          source: WatchlistSource.SIGNUP,
+          type: WatchlistType.EMAIL,
+          value: "user1@example.com",
+        },
+        {
+          id: "e2",
+          isGlobal: true,
+          organizationId: null,
+          source: WatchlistSource.MANUAL,
+          type: WatchlistType.EMAIL,
+          value: "user2@example.com",
+        },
+      ];
+      mockWatchlistRepo.findEntriesByIds.mockResolvedValue(entries);
+      mockWatchlistRepo.bulkDeleteEntries.mockResolvedValue({ deleted: 2 });
+      mockUserRepo.unlockByEmail.mockResolvedValue({ email: "user1@example.com", username: "user1" });
+
+      await service.bulkDeleteWatchlistEntries({ entryIds: ["e1", "e2"], userId: 1 });
+
+      expect(mockUserRepo.unlockByEmail).toHaveBeenCalledTimes(1);
+      expect(mockUserRepo.unlockByEmail).toHaveBeenCalledWith({ email: "user1@example.com" });
+      expect(sendEmailVerification).toHaveBeenCalledWith({
+        email: "user1@example.com",
+        username: "user1",
+      });
+    });
+
+    test("should not unlock users for non-SIGNUP entries in bulk delete", async () => {
+      const entries = [
+        {
+          id: "e1",
+          isGlobal: true,
+          organizationId: null,
+          source: WatchlistSource.MANUAL,
+          type: WatchlistType.EMAIL,
+          value: "user@example.com",
+        },
+      ];
+      mockWatchlistRepo.findEntriesByIds.mockResolvedValue(entries);
+      mockWatchlistRepo.bulkDeleteEntries.mockResolvedValue({ deleted: 1 });
+
+      await service.bulkDeleteWatchlistEntries({ entryIds: ["e1"], userId: 1 });
+
+      expect(mockUserRepo.unlockByEmail).not.toHaveBeenCalled();
+    });
+
+    test("should handle multiple SIGNUP entries in bulk delete", async () => {
+      const entries = [
+        {
+          id: "e1",
+          isGlobal: true,
+          organizationId: null,
+          source: WatchlistSource.SIGNUP,
+          type: WatchlistType.EMAIL,
+          value: "user1@example.com",
+        },
+        {
+          id: "e2",
+          isGlobal: true,
+          organizationId: null,
+          source: WatchlistSource.SIGNUP,
+          type: WatchlistType.EMAIL,
+          value: "user2@example.com",
+        },
+      ];
+      mockWatchlistRepo.findEntriesByIds.mockResolvedValue(entries);
+      mockWatchlistRepo.bulkDeleteEntries.mockResolvedValue({ deleted: 2 });
+      mockUserRepo.unlockByEmail
+        .mockResolvedValueOnce({ email: "user1@example.com", username: "user1" })
+        .mockResolvedValueOnce({ email: "user2@example.com", username: "user2" });
+
+      await service.bulkDeleteWatchlistEntries({ entryIds: ["e1", "e2"], userId: 1 });
+
+      expect(mockUserRepo.unlockByEmail).toHaveBeenCalledTimes(2);
+      expect(sendEmailVerification).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/features/watchlist/lib/service/AdminWatchlistOperationsService.ts
+++ b/packages/features/watchlist/lib/service/AdminWatchlistOperationsService.ts
@@ -221,7 +221,7 @@ export class AdminWatchlistOperationsService extends WatchlistOperationsService 
         });
       }
     } catch (error) {
-      this.adminLog.error("Failed to auto-unlock user after SIGNUP watchlist removal", { email, error });
+      this.adminLog.error("Failed to auto-unlock user after SIGNUP watchlist removal", { error });
     }
   }
 

--- a/packages/features/watchlist/lib/service/AdminWatchlistOperationsService.ts
+++ b/packages/features/watchlist/lib/service/AdminWatchlistOperationsService.ts
@@ -1,8 +1,9 @@
+import { sendEmailVerification } from "@calcom/features/auth/lib/verifyEmail";
 import type { PrismaBookingReportRepository } from "@calcom/features/bookingReport/repositories/PrismaBookingReportRepository";
+import type { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import type { WatchlistRepository } from "@calcom/features/watchlist/lib/repository/WatchlistRepository";
 import logger from "@calcom/lib/logger";
-import { SystemReportStatus, WatchlistType } from "@calcom/prisma/enums";
-
+import { SystemReportStatus, WatchlistSource, WatchlistType } from "@calcom/prisma/enums";
 import { WatchlistErrors } from "../errors/WatchlistErrors";
 import { extractDomainFromEmail, normalizeEmail } from "../utils/normalization";
 import type {
@@ -53,13 +54,16 @@ export interface BulkDismissReportsByEmailInput {
 type Deps = {
   watchlistRepo: WatchlistRepository;
   bookingReportRepo: PrismaBookingReportRepository;
+  userRepo: UserRepository;
 };
 
 export class AdminWatchlistOperationsService extends WatchlistOperationsService {
   private adminLog = logger.getSubLogger({ prefix: ["AdminWatchlistOperationsService"] });
+  private userRepo: UserRepository;
 
   constructor(deps: Deps) {
     super(deps);
+    this.userRepo = deps.userRepo;
   }
 
   protected getScope(): WatchlistOperationsScope {
@@ -94,6 +98,13 @@ export class AdminWatchlistOperationsService extends WatchlistOperationsService 
       validIds.push(id);
     }
 
+    const signupEmailEntries = validIds
+      .map((id) => entryMap.get(id))
+      .filter(
+        (e): e is NonNullable<typeof e> =>
+          !!e && e.source === WatchlistSource.SIGNUP && e.type === WatchlistType.EMAIL
+      );
+
     let successCount = 0;
     if (validIds.length > 0) {
       const result = await this.deps.watchlistRepo.bulkDeleteEntries({
@@ -102,6 +113,8 @@ export class AdminWatchlistOperationsService extends WatchlistOperationsService 
       });
       successCount = result.deleted;
     }
+
+    await Promise.all(signupEmailEntries.map((entry) => this.unlockSignupUser(entry.value)));
 
     if (successCount === 0 && failed.length > 0) {
       this.adminLog.error("Bulk delete watchlist entries failures", { failed });
@@ -130,6 +143,10 @@ export class AdminWatchlistOperationsService extends WatchlistOperationsService 
     }
 
     await this.deps.watchlistRepo.deleteEntry(input.entryId, input.userId);
+
+    if (entry.source === WatchlistSource.SIGNUP && entry.type === WatchlistType.EMAIL) {
+      await this.unlockSignupUser(entry.value);
+    }
 
     return {
       success: true,
@@ -192,6 +209,20 @@ export class AdminWatchlistOperationsService extends WatchlistOperationsService 
     }
 
     return { success: true, count: result.count };
+  }
+
+  private async unlockSignupUser(email: string): Promise<void> {
+    try {
+      const user = await this.userRepo.unlockByEmail({ email });
+      if (user) {
+        await sendEmailVerification({
+          email: user.email,
+          username: user.username || "",
+        });
+      }
+    } catch (error) {
+      this.adminLog.error("Failed to auto-unlock user after SIGNUP watchlist removal", { email, error });
+    }
   }
 
   async bulkDismissReportsByEmail(input: BulkDismissReportsByEmailInput): Promise<BulkDismissReportsResult> {

--- a/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSendEmailVerification = vi.fn().mockResolvedValue({ ok: true, skipped: false });
+const mockFindBlockedEmail = vi.fn();
+const mockDeleteEntry = vi.fn();
+
+vi.mock("@calcom/features/auth/lib/verifyEmail", () => ({
+  sendEmailVerification: (...args: unknown[]) => mockSendEmailVerification(...args),
+}));
+vi.mock("@calcom/features/watchlist/lib/repository/GlobalWatchlistRepository", () => ({
+  GlobalWatchlistRepository: class {
+    findBlockedEmail = mockFindBlockedEmail;
+    deleteEntry = mockDeleteEntry;
+  },
+}));
+vi.mock("@calcom/features/watchlist/lib/utils/normalization", () => ({
+  normalizeEmail: vi.fn((e: string) => e.toLowerCase()),
+}));
+vi.mock("@calcom/prisma", () => {
+  const mockPrisma = {
+    user: {
+      update: vi.fn(),
+    },
+  };
+  return { default: mockPrisma, prisma: mockPrisma };
+});
+
+import { prisma } from "@calcom/prisma";
+import lockUserAccountHandler from "./lockUserAccount.handler";
+
+describe("lockUserAccountHandler", () => {
+  const mockUser = {
+    id: 1,
+    email: "admin@example.com",
+    organizationId: null,
+    profile: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.user.update).mockResolvedValue({
+      id: 42,
+      email: "test@example.com",
+      username: "testuser",
+    } as never);
+    mockFindBlockedEmail.mockResolvedValue(null);
+    mockDeleteEntry.mockResolvedValue(undefined);
+    mockSendEmailVerification.mockResolvedValue({ ok: true, skipped: false });
+  });
+
+  describe("unlocking a user", () => {
+    it("should remove watchlist entry when unlocking a user", async () => {
+      const watchlistEntry = { id: "watchlist-entry-123" };
+      mockFindBlockedEmail.mockResolvedValue(watchlistEntry);
+
+      await lockUserAccountHandler({
+        ctx: { user: mockUser as never },
+        input: { userId: 42, locked: false },
+      });
+
+      expect(mockDeleteEntry).toHaveBeenCalledWith("watchlist-entry-123");
+    });
+
+    it("should send verification email after unlocking and removing from watchlist", async () => {
+      const watchlistEntry = { id: "watchlist-entry-123" };
+      mockFindBlockedEmail.mockResolvedValue(watchlistEntry);
+
+      await lockUserAccountHandler({
+        ctx: { user: mockUser as never },
+        input: { userId: 42, locked: false },
+      });
+
+      expect(mockSendEmailVerification).toHaveBeenCalledWith({
+        email: "test@example.com",
+        username: "testuser",
+      });
+    });
+
+    it("should send verification email even when no watchlist entry exists", async () => {
+      mockFindBlockedEmail.mockResolvedValue(null);
+
+      await lockUserAccountHandler({
+        ctx: { user: mockUser as never },
+        input: { userId: 42, locked: false },
+      });
+
+      expect(mockDeleteEntry).not.toHaveBeenCalled();
+      expect(mockSendEmailVerification).toHaveBeenCalledWith({
+        email: "test@example.com",
+        username: "testuser",
+      });
+    });
+
+    it("should call deleteEntry before sendEmailVerification", async () => {
+      const callOrder: string[] = [];
+      mockFindBlockedEmail.mockResolvedValue({ id: "entry-1" });
+      mockDeleteEntry.mockImplementation(async () => {
+        callOrder.push("deleteEntry");
+      });
+      mockSendEmailVerification.mockImplementation(async () => {
+        callOrder.push("sendEmailVerification");
+        return { ok: true, skipped: false };
+      });
+
+      await lockUserAccountHandler({
+        ctx: { user: mockUser as never },
+        input: { userId: 42, locked: false },
+      });
+
+      expect(callOrder).toEqual(["deleteEntry", "sendEmailVerification"]);
+    });
+  });
+
+  describe("locking a user", () => {
+    it("should not remove watchlist entry when locking a user", async () => {
+      await lockUserAccountHandler({
+        ctx: { user: mockUser as never },
+        input: { userId: 42, locked: true },
+      });
+
+      expect(mockFindBlockedEmail).not.toHaveBeenCalled();
+      expect(mockDeleteEntry).not.toHaveBeenCalled();
+    });
+
+    it("should not send verification email when locking a user", async () => {
+      await lockUserAccountHandler({
+        ctx: { user: mockUser as never },
+        input: { userId: 42, locked: true },
+      });
+
+      expect(mockSendEmailVerification).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.ts
@@ -1,7 +1,7 @@
+import { sendEmailVerification } from "@calcom/features/auth/lib/verifyEmail";
 import { GlobalWatchlistRepository } from "@calcom/features/watchlist/lib/repository/GlobalWatchlistRepository";
 import { normalizeEmail } from "@calcom/features/watchlist/lib/utils/normalization";
 import { prisma } from "@calcom/prisma";
-
 import type { TrpcSessionUser } from "../../../types";
 import type { TAdminLockUserAccountSchema } from "./lockUserAccount.schema";
 
@@ -25,6 +25,7 @@ const lockUserAccountHandler = async ({ input }: GetOptions) => {
     select: {
       id: true,
       email: true,
+      username: true,
     },
   });
 
@@ -39,6 +40,11 @@ const lockUserAccountHandler = async ({ input }: GetOptions) => {
     if (watchlistEntry) {
       await globalWatchlistRepo.deleteEntry(watchlistEntry.id);
     }
+
+    await sendEmailVerification({
+      email: user.email,
+      username: user.username || "",
+    });
   }
 
   return {


### PR DESCRIPTION
## What does this PR do?

Fixes three bugs in the signup watchlist review feature introduced in #27912, and adds auto-unlock behavior when SIGNUP-source watchlist entries are removed.

### Bug Fixes

1. **`GlobalWatchlistRepository.deleteEntry` missing `await`** — Prisma queries are lazy; without `await`, the delete was silently never executed. This caused watchlist entries to persist even after an admin unlocked a user.

2. **Email verification race condition** — `sendEmailVerification` was called (fire-and-forget) BEFORE the watchlist check added the email to the blocklist. By the time `sendEmailVerification` ran its internal watchlist check, the email was already blocked, so no verification token was ever created. Fixed by moving `sendEmailVerification` to AFTER the watchlist early-return path, so it only runs for non-watchlisted signups.

3. **No verification email on unlock** — After an admin unlocks a user and removes them from the watchlist, the user had no way to verify their email. Now `sendEmailVerification` is called after unlock in `lockUserAccount.handler.ts`.

Additionally, `sendEmailVerification` is now scoped to non-invite signups (`!checkoutSessionId && !token`) to prevent redundant verification emails for team invite users who already have `emailVerified` set.

### New: Auto-unlock on SIGNUP watchlist entry removal

When a watchlist entry with `source: SIGNUP` and `type: EMAIL` is deleted (single or bulk) via `AdminWatchlistOperationsService`, the associated user is automatically:
- Unlocked (via new `UserRepository.unlockByEmail`)
- Sent a fresh verification email

This works for both `deleteWatchlistEntry` (single) and `bulkDeleteWatchlistEntries` (bulk). Errors in the unlock/email flow are caught and logged — they do not block the deletion itself.

- Fixes issues reported in #27912 review

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A

## How should this be tested?

1. Enable the `signup-watchlist-review` feature flag in the database
2. Sign up a new user (non-invite flow, non-premium username)
3. Verify the watchlist entry has `source: 'SIGNUP'` (not `'MANUAL'`)
4. Verify no verification email is sent at signup (email is blocked by watchlist)
5. As admin, unlock the user via the admin panel
6. Verify the watchlist entry is deleted from the database
7. Verify the user receives a fresh verification email after unlock
8. Verify the verification link works
9. **New:** As admin, remove a SIGNUP-source watchlist entry directly from the watchlist management UI
10. Verify the associated user is automatically unlocked and receives a verification email
11. Verify removing a MANUAL-source entry does **not** trigger auto-unlock

## Human Review Checklist

⚠️ **Important items for reviewer attention:**


- [ ] **`sendEmailVerification` in unlock handler is `await`ed** (`lockUserAccount.handler.ts:45`): Unlike the fire-and-forget pattern in the signup handler, the unlock handler awaits the call. If the email service fails, the unlock response will also fail. Confirm this is acceptable or if it should be fire-and-forget.

- [ ] **`deleteEntry` await fix** (`GlobalWatchlistRepository.ts:166`): Confirm the missing `await` was indeed the root cause of watchlist entries not being deleted on unlock.

- [ ] **Order of operations in signup handler** (`calcomSignupHandler.ts:320-326`): The watchlist check + early return now happens BEFORE `sendEmailVerification`. For the watchlist review path, the handler returns at line 317, so `sendEmailVerification` at line 320 is never reached — which is the correct behavior.

- [ ] **`!token` guard on `sendEmailVerification`** (`calcomSignupHandler.ts:320`): Team invite signups (token flow) already set `emailVerified` directly, so they skip verification. Confirm this guard is correct.

- [ ] **Auto-unlock error handling** (`AdminWatchlistOperationsService.ts:215-227`): The `unlockSignupUser` method catches errors and logs them but does not throw. This means if unlock fails, the watchlist deletion still succeeds. Confirm this is the desired behavior (deletion should not be blocked by unlock failures).

- [ ] **Non-atomic unlock** (`UserRepository.ts:1440-1459`): `unlockByEmail` uses `findFirst` + `update` (two queries). There's a theoretical race condition if the user gets locked between find and update. Low risk but worth noting.

- [ ] **`findEntriesByIds` interface expansion** (`WatchlistRepository.ts:237-244`): Now returns `source`, `type`, `value` fields. Verify no other callers depend on the previous narrower return type.

---

Link to Devin run: https://app.devin.ai/sessions/89436f0e54694e308731b95c32036f1d
Requested by: @alishaz-polymath