### PR TITLE
feat: fetch guest avatars via avatarapi.com in booking details panel

### DIFF
--- a/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
+++ b/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
@@ -30,8 +30,8 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@calcom/ui/components/sheet";
-import { ExternalLinkIcon, RepeatIcon } from "@coss/ui/icons";
 import { BookingHistory } from "@calcom/web/modules/booking-audit/components/BookingHistory";
+import { ExternalLinkIcon, RepeatIcon } from "@coss/ui/icons";
 import assignmentReasonBadgeTitleMap from "@lib/booking/assignmentReasonBadgeTitleMap";
 import Link from "next/link";
 import { useMemo, useRef } from "react";
@@ -214,15 +214,15 @@ function BookingDetailsSheetInner({
   const recurringInfo =
     booking.recurringEventId && booking.eventType?.recurringEvent
       ? {
-        count: booking.eventType.recurringEvent.count,
-        recurringEvent: booking.eventType.recurringEvent,
-      }
+          count: booking.eventType.recurringEvent.count,
+          recurringEvent: booking.eventType.recurringEvent,
+        }
       : null;
 
   const customResponses = booking.responses
     ? Object.entries(booking.responses as Record<string, unknown>)
-      .filter(([fieldName]) => shouldShowFieldInCustomResponses(fieldName))
-      .map(([question, answer]) => [question, answer] as [string, unknown])
+        .filter(([fieldName]) => shouldShowFieldInCustomResponses(fieldName))
+        .map(([question, answer]) => [question, answer] as [string, unknown])
     : [];
 
   const reason =
@@ -460,7 +460,7 @@ function DisplayTimestamp({
   const start = startTime instanceof Date ? dayjs(startTime).tz(timeZone) : startTime;
   const end = endTime instanceof Date ? dayjs(endTime).tz(timeZone) : endTime;
   const localizedTimezone = timeZone
-    ? formatToLocalizedTimezone(start, language, timeZone) ?? timeZone
+    ? (formatToLocalizedTimezone(start, language, timeZone) ?? timeZone)
     : start.format("Z");
 
   return (
@@ -475,6 +475,17 @@ function DisplayTimestamp({
 
 function WhoSection({ booking }: { booking: BookingOutput }) {
   const { t } = useLocale();
+
+  const guestEmails = useMemo(
+    () => booking.attendees.filter((a) => !a.user?.avatarUrl).map((a) => a.email),
+    [booking.attendees]
+  );
+
+  const { data: guestAvatarMap } = trpc.viewer.bookings.getGuestAvatars.useQuery(
+    { emails: guestEmails },
+    { enabled: guestEmails.length > 0, staleTime: 30 * 60 * 1000 }
+  );
+
   return (
     <Section title={t("who")}>
       <div className="mt-2 flex flex-col gap-3">
@@ -509,6 +520,7 @@ function WhoSection({ booking }: { booking: BookingOutput }) {
 
         {booking.attendees.map((attendee, idx) => {
           const name = attendee.user?.name || attendee.name || attendee.user?.email || attendee.email;
+          const guestAvatarUrl = guestAvatarMap?.[attendee.email];
           return (
             <div key={idx} className="flex items-center gap-4">
               <Avatar
@@ -516,7 +528,7 @@ function WhoSection({ booking }: { booking: BookingOutput }) {
                 imageSrc={
                   attendee.user?.avatarUrl
                     ? getUserAvatarUrl(attendee.user)
-                    : getPlaceholderAvatar(null, name)
+                    : guestAvatarUrl || getPlaceholderAvatar(null, name)
                 }
                 alt={name}
               />

--- a/packages/features/auth/signup/utils/prefillAvatar.ts
+++ b/packages/features/auth/signup/utils/prefillAvatar.ts
@@ -1,9 +1,9 @@
-import fetch from "node-fetch";
-
+import { getAvatarUrlFromAvatarAPI } from "@calcom/features/avatars/getAvatarUrlFromAvatarAPI";
 import { uploadAvatar } from "@calcom/lib/server/avatar";
 import { resizeBase64Image } from "@calcom/lib/server/resizeBase64Image";
 import prisma from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
+import fetch from "node-fetch";
 
 interface IPrefillAvatar {
   email: string;
@@ -29,7 +29,7 @@ async function downloadImageDataFromUrl(url: string) {
 }
 
 export const prefillAvatar = async ({ email }: IPrefillAvatar) => {
-  const imageUrl = await getImageUrlAvatarAPI(email);
+  const imageUrl = await getAvatarUrlFromAvatarAPI(email);
   if (!imageUrl) return;
 
   const base64Image = await downloadImageDataFromUrl(imageUrl);
@@ -52,50 +52,4 @@ export const prefillAvatar = async ({ email }: IPrefillAvatar) => {
     where: { email: email },
     data,
   });
-};
-
-const getImageUrlAvatarAPI = async (email: string) => {
-  if (!process.env.AVATARAPI_USERNAME || !process.env.AVATARAPI_PASSWORD) {
-    console.info("No avatar api credentials found");
-    return null;
-  }
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 10_000);
-
-  try {
-    const response = await fetch("https://avatarapi.com/v2/api.aspx", {
-      method: "POST",
-      headers: {
-        "Content-Type": "text/plain",
-      },
-      body: JSON.stringify({
-        username: process.env.AVATARAPI_USERNAME,
-        password: process.env.AVATARAPI_PASSWORD,
-        email,
-      }),
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeout);
-
-    const info = await response.json();
-
-    if (!info.Success) {
-      if (info.Error === "Not found") {
-        // Expected case: no avatar for this email
-        return null;
-      }
-      console.warn("Avatar API error:", info.Error);
-      return null;
-    }
-    return info.Image as string;
-  } catch (error: unknown) {
-    if (error instanceof DOMException && error.name === "AbortError") {
-      console.warn("Avatar API request timed out");
-    } else {
-      console.error("Avatar API request failed:", error);
-    }
-    return null;
-  }
 };

--- a/packages/features/avatars/getAvatarUrlFromAvatarAPI.ts
+++ b/packages/features/avatars/getAvatarUrlFromAvatarAPI.ts
@@ -1,0 +1,45 @@
+import process from "node:process";
+export async function getAvatarUrlFromAvatarAPI(email: string): Promise<string | null> {
+  if (!process.env.AVATARAPI_USERNAME || !process.env.AVATARAPI_PASSWORD) {
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const response = await fetch("https://avatarapi.com/v2/api.aspx", {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      body: JSON.stringify({
+        username: process.env.AVATARAPI_USERNAME,
+        password: process.env.AVATARAPI_PASSWORD,
+        email,
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    const info = await response.json();
+
+    if (!info.Success) {
+      if (info.Error === "Not found") {
+        return null;
+      }
+      console.warn("Avatar API error:", info.Error);
+      return null;
+    }
+    return info.Image as string;
+  } catch (error: unknown) {
+    clearTimeout(timeout);
+    if (error instanceof DOMException && error.name === "AbortError") {
+      console.warn("Avatar API request timed out");
+    } else {
+      console.error("Avatar API request failed:", error);
+    }
+    return null;
+  }
+}

--- a/packages/trpc/server/routers/viewer/bookings/_router.tsx
+++ b/packages/trpc/server/routers/viewer/bookings/_router.tsx
@@ -13,6 +13,7 @@ import { ZGetInputSchema } from "./get.schema";
 import { ZGetBookingAttendeesInputSchema } from "./getBookingAttendees.schema";
 import { ZGetBookingDetailsInputSchema } from "./getBookingDetails.schema";
 import { ZGetBookingHistoryInputSchema } from "./getBookingHistory.schema";
+import { ZGetGuestAvatarsInputSchema } from "./getGuestAvatars.schema";
 import { ZInstantBookingInputSchema } from "./getInstantBookingLocation.schema";
 import { ZGetRoutingTraceInputSchema } from "./getRoutingTrace.schema";
 import { ZGetWrongAssignmentReportsInputSchema } from "./getWrongAssignmentReports.schema";
@@ -91,6 +92,14 @@ export const bookingsRouter = router({
 
     return getBookingDetailsHandler({
       ctx,
+      input,
+    });
+  }),
+
+  getGuestAvatars: authedProcedure.input(ZGetGuestAvatarsInputSchema).query(async ({ input }) => {
+    const { getGuestAvatarsHandler } = await import("./getGuestAvatars.handler");
+
+    return getGuestAvatarsHandler({
       input,
     });
   }),

--- a/packages/trpc/server/routers/viewer/bookings/getGuestAvatars.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/getGuestAvatars.handler.ts
@@ -1,0 +1,24 @@
+import { getAvatarUrlFromAvatarAPI } from "@calcom/features/avatars/getAvatarUrlFromAvatarAPI";
+import type { TGetGuestAvatarsInputSchema } from "./getGuestAvatars.schema";
+
+type GetGuestAvatarsOptions = {
+  input: TGetGuestAvatarsInputSchema;
+};
+
+export const getGuestAvatarsHandler = async ({ input }: GetGuestAvatarsOptions) => {
+  const results = await Promise.all(
+    input.emails.map(async (email) => {
+      const avatarUrl = await getAvatarUrlFromAvatarAPI(email);
+      return { email, avatarUrl };
+    })
+  );
+
+  const avatarMap: Record<string, string> = {};
+  for (const result of results) {
+    if (result.avatarUrl) {
+      avatarMap[result.email] = result.avatarUrl;
+    }
+  }
+
+  return avatarMap;
+};

--- a/packages/trpc/server/routers/viewer/bookings/getGuestAvatars.schema.ts
+++ b/packages/trpc/server/routers/viewer/bookings/getGuestAvatars.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export type TGetGuestAvatarsInputSchema = {
+  emails: string[];
+};
+
+export const ZGetGuestAvatarsInputSchema: z.ZodType<TGetGuestAvatarsInputSchema> = z.object({
+  emails: z.array(z.string().email()).max(50),
+});


### PR DESCRIPTION
## What does this PR do?

When the booking details side panel opens, guests (attendees without an existing user avatar) now get their avatar fetched from `avatarapi.com` — the same service already used during signup to prefill user avatars.

**Changes:**

1. **Extracted shared utility** — Moved the `avatarapi.com` calling logic from `prefillAvatar.ts` into a new shared module at `packages/features/avatars/getAvatarUrlFromAvatarAPI.ts`. The signup flow now imports from this shared utility instead of having its own copy.
2. **New tRPC endpoint** — `viewer.bookings.getGuestAvatars` accepts an array of emails (max 50), calls `avatarapi.com` for each in parallel, and returns a `Record<email, avatarUrl>`.
3. **Updated `WhoSection`** — On panel open, emails of attendees without a user avatar are collected and passed to the new endpoint. Results are cached for 30 minutes (`staleTime`). The avatar fallback chain is: user avatar → avatarapi.com result → placeholder.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Set `AVATARAPI_USERNAME` and `AVATARAPI_PASSWORD` environment variables (required for the API to return results; without them the endpoint returns an empty map and attendees fall back to placeholder avatars as before).
2. Open the bookings list view and click on a booking that has guest attendees.
3. In the side panel under **Who**, guests without a Cal.com account should show a real avatar (if `avatarapi.com` finds one for their email) instead of the colored-initial placeholder.
4. Navigating between bookings should not re-fetch avatars for the same emails within 30 minutes (cached via `staleTime`).

## Items for reviewer attention

- **No concurrency limit on `Promise.all`**: The handler fires up to 50 parallel requests to `avatarapi.com`. Consider whether a concurrency limiter (e.g. `p-limit`) is warranted, or if the max-50 cap on the schema is sufficient.
- **Authorization scope**: The endpoint is behind `authedProcedure` but does not verify the caller owns/is-host-of the booking containing those emails. Any authenticated user could query avatar URLs for arbitrary email addresses. Assess whether this is an acceptable trade-off.
- **`fetch` vs `node-fetch`**: The new shared utility uses the global `fetch` (Node 18+), whereas the original `prefillAvatar.ts` used `node-fetch`. Verify this is fine in the target Node.js runtime.
- **No unit tests added** for the new handler or shared utility.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] My PR is not too large

---

Link to Devin run: https://app.devin.ai/sessions/f5d89ec657a14199be1beedd89ac525b
Requested by: @PeerRich