### PR TITLE
fix: lazy-load companion iframe to avoid requests on every page visit

### DIFF
--- a/companion/extension/entrypoints/content.ts
+++ b/companion/extension/entrypoints/content.ts
@@ -38,6 +38,7 @@ export default defineContentScript({
 
     let isVisible = false;
     let isClosed = true;
+    let iframeLoaded = false;
 
     // Create sidebar container
     const sidebarContainer = document.createElement("div");
@@ -69,7 +70,6 @@ export default defineContentScript({
     // - ext:build-prod → uses https://companion.cal.com
     const COMPANION_URL =
       (import.meta.env.EXPO_PUBLIC_COMPANION_DEV_URL as string) || "https://companion.cal.com";
-    iframe.src = COMPANION_URL;
     // Enable clipboard access for the cross-origin iframe
     // This allows the companion app to use navigator.clipboard.writeText()
     iframe.allow = "clipboard-write; clipboard-read";
@@ -90,6 +90,8 @@ export default defineContentScript({
 
     // Listen for messages from iframe to control width and handle OAuth
     window.addEventListener("message", (event) => {
+      if (!iframeLoaded) return;
+
       // Security: Only accept messages from our iframe's origin
       // This prevents malicious scripts on the host page from manipulating the companion
       const iframeOrigin = new URL(iframe.src).origin;
@@ -505,6 +507,10 @@ export default defineContentScript({
 
     // Function to open the sidebar
     function openSidebar() {
+      if (!iframeLoaded) {
+        iframe.src = COMPANION_URL;
+        iframeLoaded = true;
+      }
       if (isClosed) {
         isClosed = false;
         isVisible = true;


### PR DESCRIPTION
## What does this PR do?

The companion Chrome extension's content script runs on `<all_urls>` and was immediately setting `iframe.src = "https://companion.cal.com"` on every page load — even though the sidebar starts hidden. This caused a network request to `companion.cal.com` on **every page the user visits**.

This PR defers setting `iframe.src` until the user actually opens the sidebar (via icon click, integration trigger, or auto-open). The iframe element is still created at page load (pointing to `about:blank`), but no network request is made until needed.

**Changes:**
- Add `iframeLoaded` flag to track whether the iframe has been initialized
- Remove eager `iframe.src = COMPANION_URL` from initialization
- Set `iframe.src` lazily inside `openSidebar()` on first call
- Guard the `message` event listener with an early return when iframe hasn't loaded (prevents `new URL(iframe.src)` from throwing on empty string)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Build the companion extension (`npm run ext:build` in `companion/`)
2. Load the unpacked extension in Chrome
3. Navigate to any page (e.g., `example.com`) — open DevTools Network tab and confirm **no request** is made to `companion.cal.com`
4. Click the extension icon to open the sidebar — confirm the iframe now loads `companion.cal.com`
5. Test opening the sidebar via Gmail/Google Calendar integrations and the `?openExtension=true` auto-open flow to verify all open paths still work

> **Note:** There is no existing test infrastructure for the content script, so this change has no automated test coverage. Manual verification is required.

## Human Review Checklist

- [ ] Verify all code paths that open the sidebar funnel through `openSidebar()` (icon click at L550, `cal-companion-open-sidebar` event at L568, auto-open at L584)
- [ ] Confirm there's no other code that accesses `iframe.src` before it's set (the message listener guard at L93 is the only early-access point)
- [ ] Consider UX tradeoff: first sidebar open will have a slight loading delay since the iframe is no longer pre-loaded — is this acceptable?

---

> Link to Devin run: https://app.devin.ai/sessions/9e3e6544437e46ad91bb8780bad8ba45
> Requested by: @volnei