### PR TITLE
fix: default icon size to 16px in createIcon wrapper and fix download button alignment

### DIFF
--- a/apps/web/modules/data-table/components/filters/AddFilterButton.tsx
+++ b/apps/web/modules/data-table/components/filters/AddFilterButton.tsx
@@ -55,7 +55,7 @@ function AddFilterButtonComponent<TData>(
             <PopoverTrigger asChild>
               <Button ref={ref} color="secondary" data-testid="add-filter-button" className="h-full">
                 <span className="sr-only">{t("filter")}</span>
-                <PlusIcon size={16} />
+                <PlusIcon />
               </Button>
             </PopoverTrigger>
           </Tooltip>

--- a/apps/web/modules/data-table/components/filters/AddFilterButton.tsx
+++ b/apps/web/modules/data-table/components/filters/AddFilterButton.tsx
@@ -55,7 +55,7 @@ function AddFilterButtonComponent<TData>(
             <PopoverTrigger asChild>
               <Button ref={ref} color="secondary" data-testid="add-filter-button" className="h-full">
                 <span className="sr-only">{t("filter")}</span>
-                <PlusIcon />
+                <PlusIcon size={16} />
               </Button>
             </PopoverTrigger>
           </Tooltip>

--- a/apps/web/modules/insights/components/filters/Download/Download.tsx
+++ b/apps/web/modules/insights/components/filters/Download/Download.tsx
@@ -99,7 +99,7 @@ const Download = () => {
           EndIcon="file-down"
           color="secondary"
           loading={isDownloading}
-          className="h-full self-end sm:self-baseline">
+          className="h-full">
           {t("download")}
         </Button>
       </DropdownMenuTrigger>

--- a/packages/coss-ui/src/icons.tsx
+++ b/packages/coss-ui/src/icons.tsx
@@ -163,7 +163,7 @@ export interface IconProps {
 }
 
 function createIcon(Icon: LucideIcon, testId: string) {
-  return function WrappedIcon({ size, className, onClick }: IconProps) {
+  return function WrappedIcon({ size = 16, className, onClick }: IconProps) {
     return <Icon size={size} className={className} onClick={onClick} data-testid={testId} />;
   };
 }


### PR DESCRIPTION
## What does this PR do?

Fixes two visual regressions on the Insights page:

1. **`@coss/ui/icons` wrapped icons defaulting to wrong size**: The icon migration in #27458 replaced `<Icon name="plus" />` (default 16px) with icons from `@coss/ui/icons`, which wrap lucide-react (default 24px). This caused icons like the "+" add-filter button to render 50% larger than intended. Fixed by setting `size = 16` as the default in the `createIcon` wrapper (`packages/coss-ui/src/icons.tsx`) so all ~155 wrapped icons match the old `<Icon>` component behavior. Callers that explicitly pass a `size` prop are unaffected.

2. **"Download" button vertically misaligned**: The button had `self-end sm:self-baseline` classes that override the parent container's `items-center` alignment. Fixed by removing the conflicting alignment classes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — visual-only changes with no existing visual regression tests.

## How should this be tested?

1. Navigate to the **Insights** page (`/insights`)
2. Verify the "+" add-filter button icon is normal small size (16px, not oversized 24px)
3. Verify the "Download" button is vertically centered with the date picker
4. Check other pages using `DataTableFilters.FilterBar` (Bookings, Members, etc.) — the "+" button should be correctly sized
5. **Spot-check icons across the app** (sidebar, event types, settings, workflows) to confirm no icons appear unexpectedly small after the global default change

## Human Review Checklist

- [ ] **Critical**: Spot-check icons across the app to confirm the global `size=16` default doesn't shrink any icons that were relying on lucide's 24px default without passing an explicit `size` prop
- [ ] Visually verify both fixes on the Insights page
- [ ] Check the "+" button size on other data table pages (Bookings, Members, etc.)
- [ ] Verify Download button alignment on narrow viewports where flex-wrap activates

---

Link to Devin run: https://app.devin.ai/sessions/c5eaaa3e63f042d6a2410c56957f64a6
Requested by: @eunjae-lee