### PR TITLE
feat: add prefetch={true} to dashboard navigation links for client-side Router Cache

### DIFF
--- a/apps/web/modules/shell/SideBar.tsx
+++ b/apps/web/modules/shell/SideBar.tsx
@@ -1,12 +1,6 @@
-import type { User as UserAuth } from "next-auth";
-import { useSession } from "next-auth/react";
-import dynamic from "next/dynamic";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-
 import { getBookerBaseUrlSync } from "@calcom/features/ee/organizations/lib/getBookerBaseUrlSync";
 import { useFlagMap } from "@calcom/features/flags/context/provider";
-import { IS_VISUAL_REGRESSION_TESTING, ENABLE_PROFILE_SWITCHER } from "@calcom/lib/constants";
+import { ENABLE_PROFILE_SWITCHER, IS_VISUAL_REGRESSION_TESTING } from "@calcom/lib/constants";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { useIsStandalone } from "@calcom/lib/hooks/useIsStandalone";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -16,11 +10,15 @@ import { Avatar } from "@calcom/ui/components/avatar";
 import { Credits } from "@calcom/ui/components/credits";
 import { ButtonOrLink } from "@calcom/ui/components/dropdown";
 import { Icon } from "@calcom/ui/components/icon";
-import { ArrowLeftIcon, ArrowRightIcon } from "@coss/ui/icons";
 import { Logo } from "@calcom/ui/components/logo";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { Tooltip } from "@calcom/ui/components/tooltip";
-
+import { ArrowLeftIcon, ArrowRightIcon } from "@coss/ui/icons";
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { User as UserAuth } from "next-auth";
+import { useSession } from "next-auth/react";
 import { KBarTrigger } from "./Kbar";
 import { Navigation } from "./navigation/Navigation";
 import { useBottomNavItems } from "./useBottomNavItems";
@@ -135,7 +133,7 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
             </div>
           </header>
           {/* logo icon for tablet */}
-          <Link href="/event-types" className="text-center md:inline lg:hidden">
+          <Link href="/event-types" prefetch={true} className="text-center md:inline lg:hidden">
             <Logo small icon />
           </Link>
           <Navigation isPlatformNavigation={isPlatformPages} />

--- a/apps/web/modules/shell/TopNav.tsx
+++ b/apps/web/modules/shell/TopNav.tsx
@@ -1,12 +1,10 @@
-import { useSession } from "next-auth/react";
-import Link from "next/link";
-
 import { useIsEmbed } from "@calcom/embed-core/embed-iframe";
 import { useIsStandalone } from "@calcom/lib/hooks/useIsStandalone";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { SettingsIcon } from "@coss/ui/icons";
 import { Logo } from "@calcom/ui/components/logo";
-
+import { SettingsIcon } from "@coss/ui/icons";
+import Link from "next/link";
+import { useSession } from "next-auth/react";
 import { KBarTrigger } from "./Kbar";
 import { UserDropdown } from "./user-dropdown/UserDropdown";
 
