### PR TITLE
fix: dropdown toggle indicator sync in workflow form

### DIFF
--- a/packages/ui/components/editor/plugins/AddVariablesDropdown.tsx
+++ b/packages/ui/components/editor/plugins/AddVariablesDropdown.tsx
@@ -6,7 +6,7 @@ import useMediaQuery from "@calcom/lib/hooks/useMediaQuery";
 import classNames from "../../../classNames";
 import { Dropdown, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../../dropdown";
 import { Input } from "../../form";
-import { ChevronDownIcon } from "@coss/ui/icons";
+import { ChevronDownIcon, ChevronUpIcon } from "@coss/ui/icons";
 
 interface IAddVariablesDropdown {
   addVariable: (variable: string) => void;
@@ -124,7 +124,11 @@ export const AddVariablesDropdown = (props: IAddVariablesDropdown) => {
           ) : (
             <div className="flex">
               {t("add_variable")}
-              <ChevronDownIcon className="ml-1 mt-[2px] h-4 w-4" />
+              {
+                isOpen ? ( <ChevronUpIcon className="ml-1 mt-[2px] h-4 w-4" />) : (
+                  <ChevronDownIcon className="ml-1 mt-[2px] h-4 w-4" />
+                )
+              }
             </div>
           )}
         </div>


### PR DESCRIPTION
## What does this PR do?

Fixes chevron icon behavior in the workflow form dropdown.
Previously, the chevron icon did not reflect the dropdown open/close state correctly.
This change updates the icon to toggle between up/down based on the dropdown state (isOpen).

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

Before 

https://github.com/user-attachments/assets/8c033ceb-3ed5-4c0b-8980-462e8e1556fb

After 

https://github.com/user-attachments/assets/17b555f5-e3a2-419f-ba31-b2a3654d99e9



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Navigate to workflow form.
Locate "Add variable" dropdown.
Click to open dropdown.
Verify chevron icon changes to up icon.
Close dropdown.
Verify chevron icon changes back to down icon.

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs
