### PR TITLE
fix: add error handling for org member invite during team migration

### DIFF
--- a/packages/trpc/server/routers/viewer/organizations/createTeams.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/createTeams.handler.ts
@@ -11,9 +11,7 @@ import type { Prisma } from "@calcom/prisma/client";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { MembershipRole, RedirectType } from "@calcom/prisma/enums";
 import { teamMetadataSchema, teamMetadataStrictSchema } from "@calcom/prisma/zod-utils";
-
 import { TRPCError } from "@trpc/server";
-
 import { inviteMembersWithNoInviterPermissionCheck } from "../teams/inviteMember/inviteMember.handler";
 import type { TCreateTeamsSchema } from "./createTeams.schema";
 
@@ -247,25 +245,50 @@ async function moveTeam({
     throw error;
   }
 
-  // Owner is already a member of the team. Inviting an existing member can throw error
   const invitableMembers = team.members.filter(isMembershipNotWithOwner).map((membership) => ({
     usernameOrEmail: membership.user.email,
     role: membership.role,
   }));
 
+  log.info(
+    "Inviting team members to org",
+    safeStringify({
+      teamId,
+      orgId: org.id,
+      totalMembers: team.members.length,
+      invitableMembersCount: invitableMembers.length,
+      invitableMembers: invitableMembers.map((m) => m.usernameOrEmail),
+      orgOwnerId: org.ownerId,
+    })
+  );
+
   if (invitableMembers.length) {
-    // Invite team members to the new org. They are already members of the team.
-    await inviteMembersWithNoInviterPermissionCheck({
-      orgSlug: org.slug,
-      invitations: invitableMembers,
-      creationSource,
-      language: "en",
-      inviterName: null,
-      teamId: org.id,
-      // This is important so that if we re-invite existing users accidentally, we don't endup erroring out.
-      // Because this is a bulk action that could be taken from organization payment webhook, we could have cases where a user was just invited through another team migration in parallel.
-      isDirectUserAction: false,
-    });
+    try {
+      await inviteMembersWithNoInviterPermissionCheck({
+        orgSlug: org.slug,
+        invitations: invitableMembers,
+        creationSource,
+        language: "en",
+        inviterName: null,
+        teamId: org.id,
+        // Silences errors for duplicate invites that can happen when migrating multiple teams with overlapping members
+        isDirectUserAction: false,
+      });
+      log.info(
+        "Successfully invited team members to org",
+        safeStringify({ teamId, orgId: org.id, invitedCount: invitableMembers.length })
+      );
+    } catch (error) {
+      log.error(
+        "Failed to invite team members to org during migration. Team was moved but members were not added to the org.",
+        safeStringify({
+          teamId,
+          orgId: org.id,
+          invitableMembers: invitableMembers.map((m) => m.usernameOrEmail),
+          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+        })
+      );
+    }
   }
 
   await addTeamRedirect({

--- a/packages/trpc/server/routers/viewer/organizations/createTeams.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/createTeams.handler.ts
@@ -257,7 +257,6 @@ async function moveTeam({
       orgId: org.id,
       totalMembers: team.members.length,
       invitableMembersCount: invitableMembers.length,
-      invitableMembers: invitableMembers.map((m) => m.usernameOrEmail),
       orgOwnerId: org.ownerId,
     })
   );
@@ -284,7 +283,6 @@ async function moveTeam({
         safeStringify({
           teamId,
           orgId: org.id,
-          invitableMembers: invitableMembers.map((m) => m.usernameOrEmail),
           error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
         })
       );

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -707,7 +707,6 @@ export async function handleExistingUsersInvites({
           "Failed to invite existing user to organization",
           safeStringify({
             userId: failedUser.id,
-            email: failedUser.email,
             organizationId: organization.id,
             error:
               result.reason instanceof Error

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -653,7 +653,7 @@ export async function handleExistingUsersInvites({
       })
     );
 
-    const existingUsersWithMembershipsNew = await Promise.all(
+    const settledResults = await Promise.allSettled(
       invitableExistingUsers.map(async (user) => {
         const shouldAutoAccept = orgConnectInfoByUsernameOrEmail[user.email].autoAccept;
         let profile = null;
@@ -678,7 +678,6 @@ export async function handleExistingUsersInvites({
           },
         });
 
-        // If auto-accepting into org, also accept any pending sub-team memberships
         if (shouldAutoAccept) {
           await prisma.membership.updateMany({
             where: {
@@ -699,6 +698,34 @@ export async function handleExistingUsersInvites({
         };
       })
     );
+
+    for (let i = 0; i < settledResults.length; i++) {
+      const result = settledResults[i];
+      if (result.status === "rejected") {
+        const failedUser = invitableExistingUsers[i];
+        log.error(
+          "Failed to invite existing user to organization",
+          safeStringify({
+            userId: failedUser.id,
+            email: failedUser.email,
+            organizationId: organization.id,
+            error:
+              result.reason instanceof Error
+                ? { message: result.reason.message, stack: result.reason.stack }
+                : result.reason,
+          })
+        );
+      }
+    }
+
+    const existingUsersWithMembershipsNew: Array<
+      InvitableExistingUser & { profile: Awaited<ReturnType<typeof createAProfileForAnExistingUser>> | null }
+    > = [];
+    for (const result of settledResults) {
+      if (result.status === "fulfilled") {
+        existingUsersWithMembershipsNew.push(result.value);
+      }
+    }
 
     if (!team.parentId && existingUsersWithMembershipsNew.length > 0) {
       const seatTracker = new SeatChangeTrackingService();


### PR DESCRIPTION
## What does this PR do?

When migrating teams to an organization, if inviting team members to the org fails (e.g. profile creation error, unique constraint violation), the entire migration could silently leave teams moved but with **no org-level memberships created**. This results in members appearing on the team members page but not on the org members page.

Two changes:

1. **`createTeams.handler.ts` (`moveTeam`)**: Wraps `inviteMembersWithNoInviterPermissionCheck` in a try-catch so that a failed invite does not block the rest of the migration (redirects, subscription cancellation, subsequent team migrations). Adds logging for invite attempt details, success, and failure with full error context.

2. **`inviteMember/utils.ts` (`handleExistingUsersInvites`)**: Changes `Promise.all` → `Promise.allSettled` for the org invite path. Previously, if creating a profile/membership for **any single user** failed, the entire batch would reject and **no users** would get org memberships. Now each user is processed independently — failures are logged per-user while successful invites still proceed.

> **Note:** This PR adds resilience and diagnostic logging to help identify the root cause of missing org members after migration. The exact trigger for the original failure is not yet confirmed — these logs will surface it on next reproduction.

### Updates since last revision

- Removed PII (email addresses) from all log statements. Logs now identify users by `userId` only, not by email.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Seed a local DB (`yarn db-seed`) — use `teampro@example.com` / `teampro`
2. As instance admin, create a new org via `/settings/organizations/new` with handover flow
3. As `teampro@example.com`, resume onboarding and select all teams to migrate
4. After completion, check `/settings/organizations/<orgslug>/members` — previously no members would appear
5. Check server logs (`NEXT_PUBLIC_LOGGER_LEVEL=3`) for the new log lines:
   - `"Inviting team members to org"` with member count and team/org IDs
   - `"Successfully invited team members to org"` or `"Failed to invite team members to org during migration"` with error details
   - Per-user `"Failed to invite existing user to organization"` (identified by userId) if individual invites fail

## Human Review Checklist

- [ ] **Swallowed errors in `moveTeam`**: The catch block logs but does not re-throw. This means the org creation succeeds even if ALL member invites fail — the user sees no error, just missing members. Is this the right tradeoff vs. failing the whole migration?
- [ ] **`Promise.allSettled` downstream safety**: Verify that `existingUsersWithMembershipsNew` (now filtered to only fulfilled results) is safe for seat tracking and email sending logic below it.
- [ ] **No tests added**: This is an error-handling + logging change; consider whether integration tests covering the migration failure path should be added.
- [ ] **Logging without emails**: Failed user invites are now identified only by `userId` (PII removed). Confirm this is sufficient for debugging — correlating userId to email requires a separate DB lookup.

---

**Link to Devin run:** https://app.devin.ai/sessions/cfe7ebd1961740cea3181ccfb7e61f1e
**Requested by:** @eunjae-lee