@@ -25,7 +23,7 @@ function TopNav() {
       <nav
         style={isEmbed ? { display: "none" } : {}}
         className="bg-cal-muted/50 border-subtle sticky top-0 z-40 flex w-full items-center justify-between border-b px-4 py-1.5 backdrop-blur-lg sm:p-4 md:hidden">
-        <Link href="/event-types">
+        <Link href="/event-types" prefetch={true}>
           <Logo />
         </Link>
         <div className="flex items-center gap-2 self-center">

--- a/apps/web/modules/shell/navigation/NavigationItem.tsx
+++ b/apps/web/modules/shell/navigation/NavigationItem.tsx
@@ -1,18 +1,17 @@
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import posthog from "posthog-js";
-import React, { Fragment, useState, useEffect } from "react";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useMediaQuery from "@calcom/lib/hooks/useMediaQuery";
 import { sessionStorage } from "@calcom/lib/webstorage";
 import classNames from "@calcom/ui/classNames";
 import { Badge } from "@calcom/ui/components/badge";
-import { Icon } from "@calcom/ui/components/icon";
 import type { IconName } from "@calcom/ui/components/icon";
+import { Icon } from "@calcom/ui/components/icon";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { Tooltip } from "@calcom/ui/components/tooltip";
-
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import posthog from "posthog-js";
+import type React from "react";
+import { Fragment, useEffect, useState } from "react";
 import { useShouldDisplayNavigationItem } from "./useShouldDisplayNavigationItem";
 
 const usePersistedExpansionState = (itemName: string) => {
@@ -123,6 +122,7 @@ export const NavigationItem: React.FC<{
                       <Link
                         key={childItem.name}
                         href={childItem.href}
+                        prefetch={true}
                         aria-current={childIsCurrent ? "page" : undefined}
                         onClick={() => {
                           setIsTooltipOpen(false);
@@ -208,6 +208,7 @@ export const NavigationItem: React.FC<{
             data-test-id={item.name}
             onClick={() => trackNavigationClick(item.name)}
             href={item.href}
+            prefetch={true}
             aria-label={t(item.name)}
             target={item.target}
             className={classNames(
@@ -283,6 +284,7 @@ export const MobileNavigationItem: React.FC<{
     <Link
       key={item.name}
       href={item.href}
+      prefetch={true}
       target={item.target}
       className="[&[aria-current='page']]:text-emphasis hover:text-default text-muted bg-transparent! relative my-2 min-w-0 flex-1 overflow-hidden rounded-md p-1 text-center text-xs font-medium focus:z-10 sm:text-sm"
       aria-current={current ? "page" : undefined}>
@@ -353,6 +355,7 @@ export const MobileNavigationMoreItem: React.FC<{
                     <li key={childItem.name} className="border-subtle border-t">
                       <Link
                         href={childItem.href}
+                        prefetch={true}
                         className="hover:bg-cal-muted flex items-center p-4 pl-12 transition">
                         <span className="text-default font-medium">
                           {isLocaleReady ? t(childItem.name) : <SkeletonText />}
@@ -374,6 +377,7 @@ export const MobileNavigationMoreItem: React.FC<{
       ) : (
         <Link
           href={item.href}
+          prefetch={true}
           target={item.target}
           className="hover:bg-subtle flex items-center justify-between p-5 transition">
           {itemContent}


### PR DESCRIPTION
## What does this PR do?

Adds `prefetch={true}` to all `<Link>` components in the dashboard shell navigation (sidebar, top nav, mobile nav) to leverage Next.js client-side Router Cache for full RSC payload prefetching.

**Problem:** Users see the `loading.tsx` skeleton every time they switch between dashboard routes like `/event-types`, `/availability`, `/members` — even when returning to a page they just visited. This is because Next.js App Router only prefetches the loading state boundary for dynamic routes by default (`prefetch={null}`).

**Solution (per Next.js team recommendation):** Setting `prefetch={true}` on `<Link>` triggers a full prefetch of the page's RSC payload and caches it client-side for 5 minutes. This means navigating between previously-visited (or visible-in-nav) dashboard pages should be instant without showing `loading.tsx`.

### Changes

- **`NavigationItem.tsx`** — Added `prefetch={true}` to all 5 `<Link>` instances: desktop nav items, desktop child tooltip links, mobile bottom nav, mobile "more" items, and mobile "more" child items
- **`SideBar.tsx`** — Added `prefetch={true}` to the tablet logo link (`/event-types`)
- **`TopNav.tsx`** — Added `prefetch={true}` to the mobile top nav logo link (`/event-types`)

> Note: Import reordering in the diff is from Biome auto-formatting (pre-commit hook), not a manual change.

## Visual Demo

#### Video Demo:

![Screencast of navigation testing with prefetch={true}](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2NzcwNWQ0ZTMyMWE5NmU4OGUxNzExZDMiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi80Y2MxNTk0MC02NWRlLTRlOWYtYjY5ZC04ODBkNzU1MDk0YmQiLCJpYXQiOjE3NzE5OTU4NzMsImV4cCI6MTc3MjYwMDY3M30.AAaLgCBeCqDcMwTKWrQcxdXEf7K8pUXwYCmWsaZ_Nuo)

[View original video (rec-35d899b719374a1cb813b6c546a70e8a-edited.mp4)](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2NzcwNWQ0ZTMyMWE5NmU4OGUxNzExZDMiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi9kM2YxOWM5ZC1kZjNhLTRhMWUtYmUwOS02OGU0ZWJiNjUxYTYiLCJpYXQiOjE3NzE5OTU4NzMsImV4cCI6MTc3MjYwMDY3M30.x_UA3SWFF1fpwmqpCdhtFb1TvaM7Qlh6U4fgmX2lHMo)

#### Local dev mode test results (annotated in recording):

- **First client-side navigation** to each route still briefly shows the `loading.tsx` skeleton in dev mode. This is expected because Turbopack compiles pages on demand, so the prefetch request takes longer to resolve than in production.
- **Subsequent navigations** to previously-visited routes load **instantly with no skeleton** — confirming the Router Cache is working.
- After staying on a page long enough for prefetches to complete (~60s in dev), navigating to _any_ visible nav target also loads instantly.
- **Rapid back-and-forth navigation** between all four tested routes (Event Types → Bookings → Availability → Teams) was fully instant once the cache was populated.

**⚠️ Important caveat:** This was tested in dev mode with Turbopack. In production, pages are pre-built so prefetch responses should be much faster — potentially eliminating the skeleton on the very first navigation too. **Production testing is recommended** to confirm the full benefit.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs change needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Log in to the dashboard
2. Navigate between sidebar routes: Event Types → Availability → Bookings → Teams → back to Event Types
3. **Before this PR:** Each navigation shows `loading.tsx` skeleton, even for previously-visited pages
4. **After this PR:** Previously-visited pages (and pages visible in the nav) should load instantly without showing the loading skeleton, as the RSC payload is cached client-side for 5 minutes

Ideally test in a **production build** (`yarn build && yarn start`) rather than dev mode, since dev mode has Turbopack compilation overhead that masks the prefetch benefit.

## Things for reviewers to verify

- [ ] Confirm `prefetch={true}` on navigation items with `target="_blank"` / external URLs (platform nav items) doesn't cause unnecessary prefetch attempts
- [ ] Assess whether prefetching all visible nav items on page load is acceptable for bandwidth/server load in production
- [ ] Verify this doesn't interfere with routes that need fresh data (booking/checkout flows are not in the sidebar, so should be unaffected)
- [ ] Consider testing in a production-like environment to confirm the full benefit (dev mode has compilation overhead)

## Checklist

- My code follows the style guidelines of this project
- My changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/27706a70a5d34ac8b2034ac25c360391
Requested by: @hbjORbj
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
