### PR TITLE
fix: handle pg pool idle client errors to prevent uncaught exceptions

### DIFF
--- a/apps/api/v2/src/modules/prisma/prisma-read.service.ts
+++ b/apps/api/v2/src/modules/prisma/prisma-read.service.ts
@@ -48,7 +48,11 @@ export class PrismaReadService implements OnModuleInit, OnModuleDestroy {
       this.pool = new Pool({
         connectionString: dbUrl,
         max: maxReadConnections,
-        idleTimeoutMillis: 300000,
+        idleTimeoutMillis: 30000,
+      });
+
+      this.pool.on("error", (err) => {
+        this.logger.warn(`Idle read pool client encountered an error: ${err.message}`);
       });
 
       const adapter = new PrismaPg(this.pool);

--- a/apps/api/v2/src/modules/prisma/prisma-write.service.ts
+++ b/apps/api/v2/src/modules/prisma/prisma-write.service.ts
@@ -54,7 +54,11 @@ export class PrismaWriteService implements OnModuleInit, OnModuleDestroy {
       this.pool = new Pool({
         connectionString: dbUrl,
         max: maxWriteConnections,
-        idleTimeoutMillis: 300000,
+        idleTimeoutMillis: 30000,
+      });
+
+      this.pool.on("error", (err) => {
+        this.logger.warn(`Idle write pool client encountered an error: ${err.message}`);
       });
 
       const adapter = new PrismaPg(this.pool);


### PR DESCRIPTION
## What does this PR do?

Fixes `Uncaught Exception: error: client_idle_timeout` errors observed on `/v2/billing/webhook` (and potentially other endpoints).

**Root cause:** The PostgreSQL server's `client_idle_timeout` setting terminates connections that have been idle too long. When this happens, the `pg` Pool emits an `error` event on the affected client. Without a listener for this event, Node.js surfaces it as an uncaught exception — which is what the stack trace shows.

**Two changes:**

1. **Add `pool.on("error", ...)` handlers** to both `PrismaReadService` and `PrismaWriteService` so server-side connection terminations are caught and logged gracefully instead of crashing as uncaught exceptions.
2. **Reduce `idleTimeoutMillis` from 300s → 30s** so the client-side pool proactively releases idle connections well before the server's `client_idle_timeout` fires, reducing the frequency of server-side kills.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A — infrastructure config change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — this is a pool configuration change; the fix prevents an uncaught exception that is only reproducible with a real PG server enforcing `client_idle_timeout`.

## How should this be tested?

- This addresses a production-only issue where the PG server terminates idle connections.
- **Verification:** After deploy, monitor for `client_idle_timeout` uncaught exceptions on `/v2/billing/webhook`. They should stop. You may see `warn`-level log lines like `Idle read/write pool client encountered an error: client_idle_timeout` — these are the gracefully handled versions of the same event.
- No special env vars or test data needed.

## Human Review Checklist

- [ ] Is 30s a reasonable idle timeout? Consider whether the server's `client_idle_timeout` is known and whether 30s provides enough margin. Connection churn will increase slightly vs. the previous 300s.
- [ ] Is `warn`-level logging appropriate? If these events are frequent, consider downgrading to `debug` to avoid log noise.
- [ ] Confirm that `pg` Pool automatically evicts the errored client after the `error` event fires (it does per [node-postgres docs](https://node-postgres.com/apis/pool#events), but worth verifying).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that my changes generate no new warnings
- [x] My PR is small and focused (2 files, ~10 lines changed)

---

Link to Devin run: https://app.devin.ai/sessions/a4977b2d46334ea9a60a7d0c9c4122a3
Requested by: @keithwillcode