### PR TITLE
fix: add loader spinner to schedule delete confirmation dialog

### DIFF
--- a/apps/web/modules/availability/availability-view.tsx
+++ b/apps/web/modules/availability/availability-view.tsx
@@ -151,9 +151,9 @@ export function AvailabilityList({ availabilities }: AvailabilityListProps) {
                   key={schedule.id}
                   schedule={schedule}
                   isDeletable={availabilities.schedules.length !== 1}
-                  updateDefault={updateMutation.mutateAsync}
+                  updateDefault={updateMutation.mutate}
                   deleteFunction={deleteMutation.mutateAsync}
-                  duplicateFunction={duplicateMutation.mutateAsync}
+                  duplicateFunction={duplicateMutation.mutate}
                 />
               ))}
             </ul>

--- a/apps/web/modules/availability/availability-view.tsx
+++ b/apps/web/modules/availability/availability-view.tsx
@@ -151,9 +151,9 @@ export function AvailabilityList({ availabilities }: AvailabilityListProps) {
                   key={schedule.id}
                   schedule={schedule}
                   isDeletable={availabilities.schedules.length !== 1}
-                  updateDefault={updateMutation.mutate}
-                  deleteFunction={deleteMutation.mutate}
-                  duplicateFunction={duplicateMutation.mutate}
+                  updateDefault={updateMutation.mutateAsync}
+                  deleteFunction={deleteMutation.mutateAsync}
+                  duplicateFunction={duplicateMutation.mutateAsync}
                 />
               ))}
             </ul>

--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -54,8 +54,8 @@ export function ScheduleListItem({
     weekStart?: string;
   };
   isDeletable: boolean;
-  updateDefault: ({ scheduleId, isDefault }: { scheduleId: number; isDefault: boolean }) => void;
-  duplicateFunction: ({ scheduleId }: { scheduleId: number }) => void;
+  updateDefault: ({ scheduleId, isDefault }: { scheduleId: number; isDefault: boolean }) => Promise<any>;
+  duplicateFunction: ({ scheduleId }: { scheduleId: number }) => Promise<any>;
   redirectUrl: string;
 }) {
   const { t, i18n } = useLocale();
@@ -128,7 +128,7 @@ export function ScheduleListItem({
                     updateDefault({
                       scheduleId: schedule.id,
                       isDefault: true,
-                    });
+                    }).catch(()=>{});
                   }}>
                   {t("set_as_default")}
                 </DropdownItem>
@@ -142,7 +142,7 @@ export function ScheduleListItem({
                 onClick={() => {
                   duplicateFunction({
                     scheduleId: schedule.id,
-                  });
+                  }).catch(()=>{});
                 }}>
                 {t("duplicate")}
               </DropdownItem>

