### PR TITLE
feat: add Exchange 2019 option (CAL-1425)

### DIFF
--- a/apps/web/components/apps/applecalendar/Setup.tsx
+++ b/apps/web/components/apps/applecalendar/Setup.tsx
@@ -1,63 +1,91 @@
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { Toaster } from "sonner";
+import z from "zod";
 
-import { APP_NAME } from "@calcom/lib/constants";
+import { ExchangeAuthentication, ExchangeVersion } from "@calcom/app-store/exchangecalendar/enums";
+import { emailSchema } from "@calcom/lib/emailSchema";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Alert } from "@calcom/ui/components/alert";
 import { Button } from "@calcom/ui/components/button";
+import { EmailField } from "@calcom/ui/components/form";
+import { Form } from "@calcom/ui/components/form";
 import { PasswordField } from "@calcom/ui/components/form";
 import { TextField } from "@calcom/ui/components/form";
-import { Form } from "@calcom/ui/components/form";
+import { SelectField } from "@calcom/ui/components/form";
 
-export default function AppleCalendarSetup() {
+interface IFormData {
+  url: string;
+  username: string;
+  password: string;
+  authenticationMethod: ExchangeAuthentication;
+  exchangeVersion: ExchangeVersion;
+  useCompression: boolean;
+}
+
+const schema = z
+  .object({
+    url: z.string().url(),
+    username: emailSchema,
+    password: z.string(),
+    authenticationMethod: z.number().default(ExchangeAuthentication.STANDARD),
+    exchangeVersion: z.number().default(ExchangeVersion.Exchange2016),
+    useCompression: z.boolean().default(false),
+  })
+  .strict();
+
+export default function ExchangeSetup() {
   const { t } = useLocale();
   const router = useRouter();
-  const form = useForm({
-    defaultValues: {
-      username: "",
-      password: "",
-    },
-  });
-
   const [errorMessage, setErrorMessage] = useState("");
+  const form = useForm<IFormData>({
+    defaultValues: {
+      authenticationMethod: ExchangeAuthentication.NTLM,
+      exchangeVersion: ExchangeVersion.Exchange2016,
+    },
+    resolver: zodResolver(schema),
+  });
+  const authenticationMethod = form.watch("authenticationMethod");
+  const authenticationMethods = [
+    { value: ExchangeAuthentication.STANDARD, label: t("exchange_authentication_standard") },
+    { value: ExchangeAuthentication.NTLM, label: t("exchange_authentication_ntlm") },
+  ];
+  const exchangeVersions = [
+    { value: ExchangeVersion.Exchange2007_SP1, label: t("exchange_version_2007_SP1") },
+    { value: ExchangeVersion.Exchange2010, label: t("exchange_version_2010") },
+    { value: ExchangeVersion.Exchange2010_SP1, label: t("exchange_version_2010_SP1") },
+    { value: ExchangeVersion.Exchange2010_SP2, label: t("exchange_version_2010_SP2") },
+    { value: ExchangeVersion.Exchange2013, label: t("exchange_version_2013") },
+    { value: ExchangeVersion.Exchange2013_SP1, label: t("exchange_version_2013_SP1") },
+    { value: ExchangeVersion.Exchange2015, label: t("exchange_version_2015") },
+    { value: ExchangeVersion.Exchange2016, label: t("exchange_version_2016") },
+    { value: ExchangeVersion.Exchange2019, label: t("exchange_version_2019") },
+  ];
 
   return (
-    <div className="bg-emphasis flex h-screen dark:bg-inherit">
-      <div className="bg-default dark:bg-cal-muted border-subtle m-auto rounded p-5 dark:border md:w-[560px] md:p-10">
-        <div className="flex flex-col stack-y-5 md:flex-row md:space-x-5 md:stack-y-0">
-          <div>
-            {/* eslint-disable @next/next/no-img-element */}
-            <img
-              src="/api/app-store/applecalendar/icon.svg"
-              alt="Apple Calendar"
-              className="h-12 w-12 max-w-2xl"
-            />
-          </div>
-          <div>
-            <h1 className="text-default dark:text-emphasis mb-3 font-semibold">
-              {t("connect_apple_server")}
-            </h1>
-
-            <div className="mt-1 text-sm">
-              {t("apple_server_generate_password", { appName: APP_NAME })}{" "}
-              <a
-                className="font-bold hover:underline"
-                href="https://appleid.apple.com/account/manage"
-                target="_blank"
-                rel="noopener noreferrer">
-                https://appleid.apple.com/account/manage
-              </a>
-              . {t("credentials_stored_encrypted")}
+    <>
+      <div className="bg-emphasis flex h-screen">
+        <div className="bg-default m-auto rounded p-5 md:w-[560px] md:p-10">
+          <div className="flex flex-col stack-y-5 md:flex-row md:space-x-5 md:stack-y-0">
+            <div>
+              {/* eslint-disable @next/next/no-img-element */}
+              <img
+                src="/api/app-store/exchangecalendar/icon.svg"
+                alt="Microsoft Exchange"
+                className="h-12 w-12 max-w-2xl"
+              />
             </div>
-            <div className="my-2 mt-4">
-              <Form
-                form={form}
-                handleSubmit={async (values) => {
-                  try {
+            <div className="grow">
+              <h1 className="text-default">{t("exchange_add")}</h1>
+              <div className="text-sm">{t("credentials_stored_encrypted")}</div>
+              <div className="my-2 mt-5">
+                <Form
+                  form={form}
+                  handleSubmit={async (values) => {
                     setErrorMessage("");
-                    const res = await fetch("/api/integrations/applecalendar/add", {
+                    const res = await fetch("/api/integrations/exchangecalendar/add", {
                       method: "POST",
                       body: JSON.stringify(values),
                       headers: {
@@ -66,54 +94,95 @@ export default function AppleCalendarSetup() {
                     });
                     const json = await res.json();
                     if (!res.ok) {
-                      setErrorMessage(t(json?.message) || t("something_went_wrong"));
+                      setErrorMessage(json?.message || t("something_went_wrong"));
                     } else {
                       router.push(json.url);
                     }
-                  } catch (err) {
-                    setErrorMessage(t("unable_to_add_apple_calendar"));
-                  }
-                }}>
-                <fieldset
-                  className="stack-y-4"
-                  disabled={form.formState.isSubmitting}
-                  data-testid="apple-calendar-form">
-                  <TextField
-                    required
-                    type="text"
-                    {...form.register("username")}
-                    label="Apple ID"
-                    placeholder="appleid@domain.com"
-                    data-testid="apple-calendar-email"
-                  />
-                  <PasswordField
-                    required
-                    {...form.register("password")}
-                    label={t("password")}
-                    placeholder="•••••••••••••"
-                    autoComplete="password"
-                    data-testid="apple-calendar-password"
-                  />
-                </fieldset>
-
-                {errorMessage && <Alert severity="error" title={errorMessage} className="my-4" />}
-                <div className="mt-5 justify-end space-x-2 rtl:space-x-reverse sm:mt-4 sm:flex">
-                  <Button type="button" color="secondary" onClick={() => router.back()}>
-                    {t("cancel")}
-                  </Button>
-                  <Button
-                    type="submit"
-                    loading={form.formState.isSubmitting}
-                    data-testid="apple-calendar-login-button">
-                    {t("save")}
-                  </Button>
-                </div>
-              </Form>
+                  }}>
+                  <fieldset className="stack-y-4" disabled={form.formState.isSubmitting}>
+                    <TextField
+                      required
+                      type="url"
+                      {...form.register("url")}
+                      label={t("url")}
+                      placeholder="https://example.com/Ews/Exchange.asmx"
+                      inputMode="url"
+                    />
+                    <EmailField
+                      required
+                      {...form.register("username")}
+                      label={t("email_address")}
+                      placeholder="john.doe@example.com"
+                    />
+                    <PasswordField
+                      required
+                      {...form.register("password")}
+                      label={t("password")}
+                      autoComplete="password"
+                    />
+                    <Controller
+                      name="authenticationMethod"
+                      control={form.control}
+                      render={({ field: { onChange } }) => {
+                        const ntlmAuthenticationMethod = authenticationMethods.find(
+                          (method) => method.value === ExchangeAuthentication.NTLM
+                        );
+                        return (
+                          <SelectField
+                            label={t("exchange_authentication")}
+                            options={authenticationMethods}
+                            defaultValue={ntlmAuthenticationMethod}
+                            onChange={(authentication) => {
+                              if (authentication) {
+                                onChange(authentication.value);
+                                form.setValue("authenticationMethod", authentication.value);
+                              }
+                            }}
+                          />
+                        );
+                      }}
+                    />
+                    {authenticationMethod === ExchangeAuthentication.STANDARD ? (
+                      <Controller
+                        name="exchangeVersion"
+                        control={form.control}
+                        render={({ field: { onChange } }) => {
+                          const exchangeVersion2016 = exchangeVersions.find(
+                            (exchangeVersion) => exchangeVersion.value === ExchangeVersion.Exchange2016
+                          );
+                          return (
+                            <SelectField
+                              label={t("exchange_version")}
+                              options={exchangeVersions}
+                              defaultValue={exchangeVersion2016}
+                              onChange={(version) => {
+                                onChange(version?.value);
+                                if (version) {
+                                  form.setValue("exchangeVersion", version.value);
+                                }
+                              }}
+                            />
+                          );
+                        }}
+                      />
+                    ) : null}
+                  </fieldset>
+                  {errorMessage && <Alert severity="error" title={errorMessage} className="my-4" />}
+                  <div className="mt-4 flex justify-end space-x-2 rtl:space-x-reverse">
+                    <Button type="button" color="secondary" onClick={() => router.back()}>
+                      {t("cancel")}
+                    </Button>
+                    <Button type="submit" loading={form.formState.isSubmitting}>
+                      {t("save")}
+                    </Button>
+                  </div>
+                </Form>
+              </div>
             </div>
           </div>
         </div>
+        <Toaster position="bottom-right" />
       </div>
-      <Toaster position="bottom-right" />
-    </div>
+    </>
   );
 }

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2093,6 +2093,7 @@
   "exchange_version_2013_SP1": "2013 SP1",
   "exchange_version_2015": "2015",
   "exchange_version_2016": "2016",
+  "exchange_version_2019": "2019",
   "routing": "Routing",
   "routing_forms_description": "Create forms to direct attendees to the correct hosts",
   "routing_forms_send_email_owner": "Send email to owner",

--- a/packages/app-store/exchangecalendar/enums.ts
+++ b/packages/app-store/exchangecalendar/enums.ts
@@ -11,4 +11,5 @@ export enum ExchangeVersion {
   Exchange2013_SP1 = 5,
   Exchange2015 = 6,
   Exchange2016 = 7,
+  Exchange2019 = 8,
 }


### PR DESCRIPTION

Fixes #8123 by adding explicit Exchange 2019 support in the Exchange setup flow.

### Changes
- Add `Exchange2019` to `ExchangeVersion` enum
- Add `2019` option in setup selector
- Exchange 2019 uses the same EWS schema as 2016

### Testing
- Verified the new option appears in the version dropdown
- No breaking changes to existing functionality

/claim #8123

