### PR TITLE
fix: inline package.json descriptions in app-store _metadata.ts to fix Vitest RPC errors

### DIFF
--- a/packages/app-store/applecalendar/_metadata.ts
+++ b/packages/app-store/applecalendar/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Apple Calendar",
-  description: _package.description,
+  description:
+    "Apple calendar runs both the macOS and iOS mobile operating systems. Offering online cloud backup of calendars using Apple's iCloud service, it can sync with Google Calendar and Microsoft Exchange Server. Users can schedule events in their day that include time, location, duration, and extra notes.",
   installed: true,
   type: "apple_calendar",
   title: "Apple Calendar",

--- a/packages/app-store/caldavcalendar/_metadata.ts
+++ b/packages/app-store/caldavcalendar/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "CalDav (Beta)",
-  description: _package.description,
+  description:
+    "Caldav is a protocol that allows different clients/servers to access scheduling information on remote servers as well as schedule meetings with other users on the same server or other servers. It extends WebDAV specification and uses iCalendar format for the data.",
   installed: true,
   type: "caldav_calendar",
   title: "CalDav (Beta)",

--- a/packages/app-store/caldavcalendar/index.ts
+++ b/packages/app-store/caldavcalendar/index.ts
@@ -1,10 +1,9 @@
 import type { App } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "CalDav (Beta)",
-  description: _package.description,
+  description:
+    "Caldav is a protocol that allows different clients/servers to access scheduling information on remote servers as well as schedule meetings with other users on the same server or other servers. It extends WebDAV specification and uses iCalendar format for the data.",
   installed: true,
   type: "caldav_calendar",
   title: "CalDav (Beta)",

--- a/packages/app-store/dailyvideo/_metadata.ts
+++ b/packages/app-store/dailyvideo/_metadata.ts
@@ -1,10 +1,10 @@
+import process from "node:process";
 import type { AppMeta } from "@calcom/types/App";
-
-import _package from "./package.json";
 
 export const metadata = {
   name: "Cal Video",
-  description: _package.description,
+  description:
+    "Cal Video is the in-house web-based video conferencing platform powered by Daily.co, which is minimalistic and lightweight, but has most of the features you need.",
   installed: !!process.env.DAILY_API_KEY,
   type: "daily_video",
   variant: "conferencing",

--- a/packages/app-store/exchange2013calendar/_metadata.ts
+++ b/packages/app-store/exchange2013calendar/_metadata.ts
@@ -1,10 +1,8 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Microsoft Exchange 2013 Calendar",
-  description: _package.description,
+  description: "For calendars hosted on on-premises Microsoft Exchange 2013 servers",
   installed: true,
   type: "exchange2013_calendar",
   title: "Microsoft Exchange 2013 Calendar",

--- a/packages/app-store/exchange2016calendar/_metadata.ts
+++ b/packages/app-store/exchange2016calendar/_metadata.ts
@@ -1,10 +1,8 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Microsoft Exchange 2016 Calendar",
-  description: _package.description,
+  description: "For calendars hosted on on-premises Microsoft Exchange 2016 servers",
   installed: true,
   type: "exchange2016_calendar",
   title: "Microsoft Exchange 2016 Calendar",

--- a/packages/app-store/feishucalendar/_metadata.ts
+++ b/packages/app-store/feishucalendar/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Feishu Calendar",
-  description: _package.description,
+  description:
+    "Feishu Calendar is a time management and scheduling service developed by Feishu. Allows users to create and edit events, with options available for type and time. Available to anyone that has a Feishu account on both mobile and web versions.",
   installed: true,
   type: "feishu_calendar",
   title: "Feishu Calendar",

--- a/packages/app-store/giphy/_metadata.ts
+++ b/packages/app-store/giphy/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Giphy",
-  description: _package.description,
+  description:
+    "GIPHY is your top source for the best & newest GIFs & Animated Stickers online. Find everything from funny GIFs, reaction GIFs, unique GIFs and more.",
   installed: true,
   categories: ["other"],
   logo: "icon.svg",

--- a/packages/app-store/googlecalendar/_metadata.ts
+++ b/packages/app-store/googlecalendar/_metadata.ts
@@ -1,11 +1,11 @@
+import process from "node:process";
 import { validJson } from "@calcom/lib/jsonUtils";
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Google Calendar",
-  description: _package.description,
+  description:
+    "Google Calendar is a time management and scheduling service developed by Google. Allows users to create and edit events, with options available for type and time. Available to anyone that has a Gmail account on both mobile and web versions.",
   installed: !!(process.env.GOOGLE_API_CREDENTIALS && validJson(process.env.GOOGLE_API_CREDENTIALS)),
   type: "google_calendar",
   title: "Google Calendar",

--- a/packages/app-store/googlevideo/_metadata.ts
+++ b/packages/app-store/googlevideo/_metadata.ts
@@ -1,11 +1,11 @@
+import process from "node:process";
 import { validJson } from "@calcom/lib/jsonUtils";
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Google Meet",
-  description: _package.description,
+  description:
+    "Google Meet is Google's web-based video conferencing platform, designed to compete with major conferencing platforms.",
   installed: !!(process.env.GOOGLE_API_CREDENTIALS && validJson(process.env.GOOGLE_API_CREDENTIALS)),
   slug: "google-meet",
   category: "conferencing",

--- a/packages/app-store/hubspot/_metadata.ts
+++ b/packages/app-store/hubspot/_metadata.ts
@@ -1,11 +1,11 @@
 import type { AppMeta } from "@calcom/types/App";
-import _package from "./package.json";
 
 export const metadata = {
   name: "HubSpot CRM",
   // biome-ignore lint/correctness/noProcessGlobal: Server-only metadata evaluated at build time
   installed: !!process.env.HUBSPOT_CLIENT_ID,
-  description: _package.description,
+  description:
+    "HubSpot is a cloud-based CRM designed to help align sales and marketing teams, foster sales enablement, boost ROI and optimize your inbound marketing strategy to generate more, qualified leads.",
   type: "hubspot_crm",
   variant: "crm",
   logo: "icon.svg",

--- a/packages/app-store/huddle01video/_metadata.ts
+++ b/packages/app-store/huddle01video/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Huddle01",
-  description: _package.description,
+  description:
+    "Huddle01 is a new video conferencing software native to Web3 and is comparable to a decentralized version of Zoom. It supports conversations for NFT communities, DAOs, Builders and also has features such as token gating, NFTs as avatars, Web3 Login + ENS and recording over IPFS.",
   installed: true,
   type: "huddle01_video",
   variant: "conferencing",

--- a/packages/app-store/jitsivideo/_metadata.ts
+++ b/packages/app-store/jitsivideo/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Jitsi Video",
-  description: _package.description,
+  description:
+    "Jitsi is a free open-source video conferencing software for web and mobile. Make a call, launch on your own servers, integrate into your app, and more.",
   installed: true,
   type: "jitsi_video",
   variant: "conferencing",

--- a/packages/app-store/larkcalendar/_metadata.ts
+++ b/packages/app-store/larkcalendar/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Lark Calendar",
-  description: _package.description,
+  description:
+    "Lark Calendar is a time management and scheduling service developed by Lark. Allows users to create and edit events, with options available for type and time. Available to anyone that has a Lark account on both mobile and web versions.",
   installed: true,
   type: "lark_calendar",
   title: "Lark Calendar",

--- a/packages/app-store/office365calendar/_metadata.ts
+++ b/packages/app-store/office365calendar/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Outlook Calendar",
-  description: _package.description,
+  description:
+    "Microsoft Office 365 is a suite of apps that helps you stay connected with others and get things done. It includes but is not limited to Microsoft Word, PowerPoint, Excel, Teams, OneNote and OneDrive. Office 365 allows you to work remotely with others on a team and collaborate in an online environment. Both web versions and desktop/mobile applications are available.",
   type: "office365_calendar",
   title: "Outlook Calendar",
   variant: "calendar",

--- a/packages/app-store/office365video/_metadata.ts
+++ b/packages/app-store/office365video/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Microsoft 365/Teams (Requires work/school account)",
-  description: _package.description,
+  description:
+    "Microsoft Teams is a business communication platform and collaborative workspace included in Microsoft 365. It offers workspace chat and video conferencing, file storage, and application integration. Both web versions and desktop/mobile applications are available. NOTE: MUST HAVE A WORK / SCHOOL ACCOUNT",
   appData: {
     location: {
       linkType: "dynamic",

--- a/packages/app-store/stripepayment/_metadata.ts
+++ b/packages/app-store/stripepayment/_metadata.ts
@@ -1,10 +1,10 @@
+import process from "node:process";
 import type { AppMeta } from "@calcom/types/App";
-
-import _package from "./package.json";
 
 export const metadata = {
   name: "Stripe",
-  description: _package.description,
+  description:
+    "A Saas company a payment processing software, and application programming interfaces for e-commerce websites and mobile applications.",
   installed: !!(
     process.env.STRIPE_CLIENT_ID &&
     process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY &&

--- a/packages/app-store/tandemvideo/_metadata.ts
+++ b/packages/app-store/tandemvideo/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Tandem Video",
-  description: _package.description,
+  description:
+    "Tandem is a new virtual office space that allows teams to effortlessly connect as though they are in a physical office, online. Through co-working rooms, available statuses, live real-time video call, and chat options, you can see who's around, talk and collaborate in one click. It works cross-platform with both desktop and mobile versions.",
   type: "tandem_video",
   title: "Tandem Video",
   variant: "conferencing",

--- a/packages/app-store/vital/_metadata.ts
+++ b/packages/app-store/vital/_metadata.ts
@@ -1,10 +1,8 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Vital",
-  description: _package.description,
+  description: "Connect your health data or wearables to trigger actions on your calendar.",
   installed: true,
   category: "automation",
   categories: ["automation"],

--- a/packages/app-store/wipemycalother/_metadata.ts
+++ b/packages/app-store/wipemycalother/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
-  name: _package.name,
-  description: _package.description,
+  name: "WipeMyCal",
+  description:
+    "Wipe My Cal is a Cal.com exclusive app that redefines what it looks like to reschedule multiple meetings at the same time. Simply install the app, and select 'Wipe' for whatever date you need to mass reschedule. Handle emergencies, unexpected sick days and last minute events with the simple click of a button.",
   installed: true,
   category: "automation",
   categories: ["automation"],

--- a/packages/app-store/zapier/_metadata.ts
+++ b/packages/app-store/zapier/_metadata.ts
@@ -1,10 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   name: "Zapier",
-  description: _package.description,
+  description:
+    "Workflow automation for everyone. Use the Cal.com Zapier app to trigger your workflows when a booking is created, rescheduled, or cancelled, or after a meeting ends.",
   installed: true,
   category: "automation",
   categories: ["automation"],

--- a/packages/app-store/zoomvideo/_metadata.ts
+++ b/packages/app-store/zoomvideo/_metadata.ts
@@ -1,11 +1,10 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import _package from "./package.json";
-
 export const metadata = {
   linkType: "dynamic",
   name: "Zoom Video",
-  description: _package.description,
+  description:
+    "Zoom is a secure and reliable video platform that supports all of your online communication needs. It can provide everything from one on one meetings, chat, phone, webinars, and large-scale online events. Available with both desktop, web, and mobile versions.",
   type: "zoom_video",
   categories: ["conferencing"],
   variant: "conferencing",


### PR DESCRIPTION
## What does this PR do?

Fixes Vitest unhandled rejection errors during test runs:

```
Error: [vitest-worker]: Closing rpc while "fetch" was pending
 ❯ packages/app-store/jitsivideo/_metadata.ts:3:1
      1| import type { AppMeta } from "@calcom/types/App";
      3| import _package from "./package.json";
```

**Root cause:** 22 app-store `_metadata.ts` files used `import _package from "./package.json"` to pull in the `description` field. In Vitest's module runner, JSON imports trigger an RPC-based module fetch. When test workers shut down before all these fetches resolve, Vitest reports unhandled rejections — producing false positive test failures.

**Fix:** Inline the `description` (and in one case, `name`) string literals directly into each `_metadata.ts` file, removing the `./package.json` import entirely. Values were copied verbatim from each app's `package.json`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the full unit test suite and confirm the "Closing rpc while fetch was pending" errors no longer appear:

```bash
TZ=UTC yarn test
```

Before this change, the test run reports `8 errors` including multiple instances of the RPC error originating from `_metadata.ts` files. After this change, those specific errors should be gone.

## Human Review Checklist

- [x] **Verify inlined descriptions match `package.json`**: Each description string was copied from the corresponding app's `package.json`. Spot-check a few to confirm no transcription errors (e.g. `huddle01video`, `wipemycalother`, `office365calendar`).
- [x] **`wipemycalother` name field**: This was the only file also using `_package.name`. Verify `"WipeMyCal"` matches the `name` field in `wipemycalother/package.json`.
- [x] **`import process from "node:process"` additions**: The biome pre-commit hook auto-added explicit `process` imports in `dailyvideo`, `googlecalendar`, `googlevideo`, and `stripepayment` (files that use `process.env`). These were not manual edits — verify they are acceptable.
- [x] **Description duplication**: Descriptions now live in both `package.json` and `_metadata.ts`. Consider whether `package.json` descriptions should be removed or if this duplication is acceptable.

---

> Link to Devin run: https://app.devin.ai/sessions/b9e4b58653f74391b9b3fe80bdeeed82
> Requested by: @emrysal