### PR TITLE
fix: enforce emailVerified check on booking creation for logged-in users

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/checkIfUserEmailIsVerified.ts
+++ b/packages/features/bookings/lib/handleNewBooking/checkIfUserEmailIsVerified.ts
@@ -1,0 +1,27 @@
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
+import prisma from "@calcom/prisma";
+
+export const checkIfUserEmailIsVerified = async ({ userId }: { userId?: number }) => {
+  if (!userId || userId <= 0) {
+    return;
+  }
+
+  const user = await prisma.user.findFirst({
+    where: { id: userId },
+    select: {
+      emailVerified: true,
+    },
+  });
+
+  if (!user) {
+    return;
+  }
+
+  if (!user.emailVerified) {
+    throw new ErrorWithCode(
+      ErrorCode.UserEmailNotVerified,
+      "Your email must be verified before you can create a booking."
+    );
+  }
+};

--- a/packages/features/bookings/lib/handleNewBooking/test/booking-validations.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/booking-validations.test.ts
@@ -3,26 +3,22 @@
  * These specifications verify the business rules and validation behavior for booking creation
  */
 import prismaMock from "@calcom/testing/lib/__mocks__/prisma";
-
 import {
   createBookingScenario,
-  TestData,
-  getOrganizer,
   getBooker,
-  getScenarioData,
   getGoogleCalendarCredential,
-  mockCalendarToHaveNoBusySlots,
   getMockBookingAttendee,
+  getOrganizer,
+  getScenarioData,
+  mockCalendarToHaveNoBusySlots,
+  TestData,
 } from "@calcom/testing/lib/bookingScenario/bookingScenario";
+import process from "node:process";
+import { BookingStatus } from "@calcom/prisma/enums";
 import { getMockRequestDataForBooking } from "@calcom/testing/lib/bookingScenario/getMockRequestDataForBooking";
 import { setupAndTeardown } from "@calcom/testing/lib/bookingScenario/setupAndTeardown";
-
-import { afterEach, beforeEach, vi } from "vitest";
-import { describe, expect } from "vitest";
-
-import { BookingStatus } from "@calcom/prisma/enums";
 import { test } from "@calcom/testing/lib/fixtures/fixtures";
-
+import { afterEach, beforeEach, describe, expect, vi } from "vitest";
 import { getNewBookingHandler } from "./getNewBookingHandler";
 
 vi.mock("@calcom/features/auth/lib/verifyCodeUnAuthenticated", () => ({
@@ -1257,6 +1253,211 @@ describe("Booking Validation Specifications", () => {
       ).rejects.toThrow("Invalid verification code");
 
       expect(verifyCodeUnAuthenticated).toHaveBeenCalledWith("user@example.com", "invalid-code");
+    });
+  });
+
+  describe("Logged-in User Email Verification", () => {
+    test("should block booking when logged-in user has not verified their email", async () => {
+      const handleNewBooking = getNewBookingHandler();
+
+      const booker = getBooker({
+        email: "unverified@example.com",
+        name: "Unverified User",
+      });
+
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+        emailVerified: new Date(),
+      });
+
+      const unverifiedUser = getOrganizer({
+        name: "Unverified User",
+        email: "unverified@example.com",
+        id: 201,
+        schedules: [TestData.schedules.IstWorkHours],
+        emailVerified: null,
+      });
+
+      await createBookingScenario(
+        getScenarioData({
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 30,
+              length: 30,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+            },
+          ],
+          organizer,
+          usersApartFromOrganizer: [unverifiedUser],
+          apps: [TestData.apps["google-calendar"]],
+        })
+      );
+
+      await mockCalendarToHaveNoBusySlots("googlecalendar", {});
+
+      const mockBookingData = getMockRequestDataForBooking({
+        data: {
+          eventTypeId: 1,
+          responses: {
+            email: booker.email,
+            name: booker.name,
+            location: { optionValue: "", value: "New York" },
+          },
+        },
+      });
+
+      await expect(
+        handleNewBooking({
+          bookingData: mockBookingData,
+          userId: 201,
+        })
+      ).rejects.toThrow("Your email must be verified before you can create a booking.");
+    });
+
+    test("should allow booking when logged-in user has verified their email", async () => {
+      const handleNewBooking = getNewBookingHandler();
+
+      const booker = getBooker({
+        email: "verified@example.com",
+        name: "Verified User",
+      });
+
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+        emailVerified: new Date(),
+      });
+
+      const verifiedUser = getOrganizer({
+        name: "Verified User",
+        email: "verified@example.com",
+        id: 201,
+        schedules: [TestData.schedules.IstWorkHours],
+        emailVerified: new Date(),
+      });
+
+      await createBookingScenario(
+        getScenarioData({
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 30,
+              length: 30,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+            },
+          ],
+          organizer,
+          usersApartFromOrganizer: [verifiedUser],
+          apps: [TestData.apps["google-calendar"]],
+        })
+      );
+
+      await mockCalendarToHaveNoBusySlots("googlecalendar", {});
+
+      const mockBookingData = getMockRequestDataForBooking({
+        data: {
+          eventTypeId: 1,
+          responses: {
+            email: booker.email,
+            name: booker.name,
+            location: { optionValue: "", value: "New York" },
+          },
+        },
+      });
+
+      const createdBooking = await handleNewBooking({
+        bookingData: mockBookingData,
+        userId: 201,
+      });
+
+      expect(createdBooking).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+          uid: expect.any(String),
+          status: BookingStatus.ACCEPTED,
+        })
+      );
+    });
+
+    test("should allow booking when user is not logged in (guest booking)", async () => {
+      const handleNewBooking = getNewBookingHandler();
+
+      const booker = getBooker({
+        email: "guest@example.com",
+        name: "Guest User",
+      });
+
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+        emailVerified: new Date(),
+      });
+
+      await createBookingScenario(
+        getScenarioData({
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 30,
+              length: 30,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+            },
+          ],
+          organizer,
+          apps: [TestData.apps["google-calendar"]],
+        })
+      );
+
+      await mockCalendarToHaveNoBusySlots("googlecalendar", {});
+
+      const mockBookingData = getMockRequestDataForBooking({
+        data: {
+          eventTypeId: 1,
+          responses: {
+            email: booker.email,
+            name: booker.name,
+            location: { optionValue: "", value: "New York" },
+          },
+        },
+      });
+
+      const createdBooking = await handleNewBooking({
+        bookingData: mockBookingData,
+      });
+
+      expect(createdBooking).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+          uid: expect.any(String),
+          status: BookingStatus.ACCEPTED,
+        })
+      );
     });
   });
 });

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -113,6 +113,7 @@ import {
 } from "../handleNewBooking/buildBookingEventAuditData";
 import { checkActiveBookingsLimitForBooker } from "../handleNewBooking/checkActiveBookingsLimitForBooker";
 import { checkIfBookerEmailIsBlocked } from "../handleNewBooking/checkIfBookerEmailIsBlocked";