--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -60,9 +60,18 @@ export function ScheduleListItem({
 }) {
   const { t, i18n } = useLocale();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-
+  const [loading, setLoading] = useState(false)
   type AvailabilityItem = (typeof schedule.availability)[number];
-
+  const handleDelete=(e:React.MouseEvent)=>{
+     e.preventDefault();
+     setLoading(true);
+     setTimeout(()=> {
+      deleteFunction({
+      scheduleId: schedule.id,
+    })
+    setLoading(false)
+     },0)
+  } 
   return (
     <li key={schedule.id}>
       <div className="hover:bg-cal-muted flex items-center justify-between px-3 py-5 transition sm:px-4">
@@ -160,18 +169,20 @@ export function ScheduleListItem({
         </Dropdown>
         <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
           <ConfirmationDialogContent
-            variety="danger"
-            title={t("delete_schedule")}
-            confirmBtnText={t("delete")}
-            loadingText={t("delete")}
-            onConfirm={(e) => {
-              e.preventDefault();
-              deleteFunction({
-                scheduleId: schedule.id,
-              });
-            }}>
-            {t("delete_schedule_description")}
-          </ConfirmationDialogContent>
+  variety="danger"
+  title={t("delete_schedule")}
+  confirmBtn={
+   <Button
+      loading={loading}
+       onClick={handleDelete}
+>
+  {t("delete")}
+</Button>
+
+  }
+>
+  {t("delete_schedule_description")}
+</ConfirmationDialogContent>
         </Dialog>
       </div>
     </li>

--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -54,8 +54,8 @@ export function ScheduleListItem({
     weekStart?: string;
   };
   isDeletable: boolean;
-  updateDefault: ({ scheduleId, isDefault }: { scheduleId: number; isDefault: boolean }) => Promise<any>;
-  duplicateFunction: ({ scheduleId }: { scheduleId: number }) => Promise<any>;
+  updateDefault: ({ scheduleId, isDefault }: { scheduleId: number; isDefault: boolean }) => void;
+  duplicateFunction: ({ scheduleId }: { scheduleId: number }) => void;
   redirectUrl: string;
 }) {
   const { t, i18n } = useLocale();
@@ -128,7 +128,7 @@ export function ScheduleListItem({
                     updateDefault({
                       scheduleId: schedule.id,
                       isDefault: true,
-                    }).catch(()=>{});
+                    });
                   }}>
                   {t("set_as_default")}
                 </DropdownItem>
@@ -142,7 +142,7 @@ export function ScheduleListItem({
                 onClick={() => {
                   duplicateFunction({
                     scheduleId: schedule.id,
-                  }).catch(()=>{});
+                  });
                 }}>
                 {t("duplicate")}
               </DropdownItem>

--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -47,7 +47,7 @@ export function ScheduleListItem({
   redirectUrl,
 }: {
   schedule: Schedule;
-  deleteFunction: ({ scheduleId }: { scheduleId: number }) => void;
+  deleteFunction: ({ scheduleId }: { scheduleId: number }) => Promise<any>;
   displayOptions?: {
     timeZone?: string;
     hour12?: boolean;

--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -62,16 +62,15 @@ export function ScheduleListItem({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [loading, setLoading] = useState(false)
   type AvailabilityItem = (typeof schedule.availability)[number];
-  const handleDelete=(e:React.MouseEvent)=>{
-     e.preventDefault();
-     setLoading(true);
-     setTimeout(()=> {
-      deleteFunction({
-      scheduleId: schedule.id,
-    })
-    setLoading(false)
-     },0)
-  } 
+ const handleDelete = async (e: React.MouseEvent) => {
+  e.preventDefault();
+  setLoading(true);        
+  try {
+    await deleteFunction({ scheduleId: schedule.id });
+  } finally {
+    setLoading(false);     
+  }
+};
   return (
     <li key={schedule.id}>
       <div className="hover:bg-cal-muted flex items-center justify-between px-3 py-5 transition sm:px-4">


### PR DESCRIPTION
## What does this PR do?

- This PR improves the schedule delete confirmation dialog by adding a loader spinner to provide proper feedback during deletion.
- Previously, after deleting a schedule, there was no visual feedback, and the delete button remained static.
- Now, a loader spinner appears for the duration of the network request, giving users clear feedback that the deletion is in progress.
- The loader now properly reflects the deletion duration, staying visible while the network request is in progress

Key implementation change:

- The deleteFunction prop now expects a Promise-returning function.

- In the parent component, React Query’s mutateAsync is used instead of mutate so that await deleteFunction(...) works correctly and the spinner stays visible during the actual deletion.

Note:
I didn’t use confirmBtnText because it only accepts a string, and I wanted to show a loader spinner instead of text like “Deleting…”. Therefore, confirmBtn is used to render the spinner.

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):


Before 

https://github.com/user-attachments/assets/5aa45a5f-e6cf-4af0-a7b4-7281b8cbb43a

After 

https://github.com/user-attachments/assets/54fec67c-bbe4-4663-8bb6-681e69b6d61f





## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Go to the Availability section.
Select a schedule.
Click the three dots menu and then the delete icon.
The confirmation dialog should appear.
Click the Delete button.
Verify that a loader spinner now appears on the button while deletion is in progress.
Confirm that the schedule is deleted successfully and the spinner disappears.
Note: Previously, there was no visual feedback when deleting a schedule; this PR adds the loader to improve UX.

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

