### PR TITLE
feat: add CSRF protection to /api/book/event and affiliated booking endpoints

### DIFF
--- a/apps/web/lib/validateCsrfToken.test.ts
+++ b/apps/web/lib/validateCsrfToken.test.ts
@@ -1,0 +1,120 @@
+import { HttpError } from "@calcom/lib/http-error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { describe, expect, it, vi } from "vitest";
+import { validateCsrfTokenForPagesRouter } from "./validateCsrfToken";
+
+const VALID_TOKEN = "a".repeat(64);
+
+function createMockReqRes(options: { body?: unknown; cookies?: Record<string, string> }): {
+  req: NextApiRequest;
+  res: NextApiResponse;
+} {
+  const req = {
+    body: options.body ?? {},
+    cookies: options.cookies ?? {},
+  } as unknown as NextApiRequest;
+
+  const res = {
+    setHeader: vi.fn(),
+  } as unknown as NextApiResponse;
+
+  return { req, res };
+}
+
+describe("validateCsrfTokenForPagesRouter", () => {
+  it("passes validation when body token matches cookie token", () => {
+    const { req, res } = createMockReqRes({
+      body: { csrfToken: VALID_TOKEN },
+      cookies: { "calcom.csrf_token": VALID_TOKEN },
+    });
+
+    expect(() => validateCsrfTokenForPagesRouter(req, res)).not.toThrow();
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Set-Cookie",
+      expect.stringContaining("calcom.csrf_token=; Path=/; Max-Age=0")
+    );
+  });
+
+  it("throws 403 when csrfToken is missing from body", () => {
+    const { req, res } = createMockReqRes({
+      body: {},
+      cookies: { "calcom.csrf_token": VALID_TOKEN },
+    });
+
+    expect(() => validateCsrfTokenForPagesRouter(req, res)).toThrow(HttpError);
+    try {
+      validateCsrfTokenForPagesRouter(req, res);
+    } catch (err) {
+      expect((err as HttpError).statusCode).toBe(403);
+    }
+  });
+
+  it("throws 403 when csrfToken has wrong length", () => {
+    const { req, res } = createMockReqRes({
+      body: { csrfToken: "too-short" },
+      cookies: { "calcom.csrf_token": VALID_TOKEN },
+    });
+
+    expect(() => validateCsrfTokenForPagesRouter(req, res)).toThrow(HttpError);
+  });
+
+  it("throws 403 when csrfToken is not a string", () => {
+    const { req, res } = createMockReqRes({
+      body: { csrfToken: 12345 },
+      cookies: { "calcom.csrf_token": VALID_TOKEN },
+    });
+
+    expect(() => validateCsrfTokenForPagesRouter(req, res)).toThrow(HttpError);
+  });
+
+  it("throws 403 when cookie is missing", () => {
+    const { req, res } = createMockReqRes({
+      body: { csrfToken: VALID_TOKEN },
+      cookies: {},
+    });
+
+    expect(() => validateCsrfTokenForPagesRouter(req, res)).toThrow(HttpError);
+  });
+
+  it("throws 403 when cookie token does not match body token", () => {
+    const differentToken = "b".repeat(64);
+    const { req, res } = createMockReqRes({
+      body: { csrfToken: VALID_TOKEN },
+      cookies: { "calcom.csrf_token": differentToken },
+    });
+
+    expect(() => validateCsrfTokenForPagesRouter(req, res)).toThrow(HttpError);
+  });
+
+  it("extracts csrfToken from first element when body is an array", () => {
+    const { req, res } = createMockReqRes({
+      body: [{ csrfToken: VALID_TOKEN, start: "2024-01-01" }, { csrfToken: VALID_TOKEN }],
+      cookies: { "calcom.csrf_token": VALID_TOKEN },
+    });
+
+    expect(() => validateCsrfTokenForPagesRouter(req, res)).not.toThrow();
+  });
+
+  it("throws 403 when body is an empty array", () => {
+    const { req, res } = createMockReqRes({
+      body: [],
+      cookies: { "calcom.csrf_token": VALID_TOKEN },
+    });
+
+    expect(() => validateCsrfTokenForPagesRouter(req, res)).toThrow(HttpError);
+  });
+
+  it("clears the csrf cookie after successful validation", () => {
+    const { req, res } = createMockReqRes({
+      body: { csrfToken: VALID_TOKEN },
+      cookies: { "calcom.csrf_token": VALID_TOKEN },
+    });
+
+    validateCsrfTokenForPagesRouter(req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Set-Cookie",
+      "calcom.csrf_token=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax"
+    );
+  });
+});

