### PR TITLE
refactor: simplify phone field unification and fix edge cases

### DIFF
--- a/apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx
+++ b/apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx
@@ -1,21 +1,19 @@
-import { useMemo, useRef } from "react";
-import { useFormContext } from "react-hook-form";
-import { z } from "zod";
-
 import type { LocationObject } from "@calcom/app-store/locations";
-import { getOrganizerInputLocationTypes } from "@calcom/app-store/locations";
-import { DefaultEventLocationTypeEnum } from "@calcom/app-store/locations";
+import { DefaultEventLocationTypeEnum, getOrganizerInputLocationTypes } from "@calcom/app-store/locations";
 import { useBookerStore } from "@calcom/features/bookings/Booker/store";
 import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
 import getLocationOptionsForSelect from "@calcom/features/bookings/lib/getLocationOptionsForSelect";
-import { FormBuilderField } from "@calcom/web/modules/form-builder/components/FormBuilderField";
-import { fieldTypesConfigMap } from "@calcom/features/form-builder/fieldTypes";
 import { fieldsThatSupportLabelAsSafeHtml } from "@calcom/features/form-builder/fieldsThatSupportLabelAsSafeHtml";
+import { fieldTypesConfigMap } from "@calcom/features/form-builder/fieldTypes";
 import { SystemField } from "@calcom/lib/bookings/SystemField";
 import { createPhoneSyncHandler, useBookerPhoneFields } from "@calcom/lib/bookings/useBookerPhoneFields";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import type { RouterOutputs } from "@calcom/trpc/react";
