### PR TITLE
feat: add avatar-api.com fallback for attendee avatars in booking details

### DIFF
--- a/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
+++ b/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
@@ -30,8 +30,8 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@calcom/ui/components/sheet";
-import { ExternalLinkIcon, RepeatIcon } from "@coss/ui/icons";
 import { BookingHistory } from "@calcom/web/modules/booking-audit/components/BookingHistory";
+import { ExternalLinkIcon, RepeatIcon } from "@coss/ui/icons";
 import assignmentReasonBadgeTitleMap from "@lib/booking/assignmentReasonBadgeTitleMap";
 import Link from "next/link";
 import { useMemo, useRef } from "react";
@@ -41,6 +41,7 @@ import { BookingActionsDropdown } from "../../../components/booking/actions/Book
 import { BookingActionsStoreProvider } from "../../../components/booking/actions/BookingActionsStoreProvider";
 import { RejectBookingButton } from "../../../components/booking/RejectBookingButton";
 import type { BookingListingStatus } from "../../../components/booking/types";
+import { useAvatarUrl } from "../hooks/useAvatarUrl";
 import { usePaymentStatus } from "../hooks/usePaymentStatus";
 import { useBookingDetailsSheetStore } from "../store/bookingDetailsSheetStore";
 import type { BookingOutput } from "../types";
