### PR TITLE
feat: add booking question field types to routing forms

### DIFF
--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
@@ -15,6 +15,21 @@ function getWidgetsWithoutFactory(_configFor: ConfigFor) {
     email: {
       ...BasicConfig.widgets.text,
     },
+    address: {
+      ...BasicConfig.widgets.text,
+    },
+    url: {
+      ...BasicConfig.widgets.text,
+    },
+    checkbox: {
+      ...BasicConfig.widgets.multiselect,
+    },
+    radio: {
+      ...BasicConfig.widgets.select,
+    },
+    boolean: {
+      ...BasicConfig.widgets.select,
+    },
   };
   return widgetsWithoutFactory;
 }
@@ -40,6 +55,40 @@ function getTypes(configFor: ConfigFor) {
       ...BasicConfig.types.text,
       widgets: {
         ...BasicConfig.types.text.widgets,
+      },
+    },
+    address: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    url: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    checkbox: {
+      ...BasicConfig.types.multiselect,
+      widgets: {
+        ...BasicConfig.types.multiselect.widgets,
+        multiselect: {
+          ...BasicConfig.types.multiselect.widgets.multiselect,
+          operators: [...multiSelectOperators],
+        },
+      },
+    },
+    radio: {
+      ...BasicConfig.types.select,
+      widgets: {
+        ...BasicConfig.types.select.widgets,
+      },
+    },
+    boolean: {
+      ...BasicConfig.types.select,
+      widgets: {
+        ...BasicConfig.types.select.widgets,
       },
     },
     multiselect: {

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
@@ -6,7 +6,9 @@ import type {
   WidgetProps,
 } from "react-awesome-query-builder";
 
-import { EmailField as EmailWidget } from "@calcom/ui/components/form";
+import { AddressInput } from "@calcom/ui/components/address";
+import { CheckboxField, EmailField as EmailWidget, Checkbox } from "@calcom/ui/components/form";
+import { RadioGroup, RadioField } from "@calcom/ui/components/radio";
 
 import widgetsComponents from "../widgets";
 import type { Widgets, WidgetsWithoutFactory } from "./types";
@@ -76,6 +78,123 @@ const EmailFactory = (props: WidgetProps | undefined) => {
   );
 };
 
+const AddressFactory = (props: WidgetProps | undefined) => {
+  if (!props) {
+    return <div />;
+  }
+  return (
+    <AddressInput
+      onChange={(val: string) => {
+        props.setValue(val);
+      }}
+      className="mb-2"
+      {...props}
+    />
+  );
+};
+
+const UrlFactory = (props: WidgetProps | undefined) => {
+  if (!props) {
+    return <div />;
+  }
+  return <TextWidget type="url" autoComplete="url" {...props} />;
+};
+
+const CheckboxGroupFactory = (
+  props:
+    | (SelectWidgetProps & {
+        listValues: { title: string; value: string }[];
+      })
+    | undefined
+) => {
+  if (!props) {
+    return <div />;
+  }
+  const { listValues, value, setValue, readOnly } = props;
+  if (!listValues) {
+    return null;
+  }
+  const currentValue = (value as unknown as string[]) || [];
+  return (
+    <div className="mb-2">
+      {listValues.map((option, i) => (
+        <label key={i} className="block">
+          <Checkbox
+            disabled={readOnly}
+            onCheckedChange={(checked: boolean) => {
+              const newValue = currentValue.filter((v: string) => v !== option.value);
+              if (checked) {
+                newValue.push(option.value);
+              }
+              setValue(newValue as unknown as string);
+            }}
+            value={option.value}
+            checked={currentValue.includes(option.value)}
+          />
+          <span className="text-emphasis me-2 ms-2 text-sm">{option.title ?? ""}</span>
+        </label>
+      ))}
+    </div>
+  );
+};
+
+const RadioGroupFactory = (
+  props:
+    | (SelectWidgetProps & {
+        listValues: { title: string; value: string }[];
+      })
+    | undefined
+) => {
+  if (!props) {
+    return <div />;
+  }
+  const { listValues, value, setValue, readOnly } = props;
+  if (!listValues) {
+    return null;
+  }
+  return (
+    <div className="mb-2">
+      <RadioGroup
+        disabled={readOnly}
+        value={value as string}
+        onValueChange={(val: string) => {
+          setValue(val);
+        }}>
+        {listValues.map((option, i) => (
+          <RadioField
+            key={i}
+            label={option.title}
+            value={option.value}
+            id={`${props.name || "radio"}.option.${i}`}
+          />
+        ))}
+      </RadioGroup>
+    </div>
+  );
+};
+
+const BooleanFactory = (props: WidgetProps | undefined) => {
+  if (!props) {
+    return <div />;
+  }
+  const { value, setValue, readOnly } = props;
+  const boolValue = value === "true" || value === true;
+  return (
+    <div className="mb-2 flex">
+      <CheckboxField
+        name={props.name || "boolean"}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+          setValue(e.target.checked ? "true" : "false");
+        }}
+        placeholder=""
+        checked={boolValue}
+        disabled={readOnly}
+        description=""
+      />
+    </div>
+  );
+};
+
 // react-query-builder types have missing type property on Widget
 //TODO: Reuse FormBuilder Components - FormBuilder components are built considering Cal.com design system and coding guidelines. But when awesome-query-builder renders these components, it passes its own props which are different from what our Components expect.
 // So, a mapper should be written here that maps the props provided by awesome-query-builder to the props that our components expect.
