### PR TITLE
fix: add CSRF protection to OAuth callback via HMAC-signed nonce

### DIFF
--- a/packages/app-store/_utils/oauth/decodeOAuthState.ts
+++ b/packages/app-store/_utils/oauth/decodeOAuthState.ts
@@ -1,5 +1,6 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import process from "node:process";
 import type { NextApiRequest } from "next";
-
 import type { IntegrationOAuthCallbackState } from "../../types";
 
 export function decodeOAuthState(req: NextApiRequest) {
@@ -7,6 +8,20 @@ export function decodeOAuthState(req: NextApiRequest) {
     return undefined;
   }
   const state: IntegrationOAuthCallbackState = JSON.parse(req.query.state);
+
+  if (state.nonce && state.nonceHash) {
+    const userId = req.session?.user?.id;
+    if (!userId || !process.env.NEXTAUTH_SECRET) {
+      return undefined;
+    }
+    const expected = createHmac("sha256", process.env.NEXTAUTH_SECRET)
+      .update(`${state.nonce}:${userId}`)
+      .digest();
+    const actual = Buffer.from(state.nonceHash, "hex");
+    if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+      return undefined;
+    }
+  }
 
   return state;
 }

--- a/packages/app-store/_utils/oauth/decodeOAuthState.ts
+++ b/packages/app-store/_utils/oauth/decodeOAuthState.ts
@@ -3,24 +3,32 @@ import process from "node:process";
 import type { NextApiRequest } from "next";
 import type { IntegrationOAuthCallbackState } from "../../types";
 
-export function decodeOAuthState(req: NextApiRequest) {
+const NONCE_EXEMPT_APPS = new Set(["stripe", "basecamp3", "dub", "webex", "tandem"]);
+
+export function decodeOAuthState(req: NextApiRequest, appSlug?: string) {
   if (typeof req.query.state !== "string") {
     return undefined;
   }
   const state: IntegrationOAuthCallbackState = JSON.parse(req.query.state);
 
-  if (state.nonce && state.nonceHash) {
-    const userId = req.session?.user?.id;
-    if (!userId || !process.env.NEXTAUTH_SECRET) {
-      return undefined;
-    }
-    const expected = createHmac("sha256", process.env.NEXTAUTH_SECRET)
-      .update(`${state.nonce}:${userId}`)
-      .digest();
-    const actual = Buffer.from(state.nonceHash, "hex");
-    if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
-      return undefined;
-    }
+  if (appSlug && NONCE_EXEMPT_APPS.has(appSlug)) {
+    return state;
+  }
+
+  if (!state.nonce || !state.nonceHash) {
+    return undefined;
+  }
+
+  const userId = req.session?.user?.id;
+  if (!userId || !process.env.NEXTAUTH_SECRET) {
+    return undefined;
+  }
+  const expected = createHmac("sha256", process.env.NEXTAUTH_SECRET)
+    .update(`${state.nonce}:${userId}`)
+    .digest();
+  const actual = Buffer.from(state.nonceHash, "hex");
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    return undefined;
   }
 
   return state;

--- a/packages/app-store/basecamp3/api/callback.ts
+++ b/packages/app-store/basecamp3/api/callback.ts
@@ -87,7 +87,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     },
   });
 
-  const state = decodeOAuthState(req);
+  const state = decodeOAuthState(req, "basecamp3");
 
   res.redirect(getInstalledAppPath({ variant: appConfig.variant, slug: appConfig.slug }));
 }

--- a/packages/app-store/dub/api/callback.ts
+++ b/packages/app-store/dub/api/callback.ts
@@ -13,7 +13,7 @@ import { dubAppKeysSchema } from "../lib/utils";
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { code } = req.query;
 
-  const state = decodeOAuthState(req);
+  const state = decodeOAuthState(req, "dub");
 
   if (typeof code !== "string") {
     if (state?.onErrorReturnTo || state?.returnTo) {

--- a/packages/app-store/stripepayment/api/callback.ts
+++ b/packages/app-store/stripepayment/api/callback.ts
@@ -1,36 +1,23 @@
-import type { NextApiRequest, NextApiResponse } from "next";
 import { stringify } from "node:querystring";
-
+import { getSafeRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
 import type { Prisma } from "@calcom/prisma/client";
-
+import type { NextApiRequest, NextApiResponse } from "next";
 import getInstalledAppPath from "../../_utils/getInstalledAppPath";
 import createOAuthAppCredential from "../../_utils/oauth/createOAuthAppCredential";
 import { decodeOAuthState } from "../../_utils/oauth/decodeOAuthState";
 import type { StripeData } from "../lib/server";
 import stripe from "../lib/server";
 
-function getReturnToValueFromQueryState(req: NextApiRequest) {
-  let returnTo = "";
-  try {
-    returnTo = JSON.parse(`${req.query.state}`).returnTo;
-  } catch (error) {
-    console.info("No 'returnTo' in req.query.state");
-  }
-  return returnTo;
-}
-
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { code, error, error_description } = req.query;
   const state = decodeOAuthState(req);
 
   if (error) {
-    // User cancels flow
     if (error === "access_denied") {
-      state?.onErrorReturnTo ? res.redirect(state.onErrorReturnTo) : res.redirect("/apps/installed/payment");
+      return res.redirect(getSafeRedirectUrl(state?.onErrorReturnTo) ?? "/apps/installed/payment");
     }
     const query = stringify({ error, error_description });
-    res.redirect(`/apps/installed?${query}`);
-    return;
+    return res.redirect(`/apps/installed?${query}`);
   }
 
   if (!req.session?.user?.id) {
@@ -43,9 +30,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   });
 
   const data: StripeData = { ...response, default_currency: "" };
-  if (response["stripe_user_id"]) {
-    const account = await stripe.accounts.retrieve(response["stripe_user_id"]);
-    data["default_currency"] = account.default_currency;
+  if (response.stripe_user_id) {
+    const account = await stripe.accounts.retrieve(response.stripe_user_id);
+    data.default_currency = account.default_currency;
   }
 
   await createOAuthAppCredential(
@@ -54,6 +41,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     req
   );
 
-  const returnTo = getReturnToValueFromQueryState(req);
-  res.redirect(returnTo || getInstalledAppPath({ variant: "payment", slug: "stripe" }));
+  res.redirect(
+    getSafeRedirectUrl(state?.returnTo) ?? getInstalledAppPath({ variant: "payment", slug: "stripe" })
+  );
 }

--- a/packages/app-store/stripepayment/api/callback.ts
+++ b/packages/app-store/stripepayment/api/callback.ts
@@ -10,7 +10,7 @@ import stripe from "../lib/server";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { code, error, error_description } = req.query;
-  const state = decodeOAuthState(req);
+  const state = decodeOAuthState(req, "stripe");
 
   if (error) {
     if (error === "access_denied") {

--- a/packages/app-store/tandemvideo/api/callback.ts
+++ b/packages/app-store/tandemvideo/api/callback.ts
@@ -15,7 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const code = req.query.code as string;
-  const state = decodeOAuthState(req);
+  const state = decodeOAuthState(req, "tandem");
 
   let clientId = "";
   let clientSecret = "";

--- a/packages/app-store/types.d.ts
+++ b/packages/app-store/types.d.ts
@@ -12,6 +12,8 @@ export type IntegrationOAuthCallbackState = {
   installGoogleVideo?: boolean;
   teamId?: number;
   defaultInstall?: boolean;
+  nonce?: string;
+  nonceHash?: string;
 };
 
 export type CredentialOwner = {

--- a/packages/app-store/webex/api/callback.ts
+++ b/packages/app-store/webex/api/callback.ts
@@ -13,7 +13,7 @@ import { getWebexAppKeys } from "../lib/getWebexAppKeys";
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { code } = req.query;
   const { client_id, client_secret } = await getWebexAppKeys();
-  const state = decodeOAuthState(req);
+  const state = decodeOAuthState(req, "webex");
 
   /** @link https://developer.webex.com/docs/integrations#getting-an-access-token **/
 


### PR DESCRIPTION
## What does this PR do?

- Adds CSRF protection to the shared OAuth flow used by app-store integrations
- Hardens the Stripe OAuth callback redirect handling
- Makes nonce verification **mandatory** by default, with an explicit allowlist for unmigrated apps

## Solution

**HMAC-signed nonce (stateless, no DB needed)**:
- `encodeOAuthState`: generates a `crypto.randomUUID()` nonce, HMAC-signs it with `NEXTAUTH_SECRET + userId`, injects both into the OAuth state JSON
- `decodeOAuthState`: verifies the HMAC using `timingSafeEqual` on callback; returns `undefined` if nonce is missing or invalid
- Nonce verification is **mandatory** — apps that don't yet use `encodeOAuthState` must be explicitly listed in `NONCE_EXEMPT_APPS` and pass their slug via `decodeOAuthState(req, "appSlug")`

**Stripe callback hardening**:
- Replaced raw `state.returnTo` redirect with `getSafeRedirectUrl` (same pattern all other callbacks use)
- Removed `getReturnToValueFromQueryState` which bypassed `decodeOAuthState` entirely
- Added missing `return` before `res.redirect` on `access_denied` (was falling through to a second redirect)

## Files changed

| File | Change |
|------|--------|
| `packages/app-store/types.d.ts` | Add `nonce?` and `nonceHash?` fields |
| `packages/app-store/_utils/oauth/encodeOAuthState.ts` | Generate nonce + HMAC on encode |
| `packages/app-store/_utils/oauth/decodeOAuthState.ts` | Mandatory HMAC verification with `NONCE_EXEMPT_APPS` allowlist |
| `packages/app-store/stripepayment/api/callback.ts` | Harden redirects, pass exempt slug |
| `packages/app-store/basecamp3/api/callback.ts` | Pass exempt slug |
| `packages/app-store/dub/api/callback.ts` | Pass exempt slug |
| `packages/app-store/webex/api/callback.ts` | Pass exempt slug |
| `packages/app-store/tandemvideo/api/callback.ts` | Pass exempt slug |

## ⚠️ Items for reviewer attention

- **Verify `NONCE_EXEMPT_APPS` list is complete**: Are there any other apps that construct state manually and don't use `encodeOAuthState`? Current list: `stripe`, `basecamp3`, `dub`, `webex`, `tandem`. Any app missing from this list that doesn't use `encodeOAuthState` will have its OAuth flow silently fail (`decodeOAuthState` returns `undefined`).
- **Verify all `decodeOAuthState` callers**: Ensure every caller either uses `encodeOAuthState` or is in the exempt list
- **`NEXTAUTH_SECRET` availability**: If unset, `encodeOAuthState` won't add nonce fields and non-exempt apps will fail OAuth. Confirm this is always set in production.

## How should this be tested?

**Manual testing**:
1. Install a Google Calendar integration (uses `encodeOAuthState`) and verify OAuth flow completes successfully
2. Install a Stripe integration (exempt app) and verify OAuth flow completes successfully
3. Verify `returnTo` redirect goes to correct page after install
4. Attempt to replay an OAuth callback with a modified `state` parameter and verify it's rejected

**Environment variables**:
- `NEXTAUTH_SECRET` must be set (required for HMAC signing)

## Test plan

- [x] Existing Stripe tests pass (24/24)
- [x] Type check passes (pre-existing errors in unrelated files)
- [x] Biome lint passes
- [ ] Manual test: install a Google Calendar integration and verify OAuth flow completes
- [ ] Manual test: install a Stripe integration and verify OAuth flow completes
- [ ] Manual test: verify `returnTo` redirect goes to correct page after install

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Link to Devin run: https://app.devin.ai/sessions/8c914060a9834e7d8e244438d59384b4

Requested by: @volnei