### PR TITLE
refactor: replace manual provider logic with getAppFromLocationValue

### DIFF
--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -2,6 +2,7 @@ import type { TFunction } from "i18next";
 import short from "short-uuid";
 import { v5 as uuidv5 } from "uuid";
 
+import { getAppFromLocationValue } from "@calcom/app-store/utils";
 import getLabelValueMapFromResponses from "@calcom/lib/bookings/getLabelValueMapFromResponses";
 import { Prisma } from "@calcom/prisma/client";
 import type {
@@ -194,15 +195,15 @@ export const getLocation = (calEvent: {
 };
 
 export const getProviderName = (location?: string | null): string => {
-  // TODO: use getAppName from @calcom/app-store
   if (location && location.includes("integrations:")) {
-    let locationName = location.split(":")[1];
-    if (locationName === "daily") {
-      locationName = "Cal Video";
+    const app = getAppFromLocationValue(location);
+    if (app) {
+      return app.name;
     }
+    // Fallback for unknown integrations: capitalize the slug after "integrations:"
+    const locationName = location.split(":")[1];
     return locationName[0].toUpperCase() + locationName.slice(1);
   }
-  // If location its a url, probably we should be validating it with a custom library
   if (location && /^https?:\/\//.test(location)) {
     return location;
   }


### PR DESCRIPTION
Fixes #28095

  ## What changed
  Replaced hardcoded string splitting and manual provider name mapping in
  `getProviderName` with the centralized `getAppFromLocationValue` utility from
  `@calcom/app-store`.

  ## Why
  A TODO in the code requested this migration. The manual approach only handled 'daily'
  → 'Cal Video' and capitalized other slugs. The utility looks up the canonical app name
   from metadata, working correctly for all registered integrations.

  ## How
  - Import `getAppFromLocationValue` from `@calcom/app-store/utils`
  - Look up the app by location type and return `app.name`
  - Keep a fallback (capitalize slug) for unregistered integrations
  - Preserve URL passthrough for non-integration locations