### PR TITLE
fix: Holidays tab heading is cleared

### DIFF
--- a/apps/web/modules/settings/my-account/holidays-view.tsx
+++ b/apps/web/modules/settings/my-account/holidays-view.tsx
@@ -279,8 +279,8 @@ export function HolidaysView() {
 
   return (
     <SettingsHeader
-      title={t("out_of_office")}
-      description={t("out_of_office_description")}
+      title={t("holidays")}
+      description={t("holidays_description")}
       borderInShellHeader={true}
       CTA={<HolidaysCTA />}>
       <div className="border-subtle rounded-b-lg border border-t-0 px-4 py-6 sm:px-6">

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,6 +27,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",


### PR DESCRIPTION
###Before PR

<img width="1430" height="747" alt="image" src="https://github.com/user-attachments/assets/9f3911c6-24ba-45d0-ae73-3197d88a009a" />


###After PR

<img width="906" height="171" alt="image" src="https://github.com/user-attachments/assets/1475c6f1-6592-41fd-ade8-362bdc9cec1d" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the correct “Holidays” title and description on the Holidays settings tab. Also adds “link-as-an-app” to the redirect apps list.

<sup>Written for commit 9955cc9b91687a7498bc4ce9c476205667c00d59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

