### PR TITLE
fix: resolve infinite fetch loop in useCheckTeamBilling on platform settings page

### DIFF
--- a/apps/web/lib/hooks/settings/platform/billing/useCheckTeamBilling.ts
+++ b/apps/web/lib/hooks/settings/platform/billing/useCheckTeamBilling.ts
@@ -14,7 +14,7 @@ export const useCheckTeamBilling = (teamId?: number | null, isPlatformTeam?: boo
       return data.data;
     },
     enabled: !!teamId && !!isPlatformTeam,
-    staleTime: 5000,
+    staleTime: Infinity,
   });
 
   return isTeamBilledAlready;

--- a/apps/web/lib/hooks/settings/platform/oauth-clients/usePersistOAuthClient.ts
+++ b/apps/web/lib/hooks/settings/platform/oauth-clients/usePersistOAuthClient.ts
@@ -1,5 +1,3 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
-
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import type {
   ApiResponse,
@@ -8,6 +6,7 @@ import type {
   PlatformOAuthClientDto,
   SubscribeTeamInput,
 } from "@calcom/platform-types";
+import { useMutation } from "@tanstack/react-query";
 
 interface IPersistOAuthClient {
   onSuccess?: () => void;
@@ -117,25 +116,6 @@ export const useDeleteOAuthClient = (
   });
 
   return mutation;
-};
-
-export const useCheckTeamBilling = (teamId?: number | null, isPlatformTeam?: boolean | null) => {
-  const QUERY_KEY = "check-team-billing";
-  const isTeamBilledAlready = useQuery({
-    queryKey: [QUERY_KEY, teamId],
-    queryFn: async () => {
-      const response = await fetch(`/api/v2/billing/${teamId}/check`, {
-        method: "get",
-        headers: { "Content-type": "application/json" },
-      });
-      const data = await response.json();
-
-      return data.data;
-    },
-    enabled: !!teamId && !!isPlatformTeam,
-  });
-
-  return isTeamBilledAlready;
 };
 
 export const useSubscribeTeamToStripe = (

--- a/apps/web/modules/settings/platform/platform-view.tsx
+++ b/apps/web/modules/settings/platform/platform-view.tsx
@@ -1,23 +1,19 @@
 "use client";
 
-import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
-import { usePathname } from "next/navigation";
-import { useState, useEffect, useCallback } from "react";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { showToast } from "@calcom/ui/components/toast";
-
-import { useExternalRedirectHandler } from "@lib/hooks/settings/platform/billing/useExternalRedirectHandler";
-import { useDeleteOAuthClient } from "@lib/hooks/settings/platform/oauth-clients/useDeleteOAuthClient";
-import { useOAuthClients } from "@lib/hooks/settings/platform/oauth-clients/useOAuthClients";
-
 import { HelpCards } from "@components/settings/platform/dashboard/HelpCards";
 import NoPlatformPlan from "@components/settings/platform/dashboard/NoPlatformPlan";
 import { OAuthClientsList } from "@components/settings/platform/dashboard/oauth-clients-list";
 import { useGetUserAttributes } from "@components/settings/platform/hooks/useGetUserAttributes";
 import { PlatformPricing } from "@components/settings/platform/pricing/platform-pricing";
-
+import { useExternalRedirectHandler } from "@lib/hooks/settings/platform/billing/useExternalRedirectHandler";
+import { useDeleteOAuthClient } from "@lib/hooks/settings/platform/oauth-clients/useDeleteOAuthClient";
+import { useOAuthClients } from "@lib/hooks/settings/platform/oauth-clients/useOAuthClients";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 import Shell from "~/shell/Shell";
 
 const queryClient = new QueryClient();
@@ -113,11 +109,9 @@ export default function Platform() {
 
   useEffect(() => {
     refetchBillingState();
-  }, [pathname, refetchTeamBilling, refetchPlatformUser, refetchBillingState]);
+  }, [pathname, refetchBillingState]);
 
-  useExternalRedirectHandler(() => {
-    refetchBillingState();
-  });
+  useExternalRedirectHandler(refetchBillingState);
 
   if (isUserLoading || isOAuthClientLoading) return <PlatformSkeletonLoader />;
 


### PR DESCRIPTION
## What does this PR do?

Fixes an infinite fetch loop to `/api/v2/billing/:id/check` on the `/settings/platform` page.

**Root cause:** In `platform-view.tsx`, `useExternalRedirectHandler` received a new inline arrow function on every render. Inside that hook, the callback is a `useEffect` dependency. When the user returns from an external site (e.g. Stripe checkout), the effect fires → triggers refetch → data updates → component re-renders → new callback reference → effect fires again → **infinite loop**.

**Changes:**

1. **`platform-view.tsx`** — Pass the already-memoized `refetchBillingState` (`useCallback`) directly to `useExternalRedirectHandler` instead of wrapping it in a new arrow function each render. Also removed redundant dependencies from the billing refetch `useEffect`.
2. **`useCheckTeamBilling.ts`** — Changed `staleTime` from `5000` (5 seconds) to `Infinity`. Billing status is explicitly refetched on mount, pathname change, and external redirect return, so automatic stale-based refetching is unnecessary and contributed to excessive network requests.
3. **`usePersistOAuthClient.ts`** — Removed a duplicate `useCheckTeamBilling` definition that was dead code (never imported). Cleaned up the now-unused `useQuery` import.

## How should this be tested?

1. Navigate to `/settings/platform` as a platform user
2. Open browser DevTools Network tab and filter for `billing`
3. Verify the `/api/v2/billing/:id/check` endpoint is called once on page load, not repeatedly
4. Navigate to Stripe checkout (subscribe flow) and return — verify no infinite request loop occurs
5. Confirm billing status still displays correctly after returning from Stripe

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — this is a React hook stability fix; existing behavior is preserved.

## Human Review Checklist

- [ ] Is `staleTime: Infinity` appropriate, or should a large but finite value (e.g. 5 minutes like `usePlatformMe`) be used instead? With `Infinity`, the cache only updates on explicit `refetch()` calls.
- [ ] Verify `refetchBillingState` signature is compatible with `useExternalRedirectHandler`'s callback parameter `(referrer: string) => void` (it accepts but ignores the argument — this is safe).
- [ ] Confirm no other file imports `useCheckTeamBilling` from `usePersistOAuthClient.ts` (grep showed zero consumers).

<!-- Git context -->
Link to Devin run: https://app.devin.ai/sessions/39090d2b0a324db6bc408e86dbea97c5
Requested by: @ThyMinimalDev