### PR TITLE
fix: improve getIP header resolution for CF → Vercel setup

### DIFF
--- a/apps/web/app/api/auth/forgot-password/route.ts
+++ b/apps/web/app/api/auth/forgot-password/route.ts
@@ -17,11 +17,7 @@ async function handler(req: NextRequest) {
     return NextResponse.json({ message: "email is required" }, { status: 400 });
   }
 
-  let ip = getIP(req) ?? email.data;
-  const forwardedFor = req.headers.get("x-forwarded-for") as string;
-  if (!ip && forwardedFor) {
-    ip = forwardedFor?.split(",").at(0) ?? email.data;
-  }
+  const ip = getIP(req) ?? email.data;
 
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",

--- a/apps/web/app/api/ip/route.ts
+++ b/apps/web/app/api/ip/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import getIP from "@calcom/lib/getIP";
+import { NextResponse } from "next/server";
 
 export async function GET(req: Request) {
   const requestorIp = getIP(req);

--- a/packages/lib/getIP.test.ts
+++ b/packages/lib/getIP.test.ts
@@ -1,0 +1,124 @@
+import type { NextApiRequest } from "next";
+import { describe, expect, it } from "vitest";
+import getIP, { parseIpFromHeaders } from "./getIP";
+
+function buildRequest(headers: Record<string, string>): Request {
+  return new Request("https://example.com", { headers });
+}
+
+function buildNextApiRequest(headers: Record<string, string | string[]>): NextApiRequest {
+  return { headers } as unknown as NextApiRequest;
+}
+
+describe("parseIpFromHeaders", () => {
+  it("returns the first IP from a comma-separated string", () => {
+    expect(parseIpFromHeaders("1.2.3.4, 5.6.7.8")).toBe("1.2.3.4");
+  });
+
+  it("returns the single IP when there is no comma", () => {
+    expect(parseIpFromHeaders("1.2.3.4")).toBe("1.2.3.4");
+  });
+
+  it("returns the first element when given an array", () => {
+    expect(parseIpFromHeaders(["1.2.3.4", "5.6.7.8"])).toBe("1.2.3.4");
+  });
+});
+
+describe("getIP", () => {
+  describe("with Web Request", () => {
+    it("returns cf-connecting-ip when present", () => {
+      const req = buildRequest({ "cf-connecting-ip": "1.1.1.1" });
+      expect(getIP(req)).toBe("1.1.1.1");
+    });
+
+    it("prefers cf-connecting-ip over other headers", () => {
+      const req = buildRequest({
+        "cf-connecting-ip": "1.1.1.1",
+        "true-client-ip": "2.2.2.2",
+        "x-forwarded-for": "3.3.3.3",
+        "x-real-ip": "4.4.4.4",
+      });
+      expect(getIP(req)).toBe("1.1.1.1");
+    });
+
+    it("falls back to true-client-ip when cf-connecting-ip is absent", () => {
+      const req = buildRequest({
+        "true-client-ip": "2.2.2.2",
+        "x-forwarded-for": "3.3.3.3",
+        "x-real-ip": "4.4.4.4",
+      });
+      expect(getIP(req)).toBe("2.2.2.2");
+    });
+
+    it("falls back to x-forwarded-for when cf and true-client headers are absent", () => {
+      const req = buildRequest({
+        "x-forwarded-for": "3.3.3.3, 10.0.0.1",
+        "x-real-ip": "4.4.4.4",
+      });
+      expect(getIP(req)).toBe("3.3.3.3");
+    });
+
+    it("falls back to x-real-ip as last resort", () => {
+      const req = buildRequest({ "x-real-ip": "4.4.4.4" });
+      expect(getIP(req)).toBe("4.4.4.4");
+    });
+
+    it("returns 127.0.0.1 when no IP headers are present", () => {
+      const req = buildRequest({});
+      expect(getIP(req)).toBe("127.0.0.1");
+    });
+
+    it("extracts first IP from comma-separated x-forwarded-for", () => {
+      const req = buildRequest({ "x-forwarded-for": "9.9.9.9, 10.0.0.1, 172.16.0.1" });
+      expect(getIP(req)).toBe("9.9.9.9");
+    });
+  });
+
+  describe("with NextApiRequest", () => {
+    it("returns cf-connecting-ip when present", () => {
+      const req = buildNextApiRequest({ "cf-connecting-ip": "1.1.1.1" });
+      expect(getIP(req)).toBe("1.1.1.1");
+    });
+
+    it("prefers cf-connecting-ip over other headers", () => {
+      const req = buildNextApiRequest({
+        "cf-connecting-ip": "1.1.1.1",
+        "true-client-ip": "2.2.2.2",
+        "x-forwarded-for": "3.3.3.3",
+        "x-real-ip": "4.4.4.4",
+      });
+      expect(getIP(req)).toBe("1.1.1.1");
+    });
+
+    it("falls back to true-client-ip when cf-connecting-ip is absent", () => {
+      const req = buildNextApiRequest({
+        "true-client-ip": "2.2.2.2",
+        "x-real-ip": "4.4.4.4",
+      });
+      expect(getIP(req)).toBe("2.2.2.2");
+    });
+
+    it("falls back to x-forwarded-for when cf and true-client headers are absent", () => {
+      const req = buildNextApiRequest({
+        "x-forwarded-for": "3.3.3.3, 10.0.0.1",
+        "x-real-ip": "4.4.4.4",
+      });
+      expect(getIP(req)).toBe("3.3.3.3");
+    });
+
+    it("falls back to x-real-ip as last resort", () => {
+      const req = buildNextApiRequest({ "x-real-ip": "4.4.4.4" });
+      expect(getIP(req)).toBe("4.4.4.4");
+    });
+
+    it("returns 127.0.0.1 when no IP headers are present", () => {
+      const req = buildNextApiRequest({});
+      expect(getIP(req)).toBe("127.0.0.1");
+    });
+
+    it("handles array header values (NextApiRequest)", () => {
+      const req = buildNextApiRequest({ "x-forwarded-for": ["5.5.5.5", "6.6.6.6"] });
+      expect(getIP(req)).toBe("5.5.5.5");
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the `getIP` function which was returning incorrect IPs (Cloudflare edge IPs or `127.0.0.1`) when running behind a Cloudflare → Vercel proxy chain, as observed via the `cal.com/api/ip` endpoint.

**Root cause:** The previous implementation only checked `cf-connecting-ip` (which Vercel may not forward) and `x-real-ip` (which Vercel sets to the *connecting* IP — i.e. Cloudflare's edge server, not the real client). It never checked `x-forwarded-for`, which reliably carries the real client IP as the first entry through the CF → Vercel hop.

**Changes:**
- Rewrites `getIP` to check headers in correct priority order: `cf-connecting-ip` → `true-client-ip` → `x-forwarded-for` → `x-real-ip`
- Removes dead-code workaround in `forgot-password/route.ts` that attempted to manually check `x-forwarded-for` but could never trigger (since `getIP` always returned at least `"127.0.0.1"`)
- Adds 17 unit tests covering both `Request` and `NextApiRequest` code paths
- Minor biome auto-fixes: import sorting, `import process from "node:process"`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Deploy to a staging environment behind Cloudflare → Vercel
2. Visit `/api/ip` — should return the real client IP, not a Cloudflare edge IP or `127.0.0.1`
3. Verify rate limiting (e.g. on `/api/auth/forgot-password`) uses the correct IP
4. Run unit tests: `TZ=UTC yarn vitest run packages/lib/getIP.test.ts`

## Human Review Checklist

- [ ] Verify the header priority order (`cf-connecting-ip` > `true-client-ip` > `x-forwarded-for` > `x-real-ip`) is correct for the production CF → Vercel setup
- [ ] Confirm `true-client-ip` header is relevant (it's a Cloudflare Enterprise / Managed Transforms header — remove from the list if not applicable)
- [ ] Confirm the dead-code removal in `forgot-password/route.ts` is safe (the old `x-forwarded-for` fallback could never execute because `getIP()` always returns a truthy string)
- [ ] The `import process from "node:process"` is a biome auto-fix on pre-existing `process.env` usage — not a functional change

---


**Link to Devin run:** https://app.devin.ai/sessions/1acd487e288b4dd6ab403f7eeb6393ed  
**Requested by:** @emrysal