### PR TITLE
feat: take into account guest availability when rescheduling

### DIFF
--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -2189,4 +2189,23 @@ export class BookingRepository implements IBookingRepository {
       },
     });
   }
+
+  /**
+   * Finds attendee emails for a booking by its UID.
+   * Used during rescheduling to check guest availability.
+   */
+  async findAttendeeEmailsByUid({ bookingUid }: { bookingUid: string }) {
+    const booking = await this.prismaClient.booking.findUnique({
+      where: { uid: bookingUid },
+      select: {
+        userId: true,
+        attendees: {
+          select: {
+            email: true,
+          },
+        },
+      },
+    });
+    return booking;
+  }
 }

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1456,4 +1456,27 @@ export class UserRepository {
 
     return { email: user.email, username: user.username };
   }
+
+  /**
+   * Finds Cal.com users by their email addresses, returning data needed for availability checking.
+   * Used during rescheduling to check guest availability.
+   */
+  async findManyByEmailsForAvailability({ emails }: { emails: string[] }) {
+    if (!emails.length) return [];
+    const normalizedEmails = emails.map((e) => e.toLowerCase());
+
+    return this.prismaClient.user.findMany({
+      where: {
+        email: { in: normalizedEmails },
+        emailVerified: { not: null },
+        locked: false,
+      },
+      select: {
+        ...availabilityUserSelect,
+        credentials: {
+          select: credentialForCalendarServiceSelect,
+        },
+      },
+    });
+  }
 }

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1033,6 +1033,88 @@ export class AvailableSlotsService {
     "getRegularOrDynamicEventType"
   );
 
+  /**
+   * When a host reschedules a booking, checks if any attendees/guests are Cal.com users
+   * and filters out time slots where those guests are busy.
+   * This ensures only mutually available times are shown during rescheduling.
+   */
+  private async filterSlotsByGuestAvailability({
+    rescheduleUid,
+    availableTimeSlots,
+    eventLength,
+    startTime,
+    endTime,
+    eventTypeId,
+    loggerWithEventDetails,
+  }: {
+    rescheduleUid: string;
+    availableTimeSlots: { time: Dayjs; userIds?: number[] }[];
+    eventLength: number;
+    startTime: Dayjs;
+    endTime: Dayjs;
+    eventTypeId: number;
+    loggerWithEventDetails: Logger<unknown>;
+  }) {
+    const bookingRepo = this.dependencies.bookingRepo;
+    const booking = await bookingRepo.findAttendeeEmailsByUid({ bookingUid: rescheduleUid });
+
+    if (!booking?.attendees?.length) {
+      return availableTimeSlots;
+    }
+
+    const attendeeEmails = booking.attendees.map((a) => a.email);
+
+    const userRepo = this.dependencies.userRepo;
+    const guestCalUsers = await userRepo.findManyByEmailsForAvailability({ emails: attendeeEmails });
+
+    if (!guestCalUsers.length) {
+      return availableTimeSlots;
+    }
+
+    loggerWithEventDetails.info("Found Cal.com user guests for reschedule availability check", {
+      guestCount: guestCalUsers.length,
+      guestEmails: guestCalUsers.map((u) => u.email),
+    });
+
+    const guestUsersWithCalendars = guestCalUsers.map((user) => withSelectedCalendars(user));
+
+    // Get availability for each guest Cal.com user
+    const guestAvailabilities = await this.dependencies.userAvailabilityService.getUsersAvailability({
+      users: guestUsersWithCalendars,
+      query: {
+        dateFrom: startTime.format(),
+        dateTo: endTime.format(),
+        eventTypeId,
+        afterEventBuffer: 0,
+        beforeEventBuffer: 0,
+        duration: 0,
+        returnDateOverrides: false,
+        bypassBusyCalendarTimes: false,
+      },
+      initialData: {
+        currentSeats: undefined,
+        rescheduleUid,
+        busyTimesFromLimitsBookings: [],
+      },
+    });
+
+    // Collect all busy times from all guest Cal.com users
+    const allGuestBusyTimes: EventBusyDate[] = guestAvailabilities.flatMap((availability) => availability.busy);
+
+    if (!allGuestBusyTimes.length) {
+      return availableTimeSlots;
+    }
+
+    // Filter out slots that conflict with any guest's busy times
+    return availableTimeSlots.filter((slot) => {
+      return !checkForConflicts({
+        time: slot.time,
+        busy: allGuestBusyTimes,
+        eventLength,
+      });
+    });
+  }
+
   getAvailableSlots = withReporting(
     withSlotsCache(this.dependencies.redisClient, this._getAvailableSlots.bind(this)),
     "getAvailableSlots"
@@ -1404,6 +1486,20 @@ export class AvailableSlotsService {
             return !!item;
           }
         );
+    }
+
+    // When rescheduling, check if any attendees/guests are Cal.com users
+    // and filter out slots where they are busy
+    if (input.rescheduleUid) {
+      availableTimeSlots = await this.filterSlotsByGuestAvailability({
+        rescheduleUid: input.rescheduleUid,
+        availableTimeSlots,
+        eventLength: input.duration || eventType.length,
+        startTime,
+        endTime,
+        eventTypeId: eventType.id,
+        loggerWithEventDetails,
+      });
     }
 
     // fr-CA uses YYYY-MM-DD


### PR DESCRIPTION
## Summary
- When a host reschedules a booking, the system now looks up attendees/guests by email to check if they are Cal.com users
- If a guest is a Cal.com user, their calendar busy times and booking conflicts are fetched using the existing availability service
- Only time slots where ALL participants (host + Cal.com user guests) are available are displayed during rescheduling
- Non-Cal.com guests are unaffected (their availability cannot be checked)

## Changes
- **`packages/features/bookings/repositories/BookingRepository.ts`**: Added `findAttendeeEmailsByUid` method to retrieve attendee emails for a booking by its UID
- **`packages/features/users/repositories/UserRepository.ts`**: Added `findManyByEmailsForAvailability` method to find Cal.com users by email with data needed for availability checking
- **`packages/trpc/server/routers/viewer/slots/util.ts`**: Added `filterSlotsByGuestAvailability` private method to `AvailableSlotsService` that checks guest availability during rescheduling, and integrated it into the `_getAvailableSlots` flow

## How it works
1. When `rescheduleUid` is present in the slot calculation request, the system fetches the booking's attendees
2. Attendee emails are looked up against the Cal.com user database (only verified, non-locked users)
3. For each Cal.com user guest found, their availability is computed using `getUsersAvailability`
4. All guest busy times are collected and used with `checkForConflicts` to filter out unavailable slots
5. Early returns at each step ensure no unnecessary work is done (e.g., no guests, no Cal.com users among guests, no busy times)

## Test plan
- [ ] Host reschedules a booking where the guest is a Cal.com user with calendar events -- only slots where both host and guest are free should appear
- [ ] Host reschedules a booking where the guest is NOT a Cal.com user -- all host-available slots should appear (no change in behavior)
- [ ] Host reschedules a booking with multiple guests, some of whom are Cal.com users -- slots should respect availability of all Cal.com user guests
- [ ] Attendee reschedules their own booking -- all slots should appear as before (this feature only applies when `rescheduleUid` is present in the slot query)

/claim #16378

🤖 Generated with [Claude Code](https://claude.com/claude-code)