### PR TITLE
fix: visual indicator reflects toolbox open/close state

### DIFF
--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -29,7 +29,7 @@ import { createPortal } from "react-dom";
 
 import { Button } from "../../button";
 import { Dropdown, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../../dropdown";
-import { ChevronDownIcon } from "@coss/ui/icons";
+import { ChevronDownIcon, ChevronUpIcon } from "@coss/ui/icons";
 import type { TextEditorProps } from "../types";
 import { AddVariablesDropdown } from "./AddVariablesDropdown";
 
@@ -247,7 +247,7 @@ export default function ToolbarPlugin(props: TextEditorProps) {
   const [isLink, setIsLink] = useState(false);
   const [isBold, setIsBold] = useState(false);
   const [isItalic, setIsItalic] = useState(false);
-
+  const [isOpen, setIsOpen] = useState(false);
   const formatParagraph = () => {
     if (blockType !== "paragraph") {
       editor.update(() => {
@@ -459,14 +459,16 @@ export default function ToolbarPlugin(props: TextEditorProps) {
       <>
         {!props.excludedToolbarItems?.includes("blockType") && (
           <>
-            <Dropdown>
+            <Dropdown onOpenChange={setIsOpen} open={isOpen}>
               <DropdownMenuTrigger className="text-subtle">
                 <>
                   <span className={`icon${blockType}`} />
                   <span className="text text-default hidden sm:flex">
                     {blockTypeToBlockName[blockType as keyof BlockType]}
                   </span>
-                  <ChevronDownIcon className="text-default ml-2 h-4 w-4" />
+                  {
+                    isOpen ? (<ChevronUpIcon className="text-default ml-2 h-4 w-4" />) : (<ChevronDownIcon className="text-default ml-2 h-4 w-4" />)
+                  }
                 </>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="flex flex-col gap-1">


### PR DESCRIPTION
## What does this PR do?

fixes the chevron state icon in the editor toolbox to dynamically toggle up and down on click. 
Motivation & Context: 
Previously, the chevron icon did not reflect the open/closed state of the toolbox, which caused confusion for users. This change improves UX by making the icon state consistent with the toolbox state. 
 


- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

Before 

https://github.com/user-attachments/assets/4829797e-7742-4929-a1c2-9798daf70c3f

After 

https://github.com/user-attachments/assets/96e5ef94-8269-4fc2-afc0-60e44c44e147




## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Go to the profile settings and check the normal in toolbar

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs
