### PR TITLE
fix: Correct hours-to-days conversion and improve Event Limits UX

### DIFF
--- a/packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx
+++ b/packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx
@@ -357,7 +357,7 @@ const MinimumBookingNoticeInput = React.forwardRef<
         <InputField
           required
           disabled={passThroughProps.disabled}
-          defaultValue={minimumBookingNoticeDisplayValues.value}
+          value={minimumBookingNoticeDisplayValues.value}
           onChange={(e) =>
             setMinimumBookingNoticeDisplayValues({
               ...minimumBookingNoticeDisplayValues,
@@ -385,10 +385,10 @@ const MinimumBookingNoticeInput = React.forwardRef<
         )}
         onChange={(input) => {
           if (input) {
-            setMinimumBookingNoticeDisplayValues({
-              ...minimumBookingNoticeDisplayValues,
+            setMinimumBookingNoticeDisplayValues((prev) => ({
               type: input.value,
-            });
+              value: convertToNewDurationType(prev.type, input.value, prev.value),
+            }));
           }
         }}
         options={durationTypeOptions}

--- a/packages/lib/convertToNewDurationType.test.ts
+++ b/packages/lib/convertToNewDurationType.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+
+import convertToNewDurationType, { MINUTES_IN_HOUR, MINUTES_IN_DAY, HOURS_IN_DAY } from "./convertToNewDurationType";
+
+describe("convertToNewDurationType", () => {
+  describe("identity conversions", () => {
+    it("should return the same value when converting minutes to minutes", () => {
+      expect(convertToNewDurationType("minutes", "minutes", 120)).toBe(120);
+    });
+
+    it("should return the same value when converting hours to hours", () => {
+      expect(convertToNewDurationType("hours", "hours", 5)).toBe(5);
+    });
+
+    it("should return the same value when converting days to days", () => {
+      expect(convertToNewDurationType("days", "days", 3)).toBe(3);
+    });
+  });
+
+  describe("minutes to other types", () => {
+    it("should convert minutes to hours", () => {
+      expect(convertToNewDurationType("minutes", "hours", 120)).toBe(2);
+      expect(convertToNewDurationType("minutes", "hours", 60)).toBe(1);
+    });
+
+    it("should convert minutes to days", () => {
+      expect(convertToNewDurationType("minutes", "days", 2880)).toBe(2);
+      expect(convertToNewDurationType("minutes", "days", 1440)).toBe(1);
+    });
+  });
+
+  describe("hours to other types", () => {
+    it("should convert hours to minutes", () => {
+      expect(convertToNewDurationType("hours", "minutes", 2)).toBe(120);
+      expect(convertToNewDurationType("hours", "minutes", 1)).toBe(60);
+    });
+
+    it("should convert hours to days", () => {
+      expect(convertToNewDurationType("hours", "days", 24)).toBe(1);
+      expect(convertToNewDurationType("hours", "days", 48)).toBe(2);
+    });
+  });
+
+  describe("days to other types", () => {
+    it("should convert days to minutes", () => {
+      expect(convertToNewDurationType("days", "minutes", 1)).toBe(1440);
+      expect(convertToNewDurationType("days", "minutes", 2)).toBe(2880);
+    });
+
+    it("should convert days to hours", () => {
+      expect(convertToNewDurationType("days", "hours", 1)).toBe(24);
+      expect(convertToNewDurationType("days", "hours", 2)).toBe(48);
+    });
+  });
+
+  describe("rounding", () => {
+    it("should round up fractional results with Math.ceil", () => {
+      // 90 minutes = 1.5 hours, should ceil to 2
+      expect(convertToNewDurationType("minutes", "hours", 90)).toBe(2);
+      // 100 minutes = 0.069 days, should ceil to 1
+      expect(convertToNewDurationType("minutes", "days", 100)).toBe(1);
+      // 5 hours = 0.208 days, should ceil to 1
+      expect(convertToNewDurationType("hours", "days", 5)).toBe(1);
+    });
+  });
+
+  describe("zero values", () => {
+    it("should handle zero correctly for all conversions", () => {
+      expect(convertToNewDurationType("minutes", "hours", 0)).toBe(0);
+      expect(convertToNewDurationType("minutes", "days", 0)).toBe(0);
+      expect(convertToNewDurationType("hours", "minutes", 0)).toBe(0);
+      expect(convertToNewDurationType("hours", "days", 0)).toBe(0);
+      expect(convertToNewDurationType("days", "minutes", 0)).toBe(0);
+      expect(convertToNewDurationType("days", "hours", 0)).toBe(0);
+    });
+  });
+
+  describe("exported constants", () => {
+    it("should export correct constant values", () => {
+      expect(MINUTES_IN_HOUR).toBe(60);
+      expect(MINUTES_IN_DAY).toBe(1440);
+      expect(HOURS_IN_DAY).toBe(24);
+    });
+  });
+});

--- a/packages/lib/convertToNewDurationType.ts
+++ b/packages/lib/convertToNewDurationType.ts
@@ -16,7 +16,7 @@ export default function convertToNewDurationType(
     minutes_days: () => prevValue / MINUTES_IN_DAY,
     hours_minutes: () => prevValue * MINUTES_IN_HOUR,
     hours_hours: () => prevValue,
-    hours_days: () => prevValue * HOURS_IN_DAY,
+    hours_days: () => prevValue / HOURS_IN_DAY,
     days_minutes: () => prevValue * MINUTES_IN_DAY,
     days_hours: () => prevValue * HOURS_IN_DAY,
     days_days: () => prevValue,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- This PR fixes a math logic error in `convertToNewDurationType.ts` and enhances the "Minimum Booking Notice" UI.

**Fix :** Corrected the  `hours_days` conversion which was incorrectly multiplying by 24 (e.g., 24 hours converted to 576 days).
**UX Improvement:** Enabled automatic value conversion in the UI. Previously, changing the dropdown (e.g., Hours to Days) would not change the value at all. It now correctly recalculates the number (e.g., 24 Hours → 1 Day).
**test:** Added unit tests for the time conversion logic.
## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):
### Before:
[Screencast from 2026-02-15 02-50-34.webm](https://github.com/user-attachments/assets/06e6d5d1-d4c2-4c58-b761-b6721c96e38d)


### After:
[Screencast from 2026-02-14 23-27-22.webm](https://github.com/user-attachments/assets/5b5c73c1-0072-4349-85b6-6eaf36cbad89)


- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

To test, run yarn dev, navigate to an event's Limits tab, and switch the Minimum Booking Notice units to verify that the value now automatically recalculates (e.g., 24 Hours → 1 Day).


