### PR TITLE
fix: parse JSON string for name field prefill from URL query params

### DIFF
--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -330,7 +330,7 @@ describe("getBookingResponsesSchema", () => {
       });
 
       // TODO: Fix this behaviour later
-      test.skip("`firstAndLastName` variant to `fullName` when passed as JSON string from URL prefill", async () => {
+      test("`firstAndLastName` variant to `fullName` when passed as JSON string from URL prefill", async () => {
         const schema = getBookingResponsesSchema({
           bookingFields: [
             {

--- a/packages/features/form-builder/schema.ts
+++ b/packages/features/form-builder/schema.ts
@@ -144,6 +144,18 @@ export const fieldTypesSchemaMap = {
       }
 
       if (typeof response === "string") {
+        try {
+          const parsed = JSON.parse(response);
+          if (parsed && typeof parsed === "object" && ("firstName" in parsed || "lastName" in parsed)) {
+            const firstAndLastNameResponse = {
+              firstName: typeof parsed.firstName === "string" ? parsed.firstName : "",
+              lastName: typeof parsed.lastName === "string" ? parsed.lastName : "",
+            };
+            return preprocessNameFieldDataWithVariant(correctedVariant, firstAndLastNameResponse);
+          }
+        } catch {
+          // fall through and treat as plain fullName string
+        }
         return preprocessNameFieldDataWithVariant(correctedVariant, response);
       }
 


### PR DESCRIPTION
## What does this PR do?

This PR adds JSON.parse detection in the name field's preprocess handler in fieldTypesSchemaMap. If the string successfully parses into an object with firstName/lastName keys, it is normalized and passed to preprocessNameFieldDataWithVariant correctly. Plain strings fall through to the original behavior unchanged.

- Fixes #28034 (GitHub issue number)
- Fixes CAL-7232 (Linear issue number - should be visible at the bottom of the GitHub issue description)

#### Image Demo (if applicable):

<img width="957" height="59" alt="image" src="https://github.com/user-attachments/assets/d57df053-9436-442d-a238-f58237b24529" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.