### PR TITLE
feat: add Lever.co ATS integration app

### DIFF
--- a/packages/app-store/apps.browser.generated.tsx
+++ b/packages/app-store/apps.browser.generated.tsx
@@ -31,6 +31,7 @@ export const EventTypeAddonMap = {
   hitpay: dynamic(() => import("./hitpay/components/EventTypeAppCardInterface")),
   hubspot: dynamic(() => import("./hubspot/components/EventTypeAppCardInterface")),
   insihts: dynamic(() => import("./insihts/components/EventTypeAppCardInterface")),
+  leverco: dynamic(() => import("./leverco/components/EventTypeAppCardInterface")),
   matomo: dynamic(() => import("./matomo/components/EventTypeAppCardInterface")),
   metapixel: dynamic(() => import("./metapixel/components/EventTypeAppCardInterface")),
   "mock-payment-app": dynamic(() => import("./mock-payment-app/components/EventTypeAppCardInterface")),

--- a/packages/app-store/apps.keys-schemas.generated.ts
+++ b/packages/app-store/apps.keys-schemas.generated.ts
@@ -23,6 +23,7 @@ import { appKeysSchema as intercom_zod_ts } from "./intercom/zod";
 import { appKeysSchema as jelly_zod_ts } from "./jelly/zod";
 import { appKeysSchema as jitsivideo_zod_ts } from "./jitsivideo/zod";
 import { appKeysSchema as larkcalendar_zod_ts } from "./larkcalendar/zod";
+import { appKeysSchema as leverco_zod_ts } from "./leverco/zod";
 import { appKeysSchema as make_zod_ts } from "./make/zod";
 import { appKeysSchema as matomo_zod_ts } from "./matomo/zod";
 import { appKeysSchema as metapixel_zod_ts } from "./metapixel/zod";
@@ -74,6 +75,7 @@ export const appKeysSchemas = {
   jelly: jelly_zod_ts,
   jitsivideo: jitsivideo_zod_ts,
   larkcalendar: larkcalendar_zod_ts,
+  leverco: leverco_zod_ts,
   make: make_zod_ts,
   matomo: matomo_zod_ts,
   metapixel: metapixel_zod_ts,

--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -53,6 +53,7 @@ import intercom_config_json from "./intercom/config.json";
 import jelly_config_json from "./jelly/config.json";
 import { metadata as jitsivideo__metadata_ts } from "./jitsivideo/_metadata";
 import { metadata as larkcalendar__metadata_ts } from "./larkcalendar/_metadata";
+import leverco_config_json from "./leverco/config.json";
 import lindy_config_json from "./lindy/config.json";
 import linear_config_json from "./linear/config.json";
 import make_config_json from "./make/config.json";
@@ -164,6 +165,7 @@ export const appStoreMetadata = {
   jelly: jelly_config_json,
   jitsivideo: jitsivideo__metadata_ts,
   larkcalendar: larkcalendar__metadata_ts,
+  leverco: leverco_config_json,
   lindy: lindy_config_json,
   linear: linear_config_json,
   make: make_config_json,

--- a/packages/app-store/apps.schemas.generated.ts
+++ b/packages/app-store/apps.schemas.generated.ts
@@ -23,6 +23,7 @@ import { appDataSchema as intercom_zod_ts } from "./intercom/zod";
 import { appDataSchema as jelly_zod_ts } from "./jelly/zod";
 import { appDataSchema as jitsivideo_zod_ts } from "./jitsivideo/zod";
 import { appDataSchema as larkcalendar_zod_ts } from "./larkcalendar/zod";
+import { appDataSchema as leverco_zod_ts } from "./leverco/zod";
 import { appDataSchema as make_zod_ts } from "./make/zod";
 import { appDataSchema as matomo_zod_ts } from "./matomo/zod";
 import { appDataSchema as metapixel_zod_ts } from "./metapixel/zod";
@@ -74,6 +75,7 @@ export const appDataSchemas = {
   jelly: jelly_zod_ts,
   jitsivideo: jitsivideo_zod_ts,
   larkcalendar: larkcalendar_zod_ts,
+  leverco: leverco_zod_ts,
   make: make_zod_ts,
   matomo: matomo_zod_ts,
   metapixel: metapixel_zod_ts,

--- a/packages/app-store/apps.server.generated.ts
+++ b/packages/app-store/apps.server.generated.ts
@@ -39,6 +39,7 @@ export const apiHandlers = {
   jelly: import("./jelly/api"),
   jitsivideo: import("./jitsivideo/api"),
   larkcalendar: import("./larkcalendar/api"),
+  leverco: import("./leverco/api"),
   linear: import("./linear/api"),
   make: import("./make/api"),
   matomo: import("./matomo/api"),

--- a/packages/app-store/crm.apps.generated.ts
+++ b/packages/app-store/crm.apps.generated.ts
@@ -5,6 +5,7 @@
 export const CrmServiceMap = {
   closecom: import("./closecom/lib/CrmService"),
   hubspot: import("./hubspot/lib/CrmService"),
+  leverco: import("./leverco/lib/CrmService"),
   "pipedrive-crm": import("./pipedrive-crm/lib/CrmService"),
   salesforce: import("./salesforce/lib/CrmService"),
   "zoho-bigin": import("./zoho-bigin/lib/CrmService"),

--- a/packages/app-store/leverco/DESCRIPTION.md
+++ b/packages/app-store/leverco/DESCRIPTION.md
@@ -1,0 +1,10 @@
+---
+items:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+---
+
+- Lever is a leading talent acquisition suite that makes it easy for talent teams to reach their hiring goals and to connect companies with top talent.
+- Automatically create and update interview activities in Lever when bookings are made through Cal.com.
+- Seamlessly sync your scheduling workflow with your recruiting pipeline.

--- a/packages/app-store/leverco/api/_getAdd.ts
+++ b/packages/app-store/leverco/api/_getAdd.ts
@@ -1,0 +1,35 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { WEBAPP_URL } from "@calcom/lib/constants";
+import { defaultResponder } from "@calcom/lib/server/defaultResponder";
+
+import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
+import { encodeOAuthState } from "../../_utils/oauth/encodeOAuthState";
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!req.session?.user?.id) {
+    return res.status(401).json({ message: "You must be logged in to do this" });
+  }
+
+  const { client_id } = await getAppKeysFromSlug("leverco");
+
+  if (!client_id || typeof client_id !== "string")
+    return res.status(400).json({ message: "Lever.co client_id missing." });
+
+  const state = encodeOAuthState(req) ?? "";
+
+  const params = new URLSearchParams({
+    client_id,
+    redirect_uri: `${WEBAPP_URL}/api/integrations/leverco/callback`,
+    response_type: "code",
+    state,
+    scope: "offline_access opportunities:read:admin candidates:read:admin",
+    audience: "https://api.lever.co/v1/",
+  });
+
+  return res.status(200).json({
+    url: `https://auth.lever.co/authorize?${params.toString()}`,
+  });
+}
+
+export default defaultResponder(handler);

--- a/packages/app-store/leverco/api/add.ts
+++ b/packages/app-store/leverco/api/add.ts
@@ -1,0 +1,5 @@
+import { defaultHandler } from "@calcom/lib/server/defaultHandler";
+
+export default defaultHandler({
+  GET: import("./_getAdd"),
+});

--- a/packages/app-store/leverco/api/callback.ts
+++ b/packages/app-store/leverco/api/callback.ts
@@ -1,0 +1,89 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { WEBAPP_URL } from "@calcom/lib/constants";
+import { getSafeRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
+import { HttpError } from "@calcom/lib/http-error";
+import { defaultHandler } from "@calcom/lib/server/defaultHandler";
+import { defaultResponder } from "@calcom/lib/server/defaultResponder";
+import prisma from "@calcom/prisma";
+
+import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
+import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+import { decodeOAuthState } from "../../_utils/oauth/decodeOAuthState";
+import appConfig from "../config.json";
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { code } = req.query;
+
+  const state = decodeOAuthState(req);
+
+  const redirectAfterSuccess =
+    getSafeRedirectUrl(state?.returnTo) ??
+    getInstalledAppPath({ variant: appConfig.variant, slug: appConfig.slug });
+  const redirectAfterSuccessOrError = getSafeRedirectUrl(state?.onErrorReturnTo) ?? redirectAfterSuccess;
+  if (!code || typeof code !== "string") {
+    if (state?.onErrorReturnTo || state?.returnTo) {
+      res.redirect(redirectAfterSuccessOrError);
+      return;
+    }
+    throw new HttpError({ statusCode: 400, message: "`code` must be a string" });
+  }
+
+  if (!req.session?.user?.id) {
+    throw new HttpError({ statusCode: 401, message: "You must be logged in to do this" });
+  }
+
+  const { client_id, client_secret } = await getAppKeysFromSlug("leverco");
+
+  if (!client_id || typeof client_id !== "string")
+    return res.status(400).json({ message: "Lever.co client_id missing." });
+  if (!client_secret || typeof client_secret !== "string")
+    return res.status(400).json({ message: "Lever.co client_secret missing." });
+
+  try {
+    const response = await fetch("https://auth.lever.co/oauth/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id,
+        client_secret,
+        grant_type: "authorization_code",
+        code: code as string,
+        redirect_uri: `${WEBAPP_URL}/api/integrations/leverco/callback`,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to get access token");
+    }
+
+    const responseJson = await response.json();
+
+    const { access_token, refresh_token, expires_in } = responseJson;
+    const expires_at = Date.now() + expires_in * 1000;
+
+    await prisma.credential.create({
+      data: {
+        type: "leverco_crm",
+        key: {
+          access_token,
+          refresh_token,
+          expires_at,
+        },
+        userId: req.session.user.id,
+        appId: "leverco",
+      },
+    });
+
+    return res.redirect(redirectAfterSuccess);
+  } catch (error) {
+    console.error("Error getting Lever.co access token", error);
+    return res.redirect(`${redirectAfterSuccessOrError}?error=Error getting Lever.co access token`);
+  }
+}
+
+export default defaultHandler({
+  GET: Promise.resolve({ default: defaultResponder(getHandler) }),
+});

--- a/packages/app-store/leverco/api/index.ts
+++ b/packages/app-store/leverco/api/index.ts
@@ -1,0 +1,2 @@
+export { default as add } from "./add";
+export { default as callback } from "./callback";

--- a/packages/app-store/leverco/components/EventTypeAppCardInterface.tsx
+++ b/packages/app-store/leverco/components/EventTypeAppCardInterface.tsx
@@ -1,0 +1,32 @@
+import { usePathname } from "next/navigation";
+
+import AppCard from "@calcom/app-store/_components/AppCard";
+import useIsAppEnabled from "@calcom/app-store/_utils/useIsAppEnabled";
+import type { EventTypeAppCardComponent } from "@calcom/app-store/types";
+import { WEBAPP_URL } from "@calcom/lib/constants";
+
+const EventTypeAppCard: EventTypeAppCardComponent = function EventTypeAppCard({
+  app,
+  eventType,
+  onAppInstallSuccess,
+}) {
+  const pathname = usePathname();
+
+  const { enabled, updateEnabled } = useIsAppEnabled(app);
+
+  return (
+    <AppCard
+      onAppInstallSuccess={onAppInstallSuccess}
+      returnTo={`${WEBAPP_URL}${pathname}?tabName=apps`}
+      app={app}
+      teamId={eventType.team?.id || undefined}
+      switchOnClick={(e) => {
+        updateEnabled(e);
+      }}
+      switchChecked={enabled}
+      hideAppCardOptions
+    />
+  );
+};
+
+export default EventTypeAppCard;

--- a/packages/app-store/leverco/config.json
+++ b/packages/app-store/leverco/config.json
@@ -1,0 +1,18 @@
+{
+  "/*": "Don't modify slug - If required, do it using cli edit command",
+  "name": "Lever.co",
+  "title": "Lever.co",
+  "slug": "leverco",
+  "type": "leverco_crm",
+  "logo": "icon.svg",
+  "url": "https://www.lever.co",
+  "variant": "crm",
+  "categories": ["crm"],
+  "publisher": "Cal.com, Inc.",
+  "extendsFeature": "EventType",
+  "email": "help@cal.com",
+  "description": "Lever is a leading talent acquisition suite that makes it easy for talent teams to reach their hiring goals and to connect companies with top talent.",
+  "__createdUsingCli": true,
+  "isOAuth": true,
+  "dirName": "leverco"
+}

--- a/packages/app-store/leverco/index.ts
+++ b/packages/app-store/leverco/index.ts
@@ -1,0 +1,2 @@
+export * as api from "./api";
+export * as lib from "./lib";

--- a/packages/app-store/leverco/lib/CrmService.ts
+++ b/packages/app-store/leverco/lib/CrmService.ts
@@ -1,0 +1,249 @@
+import z from "zod";
+
+import logger from "@calcom/lib/logger";
+import type { CalendarEvent } from "@calcom/types/Calendar";
+import type { CredentialPayload } from "@calcom/types/Credential";
+import type { CRM, ContactCreateInput, CrmEvent, Contact } from "@calcom/types/CrmService";
+
+const API_BASE_URL = "https://api.lever.co/v1";
+
+const credentialSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string().optional(),
+  expires_at: z.number().optional(),
+});
+
+/**
+ * Lever.co CRM Service
+ *
+ * Lever uses OAuth2 for authentication.
+ * The API provides endpoints for managing opportunities, candidates, and notes.
+ *
+ * When a booking is created through Cal.com, this service creates an
+ * opportunity note in Lever to track the scheduled interview.
+ *
+ * Lever API docs: https://hire.lever.co/developer/documentation
+ */
+class LeverCoCrmService implements CRM {
+  private integrationName = "leverco_crm";
+  private accessToken: string;
+  private log: typeof logger;
+
+  constructor(credential: CredentialPayload) {
+    this.log = logger.getSubLogger({ prefix: [`[[lib] ${this.integrationName}`] });
+
+    const parsedKey = credentialSchema.safeParse(credential.key);
+
+    if (!parsedKey.success) {
+      throw new Error(
+        `Invalid credentials for userId ${credential.userId} and appId ${credential.appId}: ${parsedKey.error}`
+      );
+    }
+
+    this.accessToken = parsedKey.data.access_token;
+  }
+
+  private async request(endpoint: string, options: RequestInit = {}) {
+    const url = `${API_BASE_URL}${endpoint}`;
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      this.log.error(`Lever API error: ${response.status} ${errorText}`);
+      throw new Error(`Lever API request failed: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  async createEvent(event: CalendarEvent, contacts: Contact[]): Promise<CrmEvent> {
+    // For each contact that has a Lever opportunity ID, create a note on the opportunity
+    // to track the scheduled interview
+    const contactIds = contacts.map((contact) => contact.id);
+
+    for (const contactId of contactIds) {
+      try {
+        const noteBody = this.formatEventAsNote(event);
+        await this.request(`/opportunities/${contactId}/notes`, {
+          method: "POST",
+          body: JSON.stringify({
+            value: noteBody,
+          }),
+        });
+      } catch (error) {
+        this.log.error(`Failed to create note for opportunity ${contactId}`, error);
+      }
+    }
+
+    return {
+      id: contactIds[0] || "",
+      uid: event.uid,
+      type: this.integrationName,
+      password: "",
+      url: "",
+    };
+  }
+
+  async updateEvent(uid: string, event: CalendarEvent): Promise<CrmEvent> {
+    // Lever notes cannot be updated via API, so we add a new note with updated info
+    try {
+      const noteBody = this.formatEventAsNote(event, true);
+      await this.request(`/opportunities/${uid}/notes`, {
+        method: "POST",
+        body: JSON.stringify({
+          value: noteBody,
+        }),
+      });
+    } catch (error) {
+      this.log.error(`Failed to update note for opportunity ${uid}`, error);
+    }
+
+    return {
+      id: uid,
+    };
+  }
+
+  async deleteEvent(uid: string, _event: CalendarEvent): Promise<void> {
+    // Lever notes cannot be individually deleted via API
+    // We add a cancellation note instead
+    try {
+      await this.request(`/opportunities/${uid}/notes`, {
+        method: "POST",
+        body: JSON.stringify({
+          value: "[Cal.com] Interview booking has been cancelled.",
+        }),
+      });
+    } catch (error) {
+      this.log.error(`Failed to add cancellation note for opportunity ${uid}`, error);
+    }
+  }
+
+  async getContacts({
+    emails,
+  }: {
+    emails: string | string[];
+    includeOwner?: boolean;
+    forRoundRobinSkip?: boolean;
+  }): Promise<Contact[]> {
+    const emailList = Array.isArray(emails) ? emails : [emails];
+    const contacts: Contact[] = [];
+
+    for (const email of emailList) {
+      try {
+        // Search for opportunities by email
+        const response = await this.request(`/opportunities?email=${encodeURIComponent(email)}`);
+
+        if (response.data && response.data.length > 0) {
+          for (const opportunity of response.data) {
+            contacts.push({
+              id: opportunity.id,
+              email: email,
+            });
+          }
+        }
+      } catch (error) {
+        this.log.error(`Failed to search for contact ${email} in Lever`, error);
+      }
+    }
+
+    return contacts;
+  }
+
+  async createContacts(contactsToCreate: ContactCreateInput[]): Promise<Contact[]> {
+    const contacts: Contact[] = [];
+
+    for (const contactInput of contactsToCreate) {
+      try {
+        // Create an opportunity (candidate) in Lever
+        const response = await this.request("/opportunities", {
+          method: "POST",
+          body: JSON.stringify({
+            name: contactInput.name,
+            emails: [contactInput.email],
+            phones: contactInput.phone ? [{ value: contactInput.phone }] : [],
+            tags: ["cal.com"],
+          }),
+        });
+
+        if (response.data) {
+          contacts.push({
+            id: response.data.id,
+            email: contactInput.email,
+          });
+        }
+      } catch (error) {
+        this.log.error(`Failed to create opportunity for ${contactInput.email} in Lever`, error);
+      }
+    }
+
+    return contacts;
+  }
+
+  getAppOptions() {
+    // No configurable options for Lever integration
+  }
+
+  async handleAttendeeNoShow(
+    bookingUid: string,
+    attendees: { email: string; noShow: boolean }[]
+  ): Promise<void> {
+    // Add a note about no-shows to the relevant opportunities
+    for (const attendee of attendees) {
+      if (!attendee.noShow) continue;
+
+      try {
+        const contacts = await this.getContacts({ emails: attendee.email });
+        for (const contact of contacts) {
+          await this.request(`/opportunities/${contact.id}/notes`, {
+            method: "POST",
+            body: JSON.stringify({
+              value: `[Cal.com] Attendee ${attendee.email} was marked as a no-show for booking ${bookingUid}.`,
+            }),
+          });
+        }
+      } catch (error) {
+        this.log.error(`Failed to record no-show for ${attendee.email} in Lever`, error);
+      }
+    }
+  }
+
+  private formatEventAsNote(event: CalendarEvent, isUpdate = false): string {
+    const prefix = isUpdate ? "[Cal.com] Updated Interview" : "[Cal.com] Interview Scheduled";
+    const startTime = event.startTime ? new Date(event.startTime).toISOString() : "N/A";
+    const endTime = event.endTime ? new Date(event.endTime).toISOString() : "N/A";
+    const organizer = event.organizer?.name || event.organizer?.email || "Unknown";
+    const attendees =
+      event.attendees?.map((a) => `${a.name || ""} (${a.email})`).join(", ") || "None";
+
+    const parts = [
+      prefix,
+      `Title: ${event.title || "N/A"}`,
+      `Date: ${startTime} - ${endTime}`,
+      `Organizer: ${organizer}`,
+      `Attendees: ${attendees}`,
+    ];
+
+    if (event.additionalNotes) {
+      parts.push(`Notes: ${event.additionalNotes}`);
+    }
+
+    return parts.join("\n");
+  }
+}
+
+/**
+ * Factory function that creates a Lever.co CRM service instance.
+ */
+export default function BuildCrmService(
+  credential: CredentialPayload,
+  _appOptions?: Record<string, unknown>
+): CRM {
+  return new LeverCoCrmService(credential);
+}

--- a/packages/app-store/leverco/lib/index.ts
+++ b/packages/app-store/leverco/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as BuildCrmService } from "./CrmService";

--- a/packages/app-store/leverco/package.json
+++ b/packages/app-store/leverco/package.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "private": true,
+  "name": "@calcom/leverco",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "description": "Lever is a leading talent acquisition suite that makes it easy for talent teams to reach their hiring goals and to connect companies with top talent.",
+  "dependencies": {
+    "@calcom/lib": "workspace:*",
+    "@calcom/prisma": "workspace:*"
+  },
+  "devDependencies": {
+    "@calcom/types": "workspace:*"
+  }
+}

--- a/packages/app-store/leverco/static/icon.svg
+++ b/packages/app-store/leverco/static/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#3B5998"/>
+  <path d="M16 44V20h6v18h14v6H16z" fill="white"/>
+</svg>

--- a/packages/app-store/leverco/zod.ts
+++ b/packages/app-store/leverco/zod.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+import { eventTypeAppCardZod } from "../eventTypeAppCardZod";
+
+export const appDataSchema = eventTypeAppCardZod;
+
+export const appKeysSchema = z.object({
+  client_id: z.string(),
+  client_secret: z.string(),
+});


### PR DESCRIPTION
## Summary

- Adds a new Lever.co ATS (Applicant Tracking System) integration for Cal.com
- Follows the existing CRM integration pattern (closecom, pipedrive-crm, hubspot)
- Enables talent teams to sync their interview scheduling workflow with their Lever recruiting pipeline

## What it does

When connected, bookings created through Cal.com are automatically tracked as notes on Lever opportunities. This allows recruiters to see scheduled interviews directly in their Lever pipeline.

### Features

- **OAuth2 authentication** with Lever.co (`https://auth.lever.co/authorize` and `https://auth.lever.co/oauth/token`)
- **Create interview notes** on Lever opportunities when bookings are made
- **Update notes** when bookings are rescheduled
- **Cancellation tracking** when bookings are cancelled
- **Candidate search** by email across Lever opportunities
- **Create opportunities** (candidates) in Lever from Cal.com bookings
- **No-show tracking** recorded on opportunity notes
- **EventType app card** for enabling Lever integration per event type

### Files added/modified

- `packages/app-store/leverco/` - New app directory with full integration
  - `config.json` - App metadata (CRM variant, OAuth enabled)
  - `api/` - OAuth add/callback handlers
  - `lib/CrmService.ts` - CRM service implementing the `CRM` interface
  - `components/EventTypeAppCardInterface.tsx` - Event type settings UI
  - `zod.ts` - App data and key schemas
- Updated generated files (`*.generated.ts`) to register the new app

/claim #3717

## Test plan

- [ ] Configure Lever.co OAuth credentials (client_id, client_secret) in Cal.com admin
- [ ] Install the Lever.co app and complete OAuth flow
- [ ] Enable Lever.co on an event type
- [ ] Create a booking and verify a note is created on the matching Lever opportunity
- [ ] Reschedule a booking and verify an update note is added
- [ ] Cancel a booking and verify a cancellation note is added
- [ ] Test with an attendee email that exists as a Lever candidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)