### PR TITLE
feat(bookings): add AM/PM visual indicators to time slot list

### DIFF
--- a/apps/web/modules/bookings/components/AvailableTimes.test.tsx
+++ b/apps/web/modules/bookings/components/AvailableTimes.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@calcom/features/bookings/Booker/__tests__/test-utils";
+import { TimeFormat } from "@calcom/lib/timeFormat";
+import { vi } from "vitest";
+import { AvailableTimes } from "./AvailableTimes";
+
+const mockUseBookerTime = vi.fn();
+vi.mock("@calcom/features/bookings/Booker/hooks/useBookerTime", () => ({
+  useBookerTime: () => mockUseBookerTime(),
+}));
+
+vi.mock("@calcom/features/bookings/lib/useCheckOverlapWithOverlay", () => ({
+  useCheckOverlapWithOverlay: () => ({ isOverlapping: false }),
+}));
+
+vi.mock("@calcom/atoms/hooks/useIsPlatform", () => ({
+  useIsPlatform: () => false,
+}));
+
+const createSlot = (time: string) => ({
+  time,
+  attendees: 0,
+});
+
+describe("AvailableTimes AM/PM indicator", () => {
+  const defaultProps = {
+    slots: [
+      createSlot("2024-01-15T02:00:00Z"), // 2 AM UTC
+      createSlot("2024-01-15T14:00:00Z"), // 2 PM UTC
+    ],
+    event: { data: { length: 30 } },
+    showTimeFormatToggle: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows AM indicator (sun icon) for morning slots in 12-hour format", () => {
+    mockUseBookerTime.mockReturnValue({
+      timeFormat: TimeFormat.TWELVE_HOUR,
+      timezone: "UTC",
+      timezoneFromBookerStore: null,
+      timezoneFromTimePreferences: "UTC",
+    });
+
+    render(<AvailableTimes {...defaultProps} />);
+
+    const amIndicators = screen.getAllByTestId("time-slot-am-pm-indicator");
+    expect(amIndicators.length).toBe(2);
+
+    const amOnly = amIndicators.filter((el) => el.getAttribute("data-period") === "am");
+    expect(amOnly.length).toBe(1);
+  });
+
+  it("shows PM indicator (moon icon) for afternoon slots in 12-hour format", () => {
+    mockUseBookerTime.mockReturnValue({
+      timeFormat: TimeFormat.TWELVE_HOUR,
+      timezone: "UTC",
+      timezoneFromBookerStore: null,
+      timezoneFromTimePreferences: "UTC",
+    });
+
+    render(<AvailableTimes {...defaultProps} />);
+
+    const pmIndicators = screen.getAllByTestId("time-slot-am-pm-indicator");
+    const pmOnly = pmIndicators.filter((el) => el.getAttribute("data-period") === "pm");
+    expect(pmOnly.length).toBe(1);
+  });
+
+  it("does not show AM/PM indicator in 24-hour format", () => {
+    mockUseBookerTime.mockReturnValue({
+      timeFormat: TimeFormat.TWENTY_FOUR_HOUR,
+      timezone: "UTC",
+      timezoneFromBookerStore: null,
+      timezoneFromTimePreferences: "UTC",
+    });
+
+    render(<AvailableTimes {...defaultProps} />);
+
+    expect(screen.queryByTestId("time-slot-am-pm-indicator")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/modules/bookings/components/AvailableTimes.tsx
+++ b/apps/web/modules/bookings/components/AvailableTimes.tsx
@@ -1,28 +1,28 @@
 // We do not need to worry about importing framer-motion here as it is lazy imported in Booker.
-import * as HoverCard from "@radix-ui/react-hover-card";
-import { AnimatePresence, m } from "framer-motion";
-import { useMemo } from "react";
 
 import { getPaymentAppData } from "@calcom/app-store/_utils/payments/getPaymentAppData";
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import dayjs from "@calcom/dayjs";
 import type { IOutOfOfficeData } from "@calcom/features/availability/lib/getUserAvailability";
 import { useBookerStoreContext } from "@calcom/features/bookings/Booker/BookerStoreProvider";
-import { OutOfOfficeInSlots } from "./OutOfOfficeInSlots";
-import type { IUseBookingLoadingStates } from "../hooks/useBookings";
-import type { BookerEvent } from "@calcom/features/bookings/types";
-import type { Slot } from "~/schedules/lib/types";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { localStorage } from "@calcom/lib/webstorage";
-import classNames from "@calcom/ui/classNames";
-import { Button } from "@calcom/ui/components/button";
-import { SkeletonText } from "@calcom/ui/components/skeleton";
-import { CalendarX2Icon } from "@coss/ui/icons";
-
 import { useBookerTime } from "@calcom/features/bookings/Booker/hooks/useBookerTime";
 import { getQueryParam } from "@calcom/features/bookings/Booker/utils/query-param";
 import { useCheckOverlapWithOverlay } from "@calcom/features/bookings/lib/useCheckOverlapWithOverlay";
-import type { Slots } from "@calcom/features/bookings/types";
+import type { BookerEvent, Slots } from "@calcom/features/bookings/types";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { TimeFormat } from "@calcom/lib/timeFormat";
+import { localStorage } from "@calcom/lib/webstorage";
+import classNames from "@calcom/ui/classNames";
+import { Button } from "@calcom/ui/components/button";
+import { Icon } from "@calcom/ui/components/icon";
+import { SkeletonText } from "@calcom/ui/components/skeleton";
+import { CalendarX2Icon } from "@coss/ui/icons";
+import * as HoverCard from "@radix-ui/react-hover-card";
+import { AnimatePresence, m } from "framer-motion";
+import { useMemo } from "react";
+import type { Slot } from "~/schedules/lib/types";
+import type { IUseBookingLoadingStates } from "../hooks/useBookings";
+import { OutOfOfficeInSlots } from "./OutOfOfficeInSlots";
 import { SeatsAvailabilityText } from "./SeatsAvailabilityText";
 
 type TOnTimeSelect = (
@@ -184,6 +184,24 @@ const SlotItem = ({
               />
             )}
             {computedDateWithUsersTimezone.format(timeFormat)}
+            {timeFormat === TimeFormat.TWELVE_HOUR &&
+              (() => {
+                const isAM = computedDateWithUsersTimezone.hour() < 12;
+                return (
+                  <span
+                    aria-hidden
+                    data-testid="time-slot-am-pm-indicator"
+                    data-period={isAM ? "am" : "pm"}
+                    className={classNames(
+                      "inline-flex items-center justify-center rounded p-0.5",
+                      isAM
+                        ? "bg-amber-500/15 text-amber-700 dark:text-amber-400"
+                        : "bg-slate-500/15 text-slate-700 dark:text-slate-400"
+                    )}>
+                    <Icon name={isAM ? "sun" : "moon"} className="h-3 w-3" />
+                  </span>
+                );
+              })()}
           </div>
           {bookingFull && <p className="text-sm">{t("booking_full")}</p>}
           {hasTimeSlots && !bookingFull && (


### PR DESCRIPTION
Closes #28090 
Relates to #28086

## What does this PR do?

Adds a subtle visual indicator to the **default booking page** time-slot list to make it easier to distinguish **AM vs PM** at a glance in 12-hour locales—reducing accidental “2:00am vs 2:00pm” bookings for round-robin / multi-timezone setups.

### Changes
- Shows a **sun icon** for AM slots and a **moon icon** for PM slots when the viewer is using **12-hour time**.
- **No indicator** is shown in **24-hour** format (UI remains unchanged).
- Uses the slot’s **hour in the viewer’s timezone** (no AM/PM string parsing).
- Indicator is **icon-only** (no duplicate AM/PM text).

### Accessibility
- The indicator is `aria-hidden` because the time text already conveys AM/PM, and the icon is purely an extra visual cue.



#### Image Demo:
- **Before:** 
<img width="544" height="970" alt="Image 2-19-26 at 17 34" src="https://github.com/user-attachments/assets/c4ba0b29-8e78-4ddf-bdf7-82ac42bff908" />

- **After:** 
<img width="284" height="488" alt="Screenshot 2026-02-19 at 8 05 03 PM" src="https://github.com/user-attachments/assets/ec0ce82f-47ac-4b5b-9f97-c5516790fa94" />
<img width="1104" height="540" alt="Screenshot 2026-02-19 at 8 05 16 PM" src="https://github.com/user-attachments/assets/39b809c3-b7d7-492b-b5e0-5ebe11a161e2" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Automated
- Run unit tests:
  - `pnpm test` (or the repo’s equivalent)
  - Tests added/updated in: `apps/web/.../AvailableTimes.test.tsx` (verifies 12h vs 24h behavior)

### Manual 
1. Open a booking page that uses the **default** time-slot list UI (not the redesigned detailed calendar view).
2. Ensure the viewer is in **12-hour** time display.
3. Confirm:
   - Morning slots render with a **sun** indicator.
   - Afternoon/evening slots render with a **moon** indicator.
4. Toggle to **24-hour** time display.
5. Confirm:
   - No AM/PM indicators appear (UI matches previous behavior).

## Checklist

- [x] I have read the contributing guide.
- [x] My code follows the style guidelines of this project.
- [x] I have checked that my changes generate no new blocking warnings.
- [ ] My PR is scoped and reasonably small.