### PR TITLE
fix: address react-doctor errors (missing alt, key props, javascript: URL)

### DIFF
--- a/apps/web/components/dialog/RerouteDialog.tsx
+++ b/apps/web/components/dialog/RerouteDialog.tsx
@@ -1,11 +1,3 @@
-import { useMutation } from "@tanstack/react-query";
-import { useSession } from "next-auth/react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { useEffect, useCallback } from "react";
-import type { z } from "zod";
-
 import FormInputFields, {
   FormInputFieldsSkeleton,
 } from "@calcom/app-store/routing-forms/components/FormInputFields";
@@ -20,7 +12,7 @@ import { createBooking } from "@calcom/features/bookings/lib/create-booking";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { getUrlSearchParamsToForwardForReroute } from "@calcom/features/routing-forms/lib/getUrlSearchParamsToForward";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import type { EventType, User, Team, Attendee, Booking as PrismaBooking } from "@calcom/prisma/client";
+import type { Attendee, EventType, Booking as PrismaBooking, Team, User } from "@calcom/prisma/client";
 import { SchedulingType } from "@calcom/prisma/enums";
 import type { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 import type { RouterOutputs } from "@calcom/trpc/react";
@@ -30,8 +22,14 @@ import { Button } from "@calcom/ui/components/button";
 import { DialogContent, DialogFooter, DialogHeader } from "@calcom/ui/components/dialog";
 import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
+import { useMutation } from "@tanstack/react-query";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useCallback, useEffect, useState } from "react";
+import type { z } from "zod";
 
