### PR TITLE
feat(api-v2): add locale query param to getCalendarLinks

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -48,6 +48,7 @@ import { Request } from "express";
 import { BookingPbacGuard } from "@/ee/bookings/2024-08-13/guards/booking-pbac.guard";
 import { BookingUidGuard } from "@/ee/bookings/2024-08-13/guards/booking-uid.guard";
 import { BookingReferencesFilterInput_2024_08_13 } from "@/ee/bookings/2024-08-13/inputs/booking-references-filter.input";
+import { GetCalendarLinksInput_2024_08_13 } from "@/ee/bookings/2024-08-13/inputs/get-calendar-links.input";
 import { BookingReferencesOutput_2024_08_13 } from "@/ee/bookings/2024-08-13/outputs/booking-references.output";
 import { CalendarLinksOutput_2024_08_13 } from "@/ee/bookings/2024-08-13/outputs/calendar-links.output";
 import { CancelBookingOutput_2024_08_13 } from "@/ee/bookings/2024-08-13/outputs/cancel-booking.output";
@@ -102,7 +103,7 @@ export class BookingsController_2024_08_13 {
     private readonly usersService: UsersService,
     private readonly bookingReferencesService: BookingReferencesService_2024_08_13,
     private readonly calVideoService: CalVideoService
-  ) {}
+  ) { }
 
   @Post("/")
   @UseGuards(OptionalApiAuthGuard)
@@ -544,8 +545,11 @@ export class BookingsController_2024_08_13 {
       `,
   })
   @HttpCode(HttpStatus.OK)
-  async getCalendarLinks(@Param("bookingUid") bookingUid: string): Promise<CalendarLinksOutput_2024_08_13> {
-    const calendarLinks = await this.bookingsService.getCalendarLinks(bookingUid);
+  async getCalendarLinks(
+    @Param("bookingUid") bookingUid: string,
+    @Query() query: GetCalendarLinksInput_2024_08_13
+  ): Promise<CalendarLinksOutput_2024_08_13> {
+    const calendarLinks = await this.bookingsService.getCalendarLinks(bookingUid, query.locale);
 
     return {
       status: SUCCESS_STATUS,

--- a/apps/api/v2/src/ee/bookings/2024-08-13/inputs/get-calendar-links.input.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/inputs/get-calendar-links.input.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsOptional, IsEnum } from "class-validator";
+
+import { Locales } from "@/lib/enums/locales";
+
+export class GetCalendarLinksInput_2024_08_13 {
+    @IsOptional()
+    @IsEnum(Locales)
+    @ApiPropertyOptional({
+        description:
+            "Locale for calendar link event names. Defaults to 'en' if not provided. Supported values include: ar, ca, de, en, es, fr, it, ja, ko, nl, pt, ru, zh-CN, etc.",
+        enum: Locales,
+        example: Locales.EN,
+    })
+    locale?: Locales;
+}

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts
@@ -115,7 +115,7 @@ export class BookingsService_2024_08_13 {
     private readonly recurringBookingService: RecurringBookingService,
     private readonly instantBookingCreateService: InstantBookingCreateService,
     private readonly eventTypeAccessService: EventTypeAccessService
-  ) {}
+  ) { }
 
   async createBooking(request: Request, body: CreateBookingInput, authUser: AuthOptionalUser) {
     let bookingTeamEventType = false;
@@ -321,8 +321,7 @@ export class BookingsService_2024_08_13 {
               const allowedOptionValues = eventTypeBookingField.options.map((opt) => opt.value);
               if (!this.isValidSingleOptionValue(submittedValue, allowedOptionValues)) {
                 throw new BadRequestException(
-                  `Invalid option '${submittedValue}' for booking field '${
-                    eventTypeBookingField.name
+                  `Invalid option '${submittedValue}' for booking field '${eventTypeBookingField.name
                   }'. Allowed options are: ${allowedOptionValues.join(", ")}.`
                 );
               }
@@ -336,8 +335,7 @@ export class BookingsService_2024_08_13 {
               const allowedOptionValues = eventTypeBookingField.options.map((opt) => opt.value);
               if (!this.areValidMultipleOptionValues(submittedValues, allowedOptionValues)) {
                 throw new BadRequestException(
-                  `One or more invalid options for booking field '${
-                    eventTypeBookingField.name
+                  `One or more invalid options for booking field '${eventTypeBookingField.name
                   }'. Allowed options are: ${allowedOptionValues.join(", ")}.`
                 );
               }
