### PR TITLE
fix(booker): prevent toggle button from unselecting when clicked again

### DIFF
--- a/packages/features/bookings/components/Header.tsx
+++ b/packages/features/bookings/components/Header.tsx
@@ -240,6 +240,7 @@ const LayoutToggle = ({
       defaultValue={layout}
       aria-label={t("layout")}
       options={layoutOptions}
+      layout={layout}
     />
   );
 };

--- a/packages/ui/components/form/toggleGroup/ToggleGroup.tsx
+++ b/packages/ui/components/form/toggleGroup/ToggleGroup.tsx
@@ -17,6 +17,7 @@ interface ToggleGroupProps extends Omit<RadixToggleGroup.ToggleGroupSingleProps,
   }[];
   isFullWidth?: boolean;
   orientation?: "horizontal" | "vertical";
+  layout?: string;
 }
 
 const OptionalTooltipWrapper = ({
@@ -42,13 +43,15 @@ export const ToggleGroup = ({
   isFullWidth,
   orientation = "horizontal",
   customClassNames,
+  layout,
   ...props
-}: ToggleGroupProps & { customClassNames?: string }) => {
+}: ToggleGroupProps & { customClassNames?: string }) => {  
   return (
     <>
       <RadixToggleGroup.Root
         type="single"
         {...props}
+        value={layout}
         orientation={orientation}
         onValueChange={onValueChange}
         style={{
@@ -83,7 +86,8 @@ export const ToggleGroup = ({
                   "flex items-center gap-1",
                   orientation === "horizontal" && "justify-center",
                   orientation === "vertical" && "justify-start"
-                )}>
+                )}
+                >
                 {option.iconLeft && <span className="flex h-4 w-4 items-center">{option.iconLeft}</span>}
                 {option.label}
               </div>


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue in the Booker layout toggle where clicking the same button again would unset the selection (aria-checked became false).The layout should remain selected unless a different option is chosen.

- Fixes #28060
- Fixes [CAL-7238](https://linear.app/calcom/issue/CAL-7238/booker-page-view-toggle-button-loses-selected-state-when-clicking-the)

## Visual Demo (For contributors especially)

https://github.com/user-attachments/assets/6fbc4de4-2963-4fad-ae93-920f48011819

## Fixes : 

- Make Radix ToggleGroup Controlled by adding value={layout} in ToggleGroup.Root

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs
