### PR TITLE
fix: set autocomplete="false" on signup password field

### DIFF
--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -541,7 +541,7 @@ export default function Signup({
                         <PasswordField
                           id="signup-password"
                           data-testid="signup-passwordfield"
-                          autoComplete="new-password"
+                          autoComplete="false"
                           label={t("password")}
                           {...register("password")}
                           hintErrors={["caplow", "min", "num"]}


### PR DESCRIPTION
## What does this PR do?

Changes the `autoComplete` attribute on the signup page password field from `"new-password"` to `"false"` to disable browser password autocomplete/autofill on the signup form.

Requested by @PeerRich.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — trivial HTML attribute change.

## How should this be tested?

1. Go to `/signup`
2. Confirm the password field does **not** trigger browser autocomplete/autofill suggestions

## Important note for reviewers

- `autocomplete="false"` is not a standard value per the HTML spec (the standard value to disable is `"off"`), but browsers commonly ignore `"off"` on password fields. Using a non-recognized value like `"false"` is a widely-used workaround to actually suppress autofill. Verify this behaves as expected in Chrome, Firefox, and Safari.

<!-- Link to Devin run: https://app.devin.ai/sessions/5ccb6520f8f2484284d9f4adca4a05c7 -->