@@ -214,15 +215,15 @@ function BookingDetailsSheetInner({
   const recurringInfo =
     booking.recurringEventId && booking.eventType?.recurringEvent
       ? {
-        count: booking.eventType.recurringEvent.count,
-        recurringEvent: booking.eventType.recurringEvent,
-      }
+          count: booking.eventType.recurringEvent.count,
+          recurringEvent: booking.eventType.recurringEvent,
+        }
       : null;
 
   const customResponses = booking.responses
     ? Object.entries(booking.responses as Record<string, unknown>)
-      .filter(([fieldName]) => shouldShowFieldInCustomResponses(fieldName))
-      .map(([question, answer]) => [question, answer] as [string, unknown])
+        .filter(([fieldName]) => shouldShowFieldInCustomResponses(fieldName))
+        .map(([question, answer]) => [question, answer] as [string, unknown])
     : [];
 
   const reason =
@@ -460,7 +461,7 @@ function DisplayTimestamp({
   const start = startTime instanceof Date ? dayjs(startTime).tz(timeZone) : startTime;
   const end = endTime instanceof Date ? dayjs(endTime).tz(timeZone) : endTime;
   const localizedTimezone = timeZone
-    ? formatToLocalizedTimezone(start, language, timeZone) ?? timeZone
+    ? (formatToLocalizedTimezone(start, language, timeZone) ?? timeZone)
     : start.format("Z");
 
   return (
@@ -507,31 +508,34 @@ function WhoSection({ booking }: { booking: BookingOutput }) {
           </div>
         )}
 
-        {booking.attendees.map((attendee, idx) => {
-          const name = attendee.user?.name || attendee.name || attendee.user?.email || attendee.email;
-          return (
-            <div key={idx} className="flex items-center gap-4">
-              <Avatar
-                size="md"
-                imageSrc={
-                  attendee.user?.avatarUrl
-                    ? getUserAvatarUrl(attendee.user)
-                    : getPlaceholderAvatar(null, name)
-                }
-                alt={name}
-              />
-              <div className="min-w-0 flex-1">
-                <p className="text-emphasis truncate text-sm leading-[1.2]">{name}</p>
-                {attendee.phoneNumber && (
-                  <p className="text-default truncate text-sm leading-[1.2]">{attendee.phoneNumber}</p>
-                )}
-                <p className="text-default truncate text-sm leading-[1.2]">{attendee.email}</p>
-              </div>
-            </div>
-          );
-        })}
+        {booking.attendees.map((attendee, idx) => (
+          <AttendeeRow key={idx} attendee={attendee} />
+        ))}
       </div>
     </Section>
+  );
+}
+
+function AttendeeRow({ attendee }: { attendee: BookingOutput["attendees"][number] }) {
+  const name = attendee.user?.name || attendee.name || attendee.user?.email || attendee.email;
+  const hasAvatar = !!attendee.user?.avatarUrl;
+  const avatarApiFallback = useAvatarUrl(attendee.email, !hasAvatar);
+
+  const imageSrc = hasAvatar
+    ? getUserAvatarUrl(attendee.user)
+    : (avatarApiFallback ?? getPlaceholderAvatar(null, name));
+
+  return (
+    <div className="flex items-center gap-4">
+      <Avatar size="md" imageSrc={imageSrc} alt={name} />
+      <div className="min-w-0 flex-1">
+        <p className="text-emphasis truncate text-sm leading-[1.2]">{name}</p>
+        {attendee.phoneNumber && (
+          <p className="text-default truncate text-sm leading-[1.2]">{attendee.phoneNumber}</p>
+        )}
+        <p className="text-default truncate text-sm leading-[1.2]">{attendee.email}</p>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
+++ b/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
@@ -518,12 +518,15 @@ function WhoSection({ booking }: { booking: BookingOutput }) {
 
 function AttendeeRow({ attendee }: { attendee: BookingOutput["attendees"][number] }) {
   const name = attendee.user?.name || attendee.name || attendee.user?.email || attendee.email;
-  const hasAvatar = !!attendee.user?.avatarUrl;
+  const hasAvatar = !!(attendee.user && attendee.user.avatarUrl);
   const avatarApiFallback = useAvatarUrl(attendee.email, !hasAvatar);
 
-  const imageSrc = hasAvatar
-    ? getUserAvatarUrl(attendee.user)
-    : (avatarApiFallback ?? getPlaceholderAvatar(null, name));
+  let imageSrc: string;
+  if (attendee.user && attendee.user.avatarUrl) {
+    imageSrc = getUserAvatarUrl(attendee.user);
+  } else {
+    imageSrc = avatarApiFallback ?? getPlaceholderAvatar(null, name);
+  }
 
   return (
     <div className="flex items-center gap-4">

--- a/apps/web/modules/bookings/hooks/useAvatarUrl.ts
+++ b/apps/web/modules/bookings/hooks/useAvatarUrl.ts
@@ -1,0 +1,15 @@
+import { trpc } from "@calcom/trpc/react";
+
+export function useAvatarUrl(email: string | undefined, enabled: boolean) {
+  const { data } = trpc.viewer.bookings.getAvatarUrl.useQuery(
+    { email: email ?? "" },
+    {
+      enabled: enabled && !!email,
+      staleTime: 24 * 60 * 60 * 1000, // 24 hours
+      gcTime: 7 * 24 * 60 * 60 * 1000, // 7 days
+      retry: false,
+    }
+  );
+
+  return data?.url ?? null;
+}

--- a/packages/features/auth/signup/utils/prefillAvatar.ts
+++ b/packages/features/auth/signup/utils/prefillAvatar.ts
@@ -1,9 +1,9 @@
-import fetch from "node-fetch";
-
+import { AvatarApiService } from "@calcom/features/avatars/services/AvatarApiService";
 import { uploadAvatar } from "@calcom/lib/server/avatar";
 import { resizeBase64Image } from "@calcom/lib/server/resizeBase64Image";
 import prisma from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
+import fetch from "node-fetch";
 
 interface IPrefillAvatar {
   email: string;
@@ -29,7 +29,10 @@ async function downloadImageDataFromUrl(url: string) {
 }
 
 export const prefillAvatar = async ({ email }: IPrefillAvatar) => {
-  const imageUrl = await getImageUrlAvatarAPI(email);
+  const service = AvatarApiService.fromEnv();
+  if (!service) return;
+
+  const imageUrl = await service.getImageUrl(email);
   if (!imageUrl) return;
 
   const base64Image = await downloadImageDataFromUrl(imageUrl);
@@ -52,50 +55,4 @@ export const prefillAvatar = async ({ email }: IPrefillAvatar) => {
     where: { email: email },
     data,
   });
-};
-
-const getImageUrlAvatarAPI = async (email: string) => {
-  if (!process.env.AVATARAPI_USERNAME || !process.env.AVATARAPI_PASSWORD) {
-    console.info("No avatar api credentials found");
-    return null;
-  }
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 10_000);
-
-  try {
-    const response = await fetch("https://avatarapi.com/v2/api.aspx", {
-      method: "POST",
-      headers: {
-        "Content-Type": "text/plain",
-      },
-      body: JSON.stringify({
-        username: process.env.AVATARAPI_USERNAME,
-        password: process.env.AVATARAPI_PASSWORD,
-        email,
-      }),
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeout);
-
-    const info = await response.json();
-
-    if (!info.Success) {
-      if (info.Error === "Not found") {
-        // Expected case: no avatar for this email
-        return null;
-      }
-      console.warn("Avatar API error:", info.Error);
-      return null;
-    }
-    return info.Image as string;
-  } catch (error: unknown) {
-    if (error instanceof DOMException && error.name === "AbortError") {
-      console.warn("Avatar API request timed out");
-    } else {
-      console.error("Avatar API request failed:", error);
-    }
-    return null;
-  }
 };

--- a/packages/features/avatars/services/AvatarApiService.test.ts
+++ b/packages/features/avatars/services/AvatarApiService.test.ts
@@ -1,0 +1,148 @@
+import process from "node:process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AvatarApiService } from "./AvatarApiService";
+
+describe("AvatarApiService", () => {
+  let service: AvatarApiService;
+
+  beforeEach(() => {
+    service = new AvatarApiService({
+      username: "test-user",
+      password: "test-pass",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getImageUrl", () => {
+    it("returns image URL on successful response", async () => {
+      const mockImageUrl = "https://s3.avatarapi.com/some-image.png";
+
+      vi.spyOn(global, "fetch").mockResolvedValueOnce({
+        json: () => Promise.resolve({ Success: true, Image: mockImageUrl }),
+      } as Response);
+
+      const result = await service.getImageUrl("test@example.com");
+
+      expect(result).toBe(mockImageUrl);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://avatarapi.com/v2/api.aspx",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "text/plain" },
+          body: JSON.stringify({
+            username: "test-user",
+            password: "test-pass",
+            email: "test@example.com",
+          }),
+        })
+      );
+    });
+
+    it("returns null when avatar is not found", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValueOnce({
+        json: () => Promise.resolve({ Success: false, Error: "Not found" }),
+      } as Response);
+
+      const result = await service.getImageUrl("unknown@example.com");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null and warns on API error", async () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      vi.spyOn(global, "fetch").mockResolvedValueOnce({
+        json: () => Promise.resolve({ Success: false, Error: "Rate limit exceeded" }),
+      } as Response);
+
+      const result = await service.getImageUrl("test@example.com");
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith("Avatar API error:", "Rate limit exceeded");
+    });
+
+    it("returns null on network error", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      vi.spyOn(global, "fetch").mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await service.getImageUrl("test@example.com");
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith("Avatar API request failed:", expect.any(Error));
+    });
+
+    it("returns null on timeout (AbortError)", async () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      const abortError = new DOMException("The operation was aborted", "AbortError");
+      vi.spyOn(global, "fetch").mockRejectedValueOnce(abortError);
+
+      const result = await service.getImageUrl("test@example.com");
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith("Avatar API request timed out");
+    });
+
+    it("uses configured timeout", () => {
+      const customService = new AvatarApiService({
+        username: "user",
+        password: "pass",
+        timeoutMs: 5000,
+      });
+
+      expect(customService).toBeInstanceOf(AvatarApiService);
+    });
+  });
+
+  describe("fromEnv", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it("returns AvatarApiService when credentials are set", () => {
+      process.env.AVATARAPI_USERNAME = "env-user";
+      process.env.AVATARAPI_PASSWORD = "env-pass";
+
+      const result = AvatarApiService.fromEnv();
+
+      expect(result).toBeInstanceOf(AvatarApiService);
+    });
+
+    it("returns null when username is missing", () => {
+      delete process.env.AVATARAPI_USERNAME;
+      process.env.AVATARAPI_PASSWORD = "env-pass";
+
+      const result = AvatarApiService.fromEnv();
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when password is missing", () => {
+      process.env.AVATARAPI_USERNAME = "env-user";
+      delete process.env.AVATARAPI_PASSWORD;
+
+      const result = AvatarApiService.fromEnv();
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when both credentials are missing", () => {
+      delete process.env.AVATARAPI_USERNAME;
+      delete process.env.AVATARAPI_PASSWORD;
+
+      const result = AvatarApiService.fromEnv();
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/features/avatars/services/AvatarApiService.ts
+++ b/packages/features/avatars/services/AvatarApiService.ts
@@ -1,0 +1,72 @@
+import process from "node:process";
+export class AvatarApiService {
+  private username: string;
+  private password: string;
+  private timeoutMs: number;
+
+  constructor({
+    username,
+    password,
+    timeoutMs = 10_000,
+  }: {
+    username: string;
+    password: string;
+    timeoutMs?: number;
+  }) {
+    this.username = username;
+    this.password = password;
+    this.timeoutMs = timeoutMs;
+  }
+
+  async getImageUrl(email: string): Promise<string | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch("https://avatarapi.com/v2/api.aspx", {
+        method: "POST",
+        headers: {
+          "Content-Type": "text/plain",
+        },
+        body: JSON.stringify({
+          username: this.username,
+          password: this.password,
+          email,
+        }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeout);
+
+      const info = await response.json();
+
+      if (!info.Success) {
+        if (info.Error === "Not found") {
+          return null;
+        }
+        console.warn("Avatar API error:", info.Error);
+        return null;
+      }
+      return info.Image as string;
+    } catch (error: unknown) {
+      clearTimeout(timeout);
+      if (error instanceof DOMException && error.name === "AbortError") {
+        console.warn("Avatar API request timed out");
+      } else {
+        console.error("Avatar API request failed:", error);
+      }
+      return null;
+    }
+  }
+
+  static fromEnv(): AvatarApiService | null {
+    const username = process.env.AVATARAPI_USERNAME;
+    const password = process.env.AVATARAPI_PASSWORD;
+
+    if (!username || !password) {
+      return null;
+    }
+
+    return new AvatarApiService({ username, password });
+  }
+}

--- a/packages/trpc/server/routers/viewer/bookings/_router.tsx
+++ b/packages/trpc/server/routers/viewer/bookings/_router.tsx
@@ -10,6 +10,7 @@ import { ZConfirmInputSchema } from "./confirm.schema";
 import { ZEditLocationInputSchema } from "./editLocation.schema";
 import { ZFindInputSchema } from "./find.schema";
 import { ZGetInputSchema } from "./get.schema";
+import { ZGetAvatarUrlInputSchema } from "./getAvatarUrl.schema";
 import { ZGetBookingAttendeesInputSchema } from "./getBookingAttendees.schema";
 import { ZGetBookingDetailsInputSchema } from "./getBookingDetails.schema";
 import { ZGetBookingHistoryInputSchema } from "./getBookingHistory.schema";
@@ -185,4 +186,12 @@ export const bookingsRouter = router({
         input,
       });
     }),
+
+  getAvatarUrl: authedProcedure.input(ZGetAvatarUrlInputSchema).query(async ({ input }) => {
+    const { getAvatarUrlHandler } = await import("./getAvatarUrl.handler");
+
+    return getAvatarUrlHandler({
+      input,
+    });
+  }),
 });

--- a/packages/trpc/server/routers/viewer/bookings/getAvatarUrl.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/getAvatarUrl.handler.ts
@@ -1,0 +1,24 @@
+import { AvatarApiService } from "@calcom/features/avatars/services/AvatarApiService";
+import { unstable_cache } from "@calcom/lib/unstable_cache";
+import type { TGetAvatarUrlInputSchema } from "./getAvatarUrl.schema";
+
+const AVATAR_CACHE_TTL = 86400; // 24 hours
+
+const getCachedAvatarUrl = unstable_cache(
+  async (email: string) => {
+    const service = AvatarApiService.fromEnv();
+    if (!service) return null;
+    return service.getImageUrl(email);
+  },
+  ["getAvatarUrl"],
+  { revalidate: AVATAR_CACHE_TTL }
+);
+
+type GetAvatarUrlOptions = {
+  input: TGetAvatarUrlInputSchema;
+};
+
+export const getAvatarUrlHandler = async ({ input }: GetAvatarUrlOptions) => {
+  const url = await getCachedAvatarUrl(input.email);
+  return { url };
+};

--- a/packages/trpc/server/routers/viewer/bookings/getAvatarUrl.schema.ts
+++ b/packages/trpc/server/routers/viewer/bookings/getAvatarUrl.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export type TGetAvatarUrlInputSchema = {
+  email: string;
+};
+
+export const ZGetAvatarUrlInputSchema: z.ZodType<TGetAvatarUrlInputSchema> = z.object({
+  email: z.string().email(),
+});


### PR DESCRIPTION
## What does this PR do?

Uses [avatar-api.com](https://avatar-api.com) as a fallback when attendees in the Booking Details sheet don't have an existing avatar, before falling back to the generic placeholder. Results are cached at two layers:

1. **Server-side**: Next.js `unstable_cache` with a 24-hour TTL (keyed by email)
2. **Client-side**: React Query via tRPC with 24h `staleTime` / 7d `gcTime`

Additionally, extracts the duplicated avatar-api.com fetch logic from `prefillAvatar.ts` into a shared `AvatarApiService` class in `packages/features/avatars/`.

### Changes

- **`AvatarApiService`** (`packages/features/avatars/services/AvatarApiService.ts`): Reusable service class with constructor injection and a `fromEnv()` factory. Extracted from inline logic previously in `prefillAvatar.ts`.
- **tRPC endpoint** (`getAvatarUrl`): New authed query in the bookings router. Wraps the service call with `unstable_cache`.
- **`useAvatarUrl` hook** (`apps/web/modules/bookings/hooks/useAvatarUrl.ts`): Thin wrapper around the tRPC query; only fires when the attendee has no existing avatar.
- **`AttendeeRow` component**: Extracted from inline `.map()` in `WhoSection` so the hook can be called per-attendee. Uses explicit `if/else` with null checks (rather than a ternary) so TypeScript can properly narrow the nullable `attendee.user` type.
- **`prefillAvatar.ts`**: Refactored to use the shared `AvatarApiService`, removing ~46 lines of duplicated code.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A** - no user-facing docs changes needed; internal caching implementation.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **10 unit tests** for `AvatarApiService` covering success, errors, timeouts, and env var handling.

## How should this be tested?

### Prerequisites

- Set `AVATARAPI_USERNAME` and `AVATARAPI_PASSWORD` in `.env` (production credentials already exist)
- Have a booking with at least one attendee who does **not** have an existing `avatarUrl` in the database

### Test Steps

1. Open the Booking Details sheet for a booking with attendees
2. For attendees **without** an existing avatar:
   - If avatar-api.com has an avatar for their email → should display that avatar
   - If avatar-api.com returns "Not found" → should display the generic placeholder (initials)
3. For attendees **with** an existing avatar → should display their existing avatar (no API call)
4. Verify the avatar loads quickly on subsequent views (cached)

### Expected Behavior

- Attendees without avatars get a real photo from avatar-api.com if available
- Fallback chain: existing avatar → avatar-api.com → placeholder
- No visible delay due to server-side caching

## Human Review Checklist

**Critical items to verify:**

- [ ] **N+1 query pattern**: Each attendee without an avatar triggers a separate tRPC query. Confirm this is acceptable for the expected number of attendees per booking (typically 1-5). React Query deduplicates identical emails.
- [ ] **Host user intentionally excluded**: The host (`booking.user`) does **not** get the avatar-api.com fallback, only attendees do. Confirm this is intentional (hosts are Cal.com users who already went through signup prefill).
- [ ] **`unstable_cache` in tRPC context**: Verify `unstable_cache` works correctly inside a tRPC handler in the Next.js server context.
- [ ] **Untyped API response**: The `info` variable from `response.json()` is untyped (`any`), and `info.Image` is cast with `as string`. Consider if this should have proper type validation (inherited from original code).
- [ ] **Visual testing gap**: Local dev environment had a pre-existing DB auth issue, so the UI couldn't be visually verified. Manual testing in a working environment is recommended.

---

**Link to Devin run:** https://app.devin.ai/sessions/d4488866712b4464a510248b08d039c1  
**Requested by:** @eunjae-lee