### PR TITLE
feat: align members table 'Last active' with active user billing definition

### DIFF
--- a/packages/features/ee/billing/active-user/di/CachedActiveUserBillingRepository.container.ts
+++ b/packages/features/ee/billing/active-user/di/CachedActiveUserBillingRepository.container.ts
@@ -1,0 +1,12 @@
+import { createContainer } from "@calcom/features/di/di";
+import type { CachedActiveUserBillingRepository } from "@calcom/features/ee/billing/active-user/repositories/CachedActiveUserBillingRepository";
+import { moduleLoader as cachedActiveUserBillingRepositoryModuleLoader } from "./CachedActiveUserBillingRepository.module";
+
+const container = createContainer();
+
+export function getCachedActiveUserBillingRepository(): CachedActiveUserBillingRepository {
+  cachedActiveUserBillingRepositoryModuleLoader.loadModule(container);
+  return container.get<CachedActiveUserBillingRepository>(
+    cachedActiveUserBillingRepositoryModuleLoader.token
+  );
+}

--- a/packages/features/ee/billing/active-user/di/CachedActiveUserBillingRepository.module.ts
+++ b/packages/features/ee/billing/active-user/di/CachedActiveUserBillingRepository.module.ts
@@ -1,0 +1,21 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { CachedActiveUserBillingRepository } from "@calcom/features/ee/billing/active-user/repositories/CachedActiveUserBillingRepository";
+import { moduleLoader as activeUserBillingRepositoryModuleLoader } from "./ActiveUserBillingRepository.module";
+import { ACTIVE_USER_BILLING_DI_TOKENS } from "./tokens";
+
+const thisModule = createModule();
+const token = ACTIVE_USER_BILLING_DI_TOKENS.CACHED_ACTIVE_USER_BILLING_REPOSITORY;
+const moduleToken = ACTIVE_USER_BILLING_DI_TOKENS.CACHED_ACTIVE_USER_BILLING_REPOSITORY_MODULE;
+
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: CachedActiveUserBillingRepository,
+  dep: activeUserBillingRepositoryModuleLoader,
+});
+
+export const moduleLoader: ModuleLoader = {
+  token,
+  loadModule,
+};

--- a/packages/features/ee/billing/active-user/di/tokens.ts
+++ b/packages/features/ee/billing/active-user/di/tokens.ts
@@ -1,6 +1,8 @@
 export const ACTIVE_USER_BILLING_DI_TOKENS = {
   ACTIVE_USER_BILLING_REPOSITORY: Symbol("ActiveUserBillingRepository"),
   ACTIVE_USER_BILLING_REPOSITORY_MODULE: Symbol("ActiveUserBillingRepositoryModule"),
+  CACHED_ACTIVE_USER_BILLING_REPOSITORY: Symbol("CachedActiveUserBillingRepository"),
+  CACHED_ACTIVE_USER_BILLING_REPOSITORY_MODULE: Symbol("CachedActiveUserBillingRepositoryModule"),
   ACTIVE_USER_BILLING_SERVICE: Symbol("ActiveUserBillingService"),
   ACTIVE_USER_BILLING_SERVICE_MODULE: Symbol("ActiveUserBillingServiceModule"),
 };

--- a/packages/features/ee/billing/active-user/repositories/ActiveUserBillingRepository.test.ts
+++ b/packages/features/ee/billing/active-user/repositories/ActiveUserBillingRepository.test.ts
@@ -1,0 +1,136 @@
+import { BookingStatus } from "@calcom/prisma/enums";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActiveUserBillingRepository } from "./ActiveUserBillingRepository";
+
+function createMockPrismaClient() {
+  return {
+    booking: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    user: {
+      findMany: vi.fn(),
+    },
+    attendee: {
+      findMany: vi.fn(),
+    },
+  };
+}
+
+describe("ActiveUserBillingRepository.getLastActiveAt", () => {
+  let repo: ActiveUserBillingRepository;
+  let mockPrisma: ReturnType<typeof createMockPrismaClient>;
+
+  beforeEach(() => {
+    mockPrisma = createMockPrismaClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    repo = new ActiveUserBillingRepository(mockPrisma as any);
+  });
+
+  it("returns null when user has no accepted bookings as host or attendee", async () => {
+    mockPrisma.booking.findFirst.mockResolvedValue(null);
+
+    const result = await repo.getLastActiveAt(1, "user@test.com");
+
+    expect(result).toBeNull();
+    expect(mockPrisma.booking.findFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the host booking date when user only hosted", async () => {
+    const hostDate = new Date("2026-01-15T10:00:00Z");
+    mockPrisma.booking.findFirst.mockResolvedValueOnce({ startTime: hostDate }).mockResolvedValueOnce(null);
+
+    const result = await repo.getLastActiveAt(1, "user@test.com");
+
+    expect(result).toEqual(hostDate);
+  });
+
+  it("returns the attendee booking date when user only attended", async () => {
+    const attendeeDate = new Date("2026-01-20T14:00:00Z");
+    mockPrisma.booking.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ startTime: attendeeDate });
+
+    const result = await repo.getLastActiveAt(1, "user@test.com");
+
+    expect(result).toEqual(attendeeDate);
+  });
+
+  it("returns the more recent date when user has both host and attendee bookings", async () => {
+    const hostDate = new Date("2026-01-10T10:00:00Z");
+    const attendeeDate = new Date("2026-01-20T14:00:00Z");
+    mockPrisma.booking.findFirst
+      .mockResolvedValueOnce({ startTime: hostDate })
+      .mockResolvedValueOnce({ startTime: attendeeDate });
+
+    const result = await repo.getLastActiveAt(1, "user@test.com");
+
+    expect(result).toEqual(attendeeDate);
+  });
+
+  it("returns the host date when it is more recent than attendee date", async () => {
+    const hostDate = new Date("2026-02-01T10:00:00Z");
+    const attendeeDate = new Date("2026-01-15T14:00:00Z");
+    mockPrisma.booking.findFirst
+      .mockResolvedValueOnce({ startTime: hostDate })
+      .mockResolvedValueOnce({ startTime: attendeeDate });
+
+    const result = await repo.getLastActiveAt(1, "user@test.com");
+
+    expect(result).toEqual(hostDate);
+  });
+
+  it("queries with correct filters for host bookings", async () => {
+    mockPrisma.booking.findFirst.mockResolvedValue(null);
+
+    await repo.getLastActiveAt(42, "host@test.com");
+
+    expect(mockPrisma.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: 42,
+        status: BookingStatus.ACCEPTED,
+      },
+      orderBy: { startTime: "desc" },
+      select: { startTime: true },
+    });
+  });
+
+  it("queries with correct filters for attendee bookings", async () => {
+    mockPrisma.booking.findFirst.mockResolvedValue(null);
+
+    await repo.getLastActiveAt(42, "attendee@test.com");
+
+    expect(mockPrisma.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        attendees: { some: { email: "attendee@test.com" } },
+        status: BookingStatus.ACCEPTED,
+      },
+      orderBy: { startTime: "desc" },
+      select: { startTime: true },
+    });
+  });
+
+  it("runs both queries in parallel", async () => {
+    const resolveOrder: string[] = [];
+
+    mockPrisma.booking.findFirst
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOrder.push("host");
+            resolve(null);
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOrder.push("attendee");
+            resolve(null);
+          })
+      );
+
+    await repo.getLastActiveAt(1, "user@test.com");
+
+    expect(resolveOrder).toEqual(["host", "attendee"]);
+  });
+});

--- a/packages/features/ee/billing/active-user/repositories/ActiveUserBillingRepository.ts
+++ b/packages/features/ee/billing/active-user/repositories/ActiveUserBillingRepository.ts
@@ -242,11 +242,6 @@ export class ActiveUserBillingRepository {
     });
   }
 
-  /**
-   * Get the most recent accepted booking startTime for a user, considering both
-   * host and attendee roles. This aligns with the active user billing definition
-   * where "active" means hosted or attended at least one accepted booking.
-   */
   async getLastActiveAt(userId: number, email: string): Promise<Date | null> {
     const [lastHostBooking, lastAttendeeBooking] = await Promise.all([
       this.prismaClient.booking.findFirst({

--- a/packages/features/ee/billing/active-user/repositories/ActiveUserBillingRepository.ts
+++ b/packages/features/ee/billing/active-user/repositories/ActiveUserBillingRepository.ts
@@ -241,4 +241,37 @@ export class ActiveUserBillingRepository {
       },
     });
   }
+
+  /**
+   * Get the most recent accepted booking startTime for a user, considering both
+   * host and attendee roles. This aligns with the active user billing definition
+   * where "active" means hosted or attended at least one accepted booking.
+   */
+  async getLastActiveAt(userId: number, email: string): Promise<Date | null> {
+    const [lastHostBooking, lastAttendeeBooking] = await Promise.all([
+      this.prismaClient.booking.findFirst({
+        where: {
+          userId,
+          status: BookingStatus.ACCEPTED,
+        },
+        orderBy: { startTime: "desc" },
+        select: { startTime: true },
+      }),
+      this.prismaClient.booking.findFirst({
+        where: {
+          attendees: { some: { email } },
+          status: BookingStatus.ACCEPTED,
+        },
+        orderBy: { startTime: "desc" },
+        select: { startTime: true },
+      }),
+    ]);
+
+    const hostTime = lastHostBooking?.startTime?.getTime() ?? 0;
+    const attendeeTime = lastAttendeeBooking?.startTime?.getTime() ?? 0;
+    const maxTime = Math.max(hostTime, attendeeTime);
+
+    if (maxTime === 0) return null;
+    return new Date(maxTime);
+  }
 }

--- a/packages/features/ee/billing/active-user/repositories/CachedActiveUserBillingRepository.ts
+++ b/packages/features/ee/billing/active-user/repositories/CachedActiveUserBillingRepository.ts
@@ -1,0 +1,20 @@
+import { Memoize } from "@calcom/features/cache";
+import { z } from "zod";
+import type { ActiveUserBillingRepository } from "./ActiveUserBillingRepository";
+
+const CACHE_PREFIX = "active-user-billing:lastActive";
+const KEY = {
+  lastActiveAt: (userId: number, _email: string): string => `${CACHE_PREFIX}:${userId}`,
+};
+
+export class CachedActiveUserBillingRepository {
+  constructor(private activeUserBillingRepository: ActiveUserBillingRepository) {}
+
+  @Memoize({
+    key: KEY.lastActiveAt,
+    schema: z.coerce.date().nullable(),
+  })
+  async getLastActiveAt(userId: number, email: string): Promise<Date | null> {
+    return this.activeUserBillingRepository.getLastActiveAt(userId, email);
+  }
+}

--- a/packages/features/ee/billing/active-user/services/ActiveUserBillingService.test.ts
+++ b/packages/features/ee/billing/active-user/services/ActiveUserBillingService.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import type { ActiveUserBillingRepository } from "../repositories/ActiveUserBillingRepository";
 import { ActiveUserBillingService } from "./ActiveUserBillingService";
 
@@ -15,6 +14,7 @@ function createMockRepository(): {
     getActiveUsersAsAttendee: vi.fn().mockResolvedValue([]),
     getBookingsByHostUserId: vi.fn().mockResolvedValue([]),
     getBookingsByAttendeeEmail: vi.fn().mockResolvedValue([]),
+    getLastActiveAt: vi.fn().mockResolvedValue(null),
   };
 }
 
@@ -224,10 +224,7 @@ describe("ActiveUserBillingService", () => {
         { id: 1, email: "alice@org.com", name: "Alice" },
         { id: 2, email: "bob@org.com", name: "Bob" },
       ]);
-      mockRepo.getActiveUsersAsHost.mockResolvedValue([
-        { email: "alice@org.com" },
-        { email: "bob@org.com" },
-      ]);
+      mockRepo.getActiveUsersAsHost.mockResolvedValue([{ email: "alice@org.com" }, { email: "bob@org.com" }]);
 
       const result = await service.getActiveUsersForOrg(orgId, periodStart, periodEnd);
 

--- a/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
@@ -1,15 +1,14 @@
 import { makeWhereClause } from "@calcom/features/data-table/lib/server";
-import { type TypedColumnFilter, ColumnFilterType } from "@calcom/features/data-table/lib/types";
-import type { FilterType } from "@calcom/types/data-table";
+import { ColumnFilterType, type TypedColumnFilter } from "@calcom/features/data-table/lib/types";
+import { getCachedActiveUserBillingRepository } from "@calcom/features/ee/billing/active-user/di/CachedActiveUserBillingRepository.container";
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { prisma } from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
-
+import type { FilterType } from "@calcom/types/data-table";
 import { TRPCError } from "@trpc/server";
-
 import type { TrpcSessionUser } from "../../../types";
 import type { TListMembersSchema } from "./listMembers.schema";
 
@@ -255,7 +254,6 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
           timeZone: true,
           disableImpersonation: true,
           completedOnboarding: true,
-          lastActiveAt: true,
           ...(ctx.user.organization.isOrgAdmin && { twoFactorEnabled: true }),
           teams: {
             select: {
@@ -279,6 +277,15 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
   });
 
   const [totalCount, teamMembers] = await Promise.all([totalCountPromise, teamMembersPromise]);
+
+  const cachedRepo = getCachedActiveUserBillingRepository();
+  const lastActiveAtMap = new Map<number, Date | null>();
+  await Promise.all(
+    teamMembers.map(async (membership) => {
+      const lastActiveAt = await cachedRepo.getLastActiveAt(membership.user.id, membership.user.email);
+      lastActiveAtMap.set(membership.user.id, lastActiveAt);
+    })
+  );
 
   const members = await Promise.all(
     teamMembers?.map(async (membership) => {
@@ -321,6 +328,7 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
           );
       }
 
+      const lastActiveAt = lastActiveAtMap.get(membership.user.id) ?? null;
       return {
         id: user.id,
         username: user.profiles[0]?.username || user.username,
@@ -332,11 +340,11 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
         accepted: membership.accepted,
         disableImpersonation: user.disableImpersonation,
         completedOnboarding: user.completedOnboarding,
-        lastActiveAt: membership.user.lastActiveAt
+        lastActiveAt: lastActiveAt
           ? new Intl.DateTimeFormat(ctx.user.locale, {
               timeZone: ctx.user.timeZone,
             })
-              .format(membership.user.lastActiveAt)
+              .format(lastActiveAt)
               .toLowerCase()
           : null,
         createdAt: membership.createdAt

--- a/packages/trpc/server/routers/viewer/teams/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/listMembers.handler.ts
@@ -1,9 +1,10 @@
+import { getCachedActiveUserBillingRepository } from "@calcom/features/ee/billing/active-user/di/CachedActiveUserBillingRepository.container";
 import { getBookerBaseUrlSync } from "@calcom/features/ee/organizations/lib/getBookerBaseUrlSync";
 import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import {
-  Resource,
   CustomAction,
-  PermissionString,
+  type PermissionString,
+  Resource,
 } from "@calcom/features/pbac/domain/types/permission-registry";
 import { getSpecificPermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
@@ -13,9 +14,7 @@ import { prisma } from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
-
 import { TRPCError } from "@trpc/server";
-
 import type { TListMembersInputSchema } from "./listMembers.schema";
 
 type ListMembersHandlerOptions = {
@@ -33,7 +32,6 @@ const userSelect = {
   id: true,
   bio: true,
   disableImpersonation: true,
-  lastActiveAt: true,
 } satisfies Prisma.UserSelect;
 
 export const listMembersHandler = async ({ ctx, input }: ListMembersHandlerOptions) => {
@@ -79,7 +77,7 @@ export const listMembersHandler = async ({ ctx, input }: ListMembersHandlerOptio
     orderBy: { id: "asc" },
   });
 
-  let nextCursor: typeof cursor | undefined = undefined;
+  let nextCursor: typeof cursor | undefined;
   if (teamMembers.length > limit) {
     const nextItem = teamMembers.pop();
     nextCursor = nextItem?.id;
@@ -118,6 +116,15 @@ export const listMembersHandler = async ({ ctx, input }: ListMembersHandlerOptio
     enrichedUserMap.set(enrichedUser.id, enrichedUser);
   });
 
+  const cachedRepo = getCachedActiveUserBillingRepository();
+  const lastActiveAtMap = new Map<number, Date | null>();
+  await Promise.all(
+    teamMembers.map(async (member) => {
+      const lastActiveAt = await cachedRepo.getLastActiveAt(member.user.id, member.user.email);
+      lastActiveAtMap.set(member.user.id, lastActiveAt);
+    })
+  );
+
   const membersWithApps = teamMembers
     .map((member) => {
       const user = enrichedUserMap.get(member.user.id);
@@ -133,6 +140,8 @@ export const listMembersHandler = async ({ ctx, input }: ListMembersHandlerOptio
       if (member.customRoleId && customRoles[member.customRoleId]) {
         customRole = customRoles[member.customRoleId];
       }
+
+      const lastActiveAt = lastActiveAtMap.get(member.user.id) ?? null;
       return {
         ...restUser,
         username: profile?.username ?? restUser.username,
@@ -146,11 +155,11 @@ export const listMembersHandler = async ({ ctx, input }: ListMembersHandlerOptio
         disableImpersonation: user.disableImpersonation,
         bookerUrl: getBookerBaseUrlSync(profile?.organization?.slug || ""),
         teamId: member.teamId,
-        lastActiveAt: member.user.lastActiveAt
+        lastActiveAt: lastActiveAt
           ? new Intl.DateTimeFormat(ctx.user.locale, {
               timeZone: ctx.user.timeZone,
             })
-              .format(member.user.lastActiveAt)
+              .format(lastActiveAt)
               .toLowerCase()
           : null,
       };


### PR DESCRIPTION
## What does this PR do?

The "Last active" column in team/org members tables previously used `User.lastActiveAt`, which only tracked when a user last **hosted** a new booking. This didn't match the active user billing definition, where "active" means the user **hosted or attended** at least one **ACCEPTED** booking.

This PR replaces the static DB field with a computed value that queries the most recent accepted booking where the user was either host or attendee, cached via the `@Memoize` Redis decorator.

**Changes:**
- Adds `getLastActiveAt(userId, email)` to `ActiveUserBillingRepository` — parallel queries for latest accepted booking as host + attendee, returns the more recent
- Creates `CachedActiveUserBillingRepository` wrapping the method with `@Memoize` (cache key: `active-user-billing:lastActive:{userId}`, default 5min TTL)
- Wires up DI (tokens, module, container)
- Updates `teams/listMembers.handler.ts` and `organizations/listMembers.handler.ts` to use the cached repository instead of `User.lastActiveAt`
- Removes `lastActiveAt` from the Prisma `select` in both handlers since it's now computed
- Adds 8 unit tests for the new repository method
- Updates existing `ActiveUserBillingService` test mock to include the new method

**Link to Devin run:** https://app.devin.ai/sessions/ac1b1321f14f4d6d93342a73ac3b30b8
**Requested by:** @sean-brydon

---

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** — internal billing logic, no user-facing docs needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

---

## How should this be tested?

1. **Setup:** Create an org/team with members who have:
   - Only hosted accepted bookings
   - Only attended accepted bookings (as attendee)
   - Both hosted and attended
   - No accepted bookings
2. **Expected:** "Last active" column should show the most recent accepted booking date (host or attendee), formatted in user's locale/timezone
3. **Cache verification:** Check Redis for keys like `active-user-billing:lastActive:{userId}` after loading members list

**Environment variables:** None required beyond standard Cal.com setup

---

## Human Review Checklist

**Critical:**
- [ ] **Filter mismatch in org handler:** The `lastActiveAtFilter` (~line 121 in `organizations/listMembers.handler.ts`) still builds a Prisma `where` clause on `User.lastActiveAt` (the old DB column), but the *displayed* value now uses the new computed logic. Filtering by "Last active" date range will return results based on the old definition. Should this filter be removed, or is a follow-up needed to reconcile it?

**Important:**
- [ ] **No time-window constraint:** Unlike the billing service (which checks bookings within a billing period), `getLastActiveAt` queries the most recent accepted booking **ever**. This is intentional for "Last active" display, but worth confirming this is the desired behavior.
- [ ] **Performance on cold cache:** Each member triggers 2 Prisma queries (host + attendee) on cache miss. For large member lists (e.g., 100 members), that's 200 queries on first load. After 5min TTL, the cache refreshes. Is this acceptable, or should we batch/optimize?
- [ ] **Cache key strategy:** The cache key is `active-user-billing:lastActive:{userId}` (email not included). If a user changes email, stale attendee data is served until TTL expires (5min). Is this acceptable?
- [ ] **Dead code:** `User.lastActiveAt` is still being written by `RegularBookingService` but is no longer read by these handlers. Should it be deprecated/removed in a follow-up?

**Nice to have:**
- [ ] Consider adding integration tests for the handler changes (currently only repository unit tests exist)
- [ ] Verify the `@Memoize` decorator's default 5min TTL is appropriate for this use case

---

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized (253 lines, 9 files)