-const enum ReroutingStatusEnum {
+enum ReroutingStatusEnum {
   REROUTING_NOT_INITIATED = "not_initiated",
   REROUTING_IN_PROGRESS = "in_progress",
   REROUTING_COMPLETE = "complete",
@@ -644,12 +642,12 @@ const NewRoutingManager = ({
       <div>
         <span className="text-attention">
           <span>Continue with rerouting in the new</span>{" "}
-          <a
-            href="javascript:void(0)"
+          <button
+            type="button"
             className="text-attention underline"
             onClick={() => reroutingState.value?.reschedulerWindow?.focus()}>
             tab
-          </a>
+          </button>
         </span>
       </div>
     );

--- a/apps/web/modules/blocklist/components/BlockedEntriesTable.tsx
+++ b/apps/web/modules/blocklist/components/BlockedEntriesTable.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import type { RowSelectionState } from "@tanstack/react-table";
-import { getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
-import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
-
-import { DataTableSelectionBar, DataTableWrapper } from "@calcom/web/modules/data-table/components";
+import type { BlocklistEntry, BlocklistPermissions, BlocklistScope } from "@calcom/features/blocklist/types";
 import { IS_CALCOM } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button } from "@calcom/ui/components/button";
 import { ConfirmationDialogContent, Dialog } from "@calcom/ui/components/dialog";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
-
-import type { BlocklistEntry, BlocklistPermissions, BlocklistScope } from "@calcom/features/blocklist/types";
+import { DataTableSelectionBar, DataTableWrapper } from "@calcom/web/modules/data-table/components";
+import type { RowSelectionState } from "@tanstack/react-table";
+import { getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
 import { useBlockedEntriesColumns } from "./BlockedEntriesColumns";
 import { BlocklistEntryDetailsSheet } from "./BlocklistEntryDetailsSheet";
 
@@ -144,7 +142,7 @@ export function BlockedEntriesTable<T extends BlocklistEntry>({
         paginationMode="standard"
         EmptyView={
           <EmptyScreen
-            customIcon={<img className="mb-6" src="/slash-icon-cards.svg" />}
+            customIcon={<img className="mb-6" src="/slash-icon-cards.svg" alt="" />}
             headline={
               searchTerm
                 ? t("no_result_found_for", { searchTerm })

--- a/apps/web/modules/blocklist/components/PendingReportsTable.tsx
+++ b/apps/web/modules/blocklist/components/PendingReportsTable.tsx
@@ -1,16 +1,14 @@
 "use client";
 
+import type { BlocklistScope, GroupedBookingReport } from "@calcom/features/blocklist/types";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import type { WatchlistType } from "@calcom/prisma/enums";
+import { EmptyScreen } from "@calcom/ui/components/empty-screen";
+import { DataTableSelectionBar, DataTableWrapper } from "@calcom/web/modules/data-table/components";
 import type { RowSelectionState } from "@tanstack/react-table";
 import { getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
-
-import { DataTableSelectionBar, DataTableWrapper } from "@calcom/web/modules/data-table/components";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import type { WatchlistType } from "@calcom/prisma/enums";
-import { EmptyScreen } from "@calcom/ui/components/empty-screen";
-
-import type { GroupedBookingReport, BlocklistScope } from "@calcom/features/blocklist/types";
 import { BookingReportDetailsModal } from "./BookingReportDetailsModal";
 import { usePendingReportsColumns } from "./PendingReportsColumns";
 
@@ -96,7 +94,7 @@ export function PendingReportsTable<T extends GroupedBookingReport>({
         paginationMode="standard"
         EmptyView={
           <EmptyScreen
-            customIcon={<img className="mb-6" src="/slash-icon-cards.svg" />}
+            customIcon={<img className="mb-6" src="/slash-icon-cards.svg" alt="" />}
             headline={t("no_pending_reports")}
             className="bg-muted mb-16"
             iconWrapperClassName="bg-default"

--- a/apps/web/modules/ee/teams/components/EditMemberSheet.tsx
+++ b/apps/web/modules/ee/teams/components/EditMemberSheet.tsx
@@ -1,27 +1,24 @@
+import type { MemberPermissions } from "@calcom/features/pbac/lib/team-member-permissions";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { MembershipRole } from "@calcom/prisma/enums";
+import { trpc } from "@calcom/trpc/react";
+import { Avatar } from "@calcom/ui/components/avatar";
+import { Form, Select, ToggleGroup } from "@calcom/ui/components/form";
+import { Icon } from "@calcom/ui/components/icon";
+import { Sheet, SheetBody, SheetContent, SheetFooter, SheetHeader } from "@calcom/ui/components/sheet";
+import { Loader, Skeleton } from "@calcom/ui/components/skeleton";
+import { showToast } from "@calcom/ui/components/toast";
+import { Tooltip } from "@calcom/ui/components/tooltip";
+import { DisplayInfo } from "@calcom/web/modules/users/components/UserTable/EditSheet/DisplayInfo";
+import { SheetFooterControls } from "@calcom/web/modules/users/components/UserTable/EditSheet/SheetFooterControls";
+import { useEditMode } from "@calcom/web/modules/users/components/UserTable/EditSheet/store";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Dispatch } from "react";
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { shallow } from "zustand/shallow";
-
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { MembershipRole } from "@calcom/prisma/enums";
-import { trpc } from "@calcom/trpc/react";
-import { Avatar } from "@calcom/ui/components/avatar";
-import { Form } from "@calcom/ui/components/form";
-import { ToggleGroup, Select } from "@calcom/ui/components/form";
-import { Icon } from "@calcom/ui/components/icon";
-import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetBody } from "@calcom/ui/components/sheet";
-import { Skeleton, Loader } from "@calcom/ui/components/skeleton";
-import { showToast } from "@calcom/ui/components/toast";
-import { Tooltip } from "@calcom/ui/components/tooltip";
-import { DisplayInfo } from "@calcom/web/modules/users/components/UserTable/EditSheet/DisplayInfo";
-import { SheetFooterControls } from "@calcom/web/modules/users/components/UserTable/EditSheet/SheetFooterControls";
-import { useEditMode } from "@calcom/web/modules/users/components/UserTable/EditSheet/store";
-import type { MemberPermissions } from "@calcom/features/pbac/lib/team-member-permissions";
-
-import { updateRoleInCache, getUpdatedUser } from "./MemberChangeRoleModal";
+import { getUpdatedUser, updateRoleInCache } from "./MemberChangeRoleModal";
 import type { Action, State, User } from "./MemberList";
 
 const formSchema = z.object({
@@ -172,13 +169,13 @@ export function EditMemberSheet({
   const appList = (connectedApps || []).map(({ logo, name, externalId }) => {
     return logo ? (
       externalId ? (
-        <div className="ltr:mr-2 rtl:ml-2 ">
+        <div key={name} className="ltr:mr-2 rtl:ml-2 ">
           <Tooltip content={externalId}>
             <img className="h-5 w-5" src={logo} alt={`${name} logo`} />
           </Tooltip>
         </div>
       ) : (
-        <div className="ltr:mr-2 rtl:ml-2">
+        <div key={name} className="ltr:mr-2 rtl:ml-2">
           <img className="h-5 w-5" src={logo} alt={`${name} logo`} />
         </div>
       )


### PR DESCRIPTION
## What does this PR do?

Fixes 5 error-severity issues reported by [react-doctor](https://www.react.doctor/) across 4 files in `apps/web`:

| File | Issue | Fix |
|------|-------|-----|
| `BlockedEntriesTable.tsx` | Missing `alt` on `<img>` | Added `alt=""` (decorative image) |
| `PendingReportsTable.tsx` | Missing `alt` on `<img>` | Added `alt=""` (decorative image) |
| `EditMemberSheet.tsx` | Missing `key` prop in `.map()` iterator (×2) | Added `key={name}` to both branches |
| `RerouteDialog.tsx` | `javascript:void(0)` URL (security) | Replaced `<a>` with `<button type="button">` |

> Import reordering in the diff is from the biome pre-commit hook, not manual edits.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — trivial attribute/element fixes with no behavioral change.

## How should this be tested?

No special setup needed. These are static fixes:
- Verify no console warnings for missing `alt` or `key` props on the affected pages (blocklist tables, team member edit sheet).
- Verify the "tab" link in the reroute dialog still focuses the rescheduler window when clicked.

## Human Review Checklist

- [ ] **RerouteDialog.tsx**: Confirm the `<a>` → `<button>` swap doesn't break visual styling (buttons have different defaults than anchors — cursor, padding, etc.). The `text-attention underline` classes are preserved but a quick visual check is worthwhile.
- [ ] **EditMemberSheet.tsx**: `key={name}` assumes connected app names are unique per user. Verify this is a safe assumption (duplicate names would produce a React duplicate-key warning, but is still better than the current missing-key error).

---

> Link to Devin run: https://app.devin.ai/sessions/8dbb3865b0e74db3a92d2aa0968d2c5a
> Requested by: @eunjae-lee