### PR TITLE
fix: order custom questions by event type bookingFields in BookingDetailsSheet

### DIFF
--- a/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
+++ b/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
@@ -30,8 +30,8 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@calcom/ui/components/sheet";
-import { ExternalLinkIcon, RepeatIcon } from "@coss/ui/icons";
 import { BookingHistory } from "@calcom/web/modules/booking-audit/components/BookingHistory";
+import { ExternalLinkIcon, RepeatIcon } from "@coss/ui/icons";
 import assignmentReasonBadgeTitleMap from "@lib/booking/assignmentReasonBadgeTitleMap";
 import Link from "next/link";
 import { useMemo, useRef } from "react";
@@ -214,16 +214,12 @@ function BookingDetailsSheetInner({
   const recurringInfo =
     booking.recurringEventId && booking.eventType?.recurringEvent
       ? {
-        count: booking.eventType.recurringEvent.count,
-        recurringEvent: booking.eventType.recurringEvent,
-      }
+          count: booking.eventType.recurringEvent.count,
+          recurringEvent: booking.eventType.recurringEvent,
+        }
       : null;
 
-  const customResponses = booking.responses
-    ? Object.entries(booking.responses as Record<string, unknown>)
-      .filter(([fieldName]) => shouldShowFieldInCustomResponses(fieldName))
-      .map(([question, answer]) => [question, answer] as [string, unknown])
-    : [];
+  const responses = (booking.responses ?? {}) as Record<string, unknown>;
 
   const reason =
     booking.assignmentReasonSortedByCreatedAt?.[booking.assignmentReasonSortedByCreatedAt.length - 1];
@@ -344,7 +340,7 @@ function BookingDetailsSheetInner({
                 <AdditionalNotesSection booking={booking} />
 
                 <CustomQuestionsSection
-                  customResponses={customResponses}
+                  responses={responses}
                   bookingFields={booking.eventType?.bookingFields}
                 />
 
@@ -460,7 +456,7 @@ function DisplayTimestamp({
   const start = startTime instanceof Date ? dayjs(startTime).tz(timeZone) : startTime;
   const end = endTime instanceof Date ? dayjs(endTime).tz(timeZone) : endTime;
   const localizedTimezone = timeZone
-    ? formatToLocalizedTimezone(start, language, timeZone) ?? timeZone
+    ? (formatToLocalizedTimezone(start, language, timeZone) ?? timeZone)
     : start.format("Z");
 
   return (
@@ -691,55 +687,41 @@ function SlotsSection({ booking }: { booking: BookingOutput }) {
 }
 
 function CustomQuestionsSection({
-  customResponses,
+  responses,
   bookingFields: rawBookingFields,
 }: {
-  customResponses: [string, unknown][];
+  responses: Record<string, unknown>;
   bookingFields?: unknown;
 }) {
   const { t } = useLocale();
 
-  // Parse and memoize booking fields
   const bookingFields = useMemo(() => {
     if (!rawBookingFields) return undefined;
     const parsed = eventTypeBookingFields.safeParse(rawBookingFields);
     return parsed.success ? parsed.data : undefined;
   }, [rawBookingFields]);
 
-  // Filter out responses with falsy answers or empty arrays
-  const validResponses = useMemo(
-    (): [string, unknown][] =>
-      customResponses.filter(([, answer]) => {
-        if (!answer) return false;
-        if (Array.isArray(answer) && answer.length === 0) return false;
-        return true;
-      }),
-    [customResponses]
-  );
-
-  // Memoize field label lookups
-  const fieldLabels = useMemo(() => {
-    if (!bookingFields) return new Map<string, string>();
-
-    return new Map<string, string>(
-      bookingFields.map(
-        (field) => [field.name, field.label || t(field.defaultLabel || field.name)] as [string, string]
-      )
-    );
-  }, [bookingFields, t]);
-
-  if (validResponses.length === 0) {
+  if (!bookingFields) {
     return null;
   }
 
   return (
     <>
-      {validResponses.map(([fieldName, answer], idx) => {
-        const fieldNameStr = String(fieldName);
-        const title: string = fieldLabels.get(fieldNameStr) ?? fieldNameStr;
+      {bookingFields.map((field) => {
+        if (!field) return null;
+        if (!shouldShowFieldInCustomResponses(field.name)) return null;
+
+        const answer = responses[field.name];
+        if (!answer) return null;
+        if (Array.isArray(answer) && answer.length === 0) return null;
+
+        const label = field.label || t(field.defaultLabel || field.name);
+
         return (
-          <Section key={idx} title={title}>
-            <p className="text-emphasis text-sm font-medium">{String(answer)}</p>
+          <Section key={field.name} title={label}>
+            <p className="text-emphasis text-sm font-medium">
+              {field.type === "boolean" ? (answer ? t("yes") : t("no")) : String(answer)}
+            </p>
           </Section>
         );
       })}


### PR DESCRIPTION
## What does this PR do?

Fixes custom questions in `BookingDetailsSheet.tsx` displaying in arbitrary order instead of following the order defined in event type settings.

The existing `bookings-single-view.tsx` iterates over `eventType.bookingFields` (the ordered array from event type settings) to display custom responses. The new `BookingDetailsSheet.tsx` was instead iterating over `Object.entries(booking.responses)`, which does not preserve the configured field order.

This PR changes `CustomQuestionsSection` to iterate over `bookingFields` and look up each response, matching the approach in `bookings-single-view.tsx`.

**Additional behavioral changes:**
- Boolean fields now render as localized "Yes"/"No" instead of raw `true`/`false` (matching `bookings-single-view.tsx`)
- Uses `field.name` as React key instead of array index
- Returns `null` when `bookingFields` is unavailable (previously would render responses with raw field names as labels)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create an event type with multiple custom booking questions (e.g., text, boolean, multiselect)
2. Reorder the questions in event type settings
3. Create a booking filling in all custom fields
4. Open the booking in the new BookingDetailsSheet (sidebar) view
5. Verify custom questions appear in the same order as configured in event type settings
6. Compare with the old `bookings-single-view.tsx` page — ordering should match

## Review checklist for reviewer

- [ ] **Behavior when `bookingFields` is undefined**: The component now returns `null` if `bookingFields` is not parseable or missing. Previously it would still render responses using raw field names. Verify this is acceptable — are there scenarios where responses exist but `bookingFields` is absent?
- [ ] **Boolean field rendering**: New `field.type === "boolean"` branch renders `t("yes")`/`t("no")`. Confirm this matches expected UX.

---

> Link to Devin run: https://app.devin.ai/sessions/b26a6500af9f4e80862efd0a6e4dd074
> Requested by: @eunjae-lee