@@ -351,8 +349,7 @@ export class BookingsService_2024_08_13 {
               const allowedOptionValues = eventTypeBookingField.options.map((opt) => opt.value);
               if (!this.areValidMultipleOptionValues(submittedValues, allowedOptionValues)) {
                 throw new BadRequestException(
-                  `One or more invalid options for booking field '${
-                    eventTypeBookingField.name
+                  `One or more invalid options for booking field '${eventTypeBookingField.name
                   }'. Allowed options are: ${allowedOptionValues.join(", ")}.`
                 );
               }
@@ -367,8 +364,7 @@ export class BookingsService_2024_08_13 {
               const allowedOptionValues = eventTypeBookingField.options.map((opt) => opt.value);
               if (!this.isValidSingleOptionValue(submittedValue, allowedOptionValues)) {
                 throw new BadRequestException(
-                  `Invalid option '${submittedValue}' for booking field '${
-                    eventTypeBookingField.name
+                  `Invalid option '${submittedValue}' for booking field '${eventTypeBookingField.name
                   }'. Allowed options are: ${allowedOptionValues.join(", ")}.`
                 );
               }
@@ -544,8 +540,8 @@ export class BookingsService_2024_08_13 {
       outputBooking,
       booking.userId
         ? {
-            isPlatformManagedUserBooking: booking.user?.isPlatformManaged ?? false,
-          }
+          isPlatformManagedUserBooking: booking.user?.isPlatformManaged ?? false,
+        }
         : {}
     );
   }
@@ -591,8 +587,8 @@ export class BookingsService_2024_08_13 {
         outputBooking,
         booking.userId
           ? {
-              isPlatformManagedUserBooking: booking.user?.isPlatformManaged ?? false,
-            }
+            isPlatformManagedUserBooking: booking.user?.isPlatformManaged ?? false,
+          }
           : {}
       );
     } catch (error) {
@@ -657,9 +653,9 @@ export class BookingsService_2024_08_13 {
     const userIsEventTypeAdminOrOwner =
       authUser && booking.eventType
         ? await this.eventTypeAccessService.userIsEventTypeAdminOrOwner(
-            authUser,
-            booking.eventType as EventType
-          )
+          authUser,
+          booking.eventType as EventType
+        )
         : false;
 
     const isRecurring = !!booking.recurringEventId;
@@ -1283,7 +1279,7 @@ export class BookingsService_2024_08_13 {
     return this.getBooking(bookingUid, requestUser);
   }
 
-  async getCalendarLinks(bookingUid: string): Promise<CalendarLink[]> {
+  async getCalendarLinks(bookingUid: string, locale?: string): Promise<CalendarLink[]> {
     const booking = await this.bookingsRepository.getByUidWithAttendeesAndUserAndEvent(bookingUid);
 
     if (!booking) {
@@ -1300,7 +1296,6 @@ export class BookingsService_2024_08_13 {
     if (!eventType) {
       throw new BadRequestException(`Booking with uid ${bookingUid} has no event type`);
     }
-    // TODO: Maybe we should get locale from query params?
     return getCalendarLinks({
       booking,
       eventType: {
@@ -1308,8 +1303,7 @@ export class BookingsService_2024_08_13 {
         // TODO: Support dynamic event bookings later. It would require a slug input it seems
         isDynamic: false,
       },
-      // It can be made customizable through the API endpoint later.
-      t: await getTranslation("en", "common"),
+      t: await getTranslation(locale || "en", "common"),
     });
   }
 }

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,6 +27,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",


### PR DESCRIPTION
This PR adds an optional locale query parameter to the getCalendarLinks endpoint in API v2, allowing API consumers to receive localized calendar links.

## Changes
- **Input DTO:** GetCalendarLinksInput_2024_08_13 created using Locales enum.
- **Controller:** getCalendarLinks updated to accept @Query params.
- **Service:** getCalendarLinks service updated to use the provided locale in getTranslation, defaulting to 'en'.

Fixes TODO in ookings.service.ts.