--- a/apps/web/lib/validateCsrfToken.ts
+++ b/apps/web/lib/validateCsrfToken.ts
@@ -1,13 +1,35 @@
+import { HttpError } from "@calcom/lib/http-error";
+import type { NextApiRequest, NextApiResponse } from "next";
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
+const CSRF_COOKIE_NAME = "calcom.csrf_token";
+const CSRF_TOKEN_LENGTH = 64;
+
 export async function validateCsrfToken(csrfToken: string): Promise<NextResponse | null> {
   const cookieStore = await cookies();
-  const cookieToken = cookieStore.get("calcom.csrf_token")?.value;
+  const cookieToken = cookieStore.get(CSRF_COOKIE_NAME)?.value;
 
   if (!cookieToken || cookieToken !== csrfToken) {
     return NextResponse.json({ success: false, message: "Invalid CSRF token" }, { status: 403 });
   }
-  cookieStore.delete("calcom.csrf_token");
+  cookieStore.delete(CSRF_COOKIE_NAME);
   return null;
+}
+
+export function validateCsrfTokenForPagesRouter(req: NextApiRequest, res: NextApiResponse): void {
+  const body = req.body;
+  const csrfToken = Array.isArray(body) ? body[0]?.csrfToken : body?.csrfToken;
+
+  if (typeof csrfToken !== "string" || csrfToken.length !== CSRF_TOKEN_LENGTH) {
+    throw new HttpError({ statusCode: 403, message: "Invalid CSRF token" });
+  }
+
+  const cookieToken = req.cookies[CSRF_COOKIE_NAME];
+
+  if (!cookieToken || cookieToken !== csrfToken) {
+    throw new HttpError({ statusCode: 403, message: "Invalid CSRF token" });
+  }
+
+  res.setHeader("Set-Cookie", `${CSRF_COOKIE_NAME}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`);
 }

--- a/apps/web/pages/api/book/event.ts
+++ b/apps/web/pages/api/book/event.ts
@@ -1,5 +1,4 @@
-import type { NextApiRequest } from "next";
-
+import process from "node:process";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { getRegularBookingService } from "@calcom/features/bookings/di/RegularBookingService.container";
 import { BotDetectionService } from "@calcom/features/bot-detection";
@@ -7,14 +6,21 @@ import { EventTypeRepository } from "@calcom/features/eventtypes/repositories/ev
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import getIP from "@calcom/lib/getIP";
-import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import { checkCfTurnstileToken } from "@calcom/lib/server/checkCfTurnstileToken";
 import { defaultResponder } from "@calcom/lib/server/defaultResponder";
+import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import type { TraceContext } from "@calcom/lib/tracing";
 import { prisma } from "@calcom/prisma";
 import { CreationSource } from "@calcom/prisma/enums";
+import { validateCsrfTokenForPagesRouter } from "@calcom/web/lib/validateCsrfToken";
+import type { NextApiRequest, NextApiResponse } from "next";
 
