### PR TITLE
fix: ensure default calendars via managed user endpoint

### DIFF
--- a/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
+++ b/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
@@ -1,3 +1,6 @@
+import { CreationSource, createNewUsersConnectToOrgIfExists, slugify } from "@calcom/platform-libraries";
+import type { PlatformOAuthClient, User } from "@calcom/prisma/client";
+import { BadRequestException, ConflictException, Injectable, Logger } from "@nestjs/common";
 import { CalendarsService } from "@/ee/calendars/services/calendars.service";
 import { EventTypesService_2024_04_15 } from "@/ee/event-types/event-types_2024_04_15/services/event-types.service";
 import { SchedulesService_2024_04_15 } from "@/ee/schedules/schedules_2024_04_15/services/schedules.service";
@@ -8,10 +11,6 @@ import { TokensRepository } from "@/modules/tokens/tokens.repository";
 import { CreateManagedUserInput } from "@/modules/users/inputs/create-managed-user.input";
 import { UpdateManagedUserInput } from "@/modules/users/inputs/update-managed-user.input";
 import { UsersRepository } from "@/modules/users/users.repository";
-import { BadRequestException, ConflictException, Injectable, Logger } from "@nestjs/common";
-
-import { createNewUsersConnectToOrgIfExists, slugify, CreationSource } from "@calcom/platform-libraries";
-import type { User, PlatformOAuthClient } from "@calcom/prisma/client";
 
 @Injectable()
 export class OAuthClientUsersService {
@@ -94,8 +93,8 @@ export class OAuthClientUsersService {
 
     try {
       this.logger.log(`Setting default calendars in db for user with id ${user.id}`);
-      await this.calendarsService.getCalendars(user.id);
-    } catch (err) {
+      await this.calendarsService.getCalendars(user.id, true);
+    } catch (_err) {
       this.logger.error(`Could not get calendars of new managed user with id ${user.id}`);
     }
 


### PR DESCRIPTION
## What does this PR do?

Ensure default calendars are created for new managed users via the managed user endpoint. This makes sure calendars exist in the DB right away for downstream flows.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure default calendars are created for new managed users via the managed user endpoint. This makes sure calendars exist in the DB right away for downstream flows.

- **Bug Fixes**
  - Force default calendar creation by calling calendarsService.getCalendars(userId, true) after user provisioning.

<sup>Written for commit 59049b4f1d608786b89c88bb637b5b04ca6ccdf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

