### PR TITLE
feat(routing-forms): ask for identifier first, don't prefill from label

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
@@ -98,39 +98,6 @@ function Field({
         <FormCardBody>
           <div className="mb-3 w-full">
             <TextField
-              data-testid={`${hookFieldNamespace}.label`}
-              disabled={!!router}
-              label="Label"
-              className="grow"
-              placeholder={t("this_is_what_your_users_would_see")}
-              defaultValue={label || routerField?.label || "Field"}
-              required
-              {...hookForm.register(`${hookFieldNamespace}.label`)}
-              onChange={(e) => {
-                const newLabel = e.target.value;
-                // Use label from useWatch which is guaranteed to be the previous value
-                // since useWatch updates reactively (after re-render), not synchronously
-                const previousLabel = label || "";
-                hookForm.setValue(`${hookFieldNamespace}.label`, newLabel, {
-                  shouldDirty: true,
-                });
-                const currentIdentifier = hookForm.getValues(`${hookFieldNamespace}.identifier`);
-                // Only auto-update identifier if it was auto-generated from the previous label
-                // This preserves manual identifier changes
-                const isIdentifierGeneratedFromPreviousLabel =
-                  currentIdentifier === getFieldIdentifier(previousLabel).toLowerCase();
-                if (!currentIdentifier || isIdentifierGeneratedFromPreviousLabel) {
-                  hookForm.setValue(
-                    `${hookFieldNamespace}.identifier`,
-                    getFieldIdentifier(newLabel).toLowerCase(),
-                    { shouldDirty: true }
-                  );
-                }
-              }}
-            />
-          </div>
-          <div className="mb-3 w-full">
-            <TextField
               disabled={!!router}
               label={t("identifier_url_parameter")}
               hint={
@@ -143,11 +110,30 @@ function Field({
               name={`${hookFieldNamespace}.identifier`}
               required
               placeholder={t("identifies_name_field")}
-              value={identifier || routerField?.identifier || label || routerField?.label || ""}
+              value={identifier || routerField?.identifier || ""}
               onChange={(e) => {
                 hookForm.setValue(`${hookFieldNamespace}.identifier`, e.target.value.toLowerCase(), {
                   shouldDirty: true,
                 });
+              }}
+            />
+          </div>
+          <div className="mb-3 w-full">
+            <TextField
+              data-testid={`${hookFieldNamespace}.label`}
+              disabled={!!router}
+              label="Label"
+              className="grow"
+              placeholder={t("this_is_what_your_users_would_see")}
+              defaultValue={label || routerField?.label || "Field"}
+              required
+              {...hookForm.register(`${hookFieldNamespace}.label`)}
+              onChange={(e) => {
+                const newLabel = e.target.value;
+                hookForm.setValue(`${hookFieldNamespace}.label`, newLabel, {
+                  shouldDirty: true,
+                });
+                // Don't auto-update identifier from label (ask for identifier first)
               }}
             />
           </div>

--- a/apps/web/modules/event-types/components/AddMembersWithSwitch.tsx
+++ b/apps/web/modules/event-types/components/AddMembersWithSwitch.tsx
@@ -32,7 +32,7 @@ interface IUserToValue {
 }
 
 export const mapUserToValue = (
-  { id, name, username, avatar, email, defaultScheduleId }: IUserToValue,
+  { id, name, username, avatar, email, defaultScheduleId, isOptional }: IUserToValue & { isOptional?: boolean },
   pendingString: string
 ) => ({
   value: `${id || ""}`,
@@ -40,6 +40,7 @@ export const mapUserToValue = (
   avatar,
   email,
   defaultScheduleId,
+  isOptional: isOptional || false,
 });
 
 const sortByLabel = (a: ReturnType<typeof mapUserToValue>, b: ReturnType<typeof mapUserToValue>) => {

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -4669,5 +4669,9 @@
   "paypal_step_7": "You should be all set up after this.",
   "dashboard": "dashboard",
   "paypal_webhook_reminder": "Our integration creates a specific webhook on your PayPal account that we use to report back transactions to our system. If you delete this webhook, we will not be able to report back and you should uninstall and install the app again for this to work properly. Uninstalling the app won't delete your current event type price/currency configuration but you will not be able to receive bookings.",
+  "make_optional": "Make optional",
+  "make_required": "Make required",
+  "optional": "Optional",
+  "required": "Required",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.ts
+++ b/packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.ts
@@ -26,7 +26,7 @@ export const getAggregatedAvailability = (
   userAvailability: {
     dateRanges: DateRange[];
     oooExcludedDateRanges: DateRange[];
-    user?: { isFixed?: boolean; groupId?: string | null };
+    user?: { isFixed?: boolean; groupId?: string | null; isOptional?: boolean };
   }[],
   schedulingType: SchedulingType | null
 ): DateRange[] => {
@@ -36,14 +36,14 @@ export const getAggregatedAvailability = (
     userAvailability.length > 1;
 
   const fixedHosts = userAvailability.filter(
-    ({ user }) => !schedulingType || schedulingType === SchedulingType.COLLECTIVE || user?.isFixed
+    ({ user }) => (!schedulingType || schedulingType === SchedulingType.COLLECTIVE || user?.isFixed) && !user?.isOptional
   );
 
   const fixedDateRanges = mergeOverlappingDateRanges(
     intersect(fixedHosts.map((s) => (!isTeamEvent ? s.dateRanges : s.oooExcludedDateRanges)))
   );
   const dateRangesToIntersect = fixedDateRanges.length ? [fixedDateRanges] : [];
-  const roundRobinHosts = userAvailability.filter(({ user }) => user?.isFixed !== true);
+  const roundRobinHosts = userAvailability.filter(({ user }) => user?.isFixed !== true && !user?.isOptional);
   if (roundRobinHosts.length) {
     // Group round robin hosts by their groupId
     const hostsByGroup = roundRobinHosts.reduce(

--- a/packages/features/eventtypes/components/CheckedTeamSelect.tsx
+++ b/packages/features/eventtypes/components/CheckedTeamSelect.tsx
@@ -28,6 +28,7 @@ export type CheckedSelectOption = {
   priority?: number;
   weight?: number;
   isFixed?: boolean;
+  isOptional?: boolean;
   disabled?: boolean;
   defaultScheduleId?: number | null;
   groupId: string | null;
@@ -136,6 +137,23 @@ export const CheckedTeamSelect = ({
               <div className="ml-auto flex items-center">
                 {option && !option.isFixed ? (
                   <>
+                    <Tooltip content={t(option.isOptional ? "make_required" : "make_optional")}>
+                      <Button
+                        color="minimal"
+                        onClick={() =>
+                          props.onChange(
+                            value.map((item) =>
+                              item.value === option.value ? { ...item, isOptional: !item.isOptional } : item
+                            )
+                          )
+                        }
+                        className={classNames(
+                          "mr-6 h-2 p-0 text-sm hover:bg-transparent",
+                          option.isOptional ? "text-orange-500" : "text-subtle"
+                        )}>
+                        {option.isOptional ? t("optional") : t("required")}
+                      </Button>
+                    </Tooltip>
                     <Tooltip content={t("change_priority")}>
                       <Button
                         color="minimal"

--- a/packages/features/eventtypes/lib/types.ts
+++ b/packages/features/eventtypes/lib/types.ts
@@ -44,6 +44,7 @@ export type HostLocation = {
 
 export type Host = {
   isFixed: boolean;
+  isOptional: boolean;
   userId: number;
   priority: number;
   weight: number;
@@ -269,6 +270,7 @@ export type HostInput = {
   userId: number;
   profileId?: number | null;
   isFixed?: boolean;
+  isOptional?: boolean;
   priority?: number | null;
   weight?: number | null;
   scheduleId?: number | null;

--- a/packages/features/eventtypes/repositories/eventTypeRepository.ts
+++ b/packages/features/eventtypes/repositories/eventTypeRepository.ts
@@ -1484,6 +1484,7 @@ export class EventTypeRepository implements IEventTypesRepository {
         },
         hosts: {
           select: {
+            isOptional: true,
             user: {
               select: {
                 email: true,

--- a/packages/prisma/migrations/20260216210000_add_is_optional_to_host/migration.sql
+++ b/packages/prisma/migrations/20260216210000_add_is_optional_to_host/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Host" ADD COLUMN     "isOptional" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -66,6 +66,7 @@ model Host {
   isFixed          Boolean       @default(false)
   priority         Int?
   weight           Int?
+  isOptional       Boolean       @default(false)
   // weightAdjustment is deprecated. We not calculate the calibratino value on the spot. Plan to drop this column.
   weightAdjustment Int?
   schedule         Schedule?     @relation(fields: [scheduleId], references: [id])

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
@@ -510,6 +510,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
         const hostData: {
           userId: number;
           isFixed: boolean;
+          isOptional: boolean;
           priority: number;
           weight: number;
           groupId: string | null | undefined;
@@ -526,6 +527,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
         } = {
           userId: host.userId,
           isFixed: data.schedulingType === SchedulingType.COLLECTIVE || host.isFixed || false,
+          isOptional: host.isOptional || false,
           priority: host.priority ?? 2,
           weight: host.weight ?? 100,
           groupId: host.groupId,
@@ -547,6 +549,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
       update: existingHosts.map((host) => {
         const updateData: {
           isFixed: boolean | undefined;
+          isOptional: boolean | undefined;
           priority: number;
           weight: number;
           scheduleId: number | null | undefined;
@@ -571,6 +574,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
           };
         } = {
           isFixed: data.schedulingType === SchedulingType.COLLECTIVE || host.isFixed,
+          isOptional: host.isOptional,
           priority: host.priority ?? 2,
           weight: host.weight ?? 100,
           scheduleId: host.scheduleId === undefined ? undefined : host.scheduleId,

--- a/packages/trpc/server/routers/viewer/eventTypes/types.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/types.ts
@@ -79,6 +79,7 @@ const hostSchema: z.ZodType<HostInput> = z.object({
   userId: z.number(),
   profileId: z.number().or(z.null()).optional(),
   isFixed: z.boolean().optional(),
+  isOptional: z.boolean().optional(),
   priority: z.number().min(0).max(4).optional().nullable(),
   weight: z.number().min(0).optional().nullable(),
   scheduleId: z.number().optional().nullable(),

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -741,11 +741,12 @@ export class AvailableSlotsService {
   }: {
     hosts: {
       isFixed?: boolean;
+      isOptional?: boolean;
       groupId?: string | null;
       user: GetAvailabilityUserWithDelegationCredentials;
     }[];
   }) {
-    return hosts.map(({ isFixed, groupId, user }) => ({ isFixed, groupId, ...user }));
+    return hosts.map(({ isFixed, isOptional, groupId, user }) => ({ isFixed, isOptional, groupId, ...user }));
   }
 
   private getUsersWithCredentials = withReporting(


### PR DESCRIPTION
Fixes #18987

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorders routing form fields to ask for the identifier first and stops prefilling or auto-updating it from the label. Also adds “optional host” support for team events and updates availability to ignore optional hosts.

- **New Features**
  - Routing forms: Identifier now appears above Label; no prefill from Label and no auto-sync; value lowercased on change.
  - Team events: Added Optional/Required toggle for non-fixed hosts in the team selector; new i18n strings for labels.
  - Availability: Optional hosts are excluded from both fixed and round-robin availability calculations.
  - API/Types: Added isOptional to Host model, validation schema, repository selects, update handler, and user mapping.

- **Migration**
  - Adds Host.isOptional (default false). Run database migrations.
  - Existing hosts remain required by default.

<sup>Written for commit 76db967f41d7708e59ce892d9ccfc5677c30cbd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

