### PR TITLE
fix: hide bookings opt-in banner on mobile viewport

### DIFF
--- a/apps/web/modules/feature-opt-in/components/FeatureOptInBanner.tsx
+++ b/apps/web/modules/feature-opt-in/components/FeatureOptInBanner.tsx
@@ -22,7 +22,7 @@ export function FeatureOptInBanner({
   return (
     <div
       data-testid="feature-opt-in-banner"
-      className="bg-default border-subtle fixed bottom-5 right-5 z-50 max-w-xs rounded-lg border shadow-lg group">
+      className="group fixed right-5 bottom-5 z-50 hidden max-w-xs rounded-lg border border-subtle bg-default shadow-lg md:block">
       <div className="p-4">
         <h3 data-testid="feature-opt-in-banner-title" className="text-emphasis text-lg font-semibold">
           {t(featureConfig.i18n.title)}


### PR DESCRIPTION
## What does this PR do?

Hides the "Try the new bookings page" opt-in banner on mobile viewports (`< 768px`) by adding `hidden md:block` Tailwind classes to the banner container.

The banner is a fixed-position popup in the bottom-right corner of `/bookings` which takes up significant screen space on mobile devices.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — CSS-only visibility change.

## How should this be tested?

1. Navigate to `/bookings` on a desktop viewport — the opt-in banner should still appear in the bottom-right corner
2. Resize the browser below `768px` (or use mobile device emulation) — the banner should not be visible
3. Verify the banner's "Try it" button and dismiss functionality still work on desktop

## Human Review Checklist

- [ ] Confirm `md` (768px) is the desired mobile breakpoint — adjust to `sm` (640px) or `lg` (1024px) if a different threshold is preferred
- [ ] Note: the banner hook/state logic still runs on mobile; only CSS visibility is toggled. This is an acceptable tradeoff for a one-line fix.

<!-- Link to Devin run: https://app.devin.ai/sessions/78348d24d9d848c2847480d5254cf92a -->
<!-- Requested by: @PeerRich -->