### PR TITLE
fix: prevent nested <a> element in NavigationItem

### DIFF
--- a/apps/web/modules/bookings/components/UnconfirmedBookingBadge.tsx
+++ b/apps/web/modules/bookings/components/UnconfirmedBookingBadge.tsx
@@ -4,18 +4,36 @@
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Badge } from "@calcom/ui/components/badge";
+import { useRouter } from "next/navigation";
 
 export default function UnconfirmedBookingBadge() {
   const { t } = useLocale();
+  const router=useRouter();
   const { data: unconfirmedBookingCount } = trpc.viewer.me.bookingUnconfirmedCount.useQuery();
   if (!unconfirmedBookingCount) return null;
   return (
-      <Badge
-        rounded
-        title={t("unconfirmed_bookings_tooltip")}
-        variant="orange"
-        className="cursor-pointer hover:bg-orange-800 hover:text-orange-100">
-        {unconfirmedBookingCount}
-      </Badge>
+      <div 
+        role="link"
+        tabIndex={0}
+        onKeyDown={(e:React.KeyboardEvent<HTMLDivElement>)=>{
+          if(e.key === "Enter" || e.key === " "){
+            e.preventDefault();
+            e.stopPropagation();
+            router.push("/bookings/unconfirmed");
+          }
+        }}
+        onClick={(e:React.MouseEvent<HTMLDivElement>)=>{
+          e.preventDefault();
+          e.stopPropagation();
+          router.push("/bookings/unconfirmed");
+      }}>
+        <Badge
+          rounded
+          title={t("unconfirmed_bookings_tooltip")}
+          variant="orange"
+          className="cursor-pointer hover:bg-orange-800 hover:text-orange-100">
+          {unconfirmedBookingCount}
+        </Badge>
+    </div>
   );
 }

--- a/apps/web/modules/bookings/components/UnconfirmedBookingBadge.tsx
+++ b/apps/web/modules/bookings/components/UnconfirmedBookingBadge.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
@@ -11,7 +10,6 @@ export default function UnconfirmedBookingBadge() {
   const { data: unconfirmedBookingCount } = trpc.viewer.me.bookingUnconfirmedCount.useQuery();
   if (!unconfirmedBookingCount) return null;
   return (
-    <Link href="/bookings/unconfirmed">
       <Badge
         rounded
         title={t("unconfirmed_bookings_tooltip")}
@@ -19,6 +17,5 @@ export default function UnconfirmedBookingBadge() {
         className="cursor-pointer hover:bg-orange-800 hover:text-orange-100">
         {unconfirmedBookingCount}
       </Badge>
-    </Link>
   );
 }


### PR DESCRIPTION
## What does this PR do?

### Problem
The `NavigationItem` component renders nested `<a>` elements due to an additional `Link` wrapper.

### Solution
Instead of using `Link`, render the badge inside a non interactive `<div>` with an onClick handler that calls `router.push("/bookings/unconfirmed")` to preserve the intended navigation without introducing nested interactive elements.

- Fixes #27984
- Fixes CAL-7217

## Visual Demo

### Before

https://github.com/user-attachments/assets/f41ddc88-5f1c-4484-a9ae-ca20bbfa5c5f

### After


https://github.com/user-attachments/assets/09187bbc-87f3-44a9-911b-1909f911f403



> Note: After the fix, all the errors and warnings related to nested `<a>` element have been resolved

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). (N/A)
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Steps to Reproduce
- Run the project locally (yarn dx)
- Navigate to a http://localhost:3000/event-types or a page which renders the navigation sidebar
- Ensure sidebar navigation is visible
- Error pops up from Next and in browser console

### Expected Behavior (After Fix)
- Repeat the steps above after applying this PR.
- No console error related to nested anchor tag should appear.



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/27985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
