### PR TITLE
[CAL-1425] Add Exchange 2019 option (mapped to EWS 2016)

### DIFF
--- a/apps/web/components/apps/exchangecalendar/Setup.tsx
+++ b/apps/web/components/apps/exchangecalendar/Setup.tsx
@@ -61,6 +61,7 @@ export default function ExchangeSetup() {
     { value: ExchangeVersion.Exchange2013_SP1, label: t("exchange_version_2013_SP1") },
     { value: ExchangeVersion.Exchange2015, label: t("exchange_version_2015") },
     { value: ExchangeVersion.Exchange2016, label: t("exchange_version_2016") },
+    { value: ExchangeVersion.Exchange2019, label: "2019" },
   ];
 
   return (

--- a/packages/app-store/exchangecalendar/enums.ts
+++ b/packages/app-store/exchangecalendar/enums.ts
@@ -11,4 +11,6 @@ export enum ExchangeVersion {
   Exchange2013_SP1 = 5,
   Exchange2015 = 6,
   Exchange2016 = 7,
+  // Exchange 2019 uses the same EWS schema version as Exchange 2016.
+  Exchange2019 = 8,
 }

--- a/packages/app-store/exchangecalendar/lib/CalendarService.ts
+++ b/packages/app-store/exchangecalendar/lib/CalendarService.ts
@@ -39,7 +39,7 @@ import type {
 } from "@calcom/types/Calendar";
 import type { CredentialPayload } from "@calcom/types/Credential";
 
-import { ExchangeAuthentication } from "../enums";
+import { ExchangeAuthentication, ExchangeVersion } from "../enums";
 
 class ExchangeCalendarService implements Calendar {
   private integrationName = "";
@@ -195,7 +195,12 @@ class ExchangeCalendarService implements Calendar {
   }
 
   private async getExchangeService(): Promise<ExchangeService> {
-    const service: ExchangeService = new ExchangeService(this.payload.exchangeVersion);
+    const resolvedExchangeVersion =
+      this.payload.exchangeVersion === ExchangeVersion.Exchange2019
+        ? ExchangeVersion.Exchange2016
+        : this.payload.exchangeVersion;
+
+    const service: ExchangeService = new ExchangeService(resolvedExchangeVersion);
     service.Credentials = new WebCredentials(this.payload.username, this.payload.password);
     service.Url = new Uri(this.payload.url);
     if (this.payload.authenticationMethod === ExchangeAuthentication.NTLM) {


### PR DESCRIPTION
## Summary
Fixes part of #8123 by adding explicit Exchange 2019 support in the Exchange setup flow while keeping EWS compatibility.

### Changes
- Add `Exchange2019` to `ExchangeVersion`
- Add `2019` option in setup selector
- Map Exchange 2019 to Exchange 2016 in `ExchangeService` creation (same EWS schema)

## Validation
- Ran: `yarn lint --filter=@calcom/exchangecalendar --filter=@calcom/web`
- Command completed; existing repo-wide lint warnings are unrelated.

/claim #8123

Bounty reference: Algora $40 on #8123
