### PR TITLE
refactor: remove PII from SeatBookedAuditActionService payload

### DIFF
--- a/packages/features/booking-audit/lib/actions/SeatBookedAuditActionService.ts
+++ b/packages/features/booking-audit/lib/actions/SeatBookedAuditActionService.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 
+import type { BaseStoredAuditData } from "./IAuditActionService";
 import type { DataRequirements } from "../service/EnrichmentDataStore";
 import { AuditActionServiceHelper } from "./AuditActionServiceHelper";
 import type {
   GetDisplayTitleParams,
   GetDisplayJsonParams,
+  GetDisplayFieldsParams,
   IAuditActionService,
   TranslationWithParams,
 } from "./IAuditActionService";
@@ -14,9 +16,11 @@ import type {
  * Handles SEAT_BOOKED action with per-action versioning
  *
  * Note: SEAT_BOOKED action captures initial state, so it doesn't use { old, new } pattern
+ *
+ * V1: Stored attendeeEmail + attendeeName (PII in payload)
+ * V2: Stores attendeeId only (PII-free), enriched via EnrichmentDataStore at display time
  */
 
-// Module-level because it is passed to IAuditActionService type outside the class scope
 const fieldsSchemaV1 = z.object({
   seatReferenceUid: z.string(),
   attendeeEmail: z.string(),
@@ -25,19 +29,30 @@ const fieldsSchemaV1 = z.object({
   endTime: z.number(),
 });
 
+const fieldsSchemaV2 = z.object({
+  seatReferenceUid: z.string(),
+  attendeeId: z.number(),
+  startTime: z.number(),
+  endTime: z.number(),
+});
+
 export class SeatBookedAuditActionService implements IAuditActionService {
-  readonly VERSION = 1;
+  readonly VERSION = 2;
   public static readonly TYPE = "SEAT_BOOKED" as const;
   private static dataSchemaV1 = z.object({
     version: z.literal(1),
     fields: fieldsSchemaV1,
   });
-  private static fieldsSchemaV1 = fieldsSchemaV1;
-  public static readonly latestFieldsSchema = fieldsSchemaV1;
-  // Union of all versions
-  public static readonly storedDataSchema = SeatBookedAuditActionService.dataSchemaV1;
-  // Union of all versions
-  public static readonly storedFieldsSchema = SeatBookedAuditActionService.fieldsSchemaV1;
+  private static dataSchemaV2 = z.object({
+    version: z.literal(2),
+    fields: fieldsSchemaV2,
+  });
+  public static readonly latestFieldsSchema = fieldsSchemaV2;
+  public static readonly storedDataSchema = z.union([
+    SeatBookedAuditActionService.dataSchemaV2,
+    SeatBookedAuditActionService.dataSchemaV1,
+  ]);
+  public static readonly storedFieldsSchema = z.union([fieldsSchemaV2, fieldsSchemaV1]);
   private helper: AuditActionServiceHelper<
     typeof SeatBookedAuditActionService.latestFieldsSchema,
     typeof SeatBookedAuditActionService.storedDataSchema
@@ -52,6 +67,14 @@ export class SeatBookedAuditActionService implements IAuditActionService {
   }
 
   getVersionedData(fields: unknown) {
+    const v2Result = fieldsSchemaV2.safeParse(fields);
+    if (v2Result.success) {
+      return { version: 2, fields: v2Result.data };
+    }
+    const v1Result = fieldsSchemaV1.safeParse(fields);
+    if (v1Result.success) {
+      return { version: 1, fields: v1Result.data };
+    }
     return this.helper.getVersionedData(fields);
   }
 
@@ -64,12 +87,29 @@ export class SeatBookedAuditActionService implements IAuditActionService {
   }
 
   migrateToLatest(data: unknown) {
-    // V1-only: validate and return as-is (no migration needed)
-    const validated = fieldsSchemaV1.parse(data);
-    return { isMigrated: false, latestData: validated };
+    const v2Result = fieldsSchemaV2.safeParse(data);
+    if (v2Result.success) {
+      return { isMigrated: false, latestData: v2Result.data };
+    }
+    const v1Result = fieldsSchemaV1.safeParse(data);
+    if (v1Result.success) {
+      return { isMigrated: false, latestData: v1Result.data };
+    }
+    throw new z.ZodError([
+      {
+        code: z.ZodIssueCode.custom,
+        message: "Data does not match any known SeatBooked schema version",
+        path: [],
+      },
+    ]);
   }
 
-  getDataRequirements(): DataRequirements {
+  getDataRequirements(storedData: BaseStoredAuditData): DataRequirements {
+    const parsed = this.parseStored(storedData);
+    if (parsed.version === 2) {
+      const fields = fieldsSchemaV2.parse(parsed.fields);
+      return { attendeeIds: [fields.attendeeId] };
+    }
     return { userUuids: [] };
   }
 
@@ -78,24 +118,55 @@ export class SeatBookedAuditActionService implements IAuditActionService {
   }
 
   getDisplayJson({ storedData, userTimeZone }: GetDisplayJsonParams): SeatBookedAuditDisplayData {
-    const { fields } = this.parseStored(storedData);
+    const parsed = this.parseStored(storedData);
 
+    if (parsed.version === 2) {
+      const fields = fieldsSchemaV2.parse(parsed.fields);
+      return {
+        seatReferenceUid: fields.seatReferenceUid,
+        attendeeId: fields.attendeeId,
+        startTime: AuditActionServiceHelper.formatDateTimeInTimeZone(fields.startTime, userTimeZone),
+        endTime: AuditActionServiceHelper.formatDateTimeInTimeZone(fields.endTime, userTimeZone),
+      };
+    }
+
+    const fields = fieldsSchemaV1.parse(parsed.fields);
     return {
       seatReferenceUid: fields.seatReferenceUid,
-      attendeeEmail: fields.attendeeEmail,
-      attendeeName: fields.attendeeName,
+      attendeeId: null,
       startTime: AuditActionServiceHelper.formatDateTimeInTimeZone(fields.startTime, userTimeZone),
       endTime: AuditActionServiceHelper.formatDateTimeInTimeZone(fields.endTime, userTimeZone),
     };
   }
+
+  async getDisplayFields({ storedData, dbStore }: GetDisplayFieldsParams): Promise<
+    Array<{
+      labelKey: string;
+      value?: string;
+    }>
+  > {
+    const parsed = this.parseStored(storedData);
+
+    if (parsed.version === 2) {
+      const fields = fieldsSchemaV2.parse(parsed.fields);
+      const attendee = dbStore.getAttendeeById(fields.attendeeId);
+      return [
+        {
+          labelKey: "booking_audit_action.attendee",
+          value: attendee?.name ?? attendee?.email ?? "Unknown",
+        },
+      ];
+    }
+
+    return [];
+  }
 }
 
-export type SeatBookedAuditData = z.infer<typeof fieldsSchemaV1>;
+export type SeatBookedAuditData = z.infer<typeof fieldsSchemaV2>;
 
 export type SeatBookedAuditDisplayData = {
   seatReferenceUid: string;
-  attendeeEmail: string;
-  attendeeName: string;
+  attendeeId: number | null;
   startTime: string;
   endTime: string;
 };

--- a/packages/features/booking-audit/lib/actions/__tests__/SeatBookedAuditActionService.test.ts
+++ b/packages/features/booking-audit/lib/actions/__tests__/SeatBookedAuditActionService.test.ts
@@ -1,29 +1,138 @@
 import { describe, expect, it, beforeEach } from "vitest";
 
-import { verifyDataRequirementsContract } from "./contractVerification";
+import { verifyDataRequirementsContract, createMockEnrichmentDataStore } from "./contractVerification";
 import { SeatBookedAuditActionService } from "../SeatBookedAuditActionService";
 
-describe("SeatBookedAuditActionService - getDataRequirements contract", () => {
+describe("SeatBookedAuditActionService", () => {
   let service: SeatBookedAuditActionService;
 
   beforeEach(() => {
     service = new SeatBookedAuditActionService();
   });
 
-  it("should not access any dbStore methods", async () => {
-    const storedData = {
-      version: 1,
-      fields: {
-        seatReferenceUid: "seat-123",
-        attendeeEmail: "attendee@example.com",
-        attendeeName: "John Doe",
-        startTime: Date.now(),
-        endTime: Date.now() + 3600000,
-      },
+  describe("V2 schema (PII-free)", () => {
+    const v2Fields = {
+      seatReferenceUid: "seat-123",
+      attendeeId: 42,
+      startTime: 1700000000000,
+      endTime: 1700003600000,
     };
 
-    const { errors, accessedData } = await verifyDataRequirementsContract(service, storedData);
-    expect(errors).toEqual([]);
-    expect(accessedData.userUuids.size).toBe(0);
+    it("should produce versioned data with version 2", () => {
+      const result = service.getVersionedData(v2Fields);
+      expect(result.version).toBe(2);
+      expect(result.fields).toEqual(v2Fields);
+    });
+
+    it("should parse stored V2 data", () => {
+      const storedData = { version: 2, fields: v2Fields };
+      const parsed = service.parseStored(storedData);
+      expect(parsed.version).toBe(2);
+      expect(parsed.fields).toEqual(v2Fields);
+    });
+
+    it("should migrate V2 data as-is", () => {
+      const result = service.migrateToLatest(v2Fields);
+      expect(result.isMigrated).toBe(false);
+      expect(result.latestData).toEqual(v2Fields);
+    });
+
+    it("should declare attendeeId in data requirements for V2", () => {
+      const storedData = { version: 2, fields: v2Fields };
+      const requirements = service.getDataRequirements(storedData);
+      expect(requirements.attendeeIds).toEqual([42]);
+    });
+
+    it("should return attendeeId in display JSON for V2", () => {
+      const storedData = { version: 2, fields: v2Fields };
+      const displayJson = service.getDisplayJson({ storedData, userTimeZone: "UTC" });
+      expect(displayJson).toHaveProperty("attendeeId", 42);
+      expect(displayJson).not.toHaveProperty("attendeeEmail");
+      expect(displayJson).not.toHaveProperty("attendeeName");
+    });
+
+    it("should return enriched attendee in display fields for V2", async () => {
+      const storedData = { version: 2, fields: v2Fields };
+      const requirements = service.getDataRequirements(storedData);
+      const dbStore = createMockEnrichmentDataStore(
+        { attendees: [{ id: 42, name: "John Doe", email: "john@example.com" }] },
+        requirements
+      );
+      const displayFields = await service.getDisplayFields!({ storedData, dbStore });
+      expect(displayFields).toEqual([
+        { labelKey: "booking_audit_action.attendee", value: "John Doe" },
+      ]);
+    });
+
+    it("should fulfill data requirements contract for V2", async () => {
+      const storedData = { version: 2, fields: v2Fields };
+      const { errors } = await verifyDataRequirementsContract(service, storedData);
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe("V1 schema (backward compatibility)", () => {
+    const v1Fields = {
+      seatReferenceUid: "seat-123",
+      attendeeEmail: "attendee@example.com",
+      attendeeName: "John Doe",
+      startTime: 1700000000000,
+      endTime: 1700003600000,
+    };
+
+    it("should produce versioned data with version 1 for V1 fields", () => {
+      const result = service.getVersionedData(v1Fields);
+      expect(result.version).toBe(1);
+      expect(result.fields).toEqual(v1Fields);
+    });
+
+    it("should parse stored V1 data", () => {
+      const storedData = { version: 1, fields: v1Fields };
+      const parsed = service.parseStored(storedData);
+      expect(parsed.version).toBe(1);
+      expect(parsed.fields).toEqual(v1Fields);
+    });
+
+    it("should migrate V1 data as-is (cannot migrate without DB lookup)", () => {
+      const result = service.migrateToLatest(v1Fields);
+      expect(result.isMigrated).toBe(false);
+      expect(result.latestData).toEqual(v1Fields);
+    });
+
+    it("should not declare attendeeIds in data requirements for V1", () => {
+      const storedData = { version: 1, fields: v1Fields };
+      const requirements = service.getDataRequirements(storedData);
+      expect(requirements.attendeeIds).toBeUndefined();
+    });
+
+    it("should return null attendeeId in display JSON for V1", () => {
+      const storedData = { version: 1, fields: v1Fields };
+      const displayJson = service.getDisplayJson({ storedData, userTimeZone: "UTC" });
+      expect(displayJson).toHaveProperty("attendeeId", null);
+      expect(displayJson).not.toHaveProperty("attendeeEmail");
+      expect(displayJson).not.toHaveProperty("attendeeName");
+    });
+
+    it("should return empty display fields for V1", async () => {
+      const storedData = { version: 1, fields: v1Fields };
+      const requirements = service.getDataRequirements(storedData);
+      const dbStore = createMockEnrichmentDataStore({}, requirements);
+      const displayFields = await service.getDisplayFields!({ storedData, dbStore });
+      expect(displayFields).toEqual([]);
+    });
+
+    it("should not access any dbStore methods for V1", async () => {
+      const storedData = { version: 1, fields: v1Fields };
+      const { errors, accessedData } = await verifyDataRequirementsContract(service, storedData);
+      expect(errors).toEqual([]);
+      expect(accessedData.userUuids.size).toBe(0);
+      expect(accessedData.attendeeIds.size).toBe(0);
+    });
+  });
+
+  describe("migrateToLatest error handling", () => {
+    it("should throw for invalid data", () => {
+      expect(() => service.migrateToLatest({ invalid: "data" })).toThrow();
+    });
   });
 });

--- a/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
+++ b/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
@@ -301,6 +301,7 @@ const createNewSeat = async (
   }
 
   resultBooking["seatReferenceUid"] = evt.attendeeSeatId;
+  resultBooking["bookerAttendeeId"] = newBookingSeat?.attendeeId;
 
   return resultBooking;
 };

--- a/packages/features/bookings/lib/handleSeats/handleSeats.ts
+++ b/packages/features/bookings/lib/handleSeats/handleSeats.ts
@@ -110,20 +110,22 @@ const fireBookingEvents = async ({
         isBookingAuditEnabled,
       });
     } else {
-      await deps.bookingEventHandler.onSeatBooked({
-        bookingUid: previousSeatedBooking.uid,
-        actor: auditActor,
-        organizationId: organizationId ?? null,
-        auditData: {
-          seatReferenceUid,
-          attendeeEmail: bookerEmail,
-          attendeeName: bookerName,
-          startTime: previousSeatedBooking.startTime.getTime(),
-          endTime: previousSeatedBooking.endTime.getTime(),
-        },
-        source: actionSource,
-        isBookingAuditEnabled,
-      });
+      const bookerAttendeeId = newBooking.bookerAttendeeId;
+      if (bookerAttendeeId) {
+        await deps.bookingEventHandler.onSeatBooked({
+          bookingUid: previousSeatedBooking.uid,
+          actor: auditActor,
+          organizationId: organizationId ?? null,
+          auditData: {
+            seatReferenceUid,
+            attendeeId: bookerAttendeeId,
+            startTime: previousSeatedBooking.startTime.getTime(),
+            endTime: previousSeatedBooking.endTime.getTime(),
+          },
+          source: actionSource,
+          isBookingAuditEnabled,
+        });
+      }
     }
   } catch (error) {
     deps.logger.error("Error while firing booking events", safeStringify(error));

--- a/packages/features/bookings/lib/handleSeats/types.d.ts
+++ b/packages/features/bookings/lib/handleSeats/types.d.ts
@@ -91,6 +91,7 @@ export type HandleSeatsResultBooking =
   | (Partial<Booking> & {
     appsStatus?: AppsStatus[];
     seatReferenceUid?: string;
+    bookerAttendeeId?: number;
     paymentUid?: string;
     message?: string;
     paymentId?: number;


### PR DESCRIPTION
## What does this PR do?

Removes PII (`attendeeEmail`, `attendeeName`) from the `SeatBookedAuditActionService` audit data payload. Instead, the new V2 schema stores only `attendeeId`, and attendee details are resolved at display time via the existing `EnrichmentDataStore`.

This is the first action service being migrated as part of the broader effort to sanitize PII from booking audit `data` fields (the `actor` field is already PII-free).

### Changes

- **V2 schema**: New `fieldsSchemaV2` with `attendeeId: z.number()` replacing `attendeeEmail`/`attendeeName`
- **Backward compat**: V1 schema retained in `storedDataSchema` union so existing stored audit records still parse correctly
- **Producer**: `createNewSeat.ts` now sets `bookerAttendeeId` on the result booking; `handleSeats.ts` passes `attendeeId` instead of email/name
- **Display**: `getDisplayJson` returns `attendeeId` (or `null` for V1); new `getDisplayFields` method resolves attendee name via `dbStore.getAttendeeById()`
- **Tests**: 15 tests covering V2 schema, V1 backward compat, enrichment contract, and error handling

### ⚠️ Items for reviewer attention

1. **Silent audit skip**: In `handleSeats.ts`, the `onSeatBooked` call is now gated behind `if (bookerAttendeeId)`. If `newBookingSeat?.attendeeId` is ever falsy, the audit event will be silently dropped rather than recorded. Previously it always fired. Is this acceptable, or should we log a warning / fall back?
2. **Display type breaking change**: `SeatBookedAuditDisplayData` changed from `{attendeeEmail, attendeeName}` to `{attendeeId: number | null}`. Any frontend code consuming this type will need updating — no frontend changes are included here.
3. **V1 migration strategy**: `migrateToLatest` returns V1 data as-is (can't convert email→ID without a DB lookup). `getVersionedData` stamps it as `version: 1`. Verify the consumer flow handles storing records with version != `this.VERSION`.

Link to Devin run: https://app.devin.ai/sessions/3fd80fff1e804111ab543f9666768aa5
Requested by: @hariombalhara

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no public API or docs impact.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Unit tests** — `TZ=UTC yarn vitest run packages/features/booking-audit/lib/actions/__tests__/SeatBookedAuditActionService.test.ts` (15 tests)
2. **Type check** — `yarn type-check:ci --force --filter=@calcom/features` passes clean
3. **Manual verification** (if desired):
   - Create a seated event type with `seatsPerTimeSlot > 1`
   - Book a seat as a guest
   - Verify the `SEAT_BOOKED` audit record in the DB has `data.fields.attendeeId` (not `attendeeEmail`/`attendeeName`)
   - Check that the audit log UI displays the attendee name correctly (requires frontend changes not in this PR)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized (<500 lines, <10 files)