### PR TITLE
fix: use dateTarget for date grouping and fix timezone date matching in insights charts

### DIFF
--- a/packages/features/insights/lib/bookingUtils.ts
+++ b/packages/features/insights/lib/bookingUtils.ts
@@ -13,7 +13,7 @@ export function extractDateRangeFromColumnFilters(columnFilters?: ColumnFilter[]
         return {
           startDate: dateFilter.data.startDate,
           endDate: dateFilter.data.endDate,
-          dateTarget: filter.id,
+          dateTarget: filter.id as "startTime" | "createdAt",
         };
       }
     }

--- a/packages/features/insights/services/InsightsBookingBaseService.ts
+++ b/packages/features/insights/services/InsightsBookingBaseService.ts
@@ -1,16 +1,12 @@
-import md5 from "md5";
-import { z } from "zod";
-
 import dayjs from "@calcom/dayjs";
 import { makeSqlCondition } from "@calcom/features/data-table/lib/server";
-import { ZColumnFilter } from "@calcom/features/data-table/lib/types";
-import { type ColumnFilter } from "@calcom/features/data-table/lib/types";
+import { type ColumnFilter, ZColumnFilter } from "@calcom/features/data-table/lib/types";
 import {
-  isSingleSelectFilterValue,
-  isMultiSelectFilterValue,
-  isTextFilterValue,
-  isNumberFilterValue,
   isDateRangeFilterValue,
+  isMultiSelectFilterValue,
+  isNumberFilterValue,
+  isSingleSelectFilterValue,
+  isTextFilterValue,
 } from "@calcom/features/data-table/lib/utils";
 import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { extractDateRangeFromColumnFilters } from "@calcom/features/insights/lib/bookingUtils";
@@ -20,8 +16,9 @@ import { PermissionCheckService } from "@calcom/features/pbac/services/permissio
 import type { PrismaClient } from "@calcom/prisma";
 import { Prisma } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
-
-import { transformBookingsForCsv, type BookingTimeStatusData } from "./csvDataTransformer";
+import md5 from "md5";
+import { z } from "zod";
+import { type BookingTimeStatusData, transformBookingsForCsv } from "./csvDataTransformer";
 
 // Utility function to build user hash map with avatar URL fallback
 export const buildHashMapForUsers = <
@@ -608,17 +605,26 @@ export class InsightsBookingBaseService {
     return { data, total: totalCount };
   }
 
