### PR TITLE
fix: add PBAC team.create permission check to /settings/teams/new pages and tRPC handler

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/teams/new/invite/email/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/teams/new/invite/email/page.tsx
@@ -1,12 +1,11 @@
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
+import { APP_NAME } from "@calcom/lib/constants";
+import { MembershipRole } from "@calcom/prisma/enums";
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 import { _generateMetadata } from "app/_utils";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
-
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { APP_NAME } from "@calcom/lib/constants";
-
-import { buildLegacyRequest } from "@lib/buildLegacyCtx";
-
 import { TeamInviteEmailView } from "~/settings/teams/new/invite/email/team-invite-email-view";
 
 export const generateMetadata = async () => {
@@ -24,6 +23,24 @@ const ServerPage = async () => {
 
   if (!session?.user?.id) {
     return redirect("/auth/login");
+  }
+
+  const userProfile = session.user.profile;
+  const orgId = userProfile?.organizationId ?? session.user.org?.id;
+
+  // If the user is in an org, check if they have the team.create permission
+  if (orgId) {
+    const permissionCheckService = new PermissionCheckService();
+    const canCreateTeam = await permissionCheckService.checkPermission({
+      userId: session.user.id,
+      teamId: orgId,
+      permission: "team.create",
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
+
+    if (!canCreateTeam) {
+      return redirect("/teams");
+    }
   }
 
   const userEmail = session.user.email || "";

--- a/apps/web/app/(use-page-wrapper)/settings/teams/new/invite/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/teams/new/invite/page.tsx
@@ -1,12 +1,11 @@
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
+import { APP_NAME } from "@calcom/lib/constants";
+import { MembershipRole } from "@calcom/prisma/enums";
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 import { _generateMetadata } from "app/_utils";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
-
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { APP_NAME } from "@calcom/lib/constants";
-
-import { buildLegacyRequest } from "@lib/buildLegacyCtx";
-
 import { TeamInviteView } from "~/settings/teams/new/invite/team-invite-view";
 
 export const generateMetadata = async () => {
@@ -24,6 +23,24 @@ const ServerPage = async () => {
 
   if (!session?.user?.id) {
     return redirect("/auth/login");
+  }
+
+  const userProfile = session.user.profile;
+  const orgId = userProfile?.organizationId ?? session.user.org?.id;
+
+  // If the user is in an org, check if they have the team.create permission
+  if (orgId) {
+    const permissionCheckService = new PermissionCheckService();
+    const canCreateTeam = await permissionCheckService.checkPermission({
+      userId: session.user.id,
+      teamId: orgId,
+      permission: "team.create",
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
+
+    if (!canCreateTeam) {
+      return redirect("/teams");
+    }
   }
 
   const userEmail = session.user.email || "";

--- a/apps/web/app/(use-page-wrapper)/settings/teams/new/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/teams/new/page.tsx
@@ -1,11 +1,10 @@
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
+import { MembershipRole } from "@calcom/prisma/enums";
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 import { _generateMetadata } from "app/_utils";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
-
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-
-import { buildLegacyRequest } from "@lib/buildLegacyCtx";
-
 import { CreateNewTeamView, LayoutWrapper } from "~/settings/teams/new/create-new-team-view";
 
 export const generateMetadata = async () =>
@@ -22,6 +21,24 @@ const ServerPage = async () => {
 
   if (!session?.user?.id) {
     return redirect("/auth/login");
+  }
+
+  const userProfile = session.user.profile;
+  const orgId = userProfile?.organizationId ?? session.user.org?.id;
+
+  // If the user is in an org, check if they have the team.create permission
+  if (orgId) {
+    const permissionCheckService = new PermissionCheckService();
+    const canCreateTeam = await permissionCheckService.checkPermission({
+      userId: session.user.id,
+      teamId: orgId,
+      permission: "team.create",
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
+
+    if (!canCreateTeam) {
+      return redirect("/teams");
+    }
   }
 
   const userEmail = session.user.email || "";

--- a/packages/trpc/server/routers/viewer/teams/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/create.handler.ts
@@ -1,18 +1,16 @@
-import type { NextApiRequest } from "next";
-
 import { generateTeamCheckoutSession } from "@calcom/features/ee/teams/lib/payments";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { IS_TEAM_BILLING_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
 import { uploadLogo } from "@calcom/lib/server/avatar";
 import { resizeBase64Image } from "@calcom/lib/server/resizeBase64Image";
-import { getTrackingFromCookies } from "@calcom/lib/tracking";
 import type { TrackingData } from "@calcom/lib/tracking";
+import { getTrackingFromCookies } from "@calcom/lib/tracking";
 import { prisma } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
 import type { BillingPeriod as BillingPeriodEnum } from "@calcom/prisma/zod-utils";
-
 import { TRPCError } from "@trpc/server";
-
+import type { NextApiRequest } from "next";
 import type { TrpcSessionUser } from "../../../types";
 import type { TCreateInputSchema } from "./create.schema";
 
@@ -66,9 +64,19 @@ export const createHandler = async ({ ctx, input }: CreateOptions) => {
   const { slug, name, bio, isOnboarding, billingPeriod } = input;
   const isOrgChildTeam = !!user.profile?.organizationId;
 
-  // For orgs we want to create teams under the org
-  if (user.profile?.organizationId && !user.organization.isOrgAdmin) {
-    throw new TRPCError({ code: "FORBIDDEN", message: "org_admins_can_create_new_teams" });
+  // For orgs we want to create teams under the org - check PBAC permission
+  if (user.profile?.organizationId) {
+    const permissionCheckService = new PermissionCheckService();
+    const canCreateTeam = await permissionCheckService.checkPermission({
+      userId: user.id,
+      teamId: user.profile.organizationId,
+      permission: "team.create",
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
+
+    if (!canCreateTeam) {
+      throw new TRPCError({ code: "FORBIDDEN", message: "org_admins_can_create_new_teams" });
+    }
   }
 
   const slugCollisions = await prisma.team.findFirst({


### PR DESCRIPTION
## What does this PR do?

Org users without the `team.create` permission could bypass the UI guard by navigating directly to `/settings/teams/new` and successfully create a team. The "Create Team" button was correctly hidden elsewhere in the app (teams listing page), but the route itself and the backend tRPC handler lacked proper PBAC checks.

**This PR adds two layers of protection:**

1. **Page-level (server components):** Adds `PermissionCheckService.checkPermission` with `"team.create"` permission to all three pages in the team creation flow:
   - `/settings/teams/new`
   - `/settings/teams/new/invite`
   - `/settings/teams/new/invite/email`
   
   Unauthorized org users are redirected to `/teams`.

2. **API-level (tRPC handler):** Replaces the simple `user.organization.isOrgAdmin` boolean check in `create.handler.ts` with a proper PBAC `team.create` permission check via `PermissionCheckService`, using `[ADMIN, OWNER]` as fallback roles when PBAC is disabled — matching the exact same pattern already used in the teams listing server page.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Log in as an org **member** (not admin/owner) who does **not** have a custom role with `team.create` permission
2. Navigate directly to `/settings/teams/new` — should be redirected to `/teams`
3. Navigate directly to `/settings/teams/new/invite` — should be redirected to `/teams`
4. Navigate directly to `/settings/teams/new/invite/email` — should be redirected to `/teams`
5. Attempt to call the `viewer.teams.create` tRPC mutation directly — should receive a FORBIDDEN error
6. Log in as an org **admin/owner** — all routes should work normally, team creation should succeed

## Important review notes

- The permission check block is duplicated across 3 page files. This is intentional per Next.js best practices (auth checks must live in `page.tsx`, not `layout.tsx`, since layouts don't intercept all requests). A reviewer may want to consider extracting a shared helper, but the duplication is minimal.
- The tRPC handler change adds a `PermissionCheckService` DB query for org users on every create call, replacing the in-memory `isOrgAdmin` boolean. This is consistent with how permission checks work elsewhere but is a slight performance trade-off worth noting.
- When PBAC is disabled, `fallbackRoles: [ADMIN, OWNER]` preserves the previous behavior (only admins/owners can create teams).

Link to Devin run: https://app.devin.ai/sessions/f27bce8ef91640059f86405861936980
Requested by: @sean-brydon
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
