### PR TITLE
fix: allow booking rejection via GET for email clients that do not support forms

### DIFF
--- a/apps/web/app/api/verify-booking-token/__tests__/route.test.ts
+++ b/apps/web/app/api/verify-booking-token/__tests__/route.test.ts
@@ -1,7 +1,8 @@
-import type { NextRequest } from "next/server";
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { confirmHandler } from "@calcom/trpc/server/routers/viewer/bookings/confirm.handler";
+import type { NextRequest } from "next/server";
 import type { Mock } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 const mockConfirmHandler = confirmHandler as unknown as Mock<typeof confirmHandler>;
 
 vi.mock("app/api/defaultResponderForAppDir", () => ({
@@ -88,8 +89,10 @@ function expectErrorRedirect(res: Response, path: string, error: string) {
   expect(redirectUrl.searchParams.get("error")).toBe(error);
 }
 
+import process from "node:process";
 // Import after mocks are set up
 import { GET, POST } from "../route";
+
 const DB = {
   bookings: {} as Record<
     string,
@@ -179,19 +182,37 @@ describe("verify-booking-token route", () => {
   });
 
   describe("GET handler", () => {
-    it("should redirect to booking page with error when action is reject (requires POST)", async () => {
+    it("should handle reject action via GET for email clients that do not support forms", async () => {
+      createMockBooking({
+        id: 1,
+        uid: "abc123",
+        oneTimePassword: "test-token",
+      });
+      createMockUser({
+        id: 42,
+        uuid: "user-uuid",
+        email: "test@example.com",
+        username: "testuser",
+        role: "USER",
+        destinationCalendar: null,
+      });
+
       const baseUrl =
         "https://app.example.com/api/verify-booking-token?action=reject&token=test-token&bookingUid=abc123&userId=42";
       const req = createMockRequest(baseUrl, "GET");
-      const res = await GET(req, { params: Promise.resolve({}) });
-      const location = res.headers.get("location");
+      await GET(req, { params: Promise.resolve({}) });
 
-      expect(location).toBeTruthy();
-      const redirectUrl = new URL(location!);
-
-      expect(redirectUrl.origin).toBe("https://app.example.com");
-      expect(redirectUrl.pathname).toBe("/booking/abc123");
-      expect(redirectUrl.searchParams.get("error")).toBe("Rejection requires POST method");
+      expect(mockConfirmHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            bookingId: 1,
+            confirmed: false,
+            reason: undefined,
+            emailsEnabled: true,
+            actionSource: "MAGIC_LINK",
+          }),
+        })
+      );
     });
 
     it("should redirect with error when query params are invalid (missing action)", async () => {
@@ -227,6 +248,20 @@ describe("verify-booking-token route", () => {
     });
 
     it("should preserve the request origin in redirect URL (not hardcode localhost)", async () => {
+      createMockBooking({
+        id: 1,
+        uid: "booking-uid",
+        oneTimePassword: "t",
+      });
+      createMockUser({
+        id: 1,
+        uuid: "user-uuid",
+        email: "test@example.com",
+        username: "testuser",
+        role: "USER",
+        destinationCalendar: null,
+      });
+
       const baseUrl =
         "https://custom-domain.example.org/api/verify-booking-token?action=reject&token=t&bookingUid=booking-uid&userId=1";
       const req = createMockRequest(baseUrl, "GET");
@@ -302,6 +337,20 @@ describe("verify-booking-token route", () => {
 
       for (const origin of testOrigins) {
         vi.clearAllMocks();
+        createMockBooking({
+          id: 1,
+          uid: "test-uid",
+          oneTimePassword: "t",
+        });
+        createMockUser({
+          id: 1,
+          uuid: "user-uuid",
+          email: "test@example.com",
+          username: "testuser",
+          role: "USER",
+          destinationCalendar: null,
+        });
+
         const baseUrl = `${origin}/api/verify-booking-token?action=reject&token=t&bookingUid=test-uid&userId=1`;
         const req = createMockRequest(baseUrl, "GET");
 

--- a/apps/web/app/api/verify-booking-token/__tests__/route.test.ts
+++ b/apps/web/app/api/verify-booking-token/__tests__/route.test.ts
@@ -1,8 +1,7 @@
-import { confirmHandler } from "@calcom/trpc/server/routers/viewer/bookings/confirm.handler";
 import type { NextRequest } from "next/server";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { confirmHandler } from "@calcom/trpc/server/routers/viewer/bookings/confirm.handler";
 import type { Mock } from "vitest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 const mockConfirmHandler = confirmHandler as unknown as Mock<typeof confirmHandler>;
 
 vi.mock("app/api/defaultResponderForAppDir", () => ({
@@ -89,10 +88,8 @@ function expectErrorRedirect(res: Response, path: string, error: string) {
   expect(redirectUrl.searchParams.get("error")).toBe(error);
 }
 
-import process from "node:process";
 // Import after mocks are set up
 import { GET, POST } from "../route";
-
 const DB = {
   bookings: {} as Record<
     string,
@@ -182,11 +179,12 @@ describe("verify-booking-token route", () => {
   });
 
   describe("GET handler", () => {
-    it("should handle reject action via GET for email clients that do not support forms", async () => {
+    it("should process rejection via GET (for email clients that don't support POST)", async () => {
       createMockBooking({
         id: 1,
         uid: "abc123",
         oneTimePassword: "test-token",
+        recurringEventId: null,
       });
       createMockUser({
         id: 42,
@@ -200,15 +198,20 @@ describe("verify-booking-token route", () => {
       const baseUrl =
         "https://app.example.com/api/verify-booking-token?action=reject&token=test-token&bookingUid=abc123&userId=42";
       const req = createMockRequest(baseUrl, "GET");
-      await GET(req, { params: Promise.resolve({}) });
+      const res = await GET(req, { params: Promise.resolve({}) });
+      const location = res.headers.get("location");
 
+      expect(location).toBeTruthy();
+      const redirectUrl = new URL(location!);
+
+      expect(redirectUrl.origin).toBe("https://app.example.com");
+      expect(redirectUrl.pathname).toBe("/booking/abc123");
+      expect(redirectUrl.searchParams.get("error")).toBeNull();
       expect(mockConfirmHandler).toHaveBeenCalledWith(
         expect.objectContaining({
           input: expect.objectContaining({
             bookingId: 1,
             confirmed: false,
-            reason: undefined,
-            emailsEnabled: true,
             actionSource: "MAGIC_LINK",
           }),
         })
@@ -248,20 +251,6 @@ describe("verify-booking-token route", () => {
     });
 
     it("should preserve the request origin in redirect URL (not hardcode localhost)", async () => {
-      createMockBooking({
-        id: 1,
-        uid: "booking-uid",
-        oneTimePassword: "t",
-      });
-      createMockUser({
-        id: 1,
-        uuid: "user-uuid",
-        email: "test@example.com",
-        username: "testuser",
-        role: "USER",
-        destinationCalendar: null,
-      });
-
       const baseUrl =
         "https://custom-domain.example.org/api/verify-booking-token?action=reject&token=t&bookingUid=booking-uid&userId=1";
       const req = createMockRequest(baseUrl, "GET");
@@ -337,20 +326,6 @@ describe("verify-booking-token route", () => {
 
       for (const origin of testOrigins) {
         vi.clearAllMocks();
-        createMockBooking({
-          id: 1,
-          uid: "test-uid",
-          oneTimePassword: "t",
-        });
-        createMockUser({
-          id: 1,
-          uuid: "user-uuid",
-          email: "test@example.com",
-          username: "testuser",
-          role: "USER",
-          destinationCalendar: null,
-        });
-
         const baseUrl = `${origin}/api/verify-booking-token?action=reject&token=t&bookingUid=test-uid&userId=1`;
         const req = createMockRequest(baseUrl, "GET");
 

--- a/apps/web/app/api/verify-booking-token/route.ts
+++ b/apps/web/app/api/verify-booking-token/route.ts
@@ -1,14 +1,13 @@
+import { makeUserActor } from "@calcom/features/booking-audit/lib/makeActor";
+import { distributedTracing } from "@calcom/lib/tracing/factory";
+import prisma from "@calcom/prisma";
+import { confirmHandler } from "@calcom/trpc/server/routers/viewer/bookings/confirm.handler";
+import { TRPCError } from "@trpc/server";
 import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
 import { parseRequestData } from "app/api/parseRequestData";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
-
-import { distributedTracing } from "@calcom/lib/tracing/factory";
-import prisma from "@calcom/prisma";
-import { confirmHandler } from "@calcom/trpc/server/routers/viewer/bookings/confirm.handler";
-import { TRPCError } from "@trpc/server";
-import { makeUserActor } from "@calcom/features/booking-audit/lib/makeActor";
 
 enum DirectAction {
   ACCEPT = "accept",
@@ -27,16 +26,6 @@ async function getHandler(request: NextRequest) {
 
   try {
     const { action, token, bookingUid, userId } = querySchema.parse(queryParams);
-
-    if (action === DirectAction.REJECT) {
-      // Rejections should use POST method
-      return NextResponse.redirect(
-        new URL(
-          `/booking/${bookingUid}?error=${encodeURIComponent("Rejection requires POST method")}`,
-          request.url
-        )
-      );
-    }
 
     return await handleBookingAction(action, token, bookingUid, userId, request, undefined);
   } catch {


### PR DESCRIPTION
## What does this PR do?

Fixes booking rejection failing with "Rejection requires POST method" error when users reject events from Apple Mail on iPhone.

**Root cause:** `OrganizerRequestEmailV2` wraps the reject button in `<form method="POST">`. Apple Mail (and many mobile email clients) does not support HTML forms — clicking "Reject" follows the form action URL as a plain GET request. The GET handler explicitly blocked rejections, redirecting to an error page.

