### PR TITLE
docs: declare credentials and environment variables in calcom-api skill (agents/skills)

### DIFF
--- a/agents/skills/calcom-api/SKILL.md
+++ b/agents/skills/calcom-api/SKILL.md
@@ -1,6 +1,23 @@
 ---
 name: calcom-api
 description: Interact with the Cal.com API v2 to manage scheduling, bookings, event types, availability, and calendars. Use this skill when building integrations that need to create or manage bookings, check availability, configure event types, or sync calendars with Cal.com's scheduling infrastructure.
+metadata:
+  author: calcom
+  version: "1.0.0"
+  api-version: "v2"
+  env:
+    CAL_API_KEY:
+      description: "Cal.com API key (prefixed with cal_live_ or cal_test_). Required for all API requests."
+      required: true
+    CAL_CLIENT_ID:
+      description: "OAuth client ID for platform integrations managing users on behalf of others. Sent as x-cal-client-id header."
+      required: false
+    CAL_SECRET_KEY:
+      description: "OAuth client secret for platform integrations. Sent as x-cal-secret-key header."
+      required: false
+    CAL_WEBHOOK_SECRET:
+      description: "Secret used to verify webhook payload signatures via X-Cal-Signature-256 header."
+      required: false
 ---
 
 # Cal.com API v2
@@ -13,6 +30,15 @@ All API requests should be made to:
 ```
 https://api.cal.com/v2
 ```
+
+## Required Credentials
+
+| Environment Variable | Required | Description |
+|---------------------|----------|-------------|
+| `CAL_API_KEY` | Yes | Cal.com API key (prefixed with `cal_live_` or `cal_test_`). Used as Bearer token for all API requests. Generate from Settings > Developer > API Keys. |
+| `CAL_CLIENT_ID` | No | OAuth client ID for platform integrations that manage users on behalf of others. Sent as `x-cal-client-id` header. |
+| `CAL_SECRET_KEY` | No | OAuth client secret for platform integrations. Sent as `x-cal-secret-key` header. |
+| `CAL_WEBHOOK_SECRET` | No | Secret for verifying webhook payload signatures via the `X-Cal-Signature-256` header. |
 
 ## Authentication
 


### PR DESCRIPTION
## What does this PR do?

Moves the credential/environment variable declarations from #28047 to the correct location at `agents/skills/calcom-api/SKILL.md` (the old PR targeted the legacy `skills/` path).

Adds:
1. **Machine-readable `env` declarations** in the YAML frontmatter `metadata` block
2. **Human-readable "Required Credentials" table** in the markdown body

Declares four environment variables:

| Variable | Required | Purpose |
|----------|----------|---------|
| `CAL_API_KEY` | Yes | Bearer token for all API requests |
| `CAL_CLIENT_ID` | No | OAuth client ID for platform integrations |
| `CAL_SECRET_KEY` | No | OAuth client secret for platform integrations |
| `CAL_WEBHOOK_SECRET` | No | Webhook signature verification secret |

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A — this is a docs-only change to the skill file itself.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — documentation-only change.

## How should this be tested?

No functional testing required — metadata/documentation change only.

- Verify the YAML frontmatter parses correctly (the `env` block under `metadata` is valid YAML)
- Verify the markdown table renders correctly on GitHub

## Human Review Checklist

- [ ] **YAML frontmatter indentation**: Confirm the nested `metadata.env` block parses as valid YAML
- [ ] **Env var naming**: The webhook reference doc (`references/webhooks.md`) uses `process.env.WEBHOOK_SECRET`, but this PR declares `CAL_WEBHOOK_SECRET` (with `CAL_` prefix for namespacing). Confirm the preferred convention.
- [ ] **Credential completeness**: Verify no other credentials referenced in `references/` docs are missing from this declaration
- [ ] **Close #28047**: This supersedes #28047 which targets the old `skills/` path — that PR can be closed

## Checklist

- My code follows the style guidelines of this project
- My changes generate no new warnings

---

> Link to Devin run: https://app.devin.ai/sessions/12bdc7a018c3445da61ebf9b02ec8f10
> Requested by: @PeerRich