### PR TITLE
fix: revert mobile banner hide and add showBannerOn viewport config

### DIFF
--- a/apps/web/modules/feature-opt-in/components/FeatureOptInBanner.test.tsx
+++ b/apps/web/modules/feature-opt-in/components/FeatureOptInBanner.test.tsx
@@ -1,0 +1,72 @@
+import type { OptInFeatureConfig } from "@calcom/features/feature-opt-in/config";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FeatureOptInBanner } from "./FeatureOptInBanner";
+
+vi.mock("@calcom/lib/hooks/useLocale", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: Record<string, unknown>) => <img alt={props.alt as string} />,
+}));
+
+vi.mock("@calcom/ui/components/button", () => ({
+  Button: ({ children, ...props }: Record<string, unknown>) => (
+    <button {...props}>{children as React.ReactNode}</button>
+  ),
+}));
+
+const baseConfig: OptInFeatureConfig = {
+  slug: "bookings-v3",
+  i18n: { title: "title", name: "name", description: "desc" },
+  bannerImage: { src: "/img.png", width: 100, height: 100 },
+  policy: "permissive",
+};
+
+describe("FeatureOptInBanner viewport classes", () => {
+  it("applies no visibility class when showBannerOn is undefined (defaults to all)", () => {
+    render(<FeatureOptInBanner featureConfig={baseConfig} onDismiss={vi.fn()} onOpenDialog={vi.fn()} />);
+    const banner = screen.getByTestId("feature-opt-in-banner");
+    expect(banner.className).not.toContain("hidden");
+    expect(banner.className).not.toContain("md:hidden");
+  });
+
+  it("applies no visibility class when showBannerOn is 'all'", () => {
+    render(
+      <FeatureOptInBanner
+        featureConfig={{ ...baseConfig, showBannerOn: "all" }}
+        onDismiss={vi.fn()}
+        onOpenDialog={vi.fn()}
+      />
+    );
+    const banner = screen.getByTestId("feature-opt-in-banner");
+    expect(banner.className).not.toContain("hidden");
+    expect(banner.className).not.toContain("md:hidden");
+  });
+
+  it("applies 'hidden md:block' when showBannerOn is 'desktop'", () => {
+    render(
+      <FeatureOptInBanner
+        featureConfig={{ ...baseConfig, showBannerOn: "desktop" }}
+        onDismiss={vi.fn()}
+        onOpenDialog={vi.fn()}
+      />
+    );
+    const banner = screen.getByTestId("feature-opt-in-banner");
+    expect(banner.className).toContain("hidden");
+    expect(banner.className).toContain("md:block");
+  });
+
+  it("applies 'md:hidden' when showBannerOn is 'mobile'", () => {
+    render(
+      <FeatureOptInBanner
+        featureConfig={{ ...baseConfig, showBannerOn: "mobile" }}
+        onDismiss={vi.fn()}
+        onOpenDialog={vi.fn()}
+      />
+    );
+    const banner = screen.getByTestId("feature-opt-in-banner");
+    expect(banner.className).toContain("md:hidden");
+  });
+});

--- a/apps/web/modules/feature-opt-in/components/FeatureOptInBanner.tsx
+++ b/apps/web/modules/feature-opt-in/components/FeatureOptInBanner.tsx
@@ -6,6 +6,12 @@ import { Button } from "@calcom/ui/components/button";
 import Image from "next/image";
 import type { ReactElement } from "react";
 
+const VIEWPORT_CLASSES: Record<NonNullable<OptInFeatureConfig["showBannerOn"]>, string> = {
+  all: "",
+  mobile: "md:hidden",
+  desktop: "hidden md:block",
+};
+
 interface FeatureOptInBannerProps {
   featureConfig: OptInFeatureConfig;
   onDismiss: () => void;
@@ -18,11 +24,12 @@ export function FeatureOptInBanner({
   onOpenDialog,
 }: FeatureOptInBannerProps): ReactElement {
   const { t } = useLocale();
+  const viewportClass = VIEWPORT_CLASSES[featureConfig.showBannerOn ?? "all"];
 
   return (
     <div
       data-testid="feature-opt-in-banner"
-      className="group fixed right-5 bottom-5 z-50 hidden max-w-xs rounded-lg border border-subtle bg-default shadow-lg md:block">
+      className={`bg-default border-subtle fixed bottom-5 right-5 z-50 max-w-xs rounded-lg border shadow-lg group ${viewportClass}`}>
       <div className="p-4">
         <h3 data-testid="feature-opt-in-banner-title" className="text-emphasis text-lg font-semibold">
           {t(featureConfig.i18n.title)}

--- a/packages/features/feature-opt-in/config.ts
+++ b/packages/features/feature-opt-in/config.ts
@@ -30,6 +30,8 @@ export interface OptInFeatureConfig {
    * Use [] if you want the feature defined but not displayed anywhere.
    */
   displayLocations?: OptInFeatureDisplayLocation[];
+  /** Which viewports should show the opt-in banner. Defaults to 'all'. */
+  showBannerOn?: "all" | "mobile" | "desktop";
   /**
    * Formbricks feedback configuration for delayed survey triggering after opt-in.
    * When configured, a custom feedback dialog will be shown after the specified delay
@@ -75,7 +77,8 @@ export const OPT_IN_FEATURES: OptInFeatureConfig[] = [
     },
     policy: "permissive",
     displayLocations: ["banner", "settings"],
-    scope: ["org", "team", "user"], // Optional: defaults to all scopes if not specified
+    showBannerOn: "desktop",
+    scope: ["org", "team", "user"],
     formbricks: {
       waitAfterDays: 3,
       showOn: "desktop",


### PR DESCRIPTION
## What does this PR do?

Reverts the hardcoded `hidden md:block` CSS fix from #27965 and replaces it with a configurable `showBannerOn` property on `OptInFeatureConfig`. This allows each feature to declare which viewport(s) should display the opt-in banner.

**Changes:**
- Adds `showBannerOn?: 'all' | 'mobile' | 'desktop'` to `OptInFeatureConfig` (defaults to `'all'`)
- `FeatureOptInBanner` reads the config value and applies the corresponding Tailwind visibility classes via a `VIEWPORT_CLASSES` lookup
- Sets `showBannerOn: "desktop"` for the `bookings-v3` feature, preserving the mobile-hidden behavior from #27965 but driven by config

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to `/bookings` on a desktop viewport — the opt-in banner should appear
2. Resize below `768px` (or use mobile emulation) — the banner should be hidden
3. To verify the config is respected, temporarily change `showBannerOn` to `"all"` in `config.ts` and confirm the banner appears on mobile too

## Human Review Checklist

- [ ] Confirm `md` (768px) is the desired breakpoint for the desktop/mobile split
- [ ] Verify the property name `showBannerOn` is clear and fits the existing naming conventions
- [ ] Note: the className template literal produces a trailing space when `showBannerOn` is `'all'` (empty string from the map) — cosmetic only, no functional impact

<!-- Link to Devin run: https://app.devin.ai/sessions/5a58d704d4974bcdad9d48db8c831d6d -->
<!-- Requested by: @eunjae-lee -->