### PR TITLE
fix: add e2e-spec pattern to CODEOWNERS test file exclusions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,5 +41,6 @@
 # Exclude test files from requiring foundation/consumer approval
 **/*.spec.*
 **/*.e2e.*
+**/*.e2e-spec.*
 **/*.test.*
 **/*.integration-test.*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,4 +43,5 @@
 **/*.e2e.*
 **/*.e2e-spec.*
 **/*.test.*
+**/*.test-suite.*
 **/*.integration-test.*


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded CODEOWNERS test exclusions to include e2e-spec and test-suite files so they no longer request foundation/consumer approval.

<sup>Written for commit c36b6e67e0fc5e071c288a6af882745ce53cd6e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
