### PR TITLE
fix: use maxLength parameter in `truncateOnWord` instead of hardcoded value

### DIFF
--- a/packages/lib/text.test.ts
+++ b/packages/lib/text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { truncate } from "./text";
+import { truncate, truncateOnWord } from "./text";
 
 describe("Text util tests", () => {
   describe("fn: truncate", () => {
@@ -65,6 +65,86 @@ describe("Text util tests", () => {
       for (const { input, maxLength, ellipsis, expected } of cases) {
         const result = truncate(input, maxLength, ellipsis);
 
+        expect(result).toEqual(expected);
+      }
+    });
+  });
+  describe("fn: truncateOnWord", () => {
+    it("should return the original text when it is shorter than the max length", () => {
+      const cases = [
+        {
+          input: "Hello world",
+          maxLength: 100,
+          expected: "Hello world",
+        },
+        {
+          input: "Hello world",
+          maxLength: 11,
+          expected: "Hello world",
+        },
+      ];
+
+      for (const { input, maxLength, expected } of cases) {
+        const result = truncateOnWord(input, maxLength);
+
+        expect(result).toEqual(expected);
+      }
+    });
+
+    it("should return the truncated text on the last word when it is longer than the max length", () => {
+      const cases = [
+        {
+          input: "The quick brown fox jumps over the lazy dog",
+          maxLength: 12,
+          expected: "The quick...",
+        },
+        {
+          input: "Cal.com is the scheduling infrastructure for everyone",
+          maxLength: 14,
+          expected: "Cal.com is...",
+        },
+      ];
+
+      for (const { input, maxLength, expected } of cases) {
+        const result = truncateOnWord(input, maxLength);
+
+        expect(result).toEqual(expected);
+      }
+    });
+
+    it("should return the truncated text without ellipsis when it is longer than the max length and ellipsis is false", () => {
+      const cases = [
+        {
+          input: "The quick brown fox jumps over the lazy dog",
+          maxLength: 12,
+          ellipsis: false,
+          expected: "The quick",
+        },
+      ];
+
+      for (const { input, maxLength, ellipsis, expected } of cases) {
+        const result = truncateOnWord(input, maxLength, ellipsis);
+
+        expect(result).toEqual(expected);
+      }
+    });
+
+    it("should fallback to character truncation when no spaces are present in the truncated segment", () => {
+      const cases = [
+        {
+          input: "supercalifragilisticexpialidocious",
+          maxLength: 10,
+          expected: "supercalif...",
+        },
+        {
+          input: "https://cal.com/pro/30min/extremely-long-url-without-any-spaces",
+          maxLength: 20,
+          expected: "https://cal.com/pro/...",
+        },
+      ];
+
+      for (const { input, maxLength, expected } of cases) {
+        const result = truncateOnWord(input, maxLength);
         expect(result).toEqual(expected);
       }
     });

--- a/packages/lib/text.ts
+++ b/packages/lib/text.ts
@@ -8,11 +8,14 @@ export const truncateOnWord = (text: string, maxLength: number, ellipsis = true)
   if (text.length <= maxLength) return text;
 
   // First split on maxLength chars
-  let truncatedText = text.substring(0, 148);
+  let truncatedText = text.substring(0, maxLength);
 
   // Then split on the last space, this way we split on the last word,
   // which looks just a bit nicer.
-  truncatedText = truncatedText.substring(0, Math.min(truncatedText.length, truncatedText.lastIndexOf(" ")));
+  const lastSpaceIndex = truncatedText.lastIndexOf(" ");
+  if (lastSpaceIndex !== -1) {
+    truncatedText = truncatedText.substring(0, lastSpaceIndex);
+  }
 
   if (ellipsis) truncatedText += "...";
 


### PR DESCRIPTION

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR fixes the `truncateOnWord` function to correctly use the `maxLength` parameter provided by caller functions instead of a hardcoded value of 148. This ensures that `OpenGraph` metadata (which calls this function with a limit of 158 characters) can now utilize the full intended length for previews.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] NA
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.