+import { FormBuilderField } from "@calcom/web/modules/form-builder/components/FormBuilderField";
+import { useMemo, useRef } from "react";
+import { useFormContext } from "react-hook-form";
+import { z } from "zod";
 
 type TouchedFields = {
   responses?: Record<string, boolean>;
@@ -266,7 +264,6 @@ export const BookingFields = ({
           }
         }
 
-        // Check if this is the consolidated phone field
         const isThisConsolidatedPhoneField = isConsolidatedPhoneField(field.name);
 
         return (
@@ -275,12 +272,12 @@ export const BookingFields = ({
             field={{ ...fieldWithPrice, hidden }}
             readOnly={readOnly}
             key={index}
-            // Pass consent info for consolidated phone field
             {...(isThisConsolidatedPhoneField &&
               consolidatedPhoneInfo && {
-                isConsolidatedPhoneField: true,
-                hasSmsWorkflow: consolidatedPhoneInfo.hasSmsWorkflow,
-                hasCalAiWorkflow: consolidatedPhoneInfo.hasCalAiWorkflow,
+                phoneConsentConfig: {
+                  hasSmsWorkflow: consolidatedPhoneInfo.hasSmsWorkflow,
+                  hasCalAiWorkflow: consolidatedPhoneInfo.hasCalAiWorkflow,
+                },
               })}
             onValueChange={({ value }) => {
               // Sync phone value to all consolidated phone fields

--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -1,39 +1,8 @@
-import { useAutoAnimate } from "@formkit/auto-animate/react";
-import { useEffect, useState } from "react";
-import type { SubmitHandler, UseFormReturn } from "react-hook-form";
-import { Controller, useFieldArray, useForm, useFormContext } from "react-hook-form";
-import type { z } from "zod";
-import { ZodError } from "zod";
-
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { LearnMoreLink } from "@calcom/features/eventtypes/components/LearnMoreLink";
-import { getCurrencySymbol } from "@calcom/lib/currencyConversions";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { md } from "@calcom/lib/markdownIt";
-import { markdownToSafeHTMLClient } from "@calcom/lib/markdownToSafeHTMLClient";
-import turndown from "@calcom/lib/turndownService";
-import { excludeOrRequireEmailSchema } from "@calcom/prisma/zod-utils";
-import classNames from "@calcom/ui/classNames";
-import { Badge } from "@calcom/ui/components/badge";
-import { Button } from "@calcom/ui/components/button";
-import { DialogContent, DialogFooter, DialogHeader, DialogClose } from "@calcom/ui/components/dialog";
-import { Editor } from "@calcom/ui/components/editor";
-import { ToggleGroup } from "@calcom/ui/components/form";
-import {
-  Switch,
-  CheckboxField,
-  SelectField,
-  Form,
-  Input,
-  InputField,
-  Label,
-} from "@calcom/ui/components/form";
-import { ArrowDownIcon, ArrowUpIcon, MailIcon, PhoneIcon } from "@coss/ui/icons";
-import { showToast } from "@calcom/ui/components/toast";
-
-import { fieldTypesConfigMap } from "@calcom/features/form-builder/fieldTypes";
 import { fieldsThatSupportLabelAsSafeHtml } from "@calcom/features/form-builder/fieldsThatSupportLabelAsSafeHtml";
+import { fieldTypesConfigMap } from "@calcom/features/form-builder/fieldTypes";
 import type { fieldsSchema } from "@calcom/features/form-builder/schema";
 import { getFieldIdentifier } from "@calcom/features/form-builder/utils/getFieldIdentifier";
 import { getConfig as getVariantsConfig } from "@calcom/features/form-builder/utils/variantsConfig";
@@ -51,6 +20,35 @@ import {
   type ConsolidatedFormField,
   useConsolidatedPhoneFields,
 } from "@calcom/lib/bookings/useConsolidatedPhoneFields";
+import { getCurrencySymbol } from "@calcom/lib/currencyConversions";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { md } from "@calcom/lib/markdownIt";
+import { markdownToSafeHTMLClient } from "@calcom/lib/markdownToSafeHTMLClient";
+import turndown from "@calcom/lib/turndownService";
+import { excludeOrRequireEmailSchema } from "@calcom/prisma/zod-utils";
+import classNames from "@calcom/ui/classNames";
+import { Badge } from "@calcom/ui/components/badge";
+import { Button } from "@calcom/ui/components/button";
+import { DialogClose, DialogContent, DialogFooter, DialogHeader } from "@calcom/ui/components/dialog";
+import { Editor } from "@calcom/ui/components/editor";
+import {
+  CheckboxField,
+  Form,
+  Input,
+  InputField,
+  Label,
+  SelectField,
+  Switch,
+  ToggleGroup,
+} from "@calcom/ui/components/form";
+import { showToast } from "@calcom/ui/components/toast";
+import { ArrowDownIcon, ArrowUpIcon, MailIcon, PhoneIcon } from "@coss/ui/icons";
+import { useAutoAnimate } from "@formkit/auto-animate/react";
+import { useEffect, useState } from "react";
+import type { SubmitHandler, UseFormReturn } from "react-hook-form";
+import { Controller, useFieldArray, useForm, useFormContext } from "react-hook-form";
+import type { z } from "zod";
+import { ZodError } from "zod";
 import { PhoneFieldSourcesInfo } from "./PhoneFieldSourcesInfo";
 
 type RhfForm = {
@@ -166,11 +164,12 @@ export const FormBuilder = function FormBuilder({
     });
   };
 
+  const resolveOriginalIndex = (displayIdx: number) => displayToOriginalIndex?.[displayIdx] ?? displayIdx;
+
   const editField = (index: number, data: ConsolidatedFormField) => {
-    // For consolidated phone fields, we need to find the actual index in the original fields array
     const actualIndex = data._consolidatedFrom
       ? (phoneFieldIndices?.get(CANONICAL_PHONE_FIELD) ?? index)
-      : (displayToOriginalIndex?.[index] ?? index);
+      : resolveOriginalIndex(index);
     setFieldDialog({
       isOpen: true,
       fieldIndex: actualIndex,
@@ -179,8 +178,7 @@ export const FormBuilder = function FormBuilder({
   };
 
   const removeField = (index: number) => {
-    const originalIndex = displayToOriginalIndex?.[index] ?? index;
-    remove(originalIndex);
+    remove(resolveOriginalIndex(index));
   };
 
   return (
@@ -347,9 +345,7 @@ export const FormBuilder = function FormBuilder({
                         type="button"
                         className="bg-default text-muted hover:text-emphasis disabled:hover:text-muted border-subtle hover:border-emphasis invisible absolute -left-[12px] -ml-4 -mt-4 mb-4 hidden h-6 w-6 scale-0 items-center justify-center rounded-md border p-1 transition-all hover:shadow disabled:hover:border-inherit disabled:hover:shadow-none group-hover:visible group-hover:scale-100 sm:ml-0 sm:flex"
                         onClick={() => {
-                          const from = displayToOriginalIndex?.[displayIndex] ?? displayIndex;
-                          const to = displayToOriginalIndex?.[displayIndex - 1] ?? displayIndex - 1;
-                          swap(from, to);
+                          swap(resolveOriginalIndex(displayIndex), resolveOriginalIndex(displayIndex - 1));
                         }}>
                         <ArrowUpIcon className="h-5 w-5" />
                       </button>
@@ -359,9 +355,7 @@ export const FormBuilder = function FormBuilder({
                         type="button"
                         className="bg-default text-muted hover:border-emphasis border-subtle hover:text-emphasis disabled:hover:text-muted invisible absolute -left-[12px] -ml-4 mt-8 hidden h-6 w-6 scale-0 items-center justify-center rounded-md border p-1 transition-all hover:shadow disabled:hover:border-inherit disabled:hover:shadow-none group-hover:visible group-hover:scale-100 sm:ml-0 sm:flex"
                         onClick={() => {
-                          const from = displayToOriginalIndex?.[displayIndex] ?? displayIndex;
-                          const to = displayToOriginalIndex?.[displayIndex + 1] ?? displayIndex + 1;
-                          swap(from, to);
+                          swap(resolveOriginalIndex(displayIndex), resolveOriginalIndex(displayIndex + 1));
                         }}>
                         <ArrowDownIcon className="h-5 w-5" />
                       </button>
@@ -426,9 +420,9 @@ export const FormBuilder = function FormBuilder({
                               }
                             });
                           } else {
-                            const originalIndex = displayToOriginalIndex?.[displayIndex] ?? displayIndex;
-                            update(originalIndex, {
-                              ...fields[originalIndex],
+                            const idx = resolveOriginalIndex(displayIndex);
+                            update(idx, {
+                              ...fields[idx],
                               hidden: !checked,
                             });
                           }
@@ -514,7 +508,10 @@ export const FormBuilder = function FormBuilder({
                   }
                 });
               } else {
-                update(fieldDialog.fieldIndex, data);
+                const { _consolidatedFrom: _, ...cleanData } = data as typeof data & {
+                  _consolidatedFrom?: string[];
+                };
+                update(fieldDialog.fieldIndex, cleanData);
               }
             } else {
               const field: RhfFormField = {

--- a/apps/web/modules/form-builder/components/FormBuilderField.tsx
+++ b/apps/web/modules/form-builder/components/FormBuilderField.tsx
@@ -1,14 +1,9 @@
-import { ErrorMessage } from "@hookform/error-message";
-import type { TFunction } from "i18next";
-import { Controller, useFormContext } from "react-hook-form";
-import type { z } from "zod";
-
-import { fieldTypesConfigMap } from "@calcom/features/form-builder/fieldTypes";
 import { fieldsThatSupportLabelAsSafeHtml } from "@calcom/features/form-builder/fieldsThatSupportLabelAsSafeHtml";
+import { fieldTypesConfigMap } from "@calcom/features/form-builder/fieldTypes";
 import type { fieldsSchema } from "@calcom/features/form-builder/schema";
 import {
-  useShouldBeDisabledDueToPrefill,
   getFieldNameFromErrorMessage,
+  useShouldBeDisabledDueToPrefill,
 } from "@calcom/features/form-builder/useShouldBeDisabledDueToPrefill";
 import { getTranslatedConfig as getTranslatedVariantsConfig } from "@calcom/features/form-builder/utils/variantsConfig";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -17,8 +12,16 @@ import classNames from "@calcom/ui/classNames";
 import { InfoBadge } from "@calcom/ui/components/badge";
 import { Label } from "@calcom/ui/components/form";
 import { InfoIcon } from "@coss/ui/icons";
-
+import { ErrorMessage } from "@hookform/error-message";
+import type { TFunction } from "i18next";
+import { Controller, useFormContext } from "react-hook-form";
+import type { z } from "zod";
 import { Components, isValidValueProp } from "./Components";
+
+export type PhoneConsentConfig = {
+  hasSmsWorkflow: boolean;
+  hasCalAiWorkflow: boolean;
+};
 
 // helper to render markdown label safely
 const renderLabel = (field: Partial<RhfFormField>) => {
@@ -65,17 +68,13 @@ export const FormBuilderField = ({
   readOnly,
   className,
   onValueChange,
-  isConsolidatedPhoneField,
-  hasSmsWorkflow,
-  hasCalAiWorkflow,
+  phoneConsentConfig,
 }: {
   field: RhfFormFields[number];
   readOnly: boolean;
   className: string;
   onValueChange?: (args: { name: string; value: unknown; prevValue: unknown }) => void;
-  isConsolidatedPhoneField?: boolean;
-  hasSmsWorkflow?: boolean;
-  hasCalAiWorkflow?: boolean;
+  phoneConsentConfig?: PhoneConsentConfig;
 }) => {
   const { t } = useLocale();
   const { control, formState } = useFormContext();
@@ -107,9 +106,7 @@ export const FormBuilderField = ({
                 setValue={setAndNotify}
                 noLabel={noLabel}
                 translatedDefaultLabel={translatedDefaultLabel}
-                isConsolidatedPhoneField={isConsolidatedPhoneField}
-                hasSmsWorkflow={hasSmsWorkflow}
-                hasCalAiWorkflow={hasCalAiWorkflow}
+                phoneConsentConfig={phoneConsentConfig}
               />
               <ErrorMessage
                 name="responses"
@@ -154,35 +151,47 @@ function assertUnreachable(arg: never) {
 
 // TODO: Add consistent `label` support to all the components and then remove the usage of WithLabel.
 // Label should be handled by each Component itself.
+function PhoneConsentMessage({
+  fieldName,
+  phoneConsentConfig,
+}: {
+  fieldName?: string;
+  phoneConsentConfig?: PhoneConsentConfig;
+}) {
+  const { t } = useLocale();
+
+  const needsSmsConsent = phoneConsentConfig
+    ? phoneConsentConfig.hasSmsWorkflow
+    : fieldName === "smsReminderNumber";
+  const needsCalAiConsent = phoneConsentConfig?.hasCalAiWorkflow ?? false;
+
+  if (!needsSmsConsent && !needsCalAiConsent) return null;
+
+  if (needsSmsConsent && needsCalAiConsent) {
+    return <div className="text-subtle mt-2 text-sm">{t("sms_and_cal_ai_phone_consent")}</div>;
+  }
+  if (needsSmsConsent) {
+    return <div className="text-subtle mt-2 text-sm">{t("sms_workflow_consent")}</div>;
+  }
+  return <div className="text-subtle mt-2 text-sm">{t("cal_ai_phone_consent")}</div>;
+}
+
 const WithLabel = ({
   field,
   children,
   readOnly,
   htmlFor,
   noLabel = false,
-  isConsolidatedPhoneField,
-  hasSmsWorkflow,
-  hasCalAiWorkflow,
+  phoneConsentConfig,
 }: {
   field: Partial<RhfFormField>;
   readOnly: boolean;
   children: React.ReactNode;
   noLabel?: boolean;
   htmlFor: string;
-  isConsolidatedPhoneField?: boolean;
-  hasSmsWorkflow?: boolean;
-  hasCalAiWorkflow?: boolean;
+  phoneConsentConfig?: PhoneConsentConfig;
 }) => {
   const { t } = useLocale();
-
-  const needsSmsConsent = isConsolidatedPhoneField
-    ? hasSmsWorkflow
-    : field.name === "smsReminderNumber";
-  const needsCalAiConsent = isConsolidatedPhoneField ? hasCalAiWorkflow : false;
-
-  const showCombinedConsent = needsSmsConsent && needsCalAiConsent;
-  const showSmsOnlyConsent = needsSmsConsent && !needsCalAiConsent;
-  const showCalAiOnlyConsent = needsCalAiConsent && !needsSmsConsent;
 
   return (
     <div>
@@ -205,21 +214,7 @@ const WithLabel = ({
             </div>
           )}
       {children}
-      {showCombinedConsent && (
-        <div className="text-subtle mt-2 text-sm">
-          {t("sms_and_cal_ai_phone_consent")}
-        </div>
-      )}
-      {showSmsOnlyConsent && (
-        <div className="text-subtle mt-2 text-sm">
-          {t("sms_workflow_consent")}
-        </div>
-      )}
-      {showCalAiOnlyConsent && (
-        <div className="text-subtle mt-2 text-sm">
-          {t("cal_ai_phone_consent")}
-        </div>
-      )}
+      <PhoneConsentMessage fieldName={field.name} phoneConsentConfig={phoneConsentConfig} />
     </div>
   );
 };
@@ -282,9 +277,7 @@ export const ComponentForField = ({
   readOnly,
   noLabel,
   translatedDefaultLabel,
-  isConsolidatedPhoneField,
-  hasSmsWorkflow,
-  hasCalAiWorkflow,
+  phoneConsentConfig,
 }: {
   field: Omit<RhfFormField, "editable" | "label"> & {
     // Label is optional because radioInput doesn't have a label
@@ -293,9 +286,7 @@ export const ComponentForField = ({
   readOnly: boolean;
   noLabel?: boolean;
   translatedDefaultLabel?: string;
-  isConsolidatedPhoneField?: boolean;
-  hasSmsWorkflow?: boolean;
-  hasCalAiWorkflow?: boolean;
+  phoneConsentConfig?: PhoneConsentConfig;
 } & ValueProps) => {
   const fieldType = field.type || "text";
   const componentConfig = Components[fieldType];
@@ -316,7 +307,12 @@ export const ComponentForField = ({
 
   if (componentConfig.propsType === "text") {
     return (
-      <WithLabel field={field} htmlFor={field.name} readOnly={readOnly} noLabel={noLabel} isConsolidatedPhoneField={isConsolidatedPhoneField} hasSmsWorkflow={hasSmsWorkflow} hasCalAiWorkflow={hasCalAiWorkflow}>
+      <WithLabel
+        field={field}
+        htmlFor={field.name}
+        readOnly={readOnly}
+        noLabel={noLabel}
+        phoneConsentConfig={phoneConsentConfig}>
         <componentConfig.factory
           placeholder={field.placeholder}
           minLength={field.minLength}

--- a/packages/features/bookings/lib/handleNewBooking/getBookingData.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getBookingData.test.ts
@@ -53,6 +53,7 @@ const createMockSchema = () => {
       attendeePhoneNumber: z.string().optional(),
       guests: z.array(z.string()).optional(),
       smsReminderNumber: z.string().optional(),
+      aiAgentCallPhoneNumber: z.string().optional(),
       notes: z.string().optional(),
       rescheduleReason: z.string().optional(),
     }),
@@ -215,6 +216,115 @@ describe("getBookingData", () => {
 
       // The location should be the conferencing type, NOT the URL
       expect(result.location).toBe(OrganizerDefaultConferencingAppType);
+    });
+  });
+
+  describe("phone field unification", () => {
+    it("should unify phone values by default (flag undefined)", async () => {
+      const mockEventType = createMockEventType();
+      const schema = createMockSchema();
+
+      const result = await getBookingData({
+        reqBody: {
+          eventTypeId: 1,
+          start: "2024-01-15T10:00:00.000Z",
+          end: "2024-01-15T10:30:00.000Z",
+          timeZone: "UTC",
+          language: "en",
+          metadata: {},
+          responses: {
+            name: "Test User",
+            email: "test@example.com",
+            attendeePhoneNumber: "+1111",
+            smsReminderNumber: "+2222",
+          },
+        },
+        eventType: mockEventType,
+        schema,
+      });
+
+      expect(result.attendeePhoneNumber).toBe("+1111");
+      expect(result.smsReminderNumber).toBe("+1111");
+    });
+
+    it("should unify phone values when flag is explicitly true", async () => {
+      const mockEventType = createMockEventType({ metadata: { unifySystemPhoneFields: true } });
+      const schema = createMockSchema();
+
+      const result = await getBookingData({
+        reqBody: {
+          eventTypeId: 1,
+          start: "2024-01-15T10:00:00.000Z",
+          end: "2024-01-15T10:30:00.000Z",
+          timeZone: "UTC",
+          language: "en",
+          metadata: {},
+          responses: {
+            name: "Test User",
+            email: "test@example.com",
+            attendeePhoneNumber: "+1111",
+            smsReminderNumber: "+2222",
+          },
+        },
+        eventType: mockEventType,
+        schema,
+      });
+
+      expect(result.attendeePhoneNumber).toBe("+1111");
+      expect(result.smsReminderNumber).toBe("+1111");
+    });
+
+    it("should preserve separate phone values when flag is false", async () => {
+      const mockEventType = createMockEventType({ metadata: { unifySystemPhoneFields: false } });
+      const schema = createMockSchema();
+
+      const result = await getBookingData({
+        reqBody: {
+          eventTypeId: 1,
+          start: "2024-01-15T10:00:00.000Z",
+          end: "2024-01-15T10:30:00.000Z",
+          timeZone: "UTC",
+          language: "en",
+          metadata: {},
+          responses: {
+            name: "Test User",
+            email: "test@example.com",
+            attendeePhoneNumber: "+1111",
+            smsReminderNumber: "+2222",
+          },
+        },
+        eventType: mockEventType,
+        schema,
+      });
+
+      expect(result.attendeePhoneNumber).toBe("+1111");
+      expect(result.smsReminderNumber).toBe("+2222");
+    });
+
+    it("should fall back to smsReminderNumber when attendeePhoneNumber is empty", async () => {
+      const mockEventType = createMockEventType();
+      const schema = createMockSchema();
+
+      const result = await getBookingData({
+        reqBody: {
+          eventTypeId: 1,
+          start: "2024-01-15T10:00:00.000Z",
+          end: "2024-01-15T10:30:00.000Z",
+          timeZone: "UTC",
+          language: "en",
+          metadata: {},
+          responses: {
+            name: "Test User",
+            email: "test@example.com",
+            smsReminderNumber: "+2222",
+          },
+        },
+        eventType: mockEventType,
+        schema,
+      });
+
+      expect(result.attendeePhoneNumber).toBe("+2222");
+      expect(result.smsReminderNumber).toBe("+2222");
     });
   });
 });

--- a/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
@@ -25,7 +25,7 @@ const _getBookingData = async <T extends z.ZodType>({
   const parsedBody = await schema.parseAsync(reqBody);
   const parsedBodyWithEnd = (body: TgetBookingDataSchema): body is ReqBodyWithEnd => {
     // Use the event length to auto-set the event end time.
-    if (!Object.prototype.hasOwnProperty.call(body, "end")) {
+    if (!Object.hasOwn(body, "end")) {
       body.end = dayjs.utc(body.start).add(eventType.length, "minutes").format();
     }
     return true;
@@ -76,8 +76,10 @@ const _getBookingData = async <T extends z.ZodType>({
     }
   }
 
-  const phoneValue =
-    responses.attendeePhoneNumber || responses.smsReminderNumber || responses.aiAgentCallPhoneNumber;
+  const shouldUnifyPhoneFields = eventType.metadata?.unifySystemPhoneFields !== false;
+  const phoneValue = shouldUnifyPhoneFields
+    ? responses.attendeePhoneNumber || responses.smsReminderNumber || responses.aiAgentCallPhoneNumber
+    : null;
 
   return {
     ...parsedBody,
@@ -86,7 +88,6 @@ const _getBookingData = async <T extends z.ZodType>({
     attendeePhoneNumber: phoneValue || responses.attendeePhoneNumber,
     guests: responses.guests ? responses.guests : [],
     location: locationValue,
-    // Use propagated phone value for smsReminderNumber to ensure workflows receive it
     smsReminderNumber: phoneValue || responses.smsReminderNumber,
     notes: responses.notes || "",
     calEventUserFieldsResponses,


### PR DESCRIPTION
## What does this PR do?

Improvements on top of #27899 (unify system phone input fields). Contains 2 bug fixes and 2 code simplifications — no behavior changes for the happy path.

### Bug fixes

1. **Gate phone propagation behind `unifySystemPhoneFields` flag** (`getBookingData.ts`): The phone value copying logic (`attendeePhoneNumber → smsReminderNumber`) previously ran unconditionally. When `unifySystemPhoneFields` is `false`, API consumers sending different phone numbers for each field would have their values silently overwritten. Now the propagation only runs when the flag is enabled (default `true`).

2. **Strip `_consolidatedFrom` before persistence** (`FormBuilder.tsx` dialog submit): The `_consolidatedFrom` runtime property used for consolidated phone field tracking could leak into stored booking fields JSON since the dialog submit spreads the full data object into `update()`. Now stripped via destructuring before the write.

### Simplifications

3. **`resolveOriginalIndex` helper** (`FormBuilder.tsx`): Replaces 5 scattered `displayToOriginalIndex?.[x] ?? x` patterns with a single helper function.

4. **`PhoneConsentMessage` component + `phoneConsentConfig` prop** (`FormBuilderField.tsx`): Bundles three drilled props (`isConsolidatedPhoneField`, `hasSmsWorkflow`, `hasCalAiWorkflow`) into a single `phoneConsentConfig` object and extracts consent rendering into a dedicated component.

Import reordering in the diff is from Biome auto-formatting — no manual changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A** — internal refactoring only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. 4 unit tests added for the phone propagation gating logic in `getBookingData.test.ts`.

## How should this be tested?

### Test 1: Phone propagation gating
1. Set `unifySystemPhoneFields: false` in event type metadata
2. Send a booking request via API with different values for `attendeePhoneNumber`, `smsReminderNumber`, and `aiAgentCallPhoneNumber`
3. Verify each field retains its original value (no cross-field copying)

### Test 2: Consolidated phone field editing
1. Enable phone field unification (default)
2. In FormBuilder, edit the consolidated "Phone number" field
3. Verify the edit dialog opens and saves correctly without persisting `_consolidatedFrom`

### Test 3: Index mapping
1. In FormBuilder with phone unification enabled, try:
   - Swapping fields before/after the consolidated phone field
   - Removing a field after the consolidated phone field
   - Toggling visibility of a field after the consolidated phone field
2. Verify operations target the correct field in the original array

### Test 4: Consent messages
1. Create an event with SMS workflow and/or Cal AI workflow
2. Book the event and verify the phone field shows the correct consent message
3. Verify non-consolidated phone fields (when unification is off) still show SMS consent for `smsReminderNumber`

### Unit tests
```bash
TZ=UTC yarn vitest run packages/features/bookings/lib/handleNewBooking/getBookingData.test.ts
```

## Checklist


- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (N/A — code is self-explanatory)
- [x] I have checked if my changes generate no new warnings (type check shows same 5 pre-existing errors in `embed-react/inline.tsx`)
- [x] My PR is appropriately sized (5 files, ~220 net lines changed including import reordering and tests)

---

**Link to Devin run:** https://app.devin.ai/sessions/3e882ab8140e4faca7bd81b48d9eef41  
**Requested by:** @Ryukemeister

## Review notes

**⚠️ Key areas to review:**

1. **`getBookingData.ts` line 79-82**: Verify the `shouldUnifyPhoneFields !== false` check correctly handles `undefined` (should default to `true`). Verify `phoneValue = null` fallback behavior preserves original field values when unification is off.

2. **`FormBuilder.tsx` line 511-513**: The type assertion `as typeof data & { _consolidatedFrom?: string[] }` — verify this is safe. The `data` is already typed as `ConsolidatedFormField` which includes `_consolidatedFrom`, so the cast might be redundant.

3. **`FormBuilderField.tsx` line 154-179**: Verify `PhoneConsentMessage` logic matches the original `WithLabel` consent logic (particularly the fallback to `fieldName === "smsReminderNumber"` when `phoneConsentConfig` is undefined).

4. **`getBookingData.ts` line 28**: `Object.hasOwn` requires Node 16.9+ / ES2022+. Verify target environment supports this (likely fine for Cal.com).

5. **Import reordering**: Biome auto-formatted imports across all files. These are cosmetic changes — focus review on the actual logic changes above.

6. **Test coverage**: Unit tests added for phone propagation gating. No tests for FormBuilder index mapping or PhoneConsentMessage component changes (these are refactors of existing tested behavior).