-async function handler(req: NextApiRequest & { userId?: number; traceContext: TraceContext }) {
+async function handler(
+  req: NextApiRequest & { userId?: number; traceContext: TraceContext },
+  res: NextApiResponse
+) {
+  validateCsrfTokenForPagesRouter(req, res);
+
   const userIp = getIP(req);
 
   if (process.env.NEXT_PUBLIC_CLOUDFLARE_USE_TURNSTILE_IN_BOOKER === "1") {

--- a/apps/web/pages/api/book/instant-event.ts
+++ b/apps/web/pages/api/book/instant-event.ts
@@ -1,14 +1,16 @@
-import type { NextApiRequest } from "next";
-
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { getInstantBookingCreateService } from "@calcom/features/bookings/di/InstantBookingCreateService.container";
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import getIP from "@calcom/lib/getIP";
-import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import { defaultResponder } from "@calcom/lib/server/defaultResponder";
+import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import { CreationSource } from "@calcom/prisma/enums";
+import { validateCsrfTokenForPagesRouter } from "@calcom/web/lib/validateCsrfToken";
+import type { NextApiRequest, NextApiResponse } from "next";
 
-async function handler(req: NextApiRequest & { userId?: number }) {
+async function handler(req: NextApiRequest & { userId?: number }, res: NextApiResponse) {
+  validateCsrfTokenForPagesRouter(req, res);
+
   const userIp = getIP(req);
 
   await checkRateLimitAndThrowError({

--- a/apps/web/pages/api/book/recurring-event.test.ts
+++ b/apps/web/pages/api/book/recurring-event.test.ts
@@ -21,7 +21,11 @@ import { getMockRequestDataForBooking } from "@calcom/testing/lib/bookingScenari
 import { setupAndTeardown } from "@calcom/testing/lib/bookingScenario/setupAndTeardown";
 
 import { v4 as uuidv4 } from "uuid";
-import { describe, expect } from "vitest";
+import { describe, expect, vi } from "vitest";
+
+vi.mock("@calcom/web/lib/validateCsrfToken", () => ({
+  validateCsrfTokenForPagesRouter: vi.fn(),
+}));
 
 import { WEBAPP_URL, WEBSITE_URL } from "@calcom/lib/constants";
 import { ErrorCode } from "@calcom/lib/errorCodes";
@@ -156,7 +160,7 @@ describe("handleNewBooking", () => {
               }),
           });
 
-          const createdBookings = await handleRecurringEventBooking(req);
+          const createdBookings = await handleRecurringEventBooking(req, res);
           expect(createdBookings.length).toBe(numOfSlotsToBeBooked);
           for (const [index, createdBooking] of Object.entries(createdBookings)) {
             logger.debug("Assertion for Booking with index:", index, { createdBooking });
@@ -374,7 +378,7 @@ describe("handleNewBooking", () => {
               }),
           });
 
-          await expect(handleRecurringEventBooking(req)).rejects.toThrow(ErrorCode.NoAvailableUsersFound);
+          await expect(handleRecurringEventBooking(req, res)).rejects.toThrow(ErrorCode.NoAvailableUsersFound);
           // Actually the first booking goes through in this case but the status is still a failure. We should do a dry run to check if booking is possible  for the 2 slots and if yes, then only go for the actual booking otherwise fail the recurring bookign
         },
         timeout
@@ -505,7 +509,7 @@ describe("handleNewBooking", () => {
               }),
           });
 
-          const createdBookings = await handleRecurringEventBooking(req);
+          const createdBookings = await handleRecurringEventBooking(req, res);
           expect(createdBookings.length).toBe(numOfSlotsToBeBooked);
           for (const [index, createdBooking] of Object.entries(createdBookings)) {
             logger.debug("Assertion for Booking with index:", index, { createdBooking });
@@ -723,7 +727,7 @@ describe("handleNewBooking", () => {
               }),
           });
 
-          const createdBookings = await handleRecurringEventBooking(req);
+          const createdBookings = await handleRecurringEventBooking(req, res);
           expect(createdBookings.length).toBe(numOfSlotsToBeBooked);
           for (const [index, createdBooking] of Object.entries(createdBookings)) {
             logger.debug("Assertion for Booking with index:", index, { createdBooking });
@@ -983,7 +987,7 @@ describe("handleNewBooking", () => {
         });
         let error = { message: "" };
         try {
-          await handleRecurringEventBooking(req);
+          await handleRecurringEventBooking(req, res);
         } catch (e) {
           error = e as Error;
         }
@@ -1165,11 +1169,11 @@ describe("handleNewBooking", () => {
             }),
         });
 
-        const createdBookings1 = await handleRecurringEventBooking(req);
+        const createdBookings1 = await handleRecurringEventBooking(req, res);
 
         const assignedUserIds1 = createdBookings1.map((booking) => booking.userId);
 
-        const createdBookings2 = await handleRecurringEventBooking(req1);
+        const createdBookings2 = await handleRecurringEventBooking(req1, res1);
 
         const assignedUserIds2 = createdBookings2.map((booking) => booking.userId);
 
@@ -1386,11 +1390,11 @@ describe("handleNewBooking", () => {
             }),
         });
 
-        const createdBookings1 = await handleRecurringEventBooking(req);
+        const createdBookings1 = await handleRecurringEventBooking(req, res);
 
         const assignedUserIds1 = createdBookings1.map((booking) => booking.userId);
 
-        const createdBookings2 = await handleRecurringEventBooking(req1);
+        const createdBookings2 = await handleRecurringEventBooking(req1, res1);
 
         const assignedUserIds2 = createdBookings2.map((booking) => booking.userId);
 

--- a/apps/web/pages/api/book/recurring-event.ts
+++ b/apps/web/pages/api/book/recurring-event.ts
@@ -1,12 +1,14 @@
-import type { NextApiRequest } from "next";
+import process from "node:process";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { getRecurringBookingService } from "@calcom/features/bookings/di/RecurringBookingService.container";
 import type { BookingResponse } from "@calcom/features/bookings/types";
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import getIP from "@calcom/lib/getIP";
-import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import { checkCfTurnstileToken } from "@calcom/lib/server/checkCfTurnstileToken";
 import { defaultResponder } from "@calcom/lib/server/defaultResponder";
