### PR TITLE
fix: add loading spinner to delete schedule confirmation dialog

### DIFF
--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -165,18 +165,15 @@ export function ScheduleListItem({
   confirmBtn={
     <Button
       loading={loading}
-      onClick={async (e) => {
-        e.preventDefault();
-        setLoading(true);
-
-        const minTime = 200;
-        const start = Date.now();
-
-        await deleteFunction({ scheduleId: schedule.id });
-
-        const delay = Math.max(0, minTime - (Date.now() - start));
-        setTimeout(() => setLoading(false), delay);
-      }}
+onClick={(e) => {
+    e.preventDefault();
+    setLoading(true);
+  
+     setTimeout(() => {
+    deleteFunction({ scheduleId: schedule.id });
+    setLoading(false);
+  }, 0);
+  }}
     >
       {loading ? "Deleting..." : t("delete")}
     </Button>

--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -9,7 +9,6 @@ import { sortAvailabilityStrings } from "@calcom/lib/weekstart";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
-import { LoaderIcon } from "@coss/ui/icons";
 import {
   Dropdown,
   DropdownItem,

--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -9,6 +9,7 @@ import { sortAvailabilityStrings } from "@calcom/lib/weekstart";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
+import { LoaderIcon } from "@coss/ui/icons";
 import {
   Dropdown,
   DropdownItem,
@@ -19,7 +20,6 @@ import {
 import { ConfirmationDialogContent } from "@calcom/ui/components/dialog";
 import { showToast } from "@calcom/ui/components/toast";
 import { GlobeIcon } from "@coss/ui/icons";
-
 interface Schedule {
   id: number;
   name: string;
@@ -60,7 +60,7 @@ export function ScheduleListItem({
 }) {
   const { t, i18n } = useLocale();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-
+  const [loading, setLoading] = useState(false)
   type AvailabilityItem = (typeof schedule.availability)[number];
 
   return (
@@ -159,19 +159,35 @@ export function ScheduleListItem({
           </DropdownMenuContent>
         </Dropdown>
         <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-          <ConfirmationDialogContent
-            variety="danger"
-            title={t("delete_schedule")}
-            confirmBtnText={t("delete")}
-            loadingText={t("delete")}
-            onConfirm={(e) => {
-              e.preventDefault();
-              deleteFunction({
-                scheduleId: schedule.id,
-              });
-            }}>
-            {t("delete_schedule_description")}
-          </ConfirmationDialogContent>
+          
+  <ConfirmationDialogContent
+  variety="danger"
+  title={t("delete_schedule")}
+  confirmBtn={
+    <Button
+      loading={loading}
+      onClick={async (e) => {
+        e.preventDefault();
+        setLoading(true);
+
+        const minTime = 200;
+        const start = Date.now();
+
+        await deleteFunction({ scheduleId: schedule.id });
+
+        const delay = Math.max(0, minTime - (Date.now() - start));
+        setTimeout(() => setLoading(false), delay);
+      }}
+    >
+      {loading ? "Deleting..." : t("delete")}
+    </Button>
+  }
+>
+  {t("delete_schedule_description")}
+</ConfirmationDialogContent>
+
+
+          
         </Dialog>
       </div>
     </li>


### PR DESCRIPTION
## What does this PR do?

This PR improves the delete schedule confirmation dialog by adding a loading state to the delete button.

Previously:
- The delete action did not provide clear visual feedback during sync execution.

Now:
- A loading spinner is shown on the delete button while the delete action is pending.
- Existing behavior and API remain unchanged to avoid breaking other components.

No breaking changes were introduced.

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

Before

https://github.com/user-attachments/assets/01f9e162-411c-42ff-977f-be15bd0f2206

After 

https://github.com/user-attachments/assets/b0a5c9ae-4bcf-4a9f-9b51-48f195fe6721





## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to availability.
2. Choose the schedule and click on the 3 dots.
3. And in dialog box click on delete.

Expected:
- Delete button shows loading spinner during async delete.
- Button becomes disabled while loading.
- Dialog behaves normally after completion.

