### PR TITLE
feat: add PBAC protection to all API v2 organization endpoints

### DIFF
--- a/apps/api/v2/src/modules/organizations/attributes/index/controllers/organizations-attributes.controller.ts
+++ b/apps/api/v2/src/modules/organizations/attributes/index/controllers/organizations-attributes.controller.ts
@@ -1,22 +1,5 @@
-import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_HEADER } from "@/lib/docs/headers";
-import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
-import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
-import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
-import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
-import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
-import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
-import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
-import { CreateOrganizationAttributeInput } from "@/modules/organizations/attributes/index/inputs/create-organization-attribute.input";
-import { UpdateOrganizationAttributeInput } from "@/modules/organizations/attributes/index/inputs/update-organization-attribute.input";
-import { CreateOrganizationAttributesOutput } from "@/modules/organizations/attributes/index/outputs/create-organization-attributes.output";
-import { DeleteOrganizationAttributesOutput } from "@/modules/organizations/attributes/index/outputs/delete-organization-attributes.output";
-import {
-  GetOrganizationAttributesOutput,
-  GetSingleAttributeOutput,
-} from "@/modules/organizations/attributes/index/outputs/get-organization-attributes.output";
-import { UpdateOrganizationAttributesOutput } from "@/modules/organizations/attributes/index/outputs/update-organization-attributes.output";
-import { OrganizationAttributesService } from "@/modules/organizations/attributes/index/services/organization-attributes.service";
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { SkipTakePagination } from "@calcom/platform-types";
 import {
   Body,
   Controller,
@@ -30,15 +13,33 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { SkipTakePagination } from "@calcom/platform-types";
+import { API_VERSIONS_VALUES } from "@/lib/api-versions";
+import { API_KEY_HEADER } from "@/lib/docs/headers";
+import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
+import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
+import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
+import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
+import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
+import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
+import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
+import { CreateOrganizationAttributeInput } from "@/modules/organizations/attributes/index/inputs/create-organization-attribute.input";
+import { UpdateOrganizationAttributeInput } from "@/modules/organizations/attributes/index/inputs/update-organization-attribute.input";
+import { CreateOrganizationAttributesOutput } from "@/modules/organizations/attributes/index/outputs/create-organization-attributes.output";
+import { DeleteOrganizationAttributesOutput } from "@/modules/organizations/attributes/index/outputs/delete-organization-attributes.output";
+import {
+  GetOrganizationAttributesOutput,
+  GetSingleAttributeOutput,
+} from "@/modules/organizations/attributes/index/outputs/get-organization-attributes.output";
+import { UpdateOrganizationAttributesOutput } from "@/modules/organizations/attributes/index/outputs/update-organization-attributes.output";
+import { OrganizationAttributesService } from "@/modules/organizations/attributes/index/services/organization-attributes.service";
 
 @Controller({
   path: "/v2/organizations/:orgId",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @DocsTags("Orgs / Attributes")
 @ApiHeader(API_KEY_HEADER)
 export class OrganizationsAttributesController {
@@ -46,6 +47,7 @@ export class OrganizationsAttributesController {
   // Gets all attributes for an organization
   @Roles("ORG_MEMBER")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.read"])
   @Get("/attributes")
   @ApiOperation({ summary: "Get all attributes" })
   async getOrganizationAttributes(
@@ -64,6 +66,7 @@ export class OrganizationsAttributesController {
   // Gets a single attribute for an organization
   @Roles("ORG_MEMBER")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.read"])
   @Get("/attributes/:attributeId")
   @ApiOperation({ summary: "Get an attribute" })
   async getOrganizationAttribute(
@@ -80,6 +83,7 @@ export class OrganizationsAttributesController {
   // Creates an attribute for an organization
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.create"])
   @Post("/attributes")
   @ApiOperation({ summary: "Create an attribute" })
   async createOrganizationAttribute(
@@ -99,6 +103,7 @@ export class OrganizationsAttributesController {
   // Updates an attribute for an organization
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.update"])
   @Patch("/attributes/:attributeId")
   @ApiOperation({ summary: "Update an attribute" })
   async updateOrganizationAttribute(
@@ -120,6 +125,7 @@ export class OrganizationsAttributesController {
   // Deletes an attribute for an organization
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.delete"])
   @Delete("/attributes/:attributeId")
   @ApiOperation({ summary: "Delete an attribute" })
   async deleteOrganizationAttribute(

--- a/apps/api/v2/src/modules/organizations/attributes/options/organizations-attributes-options.controller.ts
+++ b/apps/api/v2/src/modules/organizations/attributes/options/organizations-attributes-options.controller.ts
@@ -1,27 +1,4 @@
-import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_HEADER } from "@/lib/docs/headers";
-import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
-import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
-import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
-import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
-import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
-import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
-import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
-import { CreateOrganizationAttributeOptionInput } from "@/modules/organizations/attributes/options/inputs/create-organization-attribute-option.input";
-import { GetAssignedAttributeOptions } from "@/modules/organizations/attributes/options/inputs/get-assigned-attribute-options.input";
-import { AssignOrganizationAttributeOptionToUserInput } from "@/modules/organizations/attributes/options/inputs/organizations-attributes-options-assign.input";
-import { UpdateOrganizationAttributeOptionInput } from "@/modules/organizations/attributes/options/inputs/update-organizaiton-attribute-option.input.ts";
-import {
-  AssignOptionUserOutput,
-  UnassignOptionUserOutput,
-} from "@/modules/organizations/attributes/options/outputs/assign-option-user.output";
-import { GetAllAttributeAssignedOptionOutput } from "@/modules/organizations/attributes/options/outputs/assigned-options.output";
-import { CreateAttributeOptionOutput } from "@/modules/organizations/attributes/options/outputs/create-option.output";
-import { DeleteAttributeOptionOutput } from "@/modules/organizations/attributes/options/outputs/delete-option.output";
-import { GetOptionUserOutput } from "@/modules/organizations/attributes/options/outputs/get-option-user.output";
-import { GetAllAttributeOptionOutput } from "@/modules/organizations/attributes/options/outputs/get-option.output";
-import { UpdateAttributeOptionOutput } from "@/modules/organizations/attributes/options/outputs/update-option.output";
-import { OrganizationAttributeOptionService } from "@/modules/organizations/attributes/options/services/organization-attributes-option.service";
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import {
   Body,
   Controller,
@@ -35,14 +12,38 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { API_VERSIONS_VALUES } from "@/lib/api-versions";
+import { API_KEY_HEADER } from "@/lib/docs/headers";
+import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
+import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
+import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
+import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
+import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
+import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
+import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
+import { CreateOrganizationAttributeOptionInput } from "@/modules/organizations/attributes/options/inputs/create-organization-attribute-option.input";
+import { GetAssignedAttributeOptions } from "@/modules/organizations/attributes/options/inputs/get-assigned-attribute-options.input";
+import { AssignOrganizationAttributeOptionToUserInput } from "@/modules/organizations/attributes/options/inputs/organizations-attributes-options-assign.input";
+import { UpdateOrganizationAttributeOptionInput } from "@/modules/organizations/attributes/options/inputs/update-organizaiton-attribute-option.input.ts";
+import {
+  AssignOptionUserOutput,
+  UnassignOptionUserOutput,
+} from "@/modules/organizations/attributes/options/outputs/assign-option-user.output";
+import { GetAllAttributeAssignedOptionOutput } from "@/modules/organizations/attributes/options/outputs/assigned-options.output";
+import { CreateAttributeOptionOutput } from "@/modules/organizations/attributes/options/outputs/create-option.output";
+import { DeleteAttributeOptionOutput } from "@/modules/organizations/attributes/options/outputs/delete-option.output";
+import { GetAllAttributeOptionOutput } from "@/modules/organizations/attributes/options/outputs/get-option.output";
+import { GetOptionUserOutput } from "@/modules/organizations/attributes/options/outputs/get-option-user.output";
+import { UpdateAttributeOptionOutput } from "@/modules/organizations/attributes/options/outputs/update-option.output";
+import { OrganizationAttributeOptionService } from "@/modules/organizations/attributes/options/services/organization-attributes-option.service";
 
 @Controller({
   path: "/v2/organizations/:orgId",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @DocsTags("Orgs / Attributes / Options")
 @ApiHeader(API_KEY_HEADER)
 export class OrganizationsAttributesOptionsController {
@@ -50,6 +51,7 @@ export class OrganizationsAttributesOptionsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.create"])
   @Post("/attributes/:attributeId/options")
   @ApiOperation({ summary: "Create an attribute option" })
   async createOrganizationAttributeOption(
@@ -71,6 +73,7 @@ export class OrganizationsAttributesOptionsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.delete"])
   @Delete("/attributes/:attributeId/options/:optionId")
   @ApiOperation({ summary: "Delete an attribute option" })
   async deleteOrganizationAttributeOption(
@@ -92,6 +95,7 @@ export class OrganizationsAttributesOptionsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.update"])
   @Patch("/attributes/:attributeId/options/:optionId")
   @ApiOperation({ summary: "Update an attribute option" })
   async updateOrganizationAttributeOption(
@@ -115,6 +119,7 @@ export class OrganizationsAttributesOptionsController {
 
   @Roles("ORG_MEMBER")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.read"])
   @Get("/attributes/:attributeId/options")
   @ApiOperation({ summary: "Get all attribute options" })
   async getOrganizationAttributeOptions(
@@ -133,6 +138,7 @@ export class OrganizationsAttributesOptionsController {
 
   @Roles("ORG_MEMBER")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.read"])
   @Get("/attributes/:attributeId/options/assigned")
   @ApiOperation({ summary: "Get all assigned attribute options by attribute ID" })
   async getOrganizationAttributeAssignedOptions(
@@ -157,6 +163,7 @@ export class OrganizationsAttributesOptionsController {
 
   @Roles("ORG_MEMBER")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.read"])
   @Get("/attributes/slugs/:attributeSlug/options/assigned")
   @ApiOperation({ summary: "Get all assigned attribute options by attribute slug" })
   async getOrganizationAttributeAssignedOptionsBySlug(
@@ -181,6 +188,7 @@ export class OrganizationsAttributesOptionsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.update"])
   @Post("/attributes/options/:userId")
   @ApiOperation({ summary: "Assign an attribute to a user" })
   async assignOrganizationAttributeOptionToUser(
@@ -202,6 +210,7 @@ export class OrganizationsAttributesOptionsController {
 
   @Roles("ORG_MEMBER")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.update"])
   @Delete("/attributes/options/:userId/:attributeOptionId")
   @ApiOperation({ summary: "Unassign an attribute from a user" })
   async unassignOrganizationAttributeOptionFromUser(
@@ -223,6 +232,7 @@ export class OrganizationsAttributesOptionsController {
 
   @Roles("ORG_MEMBER")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.attributes.read"])
   @Get("/attributes/options/:userId")
   @ApiOperation({ summary: "Get all attribute options for a user" })
   async getOrganizationAttributeOptionsForUser(

--- a/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.ts
@@ -1,31 +1,32 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { GetBookingsOutput_2024_08_13, GetOrganizationsBookingsInput } from "@calcom/platform-types";
+import { Controller, Get, HttpCode, HttpStatus, Param, ParseIntPipe, Query, UseGuards } from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { BookingsService_2024_08_13 } from "@/ee/bookings/2024-08-13/services/bookings.service";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
-  OPTIONAL_X_CAL_CLIENT_ID_HEADER,
-  OPTIONAL_X_CAL_SECRET_KEY_HEADER,
   OPTIONAL_API_KEY_HEADER,
   OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER,
+  OPTIONAL_X_CAL_CLIENT_ID_HEADER,
+  OPTIONAL_X_CAL_SECRET_KEY_HEADER,
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import { Controller, UseGuards, Get, Param, ParseIntPipe, Query, HttpStatus, HttpCode } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { GetBookingsOutput_2024_08_13, GetOrganizationsBookingsInput } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId/bookings",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @DocsTags("Orgs / Bookings")
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
@@ -37,6 +38,7 @@ export class OrganizationsBookingsController {
   @ApiOperation({ summary: "Get organization bookings" })
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["booking.readOrgBookings"])
   @HttpCode(HttpStatus.OK)
   async getAllOrgTeamBookings(
     @Query() queryParams: GetOrganizationsBookingsInput,

--- a/apps/api/v2/src/modules/organizations/conferencing/organizations-conferencing.controller.ts
+++ b/apps/api/v2/src/modules/organizations/conferencing/organizations-conferencing.controller.ts
@@ -1,51 +1,52 @@
+import { CAL_VIDEO, GOOGLE_MEET, OFFICE_365_VIDEO, SUCCESS_STATUS, ZOOM } from "@calcom/platform-constants";
+import {
+  BadRequestException,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  Redirect,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToInstance } from "class-transformer";
+import { Request } from "express";
+import { stringify } from "querystring";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
+import {
+  ConferencingAppOutputResponseDto,
+  ConferencingAppsOutputDto,
+  ConferencingAppsOutputResponseDto,
+  DisconnectConferencingAppOutputResponseDto,
+} from "@/modules/conferencing/outputs/get-conferencing-apps.output";
 import {
   ConferencingAppsOauthUrlOutputDto,
   GetConferencingAppsOauthUrlResponseDto,
 } from "@/modules/conferencing/outputs/get-conferencing-apps-oauth-url";
-import {
-  ConferencingAppsOutputResponseDto,
-  ConferencingAppOutputResponseDto,
-  ConferencingAppsOutputDto,
-  DisconnectConferencingAppOutputResponseDto,
-} from "@/modules/conferencing/outputs/get-conferencing-apps.output";
 import { GetDefaultConferencingAppOutputResponseDto } from "@/modules/conferencing/outputs/get-default-conferencing-app.output";
 import { SetDefaultConferencingAppOutputResponseDto } from "@/modules/conferencing/outputs/set-default-conferencing-app.output";
 import { ConferencingService } from "@/modules/conferencing/services/conferencing.service";
 import { OrganizationsConferencingService } from "@/modules/organizations/conferencing/services/organizations-conferencing.service";
 import { TokensRepository } from "@/modules/tokens/tokens.repository";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import {
-  Controller,
-  Get,
-  Query,
-  HttpCode,
-  HttpStatus,
-  UseGuards,
-  Post,
-  Param,
-  Delete,
-  Headers,
-  Req,
-  ParseIntPipe,
-  BadRequestException,
-  Redirect,
-} from "@nestjs/common";
-import { ApiOperation, ApiTags as DocsTags, ApiParam } from "@nestjs/swagger";
-import { plainToInstance } from "class-transformer";
-import { Request } from "express";
-import { stringify } from "querystring";
-
-import { GOOGLE_MEET, ZOOM, SUCCESS_STATUS, OFFICE_365_VIDEO, CAL_VIDEO } from "@calcom/platform-constants";
 
 export type OAuthCallbackState = {
   accessToken: string;
@@ -76,7 +77,16 @@ export class OrganizationsConferencingController {
     enum: [GOOGLE_MEET],
     required: true,
   })
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["team.update"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Post("/teams/:teamId/conferencing/:app/connect")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Connect your conferencing application to a team" })
@@ -102,7 +112,16 @@ export class OrganizationsConferencingController {
     enum: [ZOOM, OFFICE_365_VIDEO],
     required: true,
   })
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["team.update"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Get("/teams/:teamId/conferencing/:app/oauth/auth-url")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Get OAuth conferencing app's auth URL for a team" })
@@ -137,7 +156,16 @@ export class OrganizationsConferencingController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["team.read"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Get("/teams/:teamId/conferencing")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "List team conferencing applications" })
@@ -156,7 +184,16 @@ export class OrganizationsConferencingController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["team.update"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Post("/teams/:teamId/conferencing/:app/default")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Set team default conferencing application" })
@@ -180,7 +217,16 @@ export class OrganizationsConferencingController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["team.read"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Get("/teams/:teamId/conferencing/default")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Get team default conferencing application" })
@@ -203,7 +249,16 @@ export class OrganizationsConferencingController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["team.update"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Delete("/teams/:teamId/conferencing/:app/disconnect")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Disconnect team conferencing application" })
@@ -229,7 +284,16 @@ export class OrganizationsConferencingController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["team.update"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Get("/teams/:teamId/conferencing/:app/oauth/callback")
   @Redirect(undefined, 301)
   @ApiOperation({ summary: "Save conferencing app OAuth credentials" })

--- a/apps/api/v2/src/modules/organizations/delegation-credentials/organizations-delegation-credential.controller.ts
+++ b/apps/api/v2/src/modules/organizations/delegation-credentials/organizations-delegation-credential.controller.ts
@@ -1,46 +1,46 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import type { User } from "@calcom/prisma/client";
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
+import { CreateDelegationCredentialInput } from "./inputs/create-delegation-credential.input";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
+  OPTIONAL_API_KEY_HEADER,
   OPTIONAL_X_CAL_CLIENT_ID_HEADER,
   OPTIONAL_X_CAL_SECRET_KEY_HEADER,
-  OPTIONAL_API_KEY_HEADER,
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { UpdateDelegationCredentialInput } from "@/modules/organizations/delegation-credentials/inputs/update-delegation-credential.input";
 import { CreateDelegationCredentialOutput } from "@/modules/organizations/delegation-credentials/outputs/create-delegation-credential.output";
 import { DelegationCredentialOutput } from "@/modules/organizations/delegation-credentials/outputs/delegation-credential.output";
 import { UpdateDelegationCredentialOutput } from "@/modules/organizations/delegation-credentials/outputs/update-delegation-credential.output";
 import { OrganizationsDelegationCredentialService } from "@/modules/organizations/delegation-credentials/services/organizations-delegation-credential.service";
-import {
-  Controller,
-  UseGuards,
-  Param,
-  ParseIntPipe,
-  Post,
-  Body,
-  HttpCode,
-  HttpStatus,
-  Patch,
-} from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import type { User } from "@calcom/prisma/client";
-
-import { CreateDelegationCredentialInput } from "./inputs/create-delegation-credential.input";
 
 @Controller({
   path: "/v2/organizations/:orgId/delegation-credentials",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @DocsTags("Orgs / Delegation Credentials")
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
@@ -51,6 +51,7 @@ export class OrganizationsDelegationCredentialController {
   @Post("/")
   @HttpCode(HttpStatus.CREATED)
   @Roles("ORG_ADMIN")
+  @Pbac(["organization.update"])
   @PlatformPlan("SCALE")
   @ApiOperation({ summary: "Save delegation credentials for your organization" })
   async createDelegationCredential(
@@ -71,6 +72,7 @@ export class OrganizationsDelegationCredentialController {
 
   @Patch("/:credentialId")
   @Roles("ORG_ADMIN")
+  @Pbac(["organization.update"])
   @PlatformPlan("SCALE")
   @ApiOperation({ summary: "Update delegation credentials of your organization" })
   async updateDelegationCredential(

--- a/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.controller.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.controller.ts
@@ -1,3 +1,29 @@
+import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
+import { handleCreatePhoneCall } from "@calcom/platform-libraries";
+import {
+  CreateTeamEventTypeInput_2024_06_14,
+  GetOrganizationEventTypesQuery_2024_06_14,
+  GetTeamEventTypesQuery_2024_06_14,
+  TeamEventTypeOutput_2024_06_14,
+  UpdateTeamEventTypeInput_2024_06_14,
+} from "@calcom/platform-types";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { CreatePhoneCallInput } from "@/ee/event-types/event-types_2024_06_14/inputs/create-phone-call.input";
 import { CreatePhoneCallOutput } from "@/ee/event-types/event-types_2024_06_14/outputs/create-phone-call.output";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
@@ -8,11 +34,13 @@ import {
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
 import { OutputTeamEventTypesResponsePipe } from "@/modules/organizations/event-types/pipes/team-event-types-response.transformer";
@@ -25,33 +53,6 @@ import { GetTeamEventTypeOutput } from "@/modules/teams/event-types/outputs/get-
 import { GetTeamEventTypesOutput } from "@/modules/teams/event-types/outputs/get-team-event-types.output";
 import { UpdateTeamEventTypeOutput } from "@/modules/teams/event-types/outputs/update-team-event-type.output";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import {
-  Controller,
-  UseGuards,
-  Get,
-  Post,
-  Param,
-  ParseIntPipe,
-  Body,
-  Patch,
-  Delete,
-  HttpCode,
-  HttpStatus,
-  NotFoundException,
-  Query,
-  Logger,
-} from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
-import { handleCreatePhoneCall } from "@calcom/platform-libraries";
-import {
-  CreateTeamEventTypeInput_2024_06_14,
-  GetOrganizationEventTypesQuery_2024_06_14,
-  GetTeamEventTypesQuery_2024_06_14,
-  TeamEventTypeOutput_2024_06_14,
-  UpdateTeamEventTypeInput_2024_06_14,
-} from "@calcom/platform-types";
 
 export type EventTypeHandlerResponse = {
   data: DatabaseTeamEventType[] | DatabaseTeamEventType;
@@ -77,7 +78,16 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["eventType.create"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Post("/teams/:teamId/event-types")
   @ApiOperation({ summary: "Create an event type" })
   async createTeamEventType(
@@ -111,7 +121,16 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["eventType.read"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Get("/teams/:teamId/event-types/:eventTypeId")
   @ApiOperation({ summary: "Get an event type" })
   async getTeamEventType(
@@ -133,8 +152,9 @@ export class OrganizationsEventTypesController {
   }
 
   @Roles("TEAM_ADMIN")
+  @Pbac(["eventType.update"])
   @Post("/teams/:teamId/event-types/:eventTypeId/create-phone-call")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, IsTeamInOrg, RolesGuard)
+  @UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, IsTeamInOrg, RolesGuard)
   @ApiOperation({ summary: "Create a phone call" })
   async createPhoneCall(
     @Param("eventTypeId") eventTypeId: number,
@@ -157,7 +177,8 @@ export class OrganizationsEventTypesController {
     };
   }
 
-  @UseGuards(IsOrgGuard, IsTeamInOrg, IsAdminAPIEnabledGuard)
+  @Pbac(["eventType.read"])
+  @UseGuards(IsOrgGuard, PbacGuard, IsTeamInOrg, IsAdminAPIEnabledGuard)
   @Get("/teams/:teamId/event-types")
   @ApiOperation({
     summary: "Get team event types",
@@ -193,7 +214,8 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["eventType.read"])
+  @UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
   @Get("/teams/event-types")
   @ApiOperation({
     summary: "Get all team event types",
@@ -220,7 +242,16 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["eventType.update"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Patch("/teams/:teamId/event-types/:eventTypeId")
   @ApiOperation({ summary: "Update a team event type" })
   async updateTeamEventType(
@@ -251,7 +282,16 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["eventType.delete"])
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Delete("/teams/:teamId/event-types/:eventTypeId")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Delete a team event type" })

--- a/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.controller.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.controller.ts
@@ -177,8 +177,7 @@ export class OrganizationsEventTypesController {
     };
   }
 
-  @Pbac(["eventType.read"])
-  @UseGuards(IsOrgGuard, PbacGuard, IsTeamInOrg, IsAdminAPIEnabledGuard)
+  @UseGuards(IsOrgGuard, IsTeamInOrg, IsAdminAPIEnabledGuard)
   @Get("/teams/:teamId/event-types")
   @ApiOperation({
     summary: "Get team event types",

--- a/apps/api/v2/src/modules/organizations/memberships/organizations-membership.controller.ts
+++ b/apps/api/v2/src/modules/organizations/memberships/organizations-membership.controller.ts
@@ -1,3 +1,20 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { SkipTakePagination } from "@calcom/platform-types";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
   OPTIONAL_API_KEY_HEADER,
@@ -5,12 +22,14 @@ import {
   OPTIONAL_X_CAL_SECRET_KEY_HEADER,
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsMembershipInOrg } from "@/modules/auth/guards/memberships/is-membership-in-org.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { CreateOrgMembershipDto } from "@/modules/organizations/memberships/inputs/create-organization-membership.input";
 import { UpdateOrgMembershipDto } from "@/modules/organizations/memberships/inputs/update-organization-membership.input";
@@ -20,30 +39,12 @@ import { GetAllOrgMemberships } from "@/modules/organizations/memberships/output
 import { GetOrgMembership } from "@/modules/organizations/memberships/outputs/get-membership.output";
 import { UpdateOrgMembership } from "@/modules/organizations/memberships/outputs/update-membership.output";
 import { OrganizationsMembershipService } from "@/modules/organizations/memberships/services/organizations-membership.service";
-import {
-  Controller,
-  UseGuards,
-  Get,
-  Param,
-  ParseIntPipe,
-  Query,
-  Delete,
-  Patch,
-  Post,
-  Body,
-  HttpCode,
-  HttpStatus,
-} from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { SkipTakePagination } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId/memberships",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @DocsTags("Orgs / Memberships")
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
@@ -53,6 +54,7 @@ export class OrganizationsMembershipsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.listMembers"])
   @Get("/")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Get all memberships" })
@@ -74,6 +76,7 @@ export class OrganizationsMembershipsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.invite"])
   @Post("/")
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: "Create a membership" })
@@ -90,6 +93,7 @@ export class OrganizationsMembershipsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.listMembers"])
   @UseGuards(IsMembershipInOrg)
   @Get("/:membershipId")
   @HttpCode(HttpStatus.OK)
@@ -107,6 +111,7 @@ export class OrganizationsMembershipsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.remove"])
   @UseGuards(IsMembershipInOrg)
   @Delete("/:membershipId")
   @HttpCode(HttpStatus.OK)
@@ -125,6 +130,7 @@ export class OrganizationsMembershipsController {
   @UseGuards(IsMembershipInOrg)
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["organization.changeMemberRole"])
   @Patch("/:membershipId")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Update a membership" })

--- a/apps/api/v2/src/modules/organizations/organizations/organizations-organizations.controller.ts
+++ b/apps/api/v2/src/modules/organizations/organizations/organizations-organizations.controller.ts
@@ -20,12 +20,14 @@ import { X_CAL_CLIENT_ID_HEADER, X_CAL_SECRET_KEY_HEADER } from "@/lib/docs/head
 import { Throttle } from "@/lib/endpoint-throttler-decorator";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsManagedOrgInManagerOrg } from "@/modules/auth/guards/organizations/is-managed-org-in-manager-org.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
 import { CreateOrganizationInput } from "@/modules/organizations/organizations/inputs/create-managed-organization.input";
@@ -42,7 +44,7 @@ const SCALE = "SCALE";
   path: "/v2/organizations/:orgId/organizations",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @DocsTags("Managed Orgs")
 @ApiHeader(X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(X_CAL_SECRET_KEY_HEADER)
@@ -52,6 +54,7 @@ export class OrganizationsOrganizationsController {
   @Post()
   @Roles("ORG_ADMIN")
   @PlatformPlan(SCALE)
+  @Pbac(["organization.create"])
   @ApiOperation({
     summary: "Create an organization within an organization",
     description:
@@ -76,6 +79,7 @@ export class OrganizationsOrganizationsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan(SCALE)
+  @Pbac(["organization.read"])
   @Get("/:managedOrganizationId")
   @ApiOperation({
     summary: "Get an organization within an organization",
@@ -95,6 +99,7 @@ export class OrganizationsOrganizationsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan(SCALE)
+  @Pbac(["organization.read"])
   @Get("/")
   @ApiOperation({
     summary: "Get all organizations within an organization",
@@ -116,6 +121,7 @@ export class OrganizationsOrganizationsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan(SCALE)
+  @Pbac(["organization.update"])
   @Patch("/:managedOrganizationId")
   @ApiOperation({
     summary: "Update an organization within an organization",
@@ -141,6 +147,7 @@ export class OrganizationsOrganizationsController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan(SCALE)
+  @Pbac(["organization.delete"])
   @Delete("/:managedOrganizationId")
   @Throttle({ limit: 1, ttl: 1000, blockDuration: 1000, name: "organizations_delete" })
   @ApiOperation({

--- a/apps/api/v2/src/modules/organizations/routing-forms/controllers/organizations-routing-forms-responses.controller.ts
+++ b/apps/api/v2/src/modules/organizations/routing-forms/controllers/organizations-routing-forms-responses.controller.ts
@@ -1,6 +1,28 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+  Version,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { Request } from "express";
+import { CreateRoutingFormResponseInput } from "../inputs/create-routing-form-response.input";
+import { GetRoutingFormResponsesParams } from "../inputs/get-routing-form-responses-params.input";
+import { UpdateRoutingFormResponseInput } from "../inputs/update-routing-form-response.input";
+import { CreateRoutingFormResponseOutput } from "../outputs/create-routing-form-response.output";
+import { UpdateRoutingFormResponseOutput } from "../outputs/update-routing-form-response.output";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { API_KEY_HEADER } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
@@ -8,38 +30,16 @@ import { Or } from "@/modules/auth/guards/or-guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
 import { IsUserRoutingForm } from "@/modules/auth/guards/organizations/is-user-routing-form.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { GetRoutingFormResponsesOutput } from "@/modules/organizations/routing-forms/outputs/get-routing-form-responses.output";
 import { OrganizationsRoutingFormsResponsesService } from "@/modules/organizations/routing-forms/services/organizations-routing-forms-responses.service";
-import {
-  Body,
-  Controller,
-  Get,
-  Param,
-  Patch,
-  Post,
-  Query,
-  UseGuards,
-  ParseIntPipe,
-  Req,
-  Version,
-} from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
-import { Request } from "express";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-
-import { CreateRoutingFormResponseInput } from "../inputs/create-routing-form-response.input";
-import { GetRoutingFormResponsesParams } from "../inputs/get-routing-form-responses-params.input";
-import { UpdateRoutingFormResponseInput } from "../inputs/update-routing-form-response.input";
-import { CreateRoutingFormResponseOutput } from "../outputs/create-routing-form-response.output";
-import { UpdateRoutingFormResponseOutput } from "../outputs/update-routing-form-response.output";
 
 @Controller({
   path: "/v2/organizations/:orgId/routing-forms/:routingFormId/responses",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @ApiTags("Orgs / Routing forms")
 @ApiHeader(API_KEY_HEADER)
 export class OrganizationsRoutingFormsResponsesController {
@@ -50,6 +50,7 @@ export class OrganizationsRoutingFormsResponsesController {
   @Get("/")
   @ApiOperation({ summary: "Get routing form responses" })
   @Roles("ORG_ADMIN")
+  @Pbac(["routingForm.read"])
   @UseGuards(RolesGuard)
   @PlatformPlan("ESSENTIALS")
   async getRoutingFormResponses(
@@ -77,6 +78,7 @@ export class OrganizationsRoutingFormsResponsesController {
   @Post("/")
   @ApiOperation({ summary: "Create routing form response and get available slots" })
   @Roles("ORG_ADMIN")
+  @Pbac(["routingForm.create"])
   @UseGuards(Or([RolesGuard, IsUserRoutingForm]))
   @PlatformPlan("ESSENTIALS")
   async createRoutingFormResponse(
@@ -100,6 +102,7 @@ export class OrganizationsRoutingFormsResponsesController {
   @Patch("/:responseId")
   @ApiOperation({ summary: "Update routing form response" })
   @Roles("ORG_ADMIN")
+  @Pbac(["routingForm.update"])
   @UseGuards(RolesGuard)
   @PlatformPlan("ESSENTIALS")
   async updateRoutingFormResponse(

--- a/apps/api/v2/src/modules/organizations/routing-forms/controllers/organizations-routing-forms.controller.ts
+++ b/apps/api/v2/src/modules/organizations/routing-forms/controllers/organizations-routing-forms.controller.ts
@@ -1,11 +1,17 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { Controller, Get, Param, ParseIntPipe, Query, UseGuards } from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { API_KEY_HEADER } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { GetRoutingFormsParams } from "@/modules/organizations/routing-forms/inputs/get-routing-form-responses-params.input";
 import {
@@ -13,17 +19,12 @@ import {
   RoutingFormOutput,
 } from "@/modules/organizations/routing-forms/outputs/get-routing-forms.output";
 import { OrganizationsRoutingFormsService } from "@/modules/organizations/routing-forms/services/organizations-routing-forms.service";
-import { Controller, Get, Param, Query, UseGuards, ParseIntPipe } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
 
 @Controller({
   path: "/v2/organizations/:orgId/routing-forms",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @ApiTags("Orgs / Routing forms")
 @ApiHeader(API_KEY_HEADER)
 export class OrganizationsRoutingFormsController {
@@ -33,6 +34,7 @@ export class OrganizationsRoutingFormsController {
   @ApiOperation({ summary: "Get organization routing forms" })
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["routingForm.read"])
   async getOrganizationRoutingForms(
     @Param("orgId", ParseIntPipe) orgId: number,
     @Query() queryParams: GetRoutingFormsParams

--- a/apps/api/v2/src/modules/organizations/schedules/organizations-schedules.controller.ts
+++ b/apps/api/v2/src/modules/organizations/schedules/organizations-schedules.controller.ts
@@ -1,3 +1,29 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import {
+  CreateScheduleInput_2024_06_11,
+  CreateScheduleOutput_2024_06_11,
+  DeleteScheduleOutput_2024_06_11,
+  GetScheduleOutput_2024_06_11,
+  GetSchedulesOutput_2024_06_11,
+  SkipTakePagination,
+  UpdateScheduleInput_2024_06_11,
+  UpdateScheduleOutput_2024_06_11,
+} from "@calcom/platform-types";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { SchedulesService_2024_06_11 } from "@/ee/schedules/schedules_2024_06_11/services/schedules.service";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
@@ -6,47 +32,22 @@ import {
   OPTIONAL_X_CAL_SECRET_KEY_HEADER,
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsUserInOrg } from "@/modules/auth/guards/users/is-user-in-org.guard";
 import { OrganizationsSchedulesService } from "@/modules/organizations/schedules/services/organizations-schedules.service";
-import {
-  Controller,
-  UseGuards,
-  Get,
-  Post,
-  Param,
-  ParseIntPipe,
-  Body,
-  Patch,
-  Delete,
-  HttpCode,
-  HttpStatus,
-  Query,
-} from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import {
-  CreateScheduleInput_2024_06_11,
-  CreateScheduleOutput_2024_06_11,
-  DeleteScheduleOutput_2024_06_11,
-  GetScheduleOutput_2024_06_11,
-  GetSchedulesOutput_2024_06_11,
-  UpdateScheduleInput_2024_06_11,
-  UpdateScheduleOutput_2024_06_11,
-} from "@calcom/platform-types";
-import { SkipTakePagination } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
 @ApiHeader(OPTIONAL_API_KEY_HEADER)
@@ -57,6 +58,7 @@ export class OrganizationsSchedulesController {
   ) {}
 
   @Roles("ORG_ADMIN")
+  @Pbac(["availability.read"])
   @PlatformPlan("ESSENTIALS")
   @Get("/schedules")
   @DocsTags("Orgs / Schedules")
@@ -76,6 +78,7 @@ export class OrganizationsSchedulesController {
   }
 
   @Roles("ORG_ADMIN")
+  @Pbac(["availability.create"])
   @PlatformPlan("ESSENTIALS")
   @UseGuards(IsUserInOrg)
   @Post("/users/:userId/schedules")
@@ -94,6 +97,7 @@ export class OrganizationsSchedulesController {
   }
 
   @Roles("ORG_ADMIN")
+  @Pbac(["availability.read"])
   @PlatformPlan("ESSENTIALS")
   @UseGuards(IsUserInOrg)
   @Get("/users/:userId/schedules/:scheduleId")
@@ -112,6 +116,7 @@ export class OrganizationsSchedulesController {
   }
 
   @Roles("ORG_ADMIN")
+  @Pbac(["availability.read"])
   @PlatformPlan("ESSENTIALS")
   @UseGuards(IsUserInOrg)
   @Get("/users/:userId/schedules")
@@ -129,6 +134,7 @@ export class OrganizationsSchedulesController {
   }
 
   @Roles("ORG_ADMIN")
+  @Pbac(["availability.update"])
   @PlatformPlan("ESSENTIALS")
   @UseGuards(IsUserInOrg)
   @Patch("/users/:userId/schedules/:scheduleId")
@@ -148,6 +154,7 @@ export class OrganizationsSchedulesController {
   }
 
   @Roles("ORG_ADMIN")
+  @Pbac(["availability.delete"])
   @PlatformPlan("ESSENTIALS")
   @UseGuards(IsUserInOrg)
   @Delete("/users/:userId/schedules/:scheduleId")

--- a/apps/api/v2/src/modules/organizations/stripe/organizations-stripe.controller.ts
+++ b/apps/api/v2/src/modules/organizations/stripe/organizations-stripe.controller.ts
@@ -1,11 +1,32 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Query,
+  Redirect,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
+import { Request } from "express";
+import { stringify } from "querystring";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
 import { OrganizationsStripeService } from "@/modules/organizations/stripe/services/organizations-stripe.service";
@@ -19,26 +40,6 @@ import { StripeService } from "@/modules/stripe/stripe.service";
 import { getOnErrorReturnToValueFromQueryState } from "@/modules/stripe/utils/getReturnToValueFromQueryState";
 import { TokensRepository } from "@/modules/tokens/tokens.repository";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import {
-  Controller,
-  Get,
-  Query,
-  HttpCode,
-  HttpStatus,
-  UseGuards,
-  Param,
-  Headers,
-  Req,
-  ParseIntPipe,
-  Redirect,
-  BadRequestException,
-} from "@nestjs/common";
-import { ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-import { Request } from "express";
-import { stringify } from "querystring";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
 
 export type OAuthCallbackState = {
   accessToken: string;
@@ -61,8 +62,17 @@ export class OrganizationsStripeController {
   ) {}
 
   @Roles("TEAM_ADMIN")
+  @Pbac(["organization.manageBilling"])
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Get("/connect")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Get Stripe connect URL for a team" })
@@ -79,9 +89,9 @@ export class OrganizationsStripeController {
     const accessToken = authorization.replace("Bearer ", "");
 
     const state: OAuthCallbackState = {
-      onErrorReturnTo: !!onErrorReturnTo ? onErrorReturnTo : origin,
+      onErrorReturnTo: onErrorReturnTo ? onErrorReturnTo : origin,
       fromApp: false,
-      returnTo: !!returnTo ? returnTo : origin,
+      returnTo: returnTo ? returnTo : origin,
       accessToken,
       teamId,
       orgId,
@@ -100,8 +110,17 @@ export class OrganizationsStripeController {
   }
 
   @Roles("TEAM_ADMIN")
+  @Pbac(["organization.manageBilling"])
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Get("/check")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Check team Stripe connection" })
@@ -112,8 +131,17 @@ export class OrganizationsStripeController {
   }
 
   @Roles("TEAM_ADMIN")
+  @Pbac(["organization.manageBilling"])
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
   @Get("/save")
   @Redirect(undefined, 301)
   @ApiOperation({ summary: "Save Stripe credentials" })

--- a/apps/api/v2/src/modules/organizations/teams/bookings/organizations-teams-bookings.controller.ts
+++ b/apps/api/v2/src/modules/organizations/teams/bookings/organizations-teams-bookings.controller.ts
@@ -1,3 +1,7 @@
+import { BOOKING_READ, SUCCESS_STATUS } from "@calcom/platform-constants";
+import { GetBookingsOutput_2024_08_13 } from "@calcom/platform-types";
+import { Controller, Get, HttpCode, HttpStatus, Param, ParseIntPipe, Query, UseGuards } from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { BookingUidGuard } from "@/ee/bookings/2024-08-13/guards/booking-uid.guard";
 import { BookingReferencesFilterInput_2024_08_13 } from "@/ee/bookings/2024-08-13/inputs/booking-references-filter.input";
 import { BookingReferencesOutput_2024_08_13 } from "@/ee/bookings/2024-08-13/outputs/booking-references.output";
@@ -5,34 +9,39 @@ import { BookingReferencesService_2024_08_13 } from "@/ee/bookings/2024-08-13/se
 import { BookingsService_2024_08_13 } from "@/ee/bookings/2024-08-13/services/bookings.service";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
+  API_KEY_OR_ACCESS_TOKEN_HEADER,
+  OPTIONAL_API_KEY_HEADER,
   OPTIONAL_X_CAL_CLIENT_ID_HEADER,
   OPTIONAL_X_CAL_SECRET_KEY_HEADER,
-  OPTIONAL_API_KEY_HEADER,
-  API_KEY_OR_ACCESS_TOKEN_HEADER,
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
 import { GetOrganizationsTeamsBookingsInput_2024_08_13 } from "@/modules/organizations/teams/bookings/inputs/get-organizations-teams-bookings.input";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import { Controller, UseGuards, Get, Param, ParseIntPipe, Query, HttpStatus, HttpCode } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS, BOOKING_READ } from "@calcom/platform-constants";
-import { GetBookingsOutput_2024_08_13 } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId/teams/:teamId/bookings",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(
+  ApiAuthGuard,
+  IsOrgGuard,
+  PbacGuard,
+  RolesGuard,
+  IsTeamInOrg,
+  PlatformPlanGuard,
+  IsAdminAPIEnabledGuard
+)
 @DocsTags("Orgs / Teams / Bookings")
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
@@ -47,6 +56,7 @@ export class OrganizationsTeamsBookingsController {
   @ApiOperation({ summary: "Get organization team bookings" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["booking.readTeamBookings"])
   @HttpCode(HttpStatus.OK)
   async getAllOrgTeamBookings(
     @Query() queryParams: GetOrganizationsTeamsBookingsInput_2024_08_13,
@@ -69,11 +79,13 @@ export class OrganizationsTeamsBookingsController {
   @Get("/:bookingUid/references")
   @PlatformPlan("SCALE")
   @Roles("TEAM_ADMIN")
+  @Pbac(["booking.read"])
   @Permissions([BOOKING_READ])
   @UseGuards(
     ApiAuthGuard,
     BookingUidGuard,
     IsOrgGuard,
+    PbacGuard,
     RolesGuard,
     IsTeamInOrg,
     PlatformPlanGuard,

--- a/apps/api/v2/src/modules/organizations/teams/index/organizations-teams.controller.ts
+++ b/apps/api/v2/src/modules/organizations/teams/index/organizations-teams.controller.ts
@@ -27,11 +27,13 @@ import { Throttle } from "@/lib/endpoint-throttler-decorator";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetTeam } from "@/modules/auth/decorators/get-team/get-team.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
 import { OrganizationsMembershipService } from "@/modules/organizations/memberships/services/organizations-membership.service";
@@ -50,7 +52,7 @@ import { UserWithProfile } from "@/modules/users/users.repository";
   path: "/v2/organizations/:orgId/teams",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @DocsTags("Orgs / Teams")
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
@@ -65,6 +67,7 @@ export class OrganizationsTeamsController {
   @ApiOperation({ summary: "Get all teams" })
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.read"])
   async getAllTeams(
     @Param("orgId", ParseIntPipe) orgId: number,
     @Query() queryParams: SkipTakePagination
@@ -81,6 +84,7 @@ export class OrganizationsTeamsController {
   @ApiOperation({ summary: "Get teams membership for user" })
   @Roles("ORG_MEMBER")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.read"])
   async getMyTeams(
     @Param("orgId", ParseIntPipe) orgId: number,
     @Query() queryParams: SkipTakePagination,
@@ -108,6 +112,7 @@ export class OrganizationsTeamsController {
   @UseGuards(IsTeamInOrg)
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.read"])
   @Get("/:teamId")
   @ApiOperation({ summary: "Get a team" })
   async getTeam(@GetTeam() team: Team): Promise<OrgTeamOutputResponseDto> {
@@ -120,6 +125,7 @@ export class OrganizationsTeamsController {
   @UseGuards(IsTeamInOrg)
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.delete"])
   @Delete("/:teamId")
   @Throttle({ limit: 1, ttl: 1000, blockDuration: 1000, name: "org_teams_delete" })
   @ApiOperation({ summary: "Delete a team" })
@@ -137,6 +143,7 @@ export class OrganizationsTeamsController {
   @UseGuards(IsTeamInOrg)
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.update"])
   @Patch("/:teamId")
   @ApiOperation({ summary: "Update a team" })
   async updateTeam(
@@ -154,6 +161,7 @@ export class OrganizationsTeamsController {
   @Post()
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.create"])
   @ApiOperation({ summary: "Create a team" })
   async createTeam(
     @Param("orgId", ParseIntPipe) orgId: number,

--- a/apps/api/v2/src/modules/organizations/teams/invite/organizations-teams-invite.controller.ts
+++ b/apps/api/v2/src/modules/organizations/teams/invite/organizations-teams-invite.controller.ts
@@ -1,29 +1,37 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { TeamService } from "@calcom/platform-libraries";
+import { Controller, HttpCode, HttpStatus, Param, ParseIntPipe, Post, UseGuards } from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { CreateInviteOutputDto } from "./outputs/invite.output";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
   OPTIONAL_API_KEY_HEADER,
   OPTIONAL_X_CAL_CLIENT_ID_HEADER,
   OPTIONAL_X_CAL_SECRET_KEY_HEADER,
 } from "@/lib/docs/headers";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
-import { Controller, UseGuards, Post, Param, ParseIntPipe, HttpCode, HttpStatus } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { TeamService } from "@calcom/platform-libraries";
-
-import { CreateInviteOutputDto } from "./outputs/invite.output";
 
 @Controller({
   path: "/v2/organizations/:orgId/teams/:teamId",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(
+  ApiAuthGuard,
+  IsOrgGuard,
+  PbacGuard,
+  RolesGuard,
+  IsTeamInOrg,
+  PlatformPlanGuard,
+  IsAdminAPIEnabledGuard
+)
 @DocsTags("Orgs / Teams / Invite")
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
@@ -31,6 +39,7 @@ import { CreateInviteOutputDto } from "./outputs/invite.output";
 export class OrganizationsTeamsInviteController {
   @Post("/invite")
   @Roles("TEAM_ADMIN")
+  @Pbac(["team.invite"])
   @ApiOperation({ summary: "Create team invite link" })
   @HttpCode(HttpStatus.OK)
   async createInvite(

--- a/apps/api/v2/src/modules/organizations/teams/memberships/organizations-teams-memberships.controller.ts
+++ b/apps/api/v2/src/modules/organizations/teams/memberships/organizations-teams-memberships.controller.ts
@@ -1,55 +1,64 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { updateNewTeamMemberEventTypes } from "@calcom/platform-libraries/event-types";
+import { SkipTakePagination } from "@calcom/platform-types";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UnprocessableEntityException,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
   OPTIONAL_API_KEY_HEADER,
   OPTIONAL_X_CAL_CLIENT_ID_HEADER,
   OPTIONAL_X_CAL_SECRET_KEY_HEADER,
 } from "@/lib/docs/headers";
+import { OrganizationMembershipService } from "@/lib/services/organization-membership.service";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
-import { OrganizationMembershipService } from "@/lib/services/organization-membership.service";
 import { OrganizationsRepository } from "@/modules/organizations/index/organizations.repository";
 import { CreateOrgTeamMembershipDto } from "@/modules/organizations/teams/memberships/inputs/create-organization-team-membership.input";
 import { UpdateOrgTeamMembershipDto } from "@/modules/organizations/teams/memberships/inputs/update-organization-team-membership.input";
 import {
-  OrgTeamMembershipsOutputResponseDto,
   OrgTeamMembershipOutputResponseDto,
+  OrgTeamMembershipsOutputResponseDto,
 } from "@/modules/organizations/teams/memberships/outputs/organization-teams-memberships.output";
 import { OrganizationsTeamsMembershipsService } from "@/modules/organizations/teams/memberships/services/organizations-teams-memberships.service";
 import { TeamMembershipOutput } from "@/modules/teams/memberships/outputs/team-membership.output";
-import {
-  Controller,
-  UseGuards,
-  Get,
-  Param,
-  ParseIntPipe,
-  Query,
-  Delete,
-  Patch,
-  Post,
-  Body,
-  HttpStatus,
-  HttpCode,
-  UnprocessableEntityException,
-  Logger,
-} from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { updateNewTeamMemberEventTypes } from "@calcom/platform-libraries/event-types";
-import { SkipTakePagination } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId/teams/:teamId/memberships",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(
+  ApiAuthGuard,
+  IsOrgGuard,
+  PbacGuard,
+  RolesGuard,
+  IsTeamInOrg,
+  PlatformPlanGuard,
+  IsAdminAPIEnabledGuard
+)
 @DocsTags("Orgs / Teams / Memberships")
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
@@ -61,13 +70,14 @@ export class OrganizationsTeamsMembershipsController {
     private organizationsTeamsMembershipsService: OrganizationsTeamsMembershipsService,
     private readonly organizationsRepository: OrganizationsRepository,
     private readonly orgMembershipService: OrganizationMembershipService
-  ) { }
+  ) {}
 
   @Get("/")
   @ApiOperation({ summary: "Get all memberships" })
   @UseGuards()
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.listMembers"])
   @HttpCode(HttpStatus.OK)
   async getAllOrgTeamMemberships(
     @Param("orgId", ParseIntPipe) orgId: number,
@@ -94,6 +104,7 @@ export class OrganizationsTeamsMembershipsController {
   @UseGuards()
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.listMembers"])
   @HttpCode(HttpStatus.OK)
   async getOrgTeamMembership(
     @Param("orgId", ParseIntPipe) orgId: number,
@@ -113,6 +124,7 @@ export class OrganizationsTeamsMembershipsController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.remove"])
   @Delete("/:membershipId")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Delete a membership" })
@@ -135,6 +147,7 @@ export class OrganizationsTeamsMembershipsController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.changeMemberRole"])
   @Patch("/:membershipId")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Update a membership" })
@@ -170,11 +183,11 @@ export class OrganizationsTeamsMembershipsController {
     };
   }
 
-
   // TODO: Refactor to use inviteMembersWithNoInviterPermissionCheck when it is moved to a Service
   // See: packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["team.invite"])
   @Post("/")
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: "Create a membership" })

--- a/apps/api/v2/src/modules/organizations/teams/routing-forms/controllers/organizations-teams-routing-forms-responses.controller.ts
+++ b/apps/api/v2/src/modules/organizations/teams/routing-forms/controllers/organizations-teams-routing-forms-responses.controller.ts
@@ -1,11 +1,28 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { Request } from "express";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { API_KEY_HEADER } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsRoutingFormInTeam } from "@/modules/auth/guards/routing-forms/is-routing-form-in-team.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
@@ -16,22 +33,6 @@ import { CreateRoutingFormResponseOutput } from "@/modules/organizations/routing
 import { UpdateRoutingFormResponseOutput } from "@/modules/organizations/routing-forms/outputs/update-routing-form-response.output";
 import { GetRoutingFormResponsesOutput } from "@/modules/organizations/teams/routing-forms/outputs/get-routing-form-responses.output";
 import { OrganizationsTeamsRoutingFormsResponsesService } from "@/modules/organizations/teams/routing-forms/services/organizations-teams-routing-forms-responses.service";
-import {
-  Controller,
-  Get,
-  Post,
-  Patch,
-  Param,
-  ParseIntPipe,
-  Query,
-  UseGuards,
-  Body,
-  Req,
-} from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
-import { Request } from "express";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
 
 @Controller({
   path: "/v2/organizations/:orgId/teams/:teamId/routing-forms/:routingFormId/responses",
@@ -41,6 +42,7 @@ import { SUCCESS_STATUS } from "@calcom/platform-constants";
 @UseGuards(
   ApiAuthGuard,
   IsOrgGuard,
+  PbacGuard,
   IsTeamInOrg,
   IsRoutingFormInTeam,
   PlatformPlanGuard,
@@ -56,6 +58,7 @@ export class OrganizationsTeamsRoutingFormsResponsesController {
   @Get("/")
   @ApiOperation({ summary: "Get organization team routing form responses" })
   @Roles("TEAM_ADMIN")
+  @Pbac(["routingForm.read"])
   @PlatformPlan("ESSENTIALS")
   async getRoutingFormResponses(
     @Param("routingFormId") routingFormId: string,
@@ -83,6 +86,7 @@ export class OrganizationsTeamsRoutingFormsResponsesController {
   @Post("/")
   @ApiOperation({ summary: "Create routing form response and get available slots" })
   @Roles("TEAM_MEMBER")
+  @Pbac(["routingForm.create"])
   @PlatformPlan("ESSENTIALS")
   async createRoutingFormResponse(
     @Param("orgId", ParseIntPipe) orgId: number,
@@ -107,6 +111,7 @@ export class OrganizationsTeamsRoutingFormsResponsesController {
   @Patch("/:responseId")
   @ApiOperation({ summary: "Update routing form response" })
   @Roles("TEAM_ADMIN")
+  @Pbac(["routingForm.update"])
   @PlatformPlan("ESSENTIALS")
   async updateRoutingFormResponse(
     @Param("teamId", ParseIntPipe) teamId: number,

--- a/apps/api/v2/src/modules/organizations/teams/routing-forms/controllers/organizations-teams-routing-forms.controller.ts
+++ b/apps/api/v2/src/modules/organizations/teams/routing-forms/controllers/organizations-teams-routing-forms.controller.ts
@@ -1,11 +1,17 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { Controller, Get, Param, ParseIntPipe, Query, UseGuards } from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { API_KEY_HEADER } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
 import { GetRoutingFormResponsesParams } from "@/modules/organizations/routing-forms/inputs/get-routing-form-responses-params.input";
@@ -14,17 +20,20 @@ import {
   RoutingFormOutput,
 } from "@/modules/organizations/routing-forms/outputs/get-routing-forms.output";
 import { OrganizationsTeamsRoutingFormsService } from "@/modules/organizations/teams/routing-forms/services/organizations-teams-routing-forms.service";
-import { Controller, Get, Param, Query, UseGuards, ParseIntPipe } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
 
 @Controller({
   path: "/v2/organizations/:orgId/teams/:teamId/routing-forms",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(
+  ApiAuthGuard,
+  IsOrgGuard,
+  PbacGuard,
+  RolesGuard,
+  IsTeamInOrg,
+  PlatformPlanGuard,
+  IsAdminAPIEnabledGuard
+)
 @ApiTags("Orgs / Teams / Routing forms")
 @ApiHeader(API_KEY_HEADER)
 export class OrganizationsTeamsRoutingFormsController {
@@ -36,6 +45,7 @@ export class OrganizationsTeamsRoutingFormsController {
   @ApiOperation({ summary: "Get team routing forms" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["routingForm.read"])
   async getTeamRoutingForms(
     @Param("orgId", ParseIntPipe) orgId: number,
     @Param("teamId", ParseIntPipe) teamId: number,

--- a/apps/api/v2/src/modules/organizations/teams/schedules/organizations-teams-schedules.controller.ts
+++ b/apps/api/v2/src/modules/organizations/teams/schedules/organizations-teams-schedules.controller.ts
@@ -1,3 +1,7 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { GetSchedulesOutput_2024_06_11 } from "@calcom/platform-types";
+import { Controller, Get, Param, ParseIntPipe, Query, UseGuards } from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { SchedulesService_2024_06_11 } from "@/ee/schedules/schedules_2024_06_11/services/schedules.service";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
@@ -6,11 +10,13 @@ import {
   OPTIONAL_X_CAL_SECRET_KEY_HEADER,
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
 import { IsUserInOrgTeam } from "@/modules/auth/guards/users/is-user-in-org-team.guard";
@@ -19,17 +25,20 @@ import {
   GetUserSchedulesQuery,
 } from "@/modules/organizations/teams/schedules/inputs/teams-schedules.input";
 import { TeamsSchedulesService } from "@/modules/teams/schedules/services/teams-schedules.service";
-import { Controller, UseGuards, Get, Param, ParseIntPipe, Query } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { GetSchedulesOutput_2024_06_11 } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId/teams/:teamId",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, IsTeamInOrg, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(
+  ApiAuthGuard,
+  IsOrgGuard,
+  PbacGuard,
+  IsTeamInOrg,
+  RolesGuard,
+  PlatformPlanGuard,
+  IsAdminAPIEnabledGuard
+)
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
 @ApiHeader(OPTIONAL_API_KEY_HEADER)
@@ -42,6 +51,7 @@ export class OrganizationsTeamsSchedulesController {
 
   @UseGuards(IsTeamInOrg)
   @Roles("TEAM_ADMIN")
+  @Pbac(["availability.read"])
   @PlatformPlan("ESSENTIALS")
   @Get("/schedules")
   @DocsTags("Orgs / Teams / Schedules")
@@ -63,6 +73,7 @@ export class OrganizationsTeamsSchedulesController {
   }
 
   @Roles("TEAM_ADMIN")
+  @Pbac(["availability.read"])
   @PlatformPlan("ESSENTIALS")
   @UseGuards(IsUserInOrgTeam)
   @Get("/users/:userId/schedules")

--- a/apps/api/v2/src/modules/organizations/teams/verified-resources/org-teams-verified-resources.controller.ts
+++ b/apps/api/v2/src/modules/organizations/teams/verified-resources/org-teams-verified-resources.controller.ts
@@ -1,12 +1,30 @@
+import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
+import { SkipTakePagination } from "@calcom/platform-types";
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { Throttle } from "@/lib/endpoint-throttler-decorator";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
 import { RequestEmailVerificationInput } from "@/modules/verified-resources/inputs/request-email-verification.input";
@@ -26,28 +44,19 @@ import {
   TeamVerifiedPhonesOutput,
 } from "@/modules/verified-resources/outputs/verified-phone.output";
 import { VerifiedResourcesService } from "@/modules/verified-resources/services/verified-resources.service";
-import {
-  Body,
-  Controller,
-  Get,
-  HttpCode,
-  HttpStatus,
-  Param,
-  ParseIntPipe,
-  Post,
-  Query,
-  UseGuards,
-} from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
-import { SkipTakePagination } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId/teams/:teamId/verified-resources",
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(
+  ApiAuthGuard,
+  IsOrgGuard,
+  PbacGuard,
+  RolesGuard,
+  IsTeamInOrg,
+  PlatformPlanGuard,
+  IsAdminAPIEnabledGuard
+)
 @ApiTags("Organization Team Verified Resources")
 export class OrgTeamsVerifiedResourcesController {
   constructor(private readonly verifiedResourcesService: VerifiedResourcesService) {}
@@ -56,6 +65,7 @@ export class OrgTeamsVerifiedResourcesController {
     description: `Sends a verification code to the email`,
   })
   @Roles("TEAM_ADMIN")
+  @Pbac(["team.update"])
   @Throttle({
     limit: 3,
     ttl: 60000,
@@ -87,6 +97,7 @@ export class OrgTeamsVerifiedResourcesController {
   })
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @Roles("TEAM_ADMIN")
+  @Pbac(["team.update"])
   @Throttle({
     limit: 3,
     ttl: 60000,
@@ -113,6 +124,7 @@ export class OrgTeamsVerifiedResourcesController {
   })
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @Roles("TEAM_ADMIN")
+  @Pbac(["team.update"])
   @PlatformPlan("ESSENTIALS")
   @Post("/emails/verification-code/verify")
   @HttpCode(HttpStatus.OK)
@@ -139,6 +151,7 @@ export class OrgTeamsVerifiedResourcesController {
   })
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @Roles("TEAM_ADMIN")
+  @Pbac(["team.update"])
   @PlatformPlan("ESSENTIALS")
   @Post("/phones/verification-code/verify")
   @Throttle({
@@ -170,6 +183,7 @@ export class OrgTeamsVerifiedResourcesController {
   })
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @Roles("TEAM_ADMIN")
+  @Pbac(["team.read"])
   @PlatformPlan("ESSENTIALS")
   @Get("/emails")
   @HttpCode(HttpStatus.OK)
@@ -195,6 +209,7 @@ export class OrgTeamsVerifiedResourcesController {
   @PlatformPlan("ESSENTIALS")
   @Get("/phones")
   @Roles("TEAM_ADMIN")
+  @Pbac(["team.read"])
   @HttpCode(HttpStatus.OK)
   async getVerifiedPhoneNumbers(
     @Param("teamId", ParseIntPipe) teamId: number,
@@ -218,6 +233,7 @@ export class OrgTeamsVerifiedResourcesController {
   })
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @Roles("TEAM_ADMIN")
+  @Pbac(["team.read"])
   @PlatformPlan("ESSENTIALS")
   @Get("/emails/:id")
   @HttpCode(HttpStatus.OK)
@@ -237,6 +253,7 @@ export class OrgTeamsVerifiedResourcesController {
   })
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @Roles("TEAM_ADMIN")
+  @Pbac(["team.read"])
   @PlatformPlan("ESSENTIALS")
   @Get("/phones/:id")
   @HttpCode(HttpStatus.OK)

--- a/apps/api/v2/src/modules/organizations/teams/workflows/controllers/org-team-workflows.controller.ts
+++ b/apps/api/v2/src/modules/organizations/teams/workflows/controllers/org-team-workflows.controller.ts
@@ -1,3 +1,18 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { SkipTakePagination } from "@calcom/platform-types";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
   OPTIONAL_API_KEY_HEADER,
@@ -6,11 +21,13 @@ import {
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
 import { IsEventTypeWorkflowInTeam } from "@/modules/auth/guards/workflows/is-event-type-workflow-in-team";
@@ -21,8 +38,8 @@ import { CreateFormWorkflowDto } from "@/modules/workflows/inputs/create-form-wo
 import { UpdateEventTypeWorkflowDto } from "@/modules/workflows/inputs/update-event-type-workflow.input";
 import { UpdateFormWorkflowDto } from "@/modules/workflows/inputs/update-form-workflow.input";
 import {
-  GetEventTypeWorkflowsOutput,
   GetEventTypeWorkflowOutput,
+  GetEventTypeWorkflowsOutput,
 } from "@/modules/workflows/outputs/event-type-workflow.output";
 import {
   GetRoutingFormWorkflowOutput,
@@ -30,29 +47,21 @@ import {
 } from "@/modules/workflows/outputs/routing-form-workflow.output";
 import { TeamEventTypeWorkflowsService } from "@/modules/workflows/services/team-event-type-workflows.service";
 import { TeamRoutingFormWorkflowsService } from "@/modules/workflows/services/team-routing-form-workflows.service";
-import {
-  Controller,
-  Get,
-  Patch,
-  Post,
-  Param,
-  ParseIntPipe,
-  Query,
-  UseGuards,
-  Body,
-  Delete,
-} from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { SkipTakePagination } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId/teams/:teamId/workflows",
   version: API_VERSIONS_VALUES,
 })
 @ApiTags("Orgs / Teams / Workflows")
-@UseGuards(ApiAuthGuard, IsOrgGuard, IsTeamInOrg, PlatformPlanGuard, RolesGuard, IsAdminAPIEnabledGuard)
+@UseGuards(
+  ApiAuthGuard,
+  IsOrgGuard,
+  PbacGuard,
+  IsTeamInOrg,
+  PlatformPlanGuard,
+  RolesGuard,
+  IsAdminAPIEnabledGuard
+)
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
 @ApiHeader(OPTIONAL_API_KEY_HEADER)
@@ -66,6 +75,7 @@ export class OrganizationTeamWorkflowsController {
   @ApiOperation({ summary: "Get organization team workflows" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("SCALE")
+  @Pbac(["workflow.read"])
   async getWorkflows(
     @Param("orgId", ParseIntPipe) orgId: number,
     @Param("teamId", ParseIntPipe) teamId: number,
@@ -82,6 +92,7 @@ export class OrganizationTeamWorkflowsController {
   @ApiOperation({ summary: "Get organization team workflows" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("SCALE")
+  @Pbac(["workflow.read"])
   async getRoutingFormWorkflows(
     @Param("orgId", ParseIntPipe) orgId: number,
     @Param("teamId", ParseIntPipe) teamId: number,
@@ -99,6 +110,7 @@ export class OrganizationTeamWorkflowsController {
   @ApiOperation({ summary: "Get organization team workflow" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("SCALE")
+  @Pbac(["workflow.read"])
   async getWorkflowById(
     @Param("teamId", ParseIntPipe) teamId: number,
     @Param("workflowId", ParseIntPipe) workflowId: number
@@ -113,6 +125,7 @@ export class OrganizationTeamWorkflowsController {
   @ApiOperation({ summary: "Get organization team workflow" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("SCALE")
+  @Pbac(["workflow.read"])
   async getRoutingFormWorkflowById(
     @Param("teamId", ParseIntPipe) teamId: number,
     @Param("workflowId", ParseIntPipe) workflowId: number
@@ -129,6 +142,7 @@ export class OrganizationTeamWorkflowsController {
   @ApiOperation({ summary: "Create organization team workflow for event-types" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("SCALE")
+  @Pbac(["workflow.create"])
   async createEventTypeWorkflow(
     @GetUser() user: UserWithProfile,
     @Param("teamId", ParseIntPipe) teamId: number,
@@ -142,6 +156,7 @@ export class OrganizationTeamWorkflowsController {
   @ApiOperation({ summary: "Create organization team workflow for routing-forms" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("SCALE")
+  @Pbac(["workflow.create"])
   async createFormWorkflow(
     @GetUser() user: UserWithProfile,
     @Param("teamId", ParseIntPipe) teamId: number,
@@ -156,6 +171,7 @@ export class OrganizationTeamWorkflowsController {
   @ApiOperation({ summary: "Update organization team workflow" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("SCALE")
+  @Pbac(["workflow.update"])
   async updateWorkflow(
     @Param("teamId", ParseIntPipe) teamId: number,
     @Param("workflowId", ParseIntPipe) workflowId: number,
@@ -176,6 +192,7 @@ export class OrganizationTeamWorkflowsController {
   @ApiOperation({ summary: "Update organization routing form team workflow" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("SCALE")
+  @Pbac(["workflow.update"])
   async updateRoutingFormWorkflow(
     @Param("teamId", ParseIntPipe) teamId: number,
     @Param("workflowId", ParseIntPipe) workflowId: number,
@@ -196,6 +213,7 @@ export class OrganizationTeamWorkflowsController {
   @ApiOperation({ summary: "Delete organization team workflow" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("SCALE")
+  @Pbac(["workflow.delete"])
   async deleteWorkflow(
     @Param("teamId", ParseIntPipe) teamId: number,
     @Param("workflowId") workflowId: number
@@ -209,6 +227,7 @@ export class OrganizationTeamWorkflowsController {
   @ApiOperation({ summary: "Delete organization team routing-form workflow" })
   @Roles("TEAM_ADMIN")
   @PlatformPlan("SCALE")
+  @Pbac(["workflow.delete"])
   async deleteRoutingFormWorkflow(
     @Param("teamId", ParseIntPipe) teamId: number,
     @Param("workflowId") workflowId: number

--- a/apps/api/v2/src/modules/organizations/users/index/controllers/organizations-users.controller.ts
+++ b/apps/api/v2/src/modules/organizations/users/index/controllers/organizations-users.controller.ts
@@ -1,3 +1,21 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import type { Team } from "@calcom/prisma/client";
+import {
+  Body,
+  ClassSerializerInterceptor,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToInstance } from "class-transformer";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
   OPTIONAL_API_KEY_HEADER,
@@ -7,49 +25,32 @@ import {
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetOrg } from "@/modules/auth/decorators/get-org/get-org.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsUserInOrg } from "@/modules/auth/guards/users/is-user-in-org.guard";
 import { CreateOrganizationUserInput } from "@/modules/organizations/users/index/inputs/create-organization-user.input";
 import { GetOrganizationsUsersInput } from "@/modules/organizations/users/index/inputs/get-organization-users.input";
 import { UpdateOrganizationUserInput } from "@/modules/organizations/users/index/inputs/update-organization-user.input";
 import {
+  GetOrganizationUserOutput,
   GetOrganizationUsersResponseDTO,
   GetOrgUsersWithProfileOutput,
 } from "@/modules/organizations/users/index/outputs/get-organization-users.output";
-import { GetOrganizationUserOutput } from "@/modules/organizations/users/index/outputs/get-organization-users.output";
 import { OrganizationsUsersService } from "@/modules/organizations/users/index/services/organizations-users-service";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import {
-  Controller,
-  UseGuards,
-  Get,
-  Post,
-  Patch,
-  Delete,
-  Param,
-  ParseIntPipe,
-  Body,
-  UseInterceptors,
-  Query,
-} from "@nestjs/common";
-import { ClassSerializerInterceptor } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToInstance } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import type { Team } from "@calcom/prisma/client";
 
 @Controller({
   path: "/v2/organizations/:orgId/users",
   version: API_VERSIONS_VALUES,
 })
 @UseInterceptors(ClassSerializerInterceptor)
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @UseGuards(IsOrgGuard)
 @DocsTags("Orgs / Users")
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
@@ -60,6 +61,7 @@ export class OrganizationsUsersController {
 
   @Get()
   @Roles("ORG_ADMIN")
+  @Pbac(["organization.listMembers"])
   @PlatformPlan("ESSENTIALS")
   @ApiOperation({ summary: "Get all users" })
   async getOrganizationsUsers(
@@ -89,6 +91,7 @@ export class OrganizationsUsersController {
 
   @Post()
   @Roles("ORG_ADMIN")
+  @Pbac(["organization.invite"])
   @PlatformPlan("ESSENTIALS")
   @ApiOperation({ summary: "Create a user" })
   async createOrganizationUser(
@@ -113,6 +116,7 @@ export class OrganizationsUsersController {
 
   @Patch("/:userId")
   @Roles("ORG_ADMIN")
+  @Pbac(["organization.attributes.editUsers"])
   @PlatformPlan("ESSENTIALS")
   @UseGuards(IsUserInOrg)
   @ApiOperation({ summary: "Update a user" })
@@ -134,6 +138,7 @@ export class OrganizationsUsersController {
 
   @Delete("/:userId")
   @Roles("ORG_ADMIN")
+  @Pbac(["organization.remove"])
   @PlatformPlan("ESSENTIALS")
   @UseGuards(IsUserInOrg)
   @ApiOperation({ summary: "Delete a user" })

--- a/apps/api/v2/src/modules/organizations/webhooks/controllers/organizations-webhooks.controller.ts
+++ b/apps/api/v2/src/modules/organizations/webhooks/controllers/organizations-webhooks.controller.ts
@@ -1,3 +1,21 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { SkipTakePagination } from "@calcom/platform-types";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
   OPTIONAL_API_KEY_HEADER,
@@ -5,16 +23,17 @@ import {
   OPTIONAL_X_CAL_SECRET_KEY_HEADER,
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
 import { IsWebhookInOrg } from "@/modules/auth/guards/organizations/is-webhook-in-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { OrganizationsWebhooksService } from "@/modules/organizations/webhooks/services/organizations-webhooks.service";
-import { CreateWebhookInputDto } from "@/modules/webhooks/inputs/webhook.input";
-import { UpdateWebhookInputDto } from "@/modules/webhooks/inputs/webhook.input";
+import { CreateWebhookInputDto, UpdateWebhookInputDto } from "@/modules/webhooks/inputs/webhook.input";
 import {
   TeamWebhookOutputDto as OrgWebhookOutputDto,
   TeamWebhookOutputResponseDto as OrgWebhookOutputResponseDto,
@@ -23,31 +42,12 @@ import {
 import { PartialWebhookInputPipe, WebhookInputPipe } from "@/modules/webhooks/pipes/WebhookInputPipe";
 import { WebhookOutputPipe } from "@/modules/webhooks/pipes/WebhookOutputPipe";
 import { WebhooksService } from "@/modules/webhooks/services/webhooks.service";
-import {
-  Controller,
-  UseGuards,
-  Get,
-  Param,
-  ParseIntPipe,
-  Query,
-  Delete,
-  Patch,
-  Post,
-  Body,
-  HttpCode,
-  HttpStatus,
-} from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { SkipTakePagination } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId/webhooks",
   version: API_VERSIONS_VALUES,
 })
-@UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+@UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @DocsTags("Orgs / Webhooks")
 @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
@@ -60,6 +60,7 @@ export class OrganizationsWebhooksController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["webhook.read"])
   @Get("/")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Get all webhooks" })
@@ -85,6 +86,7 @@ export class OrganizationsWebhooksController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["webhook.create"])
   @Post("/")
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: "Create a webhook" })
@@ -106,6 +108,7 @@ export class OrganizationsWebhooksController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["webhook.read"])
   @UseGuards(IsWebhookInOrg)
   @Get("/:webhookId")
   @HttpCode(HttpStatus.OK)
@@ -122,6 +125,7 @@ export class OrganizationsWebhooksController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["webhook.delete"])
   @UseGuards(IsWebhookInOrg)
   @Delete("/:webhookId")
   @HttpCode(HttpStatus.OK)
@@ -138,6 +142,7 @@ export class OrganizationsWebhooksController {
 
   @Roles("ORG_ADMIN")
   @PlatformPlan("ESSENTIALS")
+  @Pbac(["webhook.update"])
   @UseGuards(IsWebhookInOrg)
   @Patch("/:webhookId")
   @HttpCode(HttpStatus.OK)


### PR DESCRIPTION
## What does this PR do?

Adds `@Pbac()` decorators and `PbacGuard` to **all** API v2 organization controllers, achieving comprehensive PBAC coverage. Prior to this change, only the roles/permissions controllers and 3 booking recording endpoints had PBAC enforcement.

The pattern applied to each controller:
1. Import `Pbac` decorator and `PbacGuard`
2. Add `PbacGuard` to `@UseGuards` (placed after `IsOrgGuard`, before `RolesGuard`)
3. Add method-level `@Pbac([...])` with permission strings mapped from the PBAC registry

**Controllers modified (23 total):**

| Controller | Permission strings used |
|---|---|
| `organizations-event-types` | `eventType.create/read/update/delete` |
| `organizations-webhooks` | `webhook.create/read/update/delete` |
| `organizations-attributes` | `organization.attributes.create/read/update/delete` |
| `organizations-attributes-options` | `organization.attributes.create/read/update/delete` |
| `organizations-teams` | `team.create/read/update/delete` |
| `organizations-bookings` | `booking.readOrgBookings` |
| `organizations-teams-memberships` | `team.listMembers/invite/remove/changeMemberRole` |
| `organizations-teams-bookings` | `booking.readTeamBookings/read` |
| `org-team-workflows` | `workflow.create/read/update/delete` |
| `organizations-teams-routing-forms` | `routingForm.read` |
| `organizations-routing-forms` | `routingForm.read` |
| `organizations-membership` | `organization.listMembers/invite/remove/changeMemberRole` |
| `organizations-organizations` | `organization.create/read/update/delete` |
| `organizations-teams-invite` | `team.invite` |
| `organizations-conferencing` | `team.read/update` |
| `organizations-delegation-credential` | `organization.update` |
| `organizations-routing-forms-responses` | `routingForm.read/create/update` |
| `organizations-schedules` | `availability.read/create/update/delete` |
| `organizations-stripe` | `organization.manageBilling` |
| `organizations-teams-routing-forms-responses` | `routingForm.read/create/update` |
| `organizations-teams-schedules` | `availability.read` |
| `org-teams-verified-resources` | `team.read/update` |
| `organizations-users` | `organization.listMembers/invite/remove`, `organization.attributes.editUsers` |

**Note:** `PbacGuard` is soft by default — if the org doesn't have the `pbac` feature flag enabled, it allows access and sets `request.pbacAuthorizedRequest = false`. This means these changes are non-breaking for orgs without PBAC enabled.

### Updates since last revision


**Second batch of controllers (9 additional):**
- Added PBAC to all remaining org API v2 controllers: conferencing, delegation-credentials, routing-forms-responses (org), schedules (org), stripe, teams/routing-forms-responses, teams/schedules, teams/verified-resources, and users
- This achieves **100% PBAC coverage** across all organization API v2 endpoints

**Previous updates:**
- **Fixed breaking change on `getTeamEventTypes`** (identified by Cubic AI, confidence 9/10): Removed `PbacGuard` and `@Pbac` from the `GET /teams/:teamId/event-types` endpoint in `organizations-event-types.controller.ts`. This endpoint has no `ApiAuthGuard` (it's unauthenticated/public), and `PbacGuard` unconditionally throws `UnauthorizedException` when `request.user` is missing — which would have broken this endpoint for all unauthenticated callers regardless of PBAC feature flag status.

## ⚠️ Items for human review

1. **`organization.delete` permission not in registry**: The `DELETE /:managedOrganizationId` endpoint in `organizations-organizations.controller.ts` uses `@Pbac(["organization.delete"])`, but this permission string does not exist in the PBAC registry at `/packages/features/pbac/domain/types/permission-registry.ts`. The `Organization` resource only defines: `create`, `read`, `update`, `listMembers`, `invite`, `remove`, `manageBilling`, `changeMemberRole`, `impersonate`, `passwordReset`. When PBAC is enabled, this endpoint would be inaccessible. Should we:
   - Add `organization.delete` to the registry?
   - Use a different permission like `organization.update`?
   - Remove PBAC from this endpoint?

2. **`organization.attributes.editUsers` for user updates**: The `PATCH /users/:userId` endpoint uses `@Pbac(["organization.attributes.editUsers"])`. This permission is defined under the `Attributes` resource in the registry, but updating a user's profile (name, email, etc.) isn't strictly about attributes. However, `organization.editUsers` doesn't exist as a standalone permission — `editUsers` only exists under `organization.attributes`. This mapping is technically correct per the registry but may be semantically confusing. Consider whether user profile updates should have their own permission or if the current mapping is acceptable.

3. **Verify permission string mappings**: Confirm all permission strings (especially nested ones like `organization.attributes.*`) match the intended authorization model.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A** - No documentation changes needed; this is internal permission enforcement.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **No automated tests added** - The PBAC guard is soft and won't break existing functionality. Manual testing would require setting up PBAC feature flag and permission configurations.

## How should this be tested?

**Prerequisites:**
- Organization with PBAC feature flag enabled
- User accounts with varying permission levels configured in the PBAC system

**Test approach:**
1. Create test users with different permission sets (e.g., one with `eventType.read` but not `eventType.create`)
2. Attempt to call protected endpoints with each user
3. Verify that users without required permissions receive appropriate authorization errors
4. Verify that users with required permissions can access endpoints successfully
5. **Test unauthenticated access**: Verify `GET /teams/:teamId/event-types` still works without authentication

**Key areas to verify:**
- [ ] Attribute endpoints correctly enforce `organization.attributes.*` permissions
- [ ] Team membership endpoints correctly enforce `team.listMembers/invite/remove/changeMemberRole`
- [ ] Booking endpoints correctly enforce `booking.readOrgBookings` and `booking.readTeamBookings`
- [ ] Workflow endpoints correctly enforce `workflow.*` permissions
- [ ] All CRUD operations on event types, webhooks, teams, and organizations are protected
- [ ] Unauthenticated `getTeamEventTypes` endpoint remains accessible
- [ ] Conferencing endpoints correctly enforce `team.read/update`
- [ ] Schedule endpoints correctly enforce `availability.*` permissions
- [ ] Stripe endpoints correctly enforce `organization.manageBilling`
- [ ] User management endpoints correctly enforce `organization.listMembers/invite/remove` and `organization.attributes.editUsers`

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas **N/A** - Changes are mechanical decorator additions
- [x] I have checked if my changes generate no new warnings
- [ ] My PR is too large (>500 lines or >10 files) and should be split into smaller PRs - **23 files changed, but changes are highly mechanical and repetitive. Splitting would make it harder to review the consistent pattern.**

---

**Additional notes:**

- **Guard ordering:** `PbacGuard` is placed after `IsOrgGuard` but before `RolesGuard` in all controllers. This matches the pattern in existing PBAC-protected controllers (roles/permissions).
- **Unassign attribute uses `update` not `delete`:** The `DELETE /attributes/options/:userId/:attributeOptionId` endpoint uses `organization.attributes.update` rather than `delete` because unassigning is a modification operation, not deletion of the attribute itself.
- **Conferencing controller uses method-level guards:** Unlike other controllers, the conferencing controller applies guards at the method level rather than class level, matching its existing pattern.

---

**Link to Devin run:** https://app.devin.ai/sessions/5a33e909745d44d786959ae2ed0f5b56  
**Requested by:** @sean-brydon