### PR TITLE
fix: preserve customReplyToEmail when hideOrganizerEmail is enabled

### DIFF
--- a/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
+++ b/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
@@ -571,12 +571,14 @@ export class EmailWorkflowService {
     const customReplyToEmail =
       evt?.eventType?.customReplyToEmail || (evt as CalendarEvent).customReplyToEmail;
 
+    const replyTo = evt.hideOrganizerEmail
+      ? customReplyToEmail
+      : customReplyToEmail || evt.organizer.email;
+
     return {
       subject: emailContent.emailSubject,
       html: emailContent.emailBody,
-      ...(!evt.hideOrganizerEmail && {
-        replyTo: customReplyToEmail || evt.organizer.email,
-      }),
+      ...(replyTo && { replyTo }),
       attachments,
       sender,
     };

--- a/packages/lib/getReplyToHeader.ts
+++ b/packages/lib/getReplyToHeader.ts
@@ -7,9 +7,7 @@ export function getReplyToHeader(
   additionalEmails?: string | string[],
   excludeOrganizerEmail?: boolean
 ) {
-  if (calEvent.hideOrganizerEmail) return {};
-
-  const replyToEmail = getReplyToEmail(calEvent, excludeOrganizerEmail);
+  const replyToEmail = getReplyToEmail(calEvent, excludeOrganizerEmail ?? calEvent.hideOrganizerEmail);
   const emailArray: string[] = [];
 
   if (additionalEmails) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensures emails keep the customReplyToEmail when hideOrganizerEmail is enabled, so replies go to the intended address without exposing the organizer. Applies the same reply-to logic across reminders, the workflow service, and the header helper.

- **Bug Fixes**
  - Use customReplyToEmail when hideOrganizerEmail is true; otherwise fall back to organizer email.
  - Add reply-to only when a value exists.
  - Align logic in scheduleEmailReminders, EmailWorkflowService, and getReplyToHeader.

<sup>Written for commit 658aa1962bbd845fe1bf0e35da8973348a91b491. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