+import { piiHasher } from "@calcom/lib/server/PiiHasher";
+import { validateCsrfTokenForPagesRouter } from "@calcom/web/lib/validateCsrfToken";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 // @TODO: Didn't look at the contents of this function in order to not break old booking page.
 
@@ -25,7 +27,9 @@ type RequestMeta = {
   noEmail?: boolean;
 } & PlatformParams;
 
-async function handler(req: NextApiRequest & RequestMeta) {
+async function handler(req: NextApiRequest & RequestMeta, res: NextApiResponse) {
+  validateCsrfTokenForPagesRouter(req, res);
+
   const userIp = getIP(req);
 
   if (process.env.NEXT_PUBLIC_CLOUDFLARE_USE_TURNSTILE_IN_BOOKER === "1") {

--- a/packages/features/bookings/lib/create-booking.ts
+++ b/packages/features/bookings/lib/create-booking.ts
@@ -1,15 +1,15 @@
 import { post } from "@calcom/lib/fetch-wrapper";
-
 import type { BookingCreateBody, BookingResponse } from "../types";
+import { fetchCsrfToken } from "./fetchCsrfToken";
 
 export const createBooking = async (data: BookingCreateBody) => {
+  const csrfToken = await fetchCsrfToken();
   const response = await post<
-    BookingCreateBody,
-    // fetch response can't have a Date type, it must be a string
+    BookingCreateBody & { csrfToken: string },
     Omit<BookingResponse, "startTime" | "endTime"> & {
       startTime: string;
       endTime: string;
     }
-  >("/api/book/event", data);
+  >("/api/book/event", { ...data, csrfToken });
   return response;
 };

--- a/packages/features/bookings/lib/create-instant-booking.ts
+++ b/packages/features/bookings/lib/create-instant-booking.ts
@@ -1,13 +1,14 @@
 import { post } from "@calcom/lib/fetch-wrapper";
-
 import type { BookingCreateBody } from "../types";
 import type { InstantBookingCreateResult } from "./dto/types";
+import { fetchCsrfToken } from "./fetchCsrfToken";
 
 export const createInstantBooking = async (data: BookingCreateBody) => {
+  const csrfToken = await fetchCsrfToken();
   const response = await post<
-    BookingCreateBody,
+    BookingCreateBody & { csrfToken: string },
     // TODO: Fetch response can't have a Date type, it must be a string. We need to type expires as a string here but it breaks types down the line, fix it in a follow-up PR.
     InstantBookingCreateResult
-  >("/api/book/instant-event", data);
+  >("/api/book/instant-event", { ...data, csrfToken });
   return response;
 };

--- a/packages/features/bookings/lib/create-recurring-booking.ts
+++ b/packages/features/bookings/lib/create-recurring-booking.ts
@@ -1,15 +1,18 @@
 import { post } from "@calcom/lib/fetch-wrapper";
+import type { BookingResponse, RecurringBookingCreateBody } from "../types";
+import { fetchCsrfToken } from "./fetchCsrfToken";
 
-import type { RecurringBookingCreateBody, BookingResponse } from "../types";
+type RecurringBookingCreateBodyWithCsrf = RecurringBookingCreateBody & { csrfToken: string };
 
 export const createRecurringBooking = async (data: RecurringBookingCreateBody[]) => {
+  const csrfToken = await fetchCsrfToken();
+  const dataWithCsrf: RecurringBookingCreateBodyWithCsrf[] = data.map((item) => ({ ...item, csrfToken }));
   const response = await post<
-    RecurringBookingCreateBody[],
-    // fetch response can't have a Date type, it must be a string
+    RecurringBookingCreateBodyWithCsrf[],
     (Omit<BookingResponse, "startTime" | "endTime"> & {
       startTime: string;
       endTime: string;
     })[]
-  >("/api/book/recurring-event", data);
+  >("/api/book/recurring-event", dataWithCsrf);
   return response;
 };

--- a/packages/features/bookings/lib/fetchCsrfToken.test.ts
+++ b/packages/features/bookings/lib/fetchCsrfToken.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchCsrfToken } from "./fetchCsrfToken";
+
+vi.mock("@calcom/lib/fetch-wrapper", () => ({
+  get: vi.fn(),
+}));
+
+import { get } from "@calcom/lib/fetch-wrapper";
+
+describe("fetchCsrfToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches a CSRF token from /api/csrf", async () => {
+    const mockToken = "a".repeat(64);
+    vi.mocked(get).mockResolvedValue({ csrfToken: mockToken });
+
+    const token = await fetchCsrfToken();
+
+    expect(get).toHaveBeenCalledWith("/api/csrf");
+    expect(token).toBe(mockToken);
+  });
+
+  it("propagates errors from the fetch call", async () => {
+    vi.mocked(get).mockRejectedValue(new Error("Network error"));
+
+    await expect(fetchCsrfToken()).rejects.toThrow("Network error");
+  });
+});

--- a/packages/features/bookings/lib/fetchCsrfToken.ts
+++ b/packages/features/bookings/lib/fetchCsrfToken.ts
@@ -1,0 +1,6 @@
+import { get } from "@calcom/lib/fetch-wrapper";
+
+export async function fetchCsrfToken(): Promise<string> {
+  const { csrfToken } = await get<{ csrfToken: string }>("/api/csrf");
+  return csrfToken;
+}


### PR DESCRIPTION
## What does this PR do?

Adds CSRF protection to the three booking creation endpoints that previously lacked it:

- `POST /api/book/event`
- `POST /api/book/recurring-event`
- `POST /api/book/instant-event`

This follows the same double-submit cookie pattern already used by `/api/cancel` and `/api/video/guest-session`: client fetches a token from `GET /api/csrf` (which also sets an `httpOnly` cookie), includes the token in the request body, and the server validates that they match.

### Server-side
- Adds `validateCsrfTokenForPagesRouter()` to `apps/web/lib/validateCsrfToken.ts` — a Pages Router variant of the existing App Router `validateCsrfToken()`, since these endpoints use Pages Router API routes (`req.cookies` instead of `cookies()` from `next/headers`).
- Each of the three booking handlers now calls this validation as its first step, throwing a 403 `HttpError` on mismatch.
- Handler signatures updated to accept `res: NextApiResponse` (needed to clear the CSRF cookie after validation).

### Client-side
- Adds `packages/features/bookings/lib/fetchCsrfToken.ts` — a small helper that calls `GET /api/csrf`.
- `create-booking.ts`, `create-recurring-booking.ts`, and `create-instant-booking.ts` each fetch a CSRF token before POSTing, and include `csrfToken` in the request body.
- For recurring events (where the body is an array), the token is attached to every element; the server reads it from `body[0]`.

### Tests
- 9 unit tests for `validateCsrfTokenForPagesRouter` (happy path, missing/wrong/mismatched token, array body, cookie clearing).
- 2 unit tests for `fetchCsrfToken`.
- Updated existing `recurring-event.test.ts` to pass `res` to the handler and mock CSRF validation (these tests cover booking logic, not CSRF — CSRF has its own dedicated test suite).

## ⚠️ Important items for reviewer

1. **Embed / cross-origin scenarios:** The CSRF cookie (`calcom.csrf_token`) is set with `SameSite=Lax` by default via `GET /api/csrf`. Embeds that render the Booker in an iframe on a third-party domain may need `SameSite=None` (the `/api/csrf` endpoint already supports a `?sameSite=none` query param). **Please verify that embedded booking flows still work** — the Booker client code calls the same `createBooking` functions being modified here.

2. **Cookie header handling:** The Pages Router version clears the cookie via `res.setHeader("Set-Cookie", ...)`. If other middleware also sets `Set-Cookie` headers, this could overwrite them. Cubic AI flagged this (confidence 8/10). Worth confirming this is safe in the current middleware stack — if not, switching to `res.appendHeader` would be the fix.

3. **Handler signature change:** The three booking handlers now accept `(req, res)` instead of just `(req)`. Any code that calls the named exports (e.g. `handleRecurringEventBooking`) directly — rather than through the `defaultResponder` default export — will need to pass `res`. The existing `recurring-event.test.ts` was the only caller found and has been updated.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no public API contract changes, internal security hardening only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Unit tests:** `TZ=UTC yarn vitest run apps/web/lib/validateCsrfToken.test.ts packages/features/bookings/lib/fetchCsrfToken.test.ts` — all 11 tests should pass.

2. **Manual testing (happy path):**
   - Start the dev server (`yarn dx`)
   - Navigate to a public booking page (e.g., `/pro/30min`)
   - Complete a booking — should succeed as normal
   - Check Network tab: you should see a `GET /api/csrf` request before the `POST /api/book/event` request

3. **Manual testing (CSRF rejection):**
   - Use browser devtools to delete the `calcom.csrf_token` cookie after the `/api/csrf` call but before submitting the booking form
   - Submit the booking — should receive a 403 "Invalid CSRF token" error

4. **Embed testing (if applicable):**
   - Test the embed snippet on a third-party domain to ensure bookings still work

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is not too large (<500 lines, <10 files)

---

Link to Devin run: https://app.devin.ai/sessions/85e471b18922411e9b66b2450d81441d
Requested by: @emrysal