### PR TITLE
feat(reschedule): check guest availability when host reschedules

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -148,6 +148,12 @@ export type GetUserAvailabilityInitialData = {
   })[];
   busyTimesFromLimitsBookings?: EventBusyDetails[];
   busyTimesFromLimits?: Map<number, EventBusyDetails[]>;
+  /**
+   * Busy times of guests (attendees who are not the host) from the booking being rescheduled.
+   * Injected by the slots service when `rescheduleUid` is present so that the availability
+   * calculation blocks any slot that conflicts with a guest's existing accepted booking.
+   */
+  guestBusyTimes?: EventBusyDetails[];
   eventTypeForLimits?: {
     id: number;
     bookingLimits?: unknown;
@@ -622,6 +628,8 @@ export class UserAvailabilityService {
       })),
       ...busyTimesFromLimits,
       ...busyTimesFromTeamLimits,
+      // Guest busy times from the booking being rescheduled: prevents double-booking guests.
+      ...(initialData?.guestBusyTimes ?? []),
     ];
 
     log.debug(

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -2171,4 +2171,45 @@ export class BookingRepository implements IBookingRepository {
       },
     });
   }
+
+  /**
+   * Returns accepted bookings whose attendee list contains at least one of the given emails,
+   * within the provided date range and excluding the booking with `excludedUid` (the booking
+   * being rescheduled).  Used to surface guest conflicts when a host reschedules.
+   */
+  async getAcceptedBookingsByAttendeeEmails({
+    attendeeEmails,
+    startDate,
+    endDate,
+    excludedUid,
+  }: {
+    attendeeEmails: string[];
+    startDate: Date;
+    endDate: Date;
+    excludedUid?: string | null;
+  }) {
+    if (attendeeEmails.length === 0) return [];
+
+    return this.prismaClient.booking.findMany({
+      where: {
+        status: BookingStatus.ACCEPTED,
+        startTime: { gte: startDate },
+        endTime: { lte: endDate },
+        ...(excludedUid ? { uid: { not: excludedUid } } : {}),
+        attendees: {
+          some: {
+            email: { in: attendeeEmails },
+          },
+        },
+      },
+      select: {
+        id: true,
+        startTime: true,
+        endTime: true,
+        title: true,
+        uid: true,
+        userId: true,
+      },
+    });
+  }
 }

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -2193,8 +2193,12 @@ export class BookingRepository implements IBookingRepository {
     return this.prismaClient.booking.findMany({
       where: {
         status: BookingStatus.ACCEPTED,
-        startTime: { gte: startDate },
-        endTime: { lte: endDate },
+        // Use overlap semantics: any booking whose time range intersects [startDate, endDate].
+        // A booking overlaps the window when it starts before the window ends AND ends after
+        // the window starts.  The previous condition (gte/lte) missed bookings that straddle
+        // a window boundary (e.g. started before startDate but ends inside the window).
+        startTime: { lt: endDate },
+        endTime: { gt: startDate },
         ...(excludedUid ? { uid: { not: excludedUid } } : {}),
         attendees: {
           some: {

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -810,6 +810,44 @@ export class AvailableSlotsService {
     const allUserIds = Array.from(userIdAndEmailMap.keys());
 
     const bookingRepo = this.dependencies.bookingRepo;
+
+    // When rescheduling, collect accepted bookings of all guests (attendees who are not
+    // the host) so we can block slots that would double-book them.
+    let guestBusyTimes: EventBusyDetails[] = [];
+    if (input.rescheduleUid) {
+      const rescheduleBooking = await bookingRepo.findByUidIncludeEventTypeAttendeesAndUser({
+        bookingUid: input.rescheduleUid,
+      });
+      if (rescheduleBooking) {
+        // Host emails: the booking's user + any event-type host emails
+        const hostEmails = new Set<string>();
+        if (rescheduleBooking.user?.email) hostEmails.add(rescheduleBooking.user.email);
+        rescheduleBooking.eventType?.hosts?.forEach((h) => {
+          if (h.user.email) hostEmails.add(h.user.email);
+        });
+
+        // Guest emails = attendees that are NOT hosts
+        const guestEmails = rescheduleBooking.attendees
+          .map((a) => a.email)
+          .filter((email) => !hostEmails.has(email));
+
+        if (guestEmails.length > 0) {
+          const guestBookings = await bookingRepo.getAcceptedBookingsByAttendeeEmails({
+            attendeeEmails: guestEmails,
+            startDate: startTimeDate,
+            endDate: endTimeDate,
+            excludedUid: input.rescheduleUid,
+          });
+          guestBusyTimes = guestBookings.map((b) => ({
+            start: b.startTime.toISOString(),
+            end: b.endTime.toISOString(),
+            title: b.title ?? undefined,
+            source: "guest",
+          }));
+        }
+      }
+    }
+
     const [currentBookingsAllUsers, outOfOfficeDaysAllUsers] = await Promise.all([
       bookingRepo.findAllExistingBookingsForEventTypeBetween({
         startDate: startTimeDate,
@@ -933,6 +971,7 @@ export class AvailableSlotsService {
         eventTypeForLimits: eventType && (bookingLimits || durationLimits) ? eventType : null,
         teamBookingLimits: teamBookingLimitsMap,
         teamForBookingLimits: teamForBookingLimits,
+        guestBusyTimes,
       },
     });
     /* We get all users working hours and busy slots */


### PR DESCRIPTION
Fixes #16378

## Summary

When a host reschedules a booking, the available slot picker now filters out time slots that conflict with the guests' (non-host attendees') existing **accepted** bookings — preventing the host from accidentally double-booking a guest.

## How it works

1. When `rescheduleUid` is present in `getSchedule`, look up the original booking's attendees via `BookingRepository`.
2. Filter out host emails (booking's user + event-type hosts) to isolate **guest-only** emails.
3. Query their accepted bookings in the slot search window, excluding the booking being rescheduled itself.
4. Pass these as `guestBusyTimes` through `initialData` into `getUserAvailability`, where they are merged into `detailedBusyTimes` — the same busy-time list that drives slot availability.

## Changes (3 files, minimal diff)

| File | Change |
|------|--------|
| `packages/features/bookings/repositories/BookingRepository.ts` | Add `getAcceptedBookingsByAttendeeEmails()` — queries bookings where any attendee is in a given email list |
| `packages/trpc/server/routers/viewer/slots/util.ts` | In `calculateHostsAndAvailabilities()`: fetch guest busy times when `rescheduleUid` is present; pass via `initialData.guestBusyTimes` |
| `packages/features/availability/lib/getUserAvailability.ts` | Add `guestBusyTimes?` to `GetUserAvailabilityInitialData`; spread into `detailedBusyTimes` |

## Design decisions

- **Minimal surface area**: the new `getAcceptedBookingsByAttendeeEmails` query is a single `prisma.booking.findMany` with an attendee email filter. No new services, no new DI tokens.
- **Host-email exclusion**: hosts are excluded from the guest list so a host's own calendar isn't counted twice.
- **Excludes the booking being rescheduled**: the `excludedUid` parameter prevents the original booking's time from being treated as a conflict.
- **No schema changes**: `guestBusyTimes` is an optional field on `GetUserAvailabilityInitialData`, fully backwards-compatible.

## Test plan

- [ ] Create a booking with at least one guest (attendee not in the org/team)
- [ ] Have the guest accept a separate booking that overlaps with a slot in the reschedule picker
- [ ] As the host, open the reschedule flow — the conflicting slot should no longer appear as available
- [ ] Slots that do not conflict with any guest booking should remain available
- [ ] Rescheduling a booking with no external guests should behave identically to before