### PR TITLE
fix: allow re-submitting rejected OAuth clients

### DIFF
--- a/packages/trpc/server/routers/viewer/oAuth/updateClient.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/updateClient.handler.test.ts
@@ -32,7 +32,7 @@ const REJECTION_REASON_RAW = "  we dont support your usecase ";
 
 vi.mock("@calcom/features/oauth/repositories/OAuthClientRepository", () => ({
   OAuthClientRepository: class {
-    constructor() {}
+    constructor() { }
     findByClientId = mocks.findByClientId;
     findByClientIdIncludeUser = mocks.findByClientIdIncludeUser;
   },
@@ -481,6 +481,64 @@ describe("updateClientHandler", () => {
         where: { clientId: CLIENT_ID },
         data: {
           redirectUri: updatedRedirectUri,
+          status: "PENDING",
+          rejectionReason: null,
+        },
+      })
+    );
+  });
+
+  it("sets status to PENDING when an owner updates a field of a REJECTED client", async () => {
+    mocks.findByClientIdIncludeUser.mockResolvedValue({
+      clientId: CLIENT_ID,
+      userId: OWNER_USER_ID,
+      name: CLIENT_NAME,
+      purpose: CLIENT_PURPOSE,
+      redirectUri: REDIRECT_URI,
+      websiteUrl: null,
+      logo: null,
+      status: "REJECTED",
+      user: null,
+    });
+
+    const newPurpose = "Updated purpose to fix rejection issues";
+
+    const prismaUpdate = vi.fn().mockResolvedValue({
+      clientId: CLIENT_ID,
+      name: CLIENT_NAME,
+      purpose: newPurpose,
+      status: "PENDING",
+      redirectUri: REDIRECT_URI,
+      websiteUrl: null,
+      logo: null,
+      rejectionReason: null,
+    });
+
+    const ctx = {
+      user: {
+        id: OWNER_USER_ID,
+        role: UserPermissionRole.USER,
+      },
+      prisma: {
+        oAuthClient: {
+          update: prismaUpdate,
+        },
+      } as unknown as PrismaClient,
+    };
+
+    await updateClientHandler({
+      ctx,
+      input: {
+        clientId: CLIENT_ID,
+        purpose: newPurpose,
+      },
+    });
+
+    expect(prismaUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clientId: CLIENT_ID },
+        data: {
+          purpose: newPurpose,
           status: "PENDING",
           rejectionReason: null,
         },

--- a/packages/trpc/server/routers/viewer/oAuth/updateClient.handler.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/updateClient.handler.ts
@@ -96,6 +96,7 @@ const updateClientHandler = async ({
     requestedStatus,
     triggersReapprovalForOwnerEdit: shouldTriggerReapprovalForOwnerEdit,
     currentStatus: clientWithUser.status,
+    isOwnerUpdatingFields: isUpdatingFields && isOwner && !isAdmin,
   });
 
   const updateData = buildUpdateClientUpdateData({
@@ -188,7 +189,7 @@ function triggersReapprovalForOwnerEdit(params: {
   ) {
     return true;
   }
-  
+
   if (
     proposedUpdates.websiteUrl !== undefined &&
     toNullableString(proposedUpdates.websiteUrl) !== toNullableString(currentClient.websiteUrl)
@@ -207,10 +208,12 @@ function computeNextStatus(params: {
   requestedStatus: OAuthClientStatus | undefined;
   triggersReapprovalForOwnerEdit: boolean;
   currentStatus: OAuthClientStatus;
+  isOwnerUpdatingFields: boolean;
 }): OAuthClientStatus {
-  const { requestedStatus, triggersReapprovalForOwnerEdit, currentStatus } = params;
+  const { requestedStatus, triggersReapprovalForOwnerEdit, currentStatus, isOwnerUpdatingFields } = params;
   if (requestedStatus !== undefined) return requestedStatus;
   if (triggersReapprovalForOwnerEdit) return "PENDING";
+  if (currentStatus === "REJECTED" && isOwnerUpdatingFields) return "PENDING";
   return currentStatus;
 }
 


### PR DESCRIPTION
## What does this PR do?

Allows OAuth client owners to re-submit their application after it has been rejected. When an owner updates any field on a REJECTED OAuth client, the status automatically transitions back to PENDING for re-review.

### Changes
- Added isOwnerUpdatingFields parameter to computeNextStatus()
- When currentStatus === 'REJECTED' && isOwnerUpdatingFields → status returns to PENDING
- Added test case verifying REJECTED → PENDING transition on owner field update

### Why
Previously, once an OAuth client was rejected, the owner had no way to fix the issues and re-submit for approval. This left rejected clients in a permanent dead state.

### Fixes
Resolves the inability for OAuth client owners to iterate on rejected applications.