-  async getEventTrendsStats({ timeZone, dateRanges }: { timeZone: string; dateRanges: DateRange[] }) {
+  async getEventTrendsStats({
+    timeZone,
+    dateRanges,
+    dateTarget = "createdAt",
+  }: {
+    timeZone: string;
+    dateRanges: DateRange[];
+    dateTarget?: "startTime" | "createdAt";
+  }) {
     if (!dateRanges.length) {
       return [];
     }
 
     const baseConditions = await this.getBaseConditions();
+    const dateColumn = dateTarget === "startTime" ? Prisma.sql`"startTime"` : Prisma.sql`"createdAt"`;
 
     const query = Prisma.sql`
     WITH booking_stats AS (
       SELECT
-        DATE("createdAt" AT TIME ZONE ${timeZone}) as "date",
+        DATE(${dateColumn} AT TIME ZONE ${timeZone}) as "date",
         "timeStatus",
         COALESCE("noShowHost", false) AS "noShowHost",
         COUNT(*) as "bookingsCount"
@@ -629,7 +635,7 @@ export class InsightsBookingBaseService {
     ),
     guest_stats AS (
       SELECT
-        DATE(b."createdAt" AT TIME ZONE ${timeZone}) as "date",
+        DATE(b.${dateColumn} AT TIME ZONE ${timeZone}) as "date",
         b."timeStatus",
         COALESCE(b."noShowHost", false) AS "noShowHost",
         COUNT(CASE WHEN a."noShow" = true THEN 1 END) as "noShowGuests"
@@ -1213,16 +1219,25 @@ export class InsightsBookingBaseService {
     };
   }
 
-  async getNoShowHostsOverTimeStats({ timeZone, dateRanges }: { timeZone: string; dateRanges: DateRange[] }) {
+  async getNoShowHostsOverTimeStats({
+    timeZone,
+    dateRanges,
+    dateTarget = "createdAt",
+  }: {
+    timeZone: string;
+    dateRanges: DateRange[];
+    dateTarget?: "startTime" | "createdAt";
+  }) {
     if (!dateRanges.length) {
       return [];
     }
 
     const baseConditions = await this.getBaseConditions();
+    const dateColumn = dateTarget === "startTime" ? Prisma.sql`"startTime"` : Prisma.sql`"createdAt"`;
 
     const query = Prisma.sql`
       SELECT
-        DATE("createdAt" AT TIME ZONE ${timeZone}) as "date",
+        DATE(${dateColumn} AT TIME ZONE ${timeZone}) as "date",
         COUNT(*) as "count"
       FROM "BookingTimeStatusDenormalized"
       WHERE ${baseConditions} AND "noShowHost" = true
@@ -1271,16 +1286,25 @@ export class InsightsBookingBaseService {
     return result;
   }
 
-  async getCSATOverTimeStats({ timeZone, dateRanges }: { timeZone: string; dateRanges: DateRange[] }) {
+  async getCSATOverTimeStats({
+    timeZone,
+    dateRanges,
+    dateTarget = "createdAt",
+  }: {
+    timeZone: string;
+    dateRanges: DateRange[];
+    dateTarget?: "startTime" | "createdAt";
+  }) {
     if (!dateRanges.length) {
       return [];
     }
 
     const baseConditions = await this.getBaseConditions();
+    const dateColumn = dateTarget === "startTime" ? Prisma.sql`"startTime"` : Prisma.sql`"createdAt"`;
 
     const query = Prisma.sql`
       SELECT
-        DATE("createdAt" AT TIME ZONE ${timeZone}) as "date",
+        DATE(${dateColumn} AT TIME ZONE ${timeZone}) as "date",
         COUNT(*) FILTER (WHERE "rating" >= 3) as "ratings_above_3",
         COUNT(*) FILTER (WHERE "rating" IS NOT NULL) as "total_ratings"
       FROM "BookingTimeStatusDenormalized"

--- a/packages/features/insights/services/InsightsBookingBaseService.ts
+++ b/packages/features/insights/services/InsightsBookingBaseService.ts
@@ -696,15 +696,22 @@ export class InsightsBookingBaseService {
       };
     });
 
+    // Precompute date strings for timezone-consistent comparison.
+    // SQL DATE(col AT TIME ZONE tz) returns a calendar date in the user's timezone,
+    // but PostgreSQL sends it as midnight UTC. Comparing raw Date objects fails
+    // because the ranges use timezone-offset timestamps. Compare date strings instead.
+    const rangesWithDateStr = dateRanges.map((range) => ({
+      ...range,
+      startStr: dayjs(range.startDate).tz(timeZone).format("YYYY-MM-DD"),
+      endStr: dayjs(range.endDate).tz(timeZone).format("YYYY-MM-DD"),
+    }));
+
     // Process the raw data and aggregate by date ranges
     data.forEach(({ date, bookingsCount, timeStatus, noShowHost, noShowGuests }) => {
-      // Find which date range this date belongs to using native Date comparison
-      const dateRange = dateRanges.find((range) => {
-        const bookingDate = new Date(date);
-        const rangeStart = new Date(range.startDate);
-        const rangeEnd = new Date(range.endDate);
-        return bookingDate >= rangeStart && bookingDate <= rangeEnd;
-      });
+      const dateStr = dayjs.utc(date).format("YYYY-MM-DD");
+      const dateRange = rangesWithDateStr.find(
+        (range) => dateStr >= range.startStr && dateStr <= range.endStr
+      );
 
       if (!dateRange) return;
 
@@ -1260,15 +1267,18 @@ export class InsightsBookingBaseService {
       aggregate[formattedDate] = 0;
     });
 
+    const rangesWithDateStr = dateRanges.map((range) => ({
+      ...range,
+      startStr: dayjs(range.startDate).tz(timeZone).format("YYYY-MM-DD"),
+      endStr: dayjs(range.endDate).tz(timeZone).format("YYYY-MM-DD"),
+    }));
+
     // Process the raw data and aggregate by date ranges
     data.forEach(({ date, count }) => {
-      // Find which date range this date belongs to using native Date comparison
-      const dateRange = dateRanges.find((range) => {
-        const bookingDate = new Date(date);
-        const rangeStart = new Date(range.startDate);
-        const rangeEnd = new Date(range.endDate);
-        return bookingDate >= rangeStart && bookingDate <= rangeEnd;
-      });
+      const dateStr = dayjs.utc(date).format("YYYY-MM-DD");
+      const dateRange = rangesWithDateStr.find(
+        (range) => dateStr >= range.startStr && dateStr <= range.endStr
+      );
 
       if (!dateRange) return;
 
@@ -1329,15 +1339,18 @@ export class InsightsBookingBaseService {
       aggregate[formattedDate] = { ratingsAbove3: 0, totalRatings: 0 };
     });
 
+    const rangesWithDateStr = dateRanges.map((range) => ({
+      ...range,
+      startStr: dayjs(range.startDate).tz(timeZone).format("YYYY-MM-DD"),
+      endStr: dayjs(range.endDate).tz(timeZone).format("YYYY-MM-DD"),
+    }));
+
     // Process the raw data and aggregate by date ranges
     data.forEach(({ date, ratings_above_3, total_ratings }) => {
-      // Find which date range this date belongs to using native Date comparison
-      const dateRange = dateRanges.find((range) => {
-        const bookingDate = new Date(date);
-        const rangeStart = new Date(range.startDate);
-        const rangeEnd = new Date(range.endDate);
-        return bookingDate >= rangeStart && bookingDate <= rangeEnd;
-      });
+      const dateStr = dayjs.utc(date).format("YYYY-MM-DD");
+      const dateRange = rangesWithDateStr.find(
+        (range) => dateStr >= range.startStr && dateStr <= range.endStr
+      );
 
       if (!dateRange) return;
 

--- a/packages/features/insights/services/__tests__/InsightsBookingDateTarget.test.ts
+++ b/packages/features/insights/services/__tests__/InsightsBookingDateTarget.test.ts
@@ -1,0 +1,195 @@
+import type { Prisma } from "@calcom/prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DateRange } from "../../server/insightsDateUtils";
+import {
+  InsightsBookingBaseService,
+  type InsightsBookingServicePublicOptions,
+} from "../InsightsBookingBaseService";
+
+const mockDateRanges: DateRange[] = [
+  {
+    startDate: "2025-01-01T00:00:00.000Z",
+    endDate: "2025-01-31T23:59:59.999Z",
+    formattedDate: "Jan",
+    formattedDateFull: "Jan",
+  },
+  {
+    startDate: "2025-02-01T00:00:00.000Z",
+    endDate: "2025-02-28T23:59:59.999Z",
+    formattedDate: "Feb",
+    formattedDateFull: "Feb",
+  },
+];
+
+const defaultOptions: InsightsBookingServicePublicOptions = {
+  scope: "user",
+  userId: 1,
+  orgId: null,
+};
+
+function createServiceWithQueryCapture() {
+  const capturedQueries: Prisma.Sql[] = [];
+
+  const mockPrisma = {
+    $queryRaw: vi.fn().mockImplementation((query: Prisma.Sql) => {
+      capturedQueries.push(query);
+      return Promise.resolve([]);
+    }),
+    membership: { findFirst: vi.fn().mockResolvedValue(null) },
+    team: { findMany: vi.fn().mockResolvedValue([]) },
+  };
+
+  const service = new InsightsBookingBaseService({
+    prisma: mockPrisma as never,
+    options: defaultOptions,
+  });
+
+  return { service, capturedQueries };
+}
+
+function sqlContainsColumn(sql: Prisma.Sql, column: string): boolean {
+  return sql.strings.some((s) => s.includes(column));
+}
+
+describe("InsightsBookingBaseService dateTarget parameter", () => {
+  describe("getEventTrendsStats", () => {
+    it("should use createdAt column when dateTarget is createdAt (default)", async () => {
+      const { service, capturedQueries } = createServiceWithQueryCapture();
+
+      await service.getEventTrendsStats({
+        timeZone: "UTC",
+        dateRanges: mockDateRanges,
+      });
+
+      expect(capturedQueries).toHaveLength(1);
+      const query = capturedQueries[0];
+      expect(sqlContainsColumn(query, '"createdAt"')).toBe(true);
+      expect(sqlContainsColumn(query, '"startTime"')).toBe(false);
+    });
+
+    it("should use createdAt column when dateTarget is explicitly createdAt", async () => {
+      const { service, capturedQueries } = createServiceWithQueryCapture();
+
+      await service.getEventTrendsStats({
+        timeZone: "UTC",
+        dateRanges: mockDateRanges,
+        dateTarget: "createdAt",
+      });
+
+      expect(capturedQueries).toHaveLength(1);
+      const query = capturedQueries[0];
+      expect(sqlContainsColumn(query, '"createdAt"')).toBe(true);
+      expect(sqlContainsColumn(query, '"startTime"')).toBe(false);
+    });
+
+    it("should use startTime column when dateTarget is startTime", async () => {
+      const { service, capturedQueries } = createServiceWithQueryCapture();
+
+      await service.getEventTrendsStats({
+        timeZone: "UTC",
+        dateRanges: mockDateRanges,
+        dateTarget: "startTime",
+      });
+
+      expect(capturedQueries).toHaveLength(1);
+      const query = capturedQueries[0];
+      expect(sqlContainsColumn(query, '"startTime"')).toBe(true);
+      expect(sqlContainsColumn(query, '"createdAt"')).toBe(false);
+    });
+
+    it("should return empty array when dateRanges is empty", async () => {
+      const { service } = createServiceWithQueryCapture();
+
+      const result = await service.getEventTrendsStats({
+        timeZone: "UTC",
+        dateRanges: [],
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getNoShowHostsOverTimeStats", () => {
+    it("should use createdAt column when dateTarget is createdAt (default)", async () => {
+      const { service, capturedQueries } = createServiceWithQueryCapture();
+
+      await service.getNoShowHostsOverTimeStats({
+        timeZone: "UTC",
+        dateRanges: mockDateRanges,
+      });
+
+      expect(capturedQueries).toHaveLength(1);
+      const query = capturedQueries[0];
+      expect(sqlContainsColumn(query, '"createdAt"')).toBe(true);
+      expect(sqlContainsColumn(query, '"startTime"')).toBe(false);
+    });
+
+    it("should use startTime column when dateTarget is startTime", async () => {
+      const { service, capturedQueries } = createServiceWithQueryCapture();
+
+      await service.getNoShowHostsOverTimeStats({
+        timeZone: "UTC",
+        dateRanges: mockDateRanges,
+        dateTarget: "startTime",
+      });
+
+      expect(capturedQueries).toHaveLength(1);
+      const query = capturedQueries[0];
+      expect(sqlContainsColumn(query, '"startTime"')).toBe(true);
+      expect(sqlContainsColumn(query, '"createdAt"')).toBe(false);
+    });
+
+    it("should return empty array when dateRanges is empty", async () => {
+      const { service } = createServiceWithQueryCapture();
+
+      const result = await service.getNoShowHostsOverTimeStats({
+        timeZone: "UTC",
+        dateRanges: [],
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getCSATOverTimeStats", () => {
+    it("should use createdAt column when dateTarget is createdAt (default)", async () => {
+      const { service, capturedQueries } = createServiceWithQueryCapture();
+
+      await service.getCSATOverTimeStats({
+        timeZone: "UTC",
+        dateRanges: mockDateRanges,
+      });
+
+      expect(capturedQueries).toHaveLength(1);
+      const query = capturedQueries[0];
+      expect(sqlContainsColumn(query, '"createdAt"')).toBe(true);
+      expect(sqlContainsColumn(query, '"startTime"')).toBe(false);
+    });
+
+    it("should use startTime column when dateTarget is startTime", async () => {
+      const { service, capturedQueries } = createServiceWithQueryCapture();
+
+      await service.getCSATOverTimeStats({
+        timeZone: "UTC",
+        dateRanges: mockDateRanges,
+        dateTarget: "startTime",
+      });
+
+      expect(capturedQueries).toHaveLength(1);
+      const query = capturedQueries[0];
+      expect(sqlContainsColumn(query, '"startTime"')).toBe(true);
+      expect(sqlContainsColumn(query, '"createdAt"')).toBe(false);
+    });
+
+    it("should return empty array when dateRanges is empty", async () => {
+      const { service } = createServiceWithQueryCapture();
+
+      const result = await service.getCSATOverTimeStats({
+        timeZone: "UTC",
+        dateRanges: [],
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/features/insights/services/__tests__/InsightsBookingDateTarget.test.ts
+++ b/packages/features/insights/services/__tests__/InsightsBookingDateTarget.test.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from "@calcom/prisma/client";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { DateRange } from "../../server/insightsDateUtils";
 import {
   InsightsBookingBaseService,
@@ -27,13 +27,13 @@ const defaultOptions: InsightsBookingServicePublicOptions = {
   orgId: null,
 };
 
-function createServiceWithQueryCapture() {
+function createServiceWithQueryCapture(mockData?: Record<string, unknown>[]) {
   const capturedQueries: Prisma.Sql[] = [];
 
   const mockPrisma = {
     $queryRaw: vi.fn().mockImplementation((query: Prisma.Sql) => {
       capturedQueries.push(query);
-      return Promise.resolve([]);
+      return Promise.resolve(mockData ?? []);
     }),
     membership: { findFirst: vi.fn().mockResolvedValue(null) },
     team: { findMany: vi.fn().mockResolvedValue([]) },
@@ -190,6 +190,223 @@ describe("InsightsBookingBaseService dateTarget parameter", () => {
       });
 
       expect(result).toEqual([]);
+    });
+  });
+});
+
+describe("InsightsBookingBaseService timezone date matching", () => {
+  // Simulates the real-world scenario: America/New_York (UTC-5).
+  // Date ranges are midnight-to-midnight in the user's timezone,
+  // which means their UTC representations are offset by 5 hours.
+  const nycDailyRanges: DateRange[] = [
+    {
+      startDate: "2026-02-10T05:00:00.000Z",
+      endDate: "2026-02-11T04:59:59.999Z",
+      formattedDate: "Feb 10",
+      formattedDateFull: "Feb 10",
+    },
+    {
+      startDate: "2026-02-11T05:00:00.000Z",
+      endDate: "2026-02-12T04:59:59.999Z",
+      formattedDate: "11",
+      formattedDateFull: "Feb 11",
+    },
+    {
+      startDate: "2026-02-12T05:00:00.000Z",
+      endDate: "2026-02-13T04:59:59.999Z",
+      formattedDate: "12",
+      formattedDateFull: "Feb 12",
+    },
+  ];
+
+  describe("getEventTrendsStats - timezone date matching", () => {
+    it("should correctly map SQL dates to date ranges with negative UTC offset", async () => {
+      const mockData = [
+        {
+          date: new Date("2026-02-10T00:00:00.000Z"),
+          bookingsCount: 3,
+          timeStatus: "completed",
+          noShowHost: false,
+          noShowGuests: 0,
+        },
+        {
+          date: new Date("2026-02-11T00:00:00.000Z"),
+          bookingsCount: 2,
+          timeStatus: "completed",
+          noShowHost: false,
+          noShowGuests: 0,
+        },
+        {
+          date: new Date("2026-02-12T00:00:00.000Z"),
+          bookingsCount: 1,
+          timeStatus: "cancelled",
+          noShowHost: false,
+          noShowGuests: 0,
+        },
+      ];
+
+      const { service } = createServiceWithQueryCapture(mockData);
+      const result = await service.getEventTrendsStats({
+        timeZone: "America/New_York",
+        dateRanges: nycDailyRanges,
+      });
+
+      expect(result).toHaveLength(3);
+      expect(result[0].Created).toBe(3);
+      expect(result[0].formattedDateFull).toBe("Feb 10");
+      expect(result[1].Created).toBe(2);
+      expect(result[1].formattedDateFull).toBe("Feb 11");
+      expect(result[2].Created).toBe(1);
+      expect(result[2].formattedDateFull).toBe("Feb 12");
+    });
+
+    it("should not drop bookings on the first day of the range", async () => {
+      const mockData = [
+        {
+          date: new Date("2026-02-10T00:00:00.000Z"),
+          bookingsCount: 5,
+          timeStatus: "completed",
+          noShowHost: false,
+          noShowGuests: 0,
+        },
+      ];
+
+      const { service } = createServiceWithQueryCapture(mockData);
+      const result = await service.getEventTrendsStats({
+        timeZone: "America/New_York",
+        dateRanges: nycDailyRanges,
+      });
+
+      expect(result[0].Created).toBe(5);
+      expect(result[0].formattedDateFull).toBe("Feb 10");
+    });
+
+    it("should handle positive UTC offset (e.g. Asia/Tokyo UTC+9)", async () => {
+      const tokyoDailyRanges: DateRange[] = [
+        {
+          startDate: "2026-02-09T15:00:00.000Z",
+          endDate: "2026-02-10T14:59:59.999Z",
+          formattedDate: "Feb 10",
+          formattedDateFull: "Feb 10",
+        },
+        {
+          startDate: "2026-02-10T15:00:00.000Z",
+          endDate: "2026-02-11T14:59:59.999Z",
+          formattedDate: "11",
+          formattedDateFull: "Feb 11",
+        },
+      ];
+
+      const mockData = [
+        {
+          date: new Date("2026-02-10T00:00:00.000Z"),
+          bookingsCount: 4,
+          timeStatus: "completed",
+          noShowHost: false,
+          noShowGuests: 0,
+        },
+        {
+          date: new Date("2026-02-11T00:00:00.000Z"),
+          bookingsCount: 2,
+          timeStatus: "completed",
+          noShowHost: false,
+          noShowGuests: 0,
+        },
+      ];
+
+      const { service } = createServiceWithQueryCapture(mockData);
+      const result = await service.getEventTrendsStats({
+        timeZone: "Asia/Tokyo",
+        dateRanges: tokyoDailyRanges,
+      });
+
+      expect(result[0].Created).toBe(4);
+      expect(result[0].formattedDateFull).toBe("Feb 10");
+      expect(result[1].Created).toBe(2);
+      expect(result[1].formattedDateFull).toBe("Feb 11");
+    });
+
+    it("should work correctly with UTC timezone", async () => {
+      const utcDailyRanges: DateRange[] = [
+        {
+          startDate: "2026-02-10T00:00:00.000Z",
+          endDate: "2026-02-10T23:59:59.999Z",
+          formattedDate: "Feb 10",
+          formattedDateFull: "Feb 10",
+        },
+        {
+          startDate: "2026-02-11T00:00:00.000Z",
+          endDate: "2026-02-11T23:59:59.999Z",
+          formattedDate: "11",
+          formattedDateFull: "Feb 11",
+        },
+      ];
+
+      const mockData = [
+        {
+          date: new Date("2026-02-10T00:00:00.000Z"),
+          bookingsCount: 3,
+          timeStatus: "completed",
+          noShowHost: false,
+          noShowGuests: 0,
+        },
+        {
+          date: new Date("2026-02-11T00:00:00.000Z"),
+          bookingsCount: 1,
+          timeStatus: "cancelled",
+          noShowHost: false,
+          noShowGuests: 0,
+        },
+      ];
+
+      const { service } = createServiceWithQueryCapture(mockData);
+      const result = await service.getEventTrendsStats({
+        timeZone: "UTC",
+        dateRanges: utcDailyRanges,
+      });
+
+      expect(result[0].Created).toBe(3);
+      expect(result[1].Created).toBe(1);
+    });
+  });
+
+  describe("getNoShowHostsOverTimeStats - timezone date matching", () => {
+    it("should correctly map SQL dates with negative UTC offset", async () => {
+      const mockData = [
+        { date: new Date("2026-02-10T00:00:00.000Z"), count: 2 },
+        { date: new Date("2026-02-11T00:00:00.000Z"), count: 1 },
+      ];
+
+      const { service } = createServiceWithQueryCapture(mockData);
+      const result = await service.getNoShowHostsOverTimeStats({
+        timeZone: "America/New_York",
+        dateRanges: nycDailyRanges,
+      });
+
+      expect(result[0].Count).toBe(2);
+      expect(result[0].formattedDateFull).toBe("Feb 10");
+      expect(result[1].Count).toBe(1);
+      expect(result[1].formattedDateFull).toBe("Feb 11");
+    });
+  });
+
+  describe("getCSATOverTimeStats - timezone date matching", () => {
+    it("should correctly map SQL dates with negative UTC offset", async () => {
+      const mockData = [
+        { date: new Date("2026-02-10T00:00:00.000Z"), ratings_above_3: 3, total_ratings: 4 },
+        { date: new Date("2026-02-11T00:00:00.000Z"), ratings_above_3: 1, total_ratings: 2 },
+      ];
+
+      const { service } = createServiceWithQueryCapture(mockData);
+      const result = await service.getCSATOverTimeStats({
+        timeZone: "America/New_York",
+        dateRanges: nycDailyRanges,
+      });
+
+      expect(result[0].CSAT).toBe(75);
+      expect(result[0].formattedDateFull).toBe("Feb 10");
+      expect(result[1].CSAT).toBe(50);
+      expect(result[1].formattedDateFull).toBe("Feb 11");
     });
   });
 });

--- a/packages/trpc/server/routers/viewer/insights/_router.ts
+++ b/packages/trpc/server/routers/viewer/insights/_router.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 import dayjs from "@calcom/dayjs";
 import { getInsightsBookingService } from "@calcom/features/di/containers/InsightsBooking";
 import { getInsightsRoutingService } from "@calcom/features/di/containers/InsightsRouting";
@@ -10,17 +8,17 @@ import {
 } from "@calcom/features/insights/lib/bookingUtils";
 import { objectToCsv } from "@calcom/features/insights/lib/objectToCsv";
 import {
-  getTimeView,
-  getDateRanges,
   type GetDateRangesParams,
+  getDateRanges,
+  getTimeView,
 } from "@calcom/features/insights/server/insightsDateUtils";
 import {
   bookingRepositoryBaseInputSchema,
   insightsRoutingServiceInputSchema,
   insightsRoutingServicePaginatedInputSchema,
-  routingRepositoryBaseInputSchema,
-  routedToPerPeriodInputSchema,
   routedToPerPeriodCsvInputSchema,
+  routedToPerPeriodInputSchema,
+  routingRepositoryBaseInputSchema,
 } from "@calcom/features/insights/server/raw-data.schema";
 import { RoutingEventsInsights } from "@calcom/features/insights/server/routing-events";
 import { VirtualQueuesInsights } from "@calcom/features/insights/server/virtual-queues";
@@ -29,9 +27,8 @@ import type { PrismaClient } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
 import authedProcedure from "@calcom/trpc/server/procedures/authedProcedure";
 import { router } from "@calcom/trpc/server/trpc";
-
 import { TRPCError } from "@trpc/server";
-
+import { z } from "zod";
 import { userBelongsToTeamProcedure } from "./procedures/userBelongsToTeam";
 
 const userSelect = {
@@ -241,7 +238,7 @@ export const insightsRouter = router({
     .input(bookingRepositoryBaseInputSchema)
     .query(async ({ ctx, input }) => {
       const { columnFilters, timeZone } = input;
-      const { startDate, endDate } = extractDateRangeFromColumnFilters(columnFilters);
+      const { startDate, endDate, dateTarget } = extractDateRangeFromColumnFilters(columnFilters);
 
       // Calculate timeView and dateRanges
       const timeView = getTimeView(startDate, endDate);
@@ -258,6 +255,7 @@ export const insightsRouter = router({
         return await insightsBookingService.getEventTrendsStats({
           timeZone,
           dateRanges,
+          dateTarget,
         });
       } catch {
         throw new TRPCError({ code: "INTERNAL_SERVER_ERROR" });
@@ -829,7 +827,7 @@ export const insightsRouter = router({
     .input(bookingRepositoryBaseInputSchema)
     .query(async ({ ctx, input }) => {
       const { columnFilters, timeZone } = input;
-      const { startDate, endDate } = extractDateRangeFromColumnFilters(columnFilters);
+      const { startDate, endDate, dateTarget } = extractDateRangeFromColumnFilters(columnFilters);
 
       // Calculate timeView and dateRanges
       const timeView = getTimeView(startDate, endDate);
@@ -846,6 +844,7 @@ export const insightsRouter = router({
         return await insightsBookingService.getNoShowHostsOverTimeStats({
           timeZone,
           dateRanges,
+          dateTarget,
         });
       } catch {
         throw new TRPCError({ code: "INTERNAL_SERVER_ERROR" });
@@ -855,7 +854,7 @@ export const insightsRouter = router({
     .input(bookingRepositoryBaseInputSchema)
     .query(async ({ ctx, input }) => {
       const { columnFilters, timeZone } = input;
-      const { startDate, endDate } = extractDateRangeFromColumnFilters(columnFilters);
+      const { startDate, endDate, dateTarget } = extractDateRangeFromColumnFilters(columnFilters);
 
       // Calculate timeView and dateRanges
       const timeView = getTimeView(startDate, endDate);
@@ -872,6 +871,7 @@ export const insightsRouter = router({
         return await insightsBookingService.getCSATOverTimeStats({
           timeZone,
           dateRanges,
+          dateTarget,
         });
       } catch {
         throw new TRPCError({ code: "INTERNAL_SERVER_ERROR" });


### PR DESCRIPTION
## What does this PR do?

Fixes two related bugs causing metric mismatches on the `/insights` page where the "Events created" value in `BookingKPICards` doesn't match the sum of the "Created" category in `EventTrendsChart`.

### Bug 1: Wrong SQL date column for grouping

`getEventTrendsStats`, `getNoShowHostsOverTimeStats`, and `getCSATOverTimeStats` always grouped results by `DATE("createdAt")`, regardless of the active `dateTarget` filter. When `dateTarget` is `"startTime"` (the default), the KPI card filters by `startTime` range but the chart groups by `createdAt` — so bookings whose `createdAt` falls outside the selected range are silently dropped from the chart, producing a lower total.

**Fix:** Pass `dateTarget` from the column filters through the tRPC handlers into the three service methods, and use it to select the correct SQL date column for grouping.

### Bug 2: Timezone-aware date range matching

SQL `DATE(col AT TIME ZONE tz)` returns a calendar date in the user's timezone, but PostgreSQL sends it to JavaScript as midnight UTC. The old code compared these raw `Date` objects against timezone-offset date ranges, causing bookings to be silently dropped. For example, with `America/New_York` (UTC-5):

- SQL returns `2026-02-10` → JS gets `2026-02-10T00:00:00.000Z` (midnight UTC)
- Range start for Feb 10 is `2026-02-10T05:00:00.000Z` (midnight EST in UTC)
- `00:00Z < 05:00Z` → booking falls outside range → **dropped**

This caused the KPI total (8) to not match the chart sum (6) even when `dateTarget` is `"createdAt"`.

**Fix:** Compare `YYYY-MM-DD` date strings instead of raw `Date` objects. The SQL date is formatted as UTC, and range boundaries are formatted in the user's timezone, making comparison timezone-consistent.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to `/insights`, set the date filter to use **"Start time"** (the default `dateTarget`).
2. Compare the "Events created" KPI card value with the sum of the "Created" bars in the Event Trends chart — they should now match.
3. Switch the date filter to **"Created at"** and confirm both still match.
4. **Important:** Test with a non-UTC timezone (e.g. `America/New_York`) to verify the timezone fix — this is where the second bug manifests.
5. Unit tests (16 tests): `TZ=UTC yarn vitest run packages/features/insights/services/__tests__/InsightsBookingDateTarget.test.ts`

## Human Review Checklist

**Critical items to verify:**

1. **Timezone date string comparison** (`InsightsBookingBaseService.ts`, three occurrences): The fix compares `YYYY-MM-DD` strings via `>=`/`<=`. This works because the format is lexicographically ordered. Verify this logic is correct by tracing through a negative-offset timezone (e.g. `America/New_York`) and a positive-offset timezone (e.g. `Asia/Tokyo`).


2. **SQL interpolation with table alias** (line 638 in `InsightsBookingBaseService.ts`): Confirm `b.${dateColumn}` produces valid SQL like `b."startTime"` or `b."createdAt"` when `dateColumn` is a `Prisma.sql` fragment. This is the most fragile part of the change.

3. **Type assertion safety** (`bookingUtils.ts:16`): The `as "startTime" | "createdAt"` assertion is safe because the preceding `if` condition on line 10 already narrows `filter.id` to exactly those two values. But worth double-checking.

4. **Behavioral change**: Bookings that were previously silently dropped due to timezone mismatch will now be correctly counted. This is the intended fix but represents a behavioral change — verify the new counts match expectations in production data.

5. **Import reorderings**: The diff shows many import reorderings in `InsightsBookingBaseService.ts` and `_router.ts`. These are cosmetic (biome auto-format) and don't affect functionality.

6. **Default value**: `dateTarget` defaults to `"createdAt"` in all three methods, maintaining backward compatibility with existing code that doesn't pass this parameter.

---

**Link to Devin run:** https://app.devin.ai/sessions/de0d621fb9b7473fa578ccc473576d7b  
**Requested by:** @eunjae-lee