### PR TITLE
feat: take into account guest's availability when rescheduling

### DIFF
--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1268,6 +1268,26 @@ export class UserRepository {
     });
   }
 
+  /**
+   * Find Cal.com users by their emails with full availability data (schedules, credentials, etc.)
+   * Used for checking guest availability when rescheduling.
+   */
+  async findManyByEmailsWithAvailabilityData(emails: string[]) {
+    if (!emails.length) return [];
+    const normalizedEmails = emails.map((e) => e.toLowerCase());
+    return this.prismaClient.user.findMany({
+      where: {
+        email: { in: normalizedEmails },
+      },
+      select: {
+        ...availabilityUserSelect,
+        credentials: {
+          select: credentialForCalendarServiceSelect,
+        },
+      },
+    });
+  }
+
   async findUsersByIds(userIds: number[]) {
     return this.prismaClient.user.findMany({
       where: {

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -970,6 +970,135 @@ export class AvailableSlotsService {
   }
 
   /**
+   * When rescheduling, looks up the booking's attendees to see if any are Cal.com users.
+   * If so, fetches their availability and filters out slots where those attendees are busy,
+   * so the host can only reschedule to times that work for the guest too.
+   */
+  private async filterSlotsByAttendeeAvailability({
+    rescheduleUid,
+    availableTimeSlots,
+    startTime,
+    endTime,
+    eventType,
+    eventLength,
+    loggerWithEventDetails,
+  }: {
+    rescheduleUid: string;
+    availableTimeSlots: { time: dayjs.Dayjs; userIds?: number[] }[];
+    startTime: Dayjs;
+    endTime: Dayjs;
+    eventType: { id: number; afterEventBuffer: number; beforeEventBuffer: number; length: number };
+    eventLength: number;
+    loggerWithEventDetails: Logger<unknown>;
+  }): Promise<typeof availableTimeSlots> {
+    const bookingRepo = this.dependencies.bookingRepo;
+
+    // Fetch booking with attendees
+    const booking = await bookingRepo.findByUidIncludeEventTypeAttendeesAndUser({
+      bookingUid: rescheduleUid,
+    });
+
+    if (!booking?.attendees?.length) {
+      return availableTimeSlots;
+    }
+
+    // Look up which attendees are Cal.com users by loading them with availability data
+    const attendeeEmails = booking.attendees.map((a) => a.email);
+    const userRepo = this.dependencies.userRepo;
+    const rawUsers = await userRepo.findManyByEmailsWithAvailabilityData(attendeeEmails);
+    const calComAttendeeUsers = rawUsers.map((user) => {
+      const userWithCalendars = withSelectedCalendars(user);
+      return userWithCalendars;
+    });
+
+    if (calComAttendeeUsers.length === 0) {
+      loggerWithEventDetails.debug("No Cal.com user attendees found for reschedule guest availability check");
+      return availableTimeSlots;
+    }
+
+    loggerWithEventDetails.debug("Checking guest availability for Cal.com user attendees", {
+      attendeeIds: calComAttendeeUsers.map((a) => a.id),
+    });
+
+    // Get availability for each Cal.com attendee
+    const attendeeAvailabilities = await this.dependencies.userAvailabilityService.getUsersAvailability({
+      users: calComAttendeeUsers.map((user) => ({
+        ...user,
+        currentBookings: [],
+        outOfOfficeDays: [],
+      })),
+      query: {
+        dateFrom: startTime.format(),
+        dateTo: endTime.format(),
+        eventTypeId: eventType.id,
+        afterEventBuffer: eventType.afterEventBuffer,
+        beforeEventBuffer: eventType.beforeEventBuffer,
+        duration: 0,
+        returnDateOverrides: false,
+      },
+      initialData: {
+        eventType: undefined,
+        currentSeats: undefined,
+        rescheduleUid,
+        busyTimesFromLimitsBookings: [],
+      },
+    });
+
+    // Collect all busy times from attendees
+    const attendeeBusyTimes: EventBusyDate[] = [];
+    for (const availability of attendeeAvailabilities) {
+      if (availability.busy) {
+        attendeeBusyTimes.push(
+          ...availability.busy.map((b) => ({
+            start: new Date(b.start as unknown as string),
+            end: new Date(b.end as unknown as string),
+          }))
+        );
+      }
+    }
+
+    // Filter slots: keep only those where no attendee has a conflict
+    // AND where the slot falls within at least one dateRange of every attendee
+    const filteredSlots = availableTimeSlots.filter((slot) => {
+      // Check that no attendee is busy during this slot
+      const hasConflict = checkForConflicts({
+        time: slot.time,
+        busy: attendeeBusyTimes,
+        eventLength,
+      });
+
+      if (hasConflict) {
+        return false;
+      }
+
+      // Check that each attendee has working hours covering this slot
+      for (const availability of attendeeAvailabilities) {
+        if (availability.dateRanges && availability.dateRanges.length > 0) {
+          const slotStart = slot.time;
+          const slotEnd = slot.time.add(eventLength, "minute");
+          const withinWorkingHours = availability.dateRanges.some(
+            (range) =>
+              (slotStart.isAfter(range.start) || slotStart.isSame(range.start)) &&
+              (slotEnd.isBefore(range.end) || slotEnd.isSame(range.end))
+          );
+          if (!withinWorkingHours) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    });
+
+    loggerWithEventDetails.debug("Filtered slots by attendee availability", {
+      originalCount: availableTimeSlots.length,
+      filteredCount: filteredSlots.length,
+    });
+
+    return filteredSlots;
+  }
+
+  /**
    * Resolves the organization ID for watchlist blocking with the following priority:
    * 1. Request context (orgSlug) - most accurate for the current request scope
    * 2. EventType team hierarchy - for team/managed events
@@ -1324,6 +1453,20 @@ export class AvailableSlotsService {
       }
     } else {
       availableTimeSlots = timeSlots;
+    }
+
+    // When rescheduling, check if any attendee is a Cal.com user and filter
+    // slots by their availability so the host can only pick times that work for the guest too.
+    if (input.rescheduleUid) {
+      availableTimeSlots = await this.filterSlotsByAttendeeAvailability({
+        rescheduleUid: input.rescheduleUid,
+        availableTimeSlots,
+        startTime,
+        endTime,
+        eventType,
+        eventLength: input.duration || eventType.length,
+        loggerWithEventDetails,
+      });
     }
 
     const reservedSlots = await this._getReservedSlotsAndCleanupExpired({


### PR DESCRIPTION
## What does this PR do?

Fixes #16378

When a host reschedules a booking, this change checks if any of the booking's attendees are Cal.com users. If they are, their availability (working hours, busy times, existing bookings) is fetched and used to filter the available time slots, ensuring the host can only reschedule to times that work for the guest too.

### How it works

1. When `rescheduleUid` is provided during slot calculation, the booking's attendees are looked up
2. Each attendee email is checked against the Cal.com user database
3. For attendees who are Cal.com users, their full availability is fetched (schedules, working hours, calendar busy times, existing bookings)
4. Available slots are filtered to only show times where:
   - No attendee has a conflicting booking/busy time
   - The slot falls within every attendee's working hours

### Changes

- **`UserRepository`**: Added `findManyByEmailsWithAvailabilityData()` - loads users with full availability data (schedules, credentials, selected calendars) by email addresses
- **`AvailableSlotsService`**: Added `filterSlotsByAttendeeAvailability()` - looks up booking attendees, finds Cal.com users among them, fetches their availability, and filters slots
- Integrated into `_getAvailableSlots()` when `rescheduleUid` is present

### Non-Cal.com attendees

If an attendee is not a Cal.com user, their availability is not checked (same as current behavior). This only enhances the experience when the guest happens to also be a Cal.com user.

### Type of change
- [x] New feature (non-breaking change which adds functionality)