@@ -110,6 +229,28 @@ function withFactoryWidgets(widgets: WidgetsWithoutFactory) {
     email: {
       ...widgets.text,
       factory: EmailFactory,
+    },
+    address: {
+      ...widgets.text,
+      factory: AddressFactory,
+      valuePlaceholder: "Enter Address",
+    },
+    url: {
+      ...widgets.text,
+      factory: UrlFactory,
+      valuePlaceholder: "Enter URL",
+    },
+    checkbox: {
+      ...widgets.multiselect,
+      factory: CheckboxGroupFactory,
+    } as SelectWidgetType,
+    radio: {
+      ...widgets.select,
+      factory: RadioGroupFactory,
+    } as SelectWidgetType,
+    boolean: {
+      ...widgets.select,
+      factory: BooleanFactory,
     },
   };
   return widgetsWithFactory;

--- a/packages/app-store/routing-forms/lib/FieldTypes.ts
+++ b/packages/app-store/routing-forms/lib/FieldTypes.ts
@@ -6,6 +6,11 @@ export const enum RoutingFormFieldType {
   MULTI_SELECT = "multiselect",
   PHONE = "phone",
   EMAIL = "email",
+  ADDRESS = "address",
+  URL = "url",
+  CHECKBOX = "checkbox",
+  RADIO = "radio",
+  BOOLEAN = "boolean",
 }
 
 export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFieldType => {
@@ -17,6 +22,11 @@ export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFi
     RoutingFormFieldType.MULTI_SELECT,
     RoutingFormFieldType.PHONE,
     RoutingFormFieldType.EMAIL,
+    RoutingFormFieldType.ADDRESS,
+    RoutingFormFieldType.URL,
+    RoutingFormFieldType.CHECKBOX,
+    RoutingFormFieldType.RADIO,
+    RoutingFormFieldType.BOOLEAN,
   ].includes(type as RoutingFormFieldType);
 };
 
@@ -48,5 +58,25 @@ export const FieldTypes = [
   {
     label: "Email",
     value: RoutingFormFieldType.EMAIL,
+  },
+  {
+    label: "Address",
+    value: RoutingFormFieldType.ADDRESS,
+  },
+  {
+    label: "URL",
+    value: RoutingFormFieldType.URL,
+  },
+  {
+    label: "Checkbox group",
+    value: RoutingFormFieldType.CHECKBOX,
+  },
+  {
+    label: "Radio group",
+    value: RoutingFormFieldType.RADIO,
+  },
+  {
+    label: "Checkbox (Yes/No)",
+    value: RoutingFormFieldType.BOOLEAN,
   },
 ] as const;

--- a/packages/app-store/routing-forms/lib/getQueryBuilderConfig.ts
+++ b/packages/app-store/routing-forms/lib/getQueryBuilderConfig.ts
@@ -63,8 +63,17 @@ export function getQueryBuilderConfigForFormFields(form: Pick<RoutingForm, "fiel
         type: widgetType,
         valueSources: ["value"],
         fieldSettings: {
-          // IMPORTANT: listValues must be undefined for non-select/multiselect fields otherwise RAQB doesn't like it. It ends up considering all the text values as per the listValues too which could be empty as well making all values invalid
-          listValues: fieldType === "select" || fieldType === "multiselect" ? options : undefined,
+          // IMPORTANT: listValues must be undefined for text-like fields otherwise RAQB doesn't like it.
+          // Fields with options (select, multiselect, checkbox, radio) need listValues for routing rules.
+          // Boolean gets predefined Yes/No options.
+          listValues: ["select", "multiselect", "checkbox", "radio"].includes(fieldType)
+            ? options
+            : fieldType === "boolean"
+              ? [
+                  { title: "Yes", value: "true" },
+                  { title: "No", value: "false" },
+                ]
+              : undefined,
         },
       };
     } else {

--- a/packages/app-store/routing-forms/lib/transformResponse.ts
+++ b/packages/app-store/routing-forms/lib/transformResponse.ts
@@ -59,7 +59,7 @@ export function getFieldResponseForJsonLogic({
   field: Pick<Field, "options" | "type">;
   value: FormResponse[string]["value"] | undefined;
 }) {
-  if (!value) {
+  if (value === undefined || value === null || value === "") {
     return "";
   }
   // type="number" still gives value as a string but we need to store that as number so that number operators can work.
@@ -69,7 +69,8 @@ export function getFieldResponseForJsonLogic({
     }
     return value;
   }
-  if (field.type === "multiselect") {
+  // Multiselect and checkbox group both produce arrays of selected values
+  if (field.type === "multiselect" || field.type === "checkbox") {
     // Could be option id(i.e. a UUIDv4) or option label for ease of prefilling
     let valueOrLabelArray = value instanceof Array ? value : value.toString().split(",");
 
@@ -80,7 +81,8 @@ export function getFieldResponseForJsonLogic({
     return valueOrLabelArray;
   }
 
-  if (field.type === "select") {
+  // Select and radio group both produce a single selected value
+  if (field.type === "select" || field.type === "radio") {
     const valueAsStringOrStringArray = typeof value === "number" ? String(value) : value;
     const valueAsString =
       valueAsStringOrStringArray instanceof Array
@@ -89,5 +91,14 @@ export function getFieldResponseForJsonLogic({
 
     return transformSelectValue({ field, idOrLabel: valueAsString });
   }
+
+  // Boolean stores "true" or "false" as string for routing logic
+  if (field.type === "boolean") {
+    if (typeof value === "boolean") {
+      return value ? "true" : "false";
+    }
+    return value === "true" ? "true" : "false";
+  }
+
   return value;
 }


### PR DESCRIPTION
this extends routing forms to support the same field types available in booking questions — address, URL, checkbox group, radio group, and boolean.

right now routing forms are limited to basic text/number/select fields, which makes it hard to build more complex intake flows. with this change you can reuse the same question types across both booking forms and routing forms.

**changes:**
- extended RAQB config with new widget types
- added widget factories for each new field type
- updated query builder config and response transforms
- everything follows the existing routing form patterns

fixes #18987