### PR TITLE
fix: refresh slots on timezone change when useBookerTimezone is enabled

### DIFF
--- a/apps/web/modules/schedules/hooks/useEvent.ts
+++ b/apps/web/modules/schedules/hooks/useEvent.ts
@@ -102,7 +102,9 @@ export const useScheduleForEvent = ({
     shallow
   );
 
-  const effectiveTimezone = useStableTimezone(rawTimezone, restrictionSchedule);
+  const effectiveTimezone = useStableTimezone(rawTimezone, restrictionSchedule, () => {
+  schedule?.invalidate?.();
+});
 
   const searchParams = useCompatSearchParams();
   const rescheduleUid = searchParams?.get("rescheduleUid");


### PR DESCRIPTION
fixes #22319

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes available booking slots when the timezone changes with useBookerTimezone enabled, so slot times reflect the user's current timezone. Implemented by invalidating the schedule when the effective timezone updates.

<sup>Written for commit f6f62f1fa9358c2d60e7b1396f388e7ad0c54896. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