+import { checkIfUserEmailIsVerified } from "../handleNewBooking/checkIfUserEmailIsVerified";
 import type { Booking } from "../handleNewBooking/createBooking";
 import { createBooking } from "../handleNewBooking/createBooking";
 import { ensureAvailableUsers } from "../handleNewBooking/ensureAvailableUsers";
@@ -670,6 +671,15 @@ async function handler(
   });
 
   const emailsAndSmsHandler = new BookingEmailSmsHandler({ logger: tracingLogger });
+
+  try {
+    await checkIfUserEmailIsVerified({ userId });
+  } catch (error) {
+    if (error instanceof ErrorWithCode) {
+      throw new HttpError({ statusCode: 403, message: error.message });
+    }
+    throw error;
+  }
 
   try {
     await checkIfBookerEmailIsBlocked({

--- a/packages/lib/errorCodes.ts
+++ b/packages/lib/errorCodes.ts
@@ -41,4 +41,5 @@ export enum ErrorCode {
   BookerEmailRequiresLogin = "booker_email_requires_login",
   InvalidVerificationCode = "invalid_verification_code",
   UnableToValidateVerificationCode = "unable_to_validate_verification_code",
+  UserEmailNotVerified = "user_email_not_verified",
 }


### PR DESCRIPTION
## What does this PR do?

Previously, logged-in users with unverified emails (`emailVerified = null`) could create bookings without restriction. This PR adds a validation check in the booking creation flow that blocks logged-in users whose email is not verified from creating bookings. Guest (unauthenticated) bookings are unaffected.

**Changes:**
- Adds `checkIfUserEmailIsVerified` validation function that queries the logged-in user's `emailVerified` status and throws a `403` if it's null
- Calls this check in `RegularBookingService` before the existing `checkIfBookerEmailIsBlocked` check
- Adds `UserEmailNotVerified` to the `ErrorCode` enum
- Adds 3 test cases: blocked unverified user, allowed verified user, allowed guest

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a user account but do not verify the email (set `emailVerified` to `null` in the database)
2. Log in as that user and attempt to book an event type
3. The booking should be rejected with a 403 error: `"Your email must be verified before you can create a booking."`
4. Verify that guest bookings (not logged in) still work normally
5. Verify that logged-in users with verified emails can still book normally

Run the unit tests:
```bash
TZ=UTC yarn vitest run packages/features/bookings/lib/handleNewBooking/test/booking-validations.test.ts
```

## Important Review Notes

- **`InstantBookingCreateService` is not covered** by this check. It has its own independent booking flow that does not go through `RegularBookingService`. A reviewer should decide whether instant bookings also need this enforcement (and if so, that can be added here or as a follow-up).
- `RecurringBookingService` delegates to `RegularBookingService` for each slot, so it **is** implicitly covered.
- The new `checkIfUserEmailIsVerified.ts` imports `prisma` directly, consistent with the sibling `checkIfBookerEmailIsBlocked.ts` in the same directory.

<!-- Link to Devin run: https://app.devin.ai/sessions/cb5b5cff9a764609ac6dc92119788065 -->
<!-- Requested by: @emrysal -->