### PR TITLE
fix: update booker hook imports in platform atoms

### DIFF
--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -7,9 +7,9 @@ import {
   useBookerStoreContext,
   useInitializeBookerStoreContext,
 } from "@calcom/features/bookings/Booker/BookerStoreProvider";
-import { useBookerLayout } from "@calcom/features/bookings/Booker/components/hooks/useBookerLayout";
-import { useBookingForm } from "@calcom/features/bookings/Booker/components/hooks/useBookingForm";
-import { useLocalSet } from "@calcom/features/bookings/Booker/components/hooks/useLocalSet";
+import { useBookerLayout } from "@calcom/features/bookings/Booker/hooks/useBookerLayout";
+import { useBookingForm } from "@calcom/features/bookings/Booker/hooks/useBookingForm";
+import { useLocalSet } from "@calcom/features/bookings/Booker/hooks/useLocalSet";
 import { useStableTimezone } from "@calcom/features/bookings/Booker/hooks/useStableTimezone";
 import { useInitializeBookerStore } from "@calcom/features/bookings/Booker/store";
 import { useTimePreferences } from "@calcom/features/bookings/lib";
@@ -299,10 +299,10 @@ const BookerPlatformWrapperComponent = (
     teamMemberEmail: teamMemberEmail ?? undefined,
     ...(props.isTeamEvent
       ? {
-          isTeamEvent: props.isTeamEvent,
-          teamId: teamId,
-          rrHostSubsetIds: rrHostSubsetIds,
-        }
+        isTeamEvent: props.isTeamEvent,
+        teamId: teamId,
+        rrHostSubsetIds: rrHostSubsetIds,
+      }
       : {}),
     enabled:
       Boolean(teamId || username) &&
@@ -322,7 +322,7 @@ const BookerPlatformWrapperComponent = (
     }
   }, [schedule.data, schedule.isPending, schedule.error, onTimeslotsLoaded]);
 
-  const bookerForm= useBookingForm({
+  const bookerForm = useBookingForm({
     event: event?.data,
     sessionEmail:
       session?.data?.email && clientId
@@ -452,8 +452,8 @@ const BookerPlatformWrapperComponent = (
     isBookingDryRun: isBookingDryRun ?? routingParams?.isBookingDryRun,
     ...(props.isTeamEvent
       ? {
-          rrHostSubsetIds: rrHostSubsetIds,
-        }
+        rrHostSubsetIds: rrHostSubsetIds,
+      }
       : {}),
   });
 


### PR DESCRIPTION
## What does this PR do?

### Problem: 

-  The booker hooks were moved from `@calcom/features/bookings/Booker/components/hooks/` to `@calcom/features/bookings/Booker/hooks/`, causing broken imports in  platform atoms.


CI link: https://github.com/calcom/cal.com/actions/runs/22255432358/job/64386321489?pr=28117#step:7:417
<img width="1690" height="226" alt="Screenshot 2026-02-21 at 4 47 29 PM" src="https://github.com/user-attachments/assets/4dff7d87-3513-48c9-938c-6ca6384f8695" />


  ## Solution

  Updated import paths for:
  - `useBookerLayout`
  - `useBookingForm`
  - `useLocalSet`

---

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs
