### PR TITLE
feat: check guest availability when rescheduling bookings

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -159,6 +159,7 @@ export type GetUserAvailabilityInitialData = {
     bookingLimits?: unknown;
     includeManagedEventsInLimits: boolean;
   } | null;
+  guestBusyTimes?: EventBusyDetails[];
 };
 
 export type GetAvailabilityUser = GetUserAvailabilityInitialData["user"];
@@ -622,6 +623,7 @@ export class UserAvailabilityService {
       })),
       ...busyTimesFromLimits,
       ...busyTimesFromTeamLimits,
+      ...(initialData?.guestBusyTimes || []),
     ];
 
     log.debug(

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1724,6 +1724,37 @@ export class BookingRepository implements IBookingRepository {
     });
   }
 
+  async findAcceptedBookingsByUserIdsOrEmails({
+    userIds,
+    emails,
+    startDate,
+    endDate,
+    excludeUid,
+  }: {
+    userIds: number[];
+    emails: string[];
+    startDate: Date;
+    endDate: Date;
+    excludeUid?: string;
+  }) {
+    if (!userIds.length && !emails.length) return [];
+    return this.prismaClient.booking.findMany({
+      where: {
+        status: BookingStatus.ACCEPTED,
+        startTime: { lte: endDate },
+        endTime: { gte: startDate },
+        ...(excludeUid ? { uid: { not: excludeUid } } : {}),
+        OR: [
+          ...(userIds.length ? [{ userId: { in: userIds } }] : []),
+          ...(emails.length
+            ? [{ attendees: { some: { email: { in: emails, mode: "insensitive" as const } } } }]
+            : []),
+        ],
+      },
+      select: { uid: true, startTime: true, endTime: true },
+    });
+  }
+
   async findByIdForReassignment(bookingId: number) {
     return await this.prismaClient.booking.findUnique({
       where: {

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1403,6 +1403,26 @@ export class UserRepository {
     return users.map(withSelectedCalendars);
   }
 
+  async findUsersByEmails({ emails }: { emails: string[] }) {
+    if (!emails.length) return [];
+    return this.prismaClient.user.findMany({
+      where: {
+        OR: [
+          { email: { in: emails, mode: "insensitive" } },
+          {
+            secondaryEmails: {
+              some: {
+                email: { in: emails, mode: "insensitive" },
+                emailVerified: { not: null },
+              },
+            },
+          },
+        ],
+      },
+      select: { id: true, email: true },
+    });
+  }
+
   async findByEmailAndTeamId({ email, teamId }: { email: string; teamId: number }) {
     return this.prismaClient.user.findFirst({
       where: {

--- a/packages/trpc/server/routers/viewer/slots/getGuestBusyTimes.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/getGuestBusyTimes.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { getGuestBusyTimesForReschedule } from "./util";
+import type { GuestBusyTimesDeps } from "./util";
+
+function makeDeps(overrides?: Partial<GuestBusyTimesDeps>): GuestBusyTimesDeps {
+  return {
+    bookingRepo: {
+      findByUidIncludeEventType: vi.fn().mockResolvedValue(null),
+      findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue([]),
+      ...overrides?.bookingRepo,
+    } as GuestBusyTimesDeps["bookingRepo"],
+    userRepo: {
+      findUsersByEmails: vi.fn().mockResolvedValue([]),
+      ...overrides?.userRepo,
+    } as GuestBusyTimesDeps["userRepo"],
+  };
+}
+
+const BASE_ARGS = {
+  rescheduleUid: "booking-uid-123",
+  startDate: new Date("2025-03-01T00:00:00Z"),
+  endDate: new Date("2025-03-02T00:00:00Z"),
+  hostEmails: ["host@example.com"],
+};
+
+describe("getGuestBusyTimesForReschedule", () => {
+  it("returns empty when booking has no attendees", async () => {
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockResolvedValue({ attendees: [] }),
+        findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue([]),
+      },
+    });
+
+    const result = await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when booking is not found", async () => {
+    const deps = makeDeps();
+    const result = await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(result).toEqual([]);
+  });
+
+  it("filters out host emails and only looks up guests", async () => {
+    const findUsersByEmails = vi.fn().mockResolvedValue([]);
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockResolvedValue({
+          attendees: [{ email: "host@example.com" }, { email: "guest@example.com" }],
+        }),
+        findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue([]),
+      },
+      userRepo: { findUsersByEmails },
+    });
+
+    await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(findUsersByEmails).toHaveBeenCalledWith({ emails: ["guest@example.com"] });
+  });
+
+  it("filters host emails case-insensitively", async () => {
+    const findUsersByEmails = vi.fn().mockResolvedValue([]);
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockResolvedValue({
+          attendees: [{ email: "Host@Example.COM" }, { email: "guest@test.com" }],
+        }),
+        findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue([]),
+      },
+      userRepo: { findUsersByEmails },
+    });
+
+    await getGuestBusyTimesForReschedule({
+      ...BASE_ARGS,
+      hostEmails: ["host@example.com"],
+      ...deps,
+    });
+    expect(findUsersByEmails).toHaveBeenCalledWith({ emails: ["guest@test.com"] });
+  });
+
+  it("returns empty when all attendees are hosts (no guests)", async () => {
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockResolvedValue({
+          attendees: [{ email: "host@example.com" }],
+        }),
+        findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue([]),
+      },
+    });
+
+    const result = await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(result).toEqual([]);
+    expect(deps.userRepo.findUsersByEmails).not.toHaveBeenCalled();
+  });
+
+  it("returns empty when guests have no Cal.com accounts", async () => {
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockResolvedValue({
+          attendees: [{ email: "host@example.com" }, { email: "external@gmail.com" }],
+        }),
+        findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue([]),
+      },
+      userRepo: {
+        findUsersByEmails: vi.fn().mockResolvedValue([]),
+      },
+    });
+
+    const result = await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(result).toEqual([]);
+    expect(deps.bookingRepo.findAcceptedBookingsByUserIdsOrEmails).not.toHaveBeenCalled();
+  });
+
+  it("returns busy times from guest bookings", async () => {
+    const guestBookings = [
+      {
+        uid: "other-booking-1",
+        startTime: new Date("2025-03-01T10:00:00Z"),
+        endTime: new Date("2025-03-01T11:00:00Z"),
+      },
+      {
+        uid: "other-booking-2",
+        startTime: new Date("2025-03-01T14:00:00Z"),
+        endTime: new Date("2025-03-01T15:00:00Z"),
+      },
+    ];
+
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockResolvedValue({
+          attendees: [{ email: "host@example.com" }, { email: "guest@cal.com" }],
+        }),
+        findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue(guestBookings),
+      },
+      userRepo: {
+        findUsersByEmails: vi.fn().mockResolvedValue([{ id: 42, email: "guest@cal.com" }]),
+      },
+    });
+
+    const result = await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(result).toEqual([
+      { start: "2025-03-01T10:00:00.000Z", end: "2025-03-01T11:00:00.000Z", source: "guest-availability" },
+      { start: "2025-03-01T14:00:00.000Z", end: "2025-03-01T15:00:00.000Z", source: "guest-availability" },
+    ]);
+  });
+
+  it("handles multiple guests with Cal.com accounts", async () => {
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockResolvedValue({
+          attendees: [
+            { email: "host@example.com" },
+            { email: "guest1@cal.com" },
+            { email: "guest2@cal.com" },
+          ],
+        }),
+        findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue([
+          {
+            uid: "b1",
+            startTime: new Date("2025-03-01T09:00:00Z"),
+            endTime: new Date("2025-03-01T09:30:00Z"),
+          },
+        ]),
+      },
+      userRepo: {
+        findUsersByEmails: vi.fn().mockResolvedValue([
+          { id: 10, email: "guest1@cal.com" },
+          { id: 20, email: "guest2@cal.com" },
+        ]),
+      },
+    });
+
+    const result = await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(result).toHaveLength(1);
+
+    // Verify we passed both user IDs
+    expect(deps.bookingRepo.findAcceptedBookingsByUserIdsOrEmails).toHaveBeenCalledWith({
+      userIds: [10, 20],
+      emails: ["guest1@cal.com", "guest2@cal.com"],
+      startDate: BASE_ARGS.startDate,
+      endDate: BASE_ARGS.endDate,
+      excludeUid: "booking-uid-123",
+    });
+  });
+
+  it("excludes the rescheduled booking from guest busy times", async () => {
+    const findAccepted = vi.fn().mockResolvedValue([]);
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockResolvedValue({
+          attendees: [{ email: "host@example.com" }, { email: "guest@cal.com" }],
+        }),
+        findAcceptedBookingsByUserIdsOrEmails: findAccepted,
+      },
+      userRepo: {
+        findUsersByEmails: vi.fn().mockResolvedValue([{ id: 1, email: "guest@cal.com" }]),
+      },
+    });
+
+    await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(findAccepted).toHaveBeenCalledWith(
+      expect.objectContaining({ excludeUid: "booking-uid-123" })
+    );
+  });
+
+  it("gracefully returns empty on repo failure", async () => {
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockRejectedValue(new Error("DB connection lost")),
+        findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue([]),
+      },
+    });
+
+    const result = await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(result).toEqual([]);
+  });
+
+  it("gracefully returns empty when user lookup fails", async () => {
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockResolvedValue({
+          attendees: [{ email: "host@example.com" }, { email: "guest@cal.com" }],
+        }),
+        findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue([]),
+      },
+      userRepo: {
+        findUsersByEmails: vi.fn().mockRejectedValue(new Error("timeout")),
+      },
+    });
+
+    const result = await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(result).toEqual([]);
+  });
+
+  it("skips bookings with missing startTime or endTime", async () => {
+    const deps = makeDeps({
+      bookingRepo: {
+        findByUidIncludeEventType: vi.fn().mockResolvedValue({
+          attendees: [{ email: "host@example.com" }, { email: "guest@cal.com" }],
+        }),
+        findAcceptedBookingsByUserIdsOrEmails: vi.fn().mockResolvedValue([
+          { uid: "b1", startTime: new Date("2025-03-01T10:00:00Z"), endTime: null },
+          { uid: "b2", startTime: null, endTime: new Date("2025-03-01T11:00:00Z") },
+          {
+            uid: "b3",
+            startTime: new Date("2025-03-01T12:00:00Z"),
+            endTime: new Date("2025-03-01T13:00:00Z"),
+          },
+        ]),
+      },
+      userRepo: {
+        findUsersByEmails: vi.fn().mockResolvedValue([{ id: 1, email: "guest@cal.com" }]),
+      },
+    });
+
+    const result = await getGuestBusyTimesForReschedule({ ...BASE_ARGS, ...deps });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      start: "2025-03-01T12:00:00.000Z",
+      end: "2025-03-01T13:00:00.000Z",
+      source: "guest-availability",
+    });
+  });
+});

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -129,6 +129,60 @@ function withSlotsCache(
   };
 }
 
+export interface GuestBusyTimesDeps {
+  bookingRepo: Pick<BookingRepository, "findByUidIncludeEventType" | "findAcceptedBookingsByUserIdsOrEmails">;
+  userRepo: Pick<UserRepository, "findUsersByEmails">;
+}
+
+export async function getGuestBusyTimesForReschedule({
+  rescheduleUid,
+  startDate,
+  endDate,
+  hostEmails,
+  bookingRepo,
+  userRepo,
+}: {
+  rescheduleUid: string;
+  startDate: Date;
+  endDate: Date;
+  hostEmails: string[];
+} & GuestBusyTimesDeps): Promise<EventBusyDetails[]> {
+  try {
+    const booking = await bookingRepo.findByUidIncludeEventType({
+      bookingUid: rescheduleUid,
+    });
+    if (!booking?.attendees?.length) return [];
+
+    const hostEmailsLower = new Set(hostEmails.map((e) => e.toLowerCase()));
+    const guestEmails = booking.attendees
+      .map((a) => a.email)
+      .filter((email) => !hostEmailsLower.has(email.toLowerCase()));
+    if (!guestEmails.length) return [];
+
+    const calUsers = await userRepo.findUsersByEmails({ emails: guestEmails });
+    if (!calUsers.length) return [];
+
+    const guestBookings = await bookingRepo.findAcceptedBookingsByUserIdsOrEmails({
+      userIds: calUsers.map((u) => u.id),
+      emails: calUsers.map((u) => u.email),
+      startDate,
+      endDate,
+      excludeUid: rescheduleUid,
+    });
+
+    return guestBookings
+      .filter((b) => b.startTime && b.endTime)
+      .map((b) => ({
+        start: b.startTime.toISOString(),
+        end: b.endTime.toISOString(),
+        source: "guest-availability",
+      }));
+  } catch {
+    log.warn("Failed to fetch guest busy times for reschedule");
+    return [];
+  }
+}
+
 export class AvailableSlotsService {
   constructor(public readonly dependencies: IAvailableSlotsService) {}
 
@@ -809,6 +863,18 @@ export class AvailableSlotsService {
     const userIdAndEmailMap = new Map(usersWithCredentials.map((user) => [user.id, user.email]));
     const allUserIds = Array.from(userIdAndEmailMap.keys());
 
+    let guestBusyTimes: EventBusyDetails[] = [];
+    if (input.rescheduleUid && eventType.schedulingType !== SchedulingType.COLLECTIVE) {
+      guestBusyTimes = await getGuestBusyTimesForReschedule({
+        rescheduleUid: input.rescheduleUid,
+        startDate: startTimeDate,
+        endDate: endTimeDate,
+        hostEmails: Array.from(userIdAndEmailMap.values()),
+        bookingRepo: this.dependencies.bookingRepo,
+        userRepo: this.dependencies.userRepo,
+      });
+    }
+
     const bookingRepo = this.dependencies.bookingRepo;
     const [currentBookingsAllUsers, outOfOfficeDaysAllUsers] = await Promise.all([
       bookingRepo.findAllExistingBookingsForEventTypeBetween({
@@ -933,6 +999,7 @@ export class AvailableSlotsService {
         eventTypeForLimits: eventType && (bookingLimits || durationLimits) ? eventType : null,
         teamBookingLimits: teamBookingLimitsMap,
         teamForBookingLimits: teamForBookingLimits,
+        guestBusyTimes,
       },
     });
     /* We get all users working hours and busy slots */


### PR DESCRIPTION
ran into this a few times — when rescheduling a meeting, the new time slot only checks the host's availability but completely ignores whether the guests are free. ends up creating conflicts.

this adds guest availability checking during reschedule:
- when a host reschedules, the system looks up guest Cal.com accounts
- if a guest has a Cal.com account, their busy times are factored into available slots
- if a guest doesn't have an account or the lookup fails, rescheduling proceeds normally (graceful degradation)

**changes:**
- added repository method to look up users by email
- new utility function to fetch and merge guest busy times
- integrated into the availability calculation pipeline
- no breaking changes — if anything goes wrong it falls back to current behavior

fixes #16378