### PR TITLE
feat(routing-forms): add booking question field types to routing forms

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FieldTypes } from "@calcom/app-store/routing-forms/lib/FieldTypes";
+import { FIELD_TYPES_WITH_OPTIONS, FieldTypes } from "@calcom/app-store/routing-forms/lib/FieldTypes";
 import type { RoutingFormWithResponseCount } from "@calcom/app-store/routing-forms/types/types";
 import { LearnMoreLink } from "@calcom/features/eventtypes/components/LearnMoreLink";
 import { getFieldIdentifier } from "@calcom/features/form-builder/utils/getFieldIdentifier";
@@ -98,6 +98,28 @@ function Field({
         <FormCardBody>
           <div className="mb-3 w-full">
             <TextField
+              disabled={!!router}
+              label={t("identifier_url_parameter")}
+              hint={
+                <LearnMoreLink
+                  t={t}
+                  i18nKey="identifier_url_parameter_hint"
+                  href="https://cal.com/help/routing/connect-routing-form-to-booking-questions"
+                />
+              }
+              name={`${hookFieldNamespace}.identifier`}
+              required
+              placeholder={t("identifies_name_field")}
+              value={identifier || routerField?.identifier || ""}
+              onChange={(e) => {
+                hookForm.setValue(`${hookFieldNamespace}.identifier`, e.target.value.toLowerCase(), {
+                  shouldDirty: true,
+                });
+              }}
+            />
+          </div>
+          <div className="mb-3 w-full">
+            <TextField
               data-testid={`${hookFieldNamespace}.label`}
               disabled={!!router}
               label="Label"
@@ -130,28 +152,6 @@ function Field({
             />
           </div>
           <div className="mb-3 w-full">
-            <TextField
-              disabled={!!router}
-              label={t("identifier_url_parameter")}
-              hint={
-                <LearnMoreLink
-                  t={t}
-                  i18nKey="identifier_url_parameter_hint"
-                  href="https://cal.com/help/routing/connect-routing-form-to-booking-questions"
-                />
-              }
-              name={`${hookFieldNamespace}.identifier`}
-              required
-              placeholder={t("identifies_name_field")}
-              value={identifier || routerField?.identifier || label || routerField?.label || ""}
-              onChange={(e) => {
-                hookForm.setValue(`${hookFieldNamespace}.identifier`, e.target.value.toLowerCase(), {
-                  shouldDirty: true,
-                });
-              }}
-            />
-          </div>
-          <div className="mb-3 w-full">
             <Controller
               name={`${hookFieldNamespace}.type`}
               control={hookForm.control}
@@ -171,7 +171,9 @@ function Field({
                             "h-8 w-full justify-between text-left text-sm",
                             !!router && "bg-subtle cursor-not-allowed"
                           )}>
-                          <span className="text-default">{defaultValue?.label || t("select_field_type")}</span>
+                          <span className="text-default">
+                            {defaultValue?.label || t("select_field_type")}
+                          </span>
                           <ChevronDownIcon className="text-default h-4 w-4" />
                         </Button>
                       </Tooltip>
@@ -208,7 +210,7 @@ function Field({
               }}
             />
           </div>
-          {["select", "multiselect"].includes(fieldType) ? (
+          {(FIELD_TYPES_WITH_OPTIONS as readonly string[]).includes(fieldType) ? (
             <div className="bg-cal-muted w-full rounded-[10px] p-2">
               <Label className="text-subtle">{t("options")}</Label>
               <MultiOptionInput

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
@@ -1,10 +1,7 @@
-// Figure out why routing-forms/env.d.ts doesn't work
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-//@ts-ignore
 import type { Operators, Types } from "./BasicConfig";
 import BasicConfig from "./BasicConfig";
-import { ConfigFor } from "./types";
 import type { WidgetsWithoutFactory } from "./types";
+import { ConfigFor } from "./types";
 
 function getWidgetsWithoutFactory(_configFor: ConfigFor) {
   const widgetsWithoutFactory: WidgetsWithoutFactory = {
@@ -14,6 +11,21 @@ function getWidgetsWithoutFactory(_configFor: ConfigFor) {
     },
     email: {
       ...BasicConfig.widgets.text,
+    },
+    address: {
+      ...BasicConfig.widgets.text,
+    },
+    url: {
+      ...BasicConfig.widgets.text,
+    },
+    boolean: {
+      ...BasicConfig.widgets.text,
+    },
+    checkbox: {
+      ...BasicConfig.widgets.multiselect,
+    },
+    radio: {
+      ...BasicConfig.widgets.select,
     },
   };
   return widgetsWithoutFactory;
@@ -50,6 +62,40 @@ function getTypes(configFor: ConfigFor) {
           ...BasicConfig.types.multiselect.widgets.multiselect,
           operators: [...multiSelectOperators],
         },
+      },
+    },
+    address: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    url: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    boolean: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    checkbox: {
+      ...BasicConfig.types.multiselect,
+      widgets: {
+        ...BasicConfig.types.multiselect.widgets,
+        multiselect: {
+          ...BasicConfig.types.multiselect.widgets.multiselect,
+          operators: [...multiSelectOperators],
+        },
+      },
+    },
+    radio: {
+      ...BasicConfig.types.select,
+      widgets: {
+        ...BasicConfig.types.select.widgets,
       },
     },
   };

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
@@ -12,6 +12,9 @@ function getWidgetsWithoutFactory(_configFor: ConfigFor) {
     email: {
       ...BasicConfig.widgets.text,
     },
+    multiemail: {
+      ...BasicConfig.widgets.text,
+    },
     address: {
       ...BasicConfig.widgets.text,
     },
@@ -49,6 +52,12 @@ function getTypes(configFor: ConfigFor) {
       },
     },
     email: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    multiemail: {
       ...BasicConfig.types.text,
       widgets: {
         ...BasicConfig.types.text.widgets,

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
@@ -108,6 +108,11 @@ function withFactoryWidgets(widgets: WidgetsWithoutFactory) {
       ...widgets.text,
       factory: EmailFactory,
     },
+    multiemail: {
+      ...widgets.text,
+      factory: TextFactory,
+      valuePlaceholder: "Enter emails",
+    },
     address: {
       ...widgets.text,
       factory: TextFactory,

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
@@ -1,20 +1,17 @@
+import { EmailField as EmailWidget } from "@calcom/ui/components/form";
 import type { ChangeEvent } from "react";
 import type {
-  Settings,
   SelectWidgetProps,
   SelectWidget as SelectWidgetType,
+  Settings,
   WidgetProps,
 } from "react-awesome-query-builder";
-
-import { EmailField as EmailWidget } from "@calcom/ui/components/form";
-
 import widgetsComponents from "../widgets";
-import type { Widgets, WidgetsWithoutFactory } from "./types";
-import type { ConfigFor } from "./types";
+import type { ConfigFor, Widgets, WidgetsWithoutFactory } from "./types";
 
 export { ConfigFor } from "./types";
 
-const renderComponent = function <T1>(props: T1 | undefined, Component: React.FC<T1>) {
+const renderComponent = <T1,>(props: T1 | undefined, Component: React.FC<T1>) => {
   if (!props) {
     return <div />;
   }
@@ -111,6 +108,29 @@ function withFactoryWidgets(widgets: WidgetsWithoutFactory) {
       ...widgets.text,
       factory: EmailFactory,
     },
+    address: {
+      ...widgets.text,
+      factory: TextFactory,
+      valuePlaceholder: "Enter Address",
+    },
+    url: {
+      ...widgets.text,
+      factory: TextFactory,
+      valuePlaceholder: "Enter URL",
+    },
+    boolean: {
+      ...widgets.text,
+      factory: TextFactory,
+      valuePlaceholder: "Yes or No",
+    },
+    checkbox: {
+      ...widgets.multiselect,
+      factory: MultiSelectFactory,
+    } as SelectWidgetType,
+    radio: {
+      ...widgets.select,
+      factory: SelectFactory,
+    } as SelectWidgetType,
   };
   return widgetsWithFactory;
 }

--- a/packages/app-store/routing-forms/lib/FieldTypes.ts
+++ b/packages/app-store/routing-forms/lib/FieldTypes.ts
@@ -1,4 +1,4 @@
-export const enum RoutingFormFieldType {
+export enum RoutingFormFieldType {
   TEXT = "text",
   NUMBER = "number",
   TEXTAREA = "textarea",
@@ -6,6 +6,11 @@ export const enum RoutingFormFieldType {
   MULTI_SELECT = "multiselect",
   PHONE = "phone",
   EMAIL = "email",
+  CHECKBOX = "checkbox",
+  RADIO = "radio",
+  BOOLEAN = "boolean",
+  ADDRESS = "address",
+  URL = "url",
 }
 
 export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFieldType => {
@@ -17,8 +22,21 @@ export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFi
     RoutingFormFieldType.MULTI_SELECT,
     RoutingFormFieldType.PHONE,
     RoutingFormFieldType.EMAIL,
+    RoutingFormFieldType.CHECKBOX,
+    RoutingFormFieldType.RADIO,
+    RoutingFormFieldType.BOOLEAN,
+    RoutingFormFieldType.ADDRESS,
+    RoutingFormFieldType.URL,
   ].includes(type as RoutingFormFieldType);
 };
+
+/** Field types with options that need a listValues config in RAQB */
+export const FIELD_TYPES_WITH_OPTIONS: readonly RoutingFormFieldType[] = [
+  RoutingFormFieldType.SINGLE_SELECT,
+  RoutingFormFieldType.MULTI_SELECT,
+  RoutingFormFieldType.CHECKBOX,
+  RoutingFormFieldType.RADIO,
+];
 
 export const FieldTypes = [
   {
@@ -48,5 +66,25 @@ export const FieldTypes = [
   {
     label: "Email",
     value: RoutingFormFieldType.EMAIL,
+  },
+  {
+    label: "Checkbox group",
+    value: RoutingFormFieldType.CHECKBOX,
+  },
+  {
+    label: "Radio group",
+    value: RoutingFormFieldType.RADIO,
+  },
+  {
+    label: "Yes/No",
+    value: RoutingFormFieldType.BOOLEAN,
+  },
+  {
+    label: "Address",
+    value: RoutingFormFieldType.ADDRESS,
+  },
+  {
+    label: "URL",
+    value: RoutingFormFieldType.URL,
   },
 ] as const;

--- a/packages/app-store/routing-forms/lib/FieldTypes.ts
+++ b/packages/app-store/routing-forms/lib/FieldTypes.ts
@@ -6,6 +6,7 @@ export enum RoutingFormFieldType {
   MULTI_SELECT = "multiselect",
   PHONE = "phone",
   EMAIL = "email",
+  MULTI_EMAIL = "multiemail",
   CHECKBOX = "checkbox",
   RADIO = "radio",
   BOOLEAN = "boolean",
@@ -22,6 +23,7 @@ export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFi
     RoutingFormFieldType.MULTI_SELECT,
     RoutingFormFieldType.PHONE,
     RoutingFormFieldType.EMAIL,
+    RoutingFormFieldType.MULTI_EMAIL,
     RoutingFormFieldType.CHECKBOX,
     RoutingFormFieldType.RADIO,
     RoutingFormFieldType.BOOLEAN,
@@ -66,6 +68,10 @@ export const FieldTypes = [
   {
     label: "Email",
     value: RoutingFormFieldType.EMAIL,
+  },
+  {
+    label: "Multiple emails",
+    value: RoutingFormFieldType.MULTI_EMAIL,
   },
   {
     label: "Checkbox group",

--- a/packages/app-store/routing-forms/lib/FieldTypes.ts
+++ b/packages/app-store/routing-forms/lib/FieldTypes.ts
@@ -1,35 +1,44 @@
-export enum RoutingFormFieldType {
-  TEXT = "text",
-  NUMBER = "number",
-  TEXTAREA = "textarea",
-  SINGLE_SELECT = "select",
-  MULTI_SELECT = "multiselect",
-  PHONE = "phone",
-  EMAIL = "email",
-  MULTI_EMAIL = "multiemail",
-  CHECKBOX = "checkbox",
-  RADIO = "radio",
-  BOOLEAN = "boolean",
-  ADDRESS = "address",
-  URL = "url",
-}
+import type { FieldType } from "@calcom/prisma/zod-utils";
+import { fieldTypeEnum } from "@calcom/prisma/zod-utils";
+
+/**
+ * System-only field types excluded from routing forms.
+ * These are tied to specific booking system behavior, not generic question types.
+ */
+const EXCLUDED_FIELD_TYPES = ["name", "radioInput"] as const;
+type ExcludedFieldType = (typeof EXCLUDED_FIELD_TYPES)[number];
+
+/**
+ * Derived from the shared fieldTypeEnum in @calcom/prisma/zod-utils.
+ * Adding a new type to fieldTypeEnum automatically makes it available
+ * in routing forms (unless explicitly excluded above).
+ */
+export type RoutingFormFieldType = Exclude<FieldType, ExcludedFieldType>;
+
+// Const object for backward compat — consumers use RoutingFormFieldType.SINGLE_SELECT etc.
+export const RoutingFormFieldType = {
+  TEXT: "text",
+  NUMBER: "number",
+  TEXTAREA: "textarea",
+  SINGLE_SELECT: "select",
+  MULTI_SELECT: "multiselect",
+  PHONE: "phone",
+  EMAIL: "email",
+  MULTI_EMAIL: "multiemail",
+  CHECKBOX: "checkbox",
+  RADIO: "radio",
+  BOOLEAN: "boolean",
+  ADDRESS: "address",
+  URL: "url",
+} as const satisfies Record<string, RoutingFormFieldType>;
+
+// Derive valid types from the shared fieldTypeEnum at runtime
+const VALID_ROUTING_FORM_FIELD_TYPES: readonly string[] = fieldTypeEnum.options.filter(
+  (type) => !(EXCLUDED_FIELD_TYPES as readonly string[]).includes(type)
+);
 
 export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFieldType => {
-  return [
-    RoutingFormFieldType.TEXT,
-    RoutingFormFieldType.NUMBER,
-    RoutingFormFieldType.TEXTAREA,
-    RoutingFormFieldType.SINGLE_SELECT,
-    RoutingFormFieldType.MULTI_SELECT,
-    RoutingFormFieldType.PHONE,
-    RoutingFormFieldType.EMAIL,
-    RoutingFormFieldType.MULTI_EMAIL,
-    RoutingFormFieldType.CHECKBOX,
-    RoutingFormFieldType.RADIO,
-    RoutingFormFieldType.BOOLEAN,
-    RoutingFormFieldType.ADDRESS,
-    RoutingFormFieldType.URL,
-  ].includes(type as RoutingFormFieldType);
+  return VALID_ROUTING_FORM_FIELD_TYPES.includes(type);
 };
 
 /** Field types with options that need a listValues config in RAQB */
@@ -40,57 +49,25 @@ export const FIELD_TYPES_WITH_OPTIONS: readonly RoutingFormFieldType[] = [
   RoutingFormFieldType.RADIO,
 ];
 
-export const FieldTypes = [
-  {
-    label: "Short text",
-    value: RoutingFormFieldType.TEXT,
-  },
-  {
-    label: "Number",
-    value: RoutingFormFieldType.NUMBER,
-  },
-  {
-    label: "Long text",
-    value: RoutingFormFieldType.TEXTAREA,
-  },
-  {
-    label: "Single-choice selection",
-    value: RoutingFormFieldType.SINGLE_SELECT,
-  },
-  {
-    label: "Multiple choice selection",
-    value: RoutingFormFieldType.MULTI_SELECT,
-  },
-  {
-    label: "Phone",
-    value: RoutingFormFieldType.PHONE,
-  },
-  {
-    label: "Email",
-    value: RoutingFormFieldType.EMAIL,
-  },
-  {
-    label: "Multiple emails",
-    value: RoutingFormFieldType.MULTI_EMAIL,
-  },
-  {
-    label: "Checkbox group",
-    value: RoutingFormFieldType.CHECKBOX,
-  },
-  {
-    label: "Radio group",
-    value: RoutingFormFieldType.RADIO,
-  },
-  {
-    label: "Yes/No",
-    value: RoutingFormFieldType.BOOLEAN,
-  },
-  {
-    label: "Address",
-    value: RoutingFormFieldType.ADDRESS,
-  },
-  {
-    label: "URL",
-    value: RoutingFormFieldType.URL,
-  },
-] as const;
+/** Human-readable labels for routing form field types */
+const FIELD_TYPE_LABELS: Partial<Record<RoutingFormFieldType, string>> = {
+  text: "Short text",
+  number: "Number",
+  textarea: "Long text",
+  select: "Single-choice selection",
+  multiselect: "Multiple choice selection",
+  phone: "Phone",
+  email: "Email",
+  multiemail: "Multiple emails",
+  checkbox: "Checkbox group",
+  radio: "Radio group",
+  boolean: "Yes/No",
+  address: "Address",
+  url: "URL",
+};
+
+/** Derived from fieldTypeEnum — new types added there appear here automatically */
+export const FieldTypes = VALID_ROUTING_FORM_FIELD_TYPES.map((type) => ({
+  label: FIELD_TYPE_LABELS[type as RoutingFormFieldType] || type.charAt(0).toUpperCase() + type.slice(1),
+  value: type as RoutingFormFieldType,
+}));

--- a/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
+++ b/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
@@ -9,13 +9,11 @@ import { HttpError } from "@calcom/lib/http-error";
 import logger from "@calcom/lib/logger";
 import { withReporting } from "@calcom/lib/sentryWrapper";
 import { prisma } from "@calcom/prisma";
-import type { Prisma } from "@calcom/prisma/client";
-import type { App_RoutingForms_Form, User } from "@calcom/prisma/client";
+import type { App_RoutingForms_Form, Prisma, User } from "@calcom/prisma/client";
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 import { RoutingFormSettings } from "@calcom/prisma/zod-utils";
 import type { Ensure } from "@calcom/types/utils";
-
-import type { FormResponse, SerializableForm, SerializableField, OrderedResponses } from "../types/types";
+import type { FormResponse, OrderedResponses, SerializableField, SerializableForm } from "../types/types";
 import getFieldIdentifier from "./getFieldIdentifier";
 
 const moduleLogger = logger.getSubLogger({ prefix: ["routing-forms/lib/formSubmissionUtils"] });
@@ -45,7 +43,13 @@ export type FORM_SUBMITTED_WEBHOOK_RESPONSES = Record<
 >;
 
 function isOptionsField(field: Pick<SerializableField, "type" | "options">) {
-  return (field.type === "select" || field.type === "multiselect") && field.options;
+  return (
+    (field.type === "select" ||
+      field.type === "multiselect" ||
+      field.type === "checkbox" ||
+      field.type === "radio") &&
+    field.options
+  );
 }
 
 export function getFieldResponse({
@@ -192,11 +196,14 @@ export async function _onFormSubmission(
       },
       rootData: {
         // Send responses unwrapped at root level for backwards compatibility
-        ...Object.entries(fieldResponsesByIdentifier).reduce((acc, [key, value]) => {
-          const normalizedKey = normalizeIdentifierForHandlebars(key);
-          acc[normalizedKey] = value.value;
-          return acc;
-        }, {} as Record<string, FormResponse[keyof FormResponse]["value"]>),
+        ...Object.entries(fieldResponsesByIdentifier).reduce(
+          (acc, [key, value]) => {
+            const normalizedKey = normalizeIdentifierForHandlebars(key);
+            acc[normalizedKey] = value.value;
+            return acc;
+          },
+          {} as Record<string, FormResponse[keyof FormResponse]["value"]>
+        ),
       },
     }).catch((e) => {
       console.error(`Error executing routing form webhook`, webhook, e);

--- a/packages/app-store/routing-forms/lib/getQueryBuilderConfig.ts
+++ b/packages/app-store/routing-forms/lib/getQueryBuilderConfig.ts
@@ -1,7 +1,6 @@
 import { AttributeType } from "@calcom/prisma/enums";
-
-import type { RoutingForm, Attribute } from "../types/types";
-import { FieldTypes, RoutingFormFieldType } from "./FieldTypes";
+import type { Attribute, RoutingForm } from "../types/types";
+import { FIELD_TYPES_WITH_OPTIONS, FieldTypes, RoutingFormFieldType } from "./FieldTypes";
 import { AttributesInitialConfig, FormFieldsInitialConfig } from "./InitialConfig";
 import { getUIOptionsForSelect } from "./selectOptions";
 
@@ -63,8 +62,10 @@ export function getQueryBuilderConfigForFormFields(form: Pick<RoutingForm, "fiel
         type: widgetType,
         valueSources: ["value"],
         fieldSettings: {
-          // IMPORTANT: listValues must be undefined for non-select/multiselect fields otherwise RAQB doesn't like it. It ends up considering all the text values as per the listValues too which could be empty as well making all values invalid
-          listValues: fieldType === "select" || fieldType === "multiselect" ? options : undefined,
+          // IMPORTANT: listValues must be undefined for non-option fields otherwise RAQB doesn't like it. It ends up considering all the text values as per the listValues too which could be empty as well making all values invalid
+          listValues: FIELD_TYPES_WITH_OPTIONS.includes(fieldType as RoutingFormFieldType)
+            ? options
+            : undefined,
         },
       };
     } else {
@@ -156,9 +157,10 @@ export function getQueryBuilderConfigForAttributes({
         type: widgetType,
         valueSources: ["value"],
         fieldSettings: {
-          // IMPORTANT: listValues must be undefined for non-select/multiselect fields otherwise RAQB doesn't like it. It ends up considering all the text values as per the listValues too which could be empty as well making all values invalid
-          listValues:
-            attributeType === "select" || attributeType === "multiselect" ? attributeOptions : undefined,
+          // IMPORTANT: listValues must be undefined for non-option fields otherwise RAQB doesn't like it. It ends up considering all the text values as per the listValues too which could be empty as well making all values invalid
+          listValues: FIELD_TYPES_WITH_OPTIONS.includes(attributeType as RoutingFormFieldType)
+            ? attributeOptions
+            : undefined,
         },
       };
     } else {

--- a/packages/app-store/routing-forms/lib/transformResponse.test.ts
+++ b/packages/app-store/routing-forms/lib/transformResponse.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect } from "vitest";
-
+import { describe, expect, it } from "vitest";
 import { getFieldResponseForJsonLogic } from "./transformResponse";
 
 describe("getFieldResponseForJsonLogic", () => {
@@ -139,6 +138,102 @@ describe("getFieldResponseForJsonLogic", () => {
       const value = 1;
       const result = getFieldResponseForJsonLogic({ field, value });
       expect(result).toBe("1");
+    });
+  });
+
+  describe("checkbox", () => {
+    it("should transform array values using option ids like multiselect", () => {
+      const field = {
+        type: "checkbox",
+        options: [
+          { id: "a1", label: "Alpha" },
+          { id: "b2", label: "Beta" },
+        ],
+      };
+      const result = getFieldResponseForJsonLogic({ field, value: ["a1", "b2"] });
+      expect(result).toEqual(["a1", "b2"]);
+    });
+
+    it("should resolve labels to ids for checkbox fields", () => {
+      const field = {
+        type: "checkbox",
+        options: [
+          { id: "a1", label: "Alpha" },
+          { id: "b2", label: "Beta" },
+        ],
+      };
+      const result = getFieldResponseForJsonLogic({ field, value: ["Alpha", "Beta"] });
+      expect(result).toEqual(["a1", "b2"]);
+    });
+
+    it("should handle comma-separated string value for checkbox", () => {
+      const field = {
+        type: "checkbox",
+        options: [
+          { id: "a1", label: "Alpha" },
+          { id: "b2", label: "Beta" },
+        ],
+      };
+      const result = getFieldResponseForJsonLogic({ field, value: "a1,b2" });
+      expect(result).toEqual(["a1", "b2"]);
+    });
+  });
+
+  describe("radio", () => {
+    it("should transform single value using option id like select", () => {
+      const field = {
+        type: "radio",
+        options: [
+          { id: "x1", label: "Yes" },
+          { id: "x2", label: "No" },
+        ],
+      };
+      const result = getFieldResponseForJsonLogic({ field, value: "x1" });
+      expect(result).toBe("x1");
+    });
+
+    it("should resolve label to id for radio fields", () => {
+      const field = {
+        type: "radio",
+        options: [
+          { id: "x1", label: "Yes" },
+          { id: "x2", label: "No" },
+        ],
+      };
+      const result = getFieldResponseForJsonLogic({ field, value: "Yes" });
+      expect(result).toBe("x1");
+    });
+
+    it("should handle number value for radio fields", () => {
+      const field = {
+        type: "radio",
+        options: [
+          { id: "1", label: "Option 1" },
+          { id: "2", label: "Option 2" },
+        ],
+      };
+      const result = getFieldResponseForJsonLogic({ field, value: 1 });
+      expect(result).toBe("1");
+    });
+  });
+
+  describe("passthrough types", () => {
+    it("should pass through boolean field value unchanged", () => {
+      const field = { type: "boolean", options: undefined };
+      const result = getFieldResponseForJsonLogic({ field, value: "true" });
+      expect(result).toBe("true");
+    });
+
+    it("should pass through address field value unchanged", () => {
+      const field = { type: "address", options: undefined };
+      const result = getFieldResponseForJsonLogic({ field, value: "123 Main St" });
+      expect(result).toBe("123 Main St");
+    });
+
+    it("should pass through url field value unchanged", () => {
+      const field = { type: "url", options: undefined };
+      const result = getFieldResponseForJsonLogic({ field, value: "https://cal.com" });
+      expect(result).toBe("https://cal.com");
     });
   });
 });

--- a/packages/app-store/routing-forms/lib/transformResponse.test.ts
+++ b/packages/app-store/routing-forms/lib/transformResponse.test.ts
@@ -217,6 +217,23 @@ describe("getFieldResponseForJsonLogic", () => {
     });
   });
 
+  describe("multiemail", () => {
+    it("should pass through multiemail field value unchanged", () => {
+      const field = { type: "multiemail", options: undefined };
+      const result = getFieldResponseForJsonLogic({ field, value: "test@example.com" });
+      expect(result).toBe("test@example.com");
+    });
+
+    it("should pass through multiemail array value unchanged", () => {
+      const field = { type: "multiemail", options: undefined };
+      const result = getFieldResponseForJsonLogic({
+        field,
+        value: ["a@example.com", "b@example.com"],
+      });
+      expect(result).toEqual(["a@example.com", "b@example.com"]);
+    });
+  });
+
   describe("passthrough types", () => {
     it("should pass through boolean field value unchanged", () => {
       const field = { type: "boolean", options: undefined };

--- a/packages/app-store/routing-forms/lib/transformResponse.ts
+++ b/packages/app-store/routing-forms/lib/transformResponse.ts
@@ -1,5 +1,4 @@
 import type { z } from "zod";
-
 import type { Field, FormResponse } from "../types/types";
 import { areSelectOptionsInLegacyFormat } from "./selectOptions";
 
@@ -69,7 +68,7 @@ export function getFieldResponseForJsonLogic({
     }
     return value;
   }
-  if (field.type === "multiselect") {
+  if (field.type === "multiselect" || field.type === "checkbox") {
     // Could be option id(i.e. a UUIDv4) or option label for ease of prefilling
     let valueOrLabelArray = value instanceof Array ? value : value.toString().split(",");
 
@@ -80,7 +79,7 @@ export function getFieldResponseForJsonLogic({
     return valueOrLabelArray;
   }
 
-  if (field.type === "select") {
+  if (field.type === "select" || field.type === "radio") {
     const valueAsStringOrStringArray = typeof value === "number" ? String(value) : value;
     const valueAsString =
       valueAsStringOrStringArray instanceof Array


### PR DESCRIPTION
## Summary

Adds 6 new field types to routing forms that already exist in event-type booking questions, and derives the type system from the shared `fieldTypeEnum` — closing the gap described in #18987.

**New types:** Multiple emails, Checkbox group, Radio group, Yes/No, Address, URL

This gives routing forms 13 field types total (up from 7), matching what event types offer for custom inputs. The only excluded types are `name` and `radioInput` — those are system fields, not generic question types.

**Key design decision:** `RoutingFormFieldType` is now derived from the shared `fieldTypeEnum` in `@calcom/prisma/zod-utils`. Adding a new type to `fieldTypeEnum` automatically makes it available in routing forms — no need to maintain two separate lists. This directly addresses the requirement in #18987 that "adding a new input type to event-types will also add it to routing forms."

Also reorders the field editor to show Identifier first (empty, not prefilled from label) — matching event-type behavior per PeerRich's ask.

## Changes (~250 lines, 8 files)

- **FieldTypes.ts** — derived from shared `fieldTypeEnum`, auto-syncs with event-type field types
- **config.ts** — RAQB widget and type entries for new fields
- **uiConfig.tsx** — factory functions so new types render in route condition builder
- **transformResponse.ts** — checkbox (multiselect logic) and radio (select logic) for JSON Logic routing
- **getQueryBuilderConfig.ts** — expanded `listValues` for checkbox/radio options
- **FormEdit.tsx** — show options editor for checkbox/radio; reorder identifier before label
- **formSubmissionUtils.ts** — include checkbox/radio in options field check for webhooks
- **transformResponse.test.ts** — 11 new tests covering all new types

## Demo

### After — 13 types, dropdown open (top half)

![After dropdown](https://files.catbox.moe/3mwppz.png)

### After — scrolled to show new types (Multiple emails, Checkbox group, Radio group, Yes/No, Address, URL)

![After scrolled](https://files.catbox.moe/88bvu3.png)

### After — Identifier first, empty (not prefilled from label)

![Field order](https://files.catbox.moe/3fpgzn.png)

### Before vs After — Type dropdown comparison

![Before vs After top](https://files.catbox.moe/s2xp9i.png)

### Before vs After — New types visible (scrolled)

![Before vs After bottom](https://files.catbox.moe/eujqro.png)

### Demo video

https://files.catbox.moe/27oaw5.mp4

## Test plan

- [x] All 163 routing-forms tests pass (`TZ=UTC yarn test`)
- [x] 11 new transform tests for multiemail, checkbox, radio, boolean, address, url
- [x] Biome lint clean
- [x] App-store package type-check passes
- [ ] Manual: create routing form with each new field type
- [ ] Manual: set route conditions using new field types
- [ ] Manual: submit form and verify routing works

Closes #18987

/claim #18987