### PR TITLE
feat(bookings): add booking audit logging to instant bookings

### DIFF
--- a/apps/web/pages/api/book/instant-event.ts
+++ b/apps/web/pages/api/book/instant-event.ts
@@ -25,6 +25,7 @@ async function handler(req: NextApiRequest & { userId?: number }) {
   // TODO: We should do the run-time schema validation here and pass a typed bookingData instead and then run-time schema could be removed from createBooking. Then we can remove the any type from req.body.
   const booking = await instantBookingService.createBooking({
     bookingData: req.body,
+    userUuid: session?.user?.uuid,
   });
 
   return booking;

--- a/apps/web/pages/api/book/instant-event.ts
+++ b/apps/web/pages/api/book/instant-event.ts
@@ -25,7 +25,9 @@ async function handler(req: NextApiRequest & { userId?: number }) {
   // TODO: We should do the run-time schema validation here and pass a typed bookingData instead and then run-time schema could be removed from createBooking. Then we can remove the any type from req.body.
   const booking = await instantBookingService.createBooking({
     bookingData: req.body,
-    userUuid: session?.user?.uuid,
+    bookingMeta: {
+      userUuid: session?.user?.uuid,
+    },
   });
 
   return booking;

--- a/apps/web/pages/api/book/instant-event.ts
+++ b/apps/web/pages/api/book/instant-event.ts
@@ -27,6 +27,7 @@ async function handler(req: NextApiRequest & { userId?: number }) {
     bookingData: req.body,
     bookingMeta: {
       userUuid: session?.user?.uuid,
+      impersonatedByUserUuid: null,
     },
   });
 

--- a/packages/features/booking-audit/lib/actions/CreatedAuditActionService.ts
+++ b/packages/features/booking-audit/lib/actions/CreatedAuditActionService.ts
@@ -80,8 +80,11 @@ export class CreatedAuditActionService implements IAuditActionService {
 
   async getDisplayTitle({ storedData, dbStore }: GetDisplayTitleParams): Promise<TranslationWithParams> {
     const { fields } = this.parseStored(storedData);
+    if (fields.status === BookingStatus.AWAITING_HOST) {
+      return { key: "booking_audit_action.created_awaiting_host", params: {} };
+    }
     const hostUser = fields.hostUserUuid ? dbStore.getUserByUuid(fields.hostUserUuid) : null;
-    const hostName = hostUser?.name || "Unknown";
+    const hostName = hostUser?.name ?? "Unknown";
     if (fields.seatReferenceUid) {
       return { key: "booking_audit_action.created_with_seat", params: { host: hostName } };
     }

--- a/packages/features/bookings/di/InstantBookingCreateService.module.ts
+++ b/packages/features/bookings/di/InstantBookingCreateService.module.ts
@@ -1,5 +1,7 @@
 import { InstantBookingCreateService } from "@calcom/features/bookings/lib/service/InstantBookingCreateService";
+import { moduleLoader as bookingEventHandlerModuleLoader } from "@calcom/features/bookings/di/BookingEventHandlerService.module";
 import { createModule, bindModuleToClassOnToken } from "@calcom/features/di/di";
+import { moduleLoader as featuresRepositoryModuleLoader } from "@calcom/features/di/modules/FeaturesRepository";
 import { DI_TOKENS } from "@calcom/features/di/tokens";
 import { moduleLoader as prismaModuleLoader } from "@calcom/features/di/modules/Prisma";
 
@@ -14,6 +16,8 @@ const loadModule = bindModuleToClassOnToken({
   depsMap: {
     // TODO: In a followup PR, we aim to remove prisma dependency and instead inject the repositories as dependencies.
     prismaClient: prismaModuleLoader,
+    bookingEventHandler: bookingEventHandlerModuleLoader,
+    featuresRepository: featuresRepositoryModuleLoader,
   },
 });
 

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.test.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.test.ts
@@ -248,22 +248,27 @@ describe("handleInstantMeeting", () => {
       expect(result.message).toBe("Success");
       expect(result.bookingId).toBeDefined();
 
-      // Verify the audit event handler was called
       expect(onBookingCreatedSpy).toHaveBeenCalledTimes(1);
 
-      // Verify the audit event was fired with correct booking data
       const callArgs = onBookingCreatedSpy.mock.calls[0][0];
       expect(callArgs.payload.booking.uid).toBe(result.bookingUid);
       expect(callArgs.payload.config.isDryRun).toBe(false);
-      expect(callArgs.actor).toBeDefined();
-      expect(callArgs.auditData).toBeDefined();
-      expect(callArgs.source).toBeDefined();
+      expect(callArgs.actor).toEqual(
+        expect.objectContaining({ identifiedBy: expect.any(String) })
+      );
+      expect(callArgs.auditData).toEqual(
+        expect.objectContaining({
+          startTime: expect.any(Number),
+          endTime: expect.any(Number),
+          status: expect.any(String),
+        })
+      );
+      expect(callArgs.source).toEqual(expect.any(String));
 
       onBookingCreatedSpy.mockRestore();
     });
 
     it("should not throw when booking audit event fails", async () => {
-      // Simulate an audit failure by making onBookingCreated throw
       const { BookingEventHandlerService } = await import("../onBookingEvents/BookingEventHandlerService");
       const onBookingCreatedSpy = vi
         .spyOn(BookingEventHandlerService.prototype, "onBookingCreated")
@@ -325,14 +330,12 @@ describe("handleInstantMeeting", () => {
         instant: true,
       };
 
-      // Even if audit event handler throws, booking should still succeed
       const result = await instantBookingCreateService.createBooking({
         bookingData: mockBookingData,
       });
 
       expect(result.message).toBe("Success");
       expect(result.bookingId).toBeDefined();
-      // Verify the audit handler was actually called (and failed)
       expect(onBookingCreatedSpy).toHaveBeenCalled();
 
       onBookingCreatedSpy.mockRestore();

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.test.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.test.ts
@@ -180,15 +180,12 @@ describe("handleInstantMeeting", () => {
     });
 
     it("should fire booking audit event with correct data when org has booking-audit feature", async () => {
-      const mockOnBookingCreated = vi.fn().mockResolvedValue(undefined);
-      const mockCheckIfTeamHasFeature = vi.fn().mockResolvedValue(true);
+      const { BookingEventHandlerService } = await import("../onBookingEvents/BookingEventHandlerService");
+      const onBookingCreatedSpy = vi
+        .spyOn(BookingEventHandlerService.prototype, "onBookingCreated")
+        .mockResolvedValue(undefined);
 
-      // Spy on the DI container to inject our mocks
-      const { getInstantBookingCreateService: getService } = await import(
-        "../../di/InstantBookingCreateService.container"
-      );
-
-      const instantBookingCreateService = getService();
+      const instantBookingCreateService = getInstantBookingCreateService();
       const organizer = getOrganizer({
         name: "Organizer",
         email: "organizer@example.com",
@@ -251,12 +248,18 @@ describe("handleInstantMeeting", () => {
       expect(result.message).toBe("Success");
       expect(result.bookingId).toBeDefined();
 
-      // Verify the booking was created with AWAITING_HOST status
-      const booking = await prismock.booking.findUnique({
-        where: { id: result.bookingId },
-        select: { status: true, uid: true, startTime: true, endTime: true },
-      });
-      expect(booking?.status).toBe(BookingStatus.AWAITING_HOST);
+      // Verify the audit event handler was called
+      expect(onBookingCreatedSpy).toHaveBeenCalledTimes(1);
+
+      // Verify the audit event was fired with correct booking data
+      const callArgs = onBookingCreatedSpy.mock.calls[0][0];
+      expect(callArgs.payload.booking.uid).toBe(result.bookingUid);
+      expect(callArgs.payload.config.isDryRun).toBe(false);
+      expect(callArgs.actor).toBeDefined();
+      expect(callArgs.auditData).toBeDefined();
+      expect(callArgs.source).toBeDefined();
+
+      onBookingCreatedSpy.mockRestore();
     });
 
     it("should not throw when booking audit event fails", async () => {

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.test.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.test.ts
@@ -260,6 +260,12 @@ describe("handleInstantMeeting", () => {
     });
 
     it("should not throw when booking audit event fails", async () => {
+      // Simulate an audit failure by making onBookingCreated throw
+      const { BookingEventHandlerService } = await import("../onBookingEvents/BookingEventHandlerService");
+      const onBookingCreatedSpy = vi
+        .spyOn(BookingEventHandlerService.prototype, "onBookingCreated")
+        .mockRejectedValue(new Error("Audit event handler failure"));
+
       const instantBookingCreateService = getInstantBookingCreateService();
       const organizer = getOrganizer({
         name: "Organizer",
@@ -323,6 +329,10 @@ describe("handleInstantMeeting", () => {
 
       expect(result.message).toBe("Success");
       expect(result.bookingId).toBeDefined();
+      // Verify the audit handler was actually called (and failed)
+      expect(onBookingCreatedSpy).toHaveBeenCalled();
+
+      onBookingCreatedSpy.mockRestore();
     });
   });
 });

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.test.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.test.ts
@@ -178,6 +178,152 @@ describe("handleInstantMeeting", () => {
         })
       ).rejects.toThrow("Only Team Event Types are supported for Instant Meeting");
     });
+
+    it("should fire booking audit event with correct data when org has booking-audit feature", async () => {
+      const mockOnBookingCreated = vi.fn().mockResolvedValue(undefined);
+      const mockCheckIfTeamHasFeature = vi.fn().mockResolvedValue(true);
+
+      // Spy on the DI container to inject our mocks
+      const { getInstantBookingCreateService: getService } = await import(
+        "../../di/InstantBookingCreateService.container"
+      );
+
+      const instantBookingCreateService = getService();
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+      });
+
+      const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+
+      await createBookingScenario(
+        getScenarioData({
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 45,
+              length: 45,
+              users: [{ id: 101 }],
+              team: { id: 1 },
+              instantMeetingExpiryTimeOffsetInSeconds: 90,
+            },
+          ],
+          organizer,
+          apps: [TestData.apps["daily-video"], TestData.apps["google-calendar"]],
+        })
+      );
+
+      mockSuccessfulVideoMeetingCreation({
+        metadataLookupKey: "dailyvideo",
+        videoMeetingData: {
+          id: "MOCK_ID",
+          password: "MOCK_PASS",
+          url: `http://mock-dailyvideo.example.com/meeting-1`,
+        },
+      });
+      mockCalendarToHaveNoBusySlots("googlecalendar", {
+        create: { uid: "MOCKED_GOOGLE_CALENDAR_EVENT_ID" },
+      });
+
+      const mockBookingData: CreateInstantBookingData = {
+        eventTypeId: 1,
+        timeZone: "UTC",
+        language: "en",
+        start: `${plus1DateString}T04:00:00.000Z`,
+        end: `${plus1DateString}T04:45:00.000Z`,
+        responses: {
+          name: "Test User",
+          email: "test@example.com",
+          attendeePhoneNumber: "+918888888888",
+        },
+        metadata: {},
+        instant: true,
+      };
+
+      const result = await instantBookingCreateService.createBooking({
+        bookingData: mockBookingData,
+      });
+
+      expect(result.message).toBe("Success");
+      expect(result.bookingId).toBeDefined();
+
+      // Verify the booking was created with AWAITING_HOST status
+      const booking = await prismock.booking.findUnique({
+        where: { id: result.bookingId },
+        select: { status: true, uid: true, startTime: true, endTime: true },
+      });
+      expect(booking?.status).toBe(BookingStatus.AWAITING_HOST);
+    });
+
+    it("should not throw when booking audit event fails", async () => {
+      const instantBookingCreateService = getInstantBookingCreateService();
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+      });
+
+      const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+
+      await createBookingScenario(
+        getScenarioData({
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 45,
+              length: 45,
+              users: [{ id: 101 }],
+              team: { id: 1 },
+              instantMeetingExpiryTimeOffsetInSeconds: 90,
+            },
+          ],
+          organizer,
+          apps: [TestData.apps["daily-video"], TestData.apps["google-calendar"]],
+        })
+      );
+
+      mockSuccessfulVideoMeetingCreation({
+        metadataLookupKey: "dailyvideo",
+        videoMeetingData: {
+          id: "MOCK_ID",
+          password: "MOCK_PASS",
+          url: `http://mock-dailyvideo.example.com/meeting-1`,
+        },
+      });
+      mockCalendarToHaveNoBusySlots("googlecalendar", {
+        create: { uid: "MOCKED_GOOGLE_CALENDAR_EVENT_ID" },
+      });
+
+      const mockBookingData: CreateInstantBookingData = {
+        eventTypeId: 1,
+        timeZone: "UTC",
+        language: "en",
+        start: `${plus1DateString}T04:00:00.000Z`,
+        end: `${plus1DateString}T04:45:00.000Z`,
+        responses: {
+          name: "Test User",
+          email: "test@example.com",
+          attendeePhoneNumber: "+918888888888",
+        },
+        metadata: {},
+        instant: true,
+      };
+
+      // Even if audit event handler throws, booking should still succeed
+      const result = await instantBookingCreateService.createBooking({
+        bookingData: mockBookingData,
+      });
+
+      expect(result.message).toBe("Success");
+      expect(result.bookingId).toBeDefined();
+    });
   });
 });
 

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -86,7 +86,7 @@ const handleInstantMeetingWebhookTrigger = async (args: {
     const { webhookData } = args;
 
     const promises = subscribers.map((sub) => {
-      sendGenericWebhookPayload({
+      return sendGenericWebhookPayload({
         secretKey: sub.secret,
         triggerEvent: eventTrigger,
         createdAt: new Date().toISOString(),

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -1,7 +1,4 @@
 import { randomBytes } from "node:crypto";
-import short from "short-uuid";
-import { v5 as uuidv5 } from "uuid";
-
 import dayjs from "@calcom/dayjs";
 import type { ActionSource } from "@calcom/features/booking-audit/lib/types/actionSource";
 import type {
@@ -11,10 +8,10 @@ import type {
 } from "@calcom/features/bookings/lib/dto/types";
 import getBookingDataSchema from "@calcom/features/bookings/lib/getBookingDataSchema";
 import { getBookingFieldsWithSystemFields } from "@calcom/features/bookings/lib/getBookingFields";
-import { getBookingData } from "@calcom/features/bookings/lib/handleNewBooking/getBookingData";
 import { buildBookingCreatedAuditData } from "@calcom/features/bookings/lib/handleNewBooking/buildBookingEventAuditData";
 import { getAuditActionSource } from "@calcom/features/bookings/lib/handleNewBooking/getAuditActionSource";
 import { getBookingAuditActorForNewBooking } from "@calcom/features/bookings/lib/handleNewBooking/getBookingAuditActorForNewBooking";
+import { getBookingData } from "@calcom/features/bookings/lib/handleNewBooking/getBookingData";
 import { getCustomInputsResponses } from "@calcom/features/bookings/lib/handleNewBooking/getCustomInputsResponses";
 import { getEventTypesFromDB } from "@calcom/features/bookings/lib/handleNewBooking/getEventTypesFromDB";
 import type { IBookingCreateService } from "@calcom/features/bookings/lib/interfaces/IBookingCreateService";
@@ -24,18 +21,19 @@ import type { FeaturesRepository } from "@calcom/features/flags/features.reposit
 import { getFullName } from "@calcom/features/form-builder/utils";
 import { sendNotification } from "@calcom/features/notifications/sendNotification";
 import { sendGenericWebhookPayload } from "@calcom/features/webhooks/lib/sendPayload";
+import { getTranslation } from "@calcom/i18n/server";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { ErrorWithCode } from "@calcom/lib/errors";
 import getOrgIdFromMemberOrTeamId from "@calcom/lib/getOrgIdFromMemberOrTeamId";
 import { isPrismaObjOrUndefined } from "@calcom/lib/isPrismaObj";
 import logger from "@calcom/lib/logger";
-import { getTranslation } from "@calcom/i18n/server";
 import type { PrismaClient } from "@calcom/prisma";
 import { Prisma } from "@calcom/prisma/client";
-import { BookingStatus, CreationSource, WebhookTriggerEvents } from "@calcom/prisma/enums";
-
+import { BookingStatus, type CreationSource, WebhookTriggerEvents } from "@calcom/prisma/enums";
+import short from "short-uuid";
+import { v5 as uuidv5 } from "uuid";
+import type { WebhookVersion } from "../../../webhooks/lib/interface/IWebhookRepository";
 import { instantMeetingSubscriptionSchema as subscriptionSchema } from "../dto/schema";
-import { WebhookVersion } from "../../../webhooks/lib/interface/IWebhookRepository";
 
 interface IInstantBookingCreateServiceDependencies {
   prismaClient: PrismaClient;
@@ -178,7 +176,7 @@ const triggerBrowserNotifications = async (args: {
 };
 
 export async function handler(
-  bookingData: CreateInstantBookingData & Required<Pick<CreateInstantBookingData, "creationSource">>,
+  bookingData: CreateInstantBookingData & { creationSource: CreationSource },
   deps: IInstantBookingCreateServiceDependencies,
   bookingMeta?: CreateBookingMeta
 ) {
@@ -302,6 +300,9 @@ export async function handler(
   const createBookingObj = {
     include: {
       attendees: true,
+      user: {
+        select: { uuid: true },
+      },
     },
     data: newBookingData,
   };
@@ -367,6 +368,7 @@ export async function handler(
     eventType,
     creationSource,
     orgId,
+    hostUserUuid: newBooking.user?.uuid ?? null,
     userUuid: userUuid ?? null,
     deps,
   });
@@ -388,15 +390,24 @@ async function fireBookingEvents({
   eventType,
   creationSource,
   orgId,
+  hostUserUuid,
   userUuid,
   deps,
 }: {
-  booking: { uid: string; startTime: Date; endTime: Date; status: BookingStatus; userId: number | null; attendees?: Array<{ id: number; email: string }> };
+  booking: {
+    uid: string;
+    startTime: Date;
+    endTime: Date;
+    status: BookingStatus;
+    userId: number | null;
+    attendees?: Array<{ id: number; email: string }>;
+  };
   bookerEmail: string;
   bookerName: string;
   eventType: { id: number };
   creationSource: CreationSource;
   orgId: number | null;
+  hostUserUuid: string | null;
   userUuid: string | null;
   deps: IInstantBookingCreateServiceDependencies;
 }) {
@@ -440,7 +451,7 @@ async function fireBookingEvents({
           startTime: booking.startTime,
           endTime: booking.endTime,
           status: booking.status,
-          userUuid: null,
+          userUuid: hostUserUuid,
         },
         attendeeSeatId: null,
       }),
@@ -459,7 +470,10 @@ async function fireBookingEvents({
 export class InstantBookingCreateService implements IBookingCreateService {
   constructor(private readonly deps: IInstantBookingCreateServiceDependencies) {}
 
-  async createBooking(input: { bookingData: CreateInstantBookingData & Required<Pick<CreateInstantBookingData, "creationSource">>; bookingMeta?: CreateBookingMeta }): Promise<InstantBookingCreateResult> {
+  async createBooking(input: {
+    bookingData: CreateInstantBookingData & { creationSource: CreationSource };
+    bookingMeta?: CreateBookingMeta;
+  }): Promise<InstantBookingCreateResult> {
     return handler(input.bookingData, this.deps, input.bookingMeta);
   }
 }

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -193,11 +193,7 @@ export async function handler(
     throw ErrorWithCode.Factory.BadRequest("Only Team Event Types are supported for Instant Meeting");
   }
 
-  if (!bookingData.creationSource) {
-    throw ErrorWithCode.Factory.BadRequest("creationSource is required for instant bookings");
-  }
-
-  const creationSource: CreationSource = bookingData.creationSource;
+  const creationSource: CreationSource = bookingData.creationSource ?? CreationSource.WEBAPP;
 
   const schema = getBookingDataSchema({
     view: bookingData?.rescheduleUid ? "reschedule" : "booking",

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -3,6 +3,7 @@ import short from "short-uuid";
 import { v5 as uuidv5 } from "uuid";
 
 import dayjs from "@calcom/dayjs";
+import type { ActionSource } from "@calcom/features/booking-audit/lib/types/actionSource";
 import type {
   CreateInstantBookingData,
   InstantBookingCreateResult,
@@ -10,10 +11,15 @@ import type {
 import getBookingDataSchema from "@calcom/features/bookings/lib/getBookingDataSchema";
 import { getBookingFieldsWithSystemFields } from "@calcom/features/bookings/lib/getBookingFields";
 import { getBookingData } from "@calcom/features/bookings/lib/handleNewBooking/getBookingData";
+import { buildBookingCreatedAuditData } from "@calcom/features/bookings/lib/handleNewBooking/buildBookingEventAuditData";
+import { getAuditActionSource } from "@calcom/features/bookings/lib/handleNewBooking/getAuditActionSource";
+import { getBookingAuditActorForNewBooking } from "@calcom/features/bookings/lib/handleNewBooking/getBookingAuditActorForNewBooking";
 import { getCustomInputsResponses } from "@calcom/features/bookings/lib/handleNewBooking/getCustomInputsResponses";
 import { getEventTypesFromDB } from "@calcom/features/bookings/lib/handleNewBooking/getEventTypesFromDB";
 import type { IBookingCreateService } from "@calcom/features/bookings/lib/interfaces/IBookingCreateService";
+import type { BookingEventHandlerService } from "@calcom/features/bookings/lib/onBookingEvents/BookingEventHandlerService";
 import { createInstantMeetingWithCalVideo } from "@calcom/features/conferencing/lib/videoClient";
+import type { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { getFullName } from "@calcom/features/form-builder/utils";
 import { sendNotification } from "@calcom/features/notifications/sendNotification";
 import { sendGenericWebhookPayload } from "@calcom/features/webhooks/lib/sendPayload";
@@ -31,6 +37,8 @@ import { WebhookVersion } from "../../../webhooks/lib/interface/IWebhookReposito
 
 interface IInstantBookingCreateServiceDependencies {
   prismaClient: PrismaClient;
+  bookingEventHandler: BookingEventHandlerService;
+  featuresRepository: FeaturesRepository;
 }
 
 const handleInstantMeetingWebhookTrigger = async (args: {
@@ -342,6 +350,60 @@ export async function handler(
     teamId: eventType.team?.id,
     prismaClient: prisma,
   });
+
+  // Fire booking audit event
+  try {
+    const orgId = eventType.team?.parentId ?? null;
+    const isBookingAuditEnabled = orgId
+      ? await deps.featuresRepository.checkIfTeamHasFeature(orgId, "booking-audit")
+      : false;
+
+    const actionSource: ActionSource = getAuditActionSource({
+      creationSource: bookingData.creationSource ?? null,
+      eventTypeId: eventType.id,
+      rescheduleUid: null,
+    });
+
+    const bookerAttendeeId = newBooking.attendees?.find((a) => a.email === bookerEmail)?.id ?? null;
+    const auditActor = getBookingAuditActorForNewBooking({
+      bookerAttendeeId,
+      actorUserUuid: null,
+      bookerEmail,
+      bookerName: fullName,
+      rescheduledBy: null,
+      logger,
+    });
+
+    await deps.bookingEventHandler.onBookingCreated({
+      payload: {
+        config: { isDryRun: false },
+        bookingFormData: { hashedLink: null },
+        booking: {
+          uid: newBooking.uid,
+          startTime: newBooking.startTime,
+          endTime: newBooking.endTime,
+          status: newBooking.status,
+          userId: newBooking.userId,
+        },
+        organizationId: orgId,
+      },
+      actor: auditActor,
+      auditData: buildBookingCreatedAuditData({
+        booking: {
+          startTime: newBooking.startTime,
+          endTime: newBooking.endTime,
+          status: newBooking.status,
+          userUuid: null,
+        },
+        attendeeSeatId: null,
+      }),
+      source: actionSource,
+      operationId: null,
+      isBookingAuditEnabled,
+    });
+  } catch (error) {
+    logger.error("Error firing booking audit event for instant booking", error);
+  }
 
   return {
     message: "Success",

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -29,7 +29,7 @@ import logger from "@calcom/lib/logger";
 import { getTranslation } from "@calcom/i18n/server";
 import type { PrismaClient } from "@calcom/prisma";
 import { Prisma } from "@calcom/prisma/client";
-import { BookingStatus, WebhookTriggerEvents } from "@calcom/prisma/enums";
+import { BookingStatus, CreationSource, WebhookTriggerEvents } from "@calcom/prisma/enums";
 
 import { instantMeetingSubscriptionSchema as subscriptionSchema } from "../dto/schema";
 import { WebhookVersion } from "../../../webhooks/lib/interface/IWebhookRepository";
@@ -191,6 +191,12 @@ export async function handler(
     throw new Error("Only Team Event Types are supported for Instant Meeting");
   }
 
+  if (!bookingData.creationSource) {
+    throw new Error("creationSource is required for instant bookings");
+  }
+
+  const creationSource: CreationSource = bookingData.creationSource;
+
   const schema = getBookingDataSchema({
     view: bookingData?.rescheduleUid ? "reschedule" : "booking",
     bookingFields: eventType.bookingFields,
@@ -289,7 +295,7 @@ export async function handler(
         data: attendeesList,
       },
     },
-    creationSource: bookingData.creationSource,
+    creationSource,
   };
 
   const createBookingObj = {
@@ -358,7 +364,7 @@ export async function handler(
     bookerEmail,
     bookerName: fullName,
     eventType,
-    creationSource: bookingData.creationSource ?? null,
+    creationSource,
     orgId,
     deps,
   });
@@ -386,7 +392,7 @@ async function fireBookingEvents({
   bookerEmail: string;
   bookerName: string;
   eventType: { id: number };
-  creationSource: string | null;
+  creationSource: CreationSource;
   orgId: number | null;
   deps: IInstantBookingCreateServiceDependencies;
 }) {

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -351,25 +351,60 @@ export async function handler(
     prismaClient: prisma,
   });
 
-  // Fire booking audit event
+  await fireBookingEvents({
+    booking: newBooking,
+    bookerEmail,
+    bookerName: fullName,
+    eventType,
+    creationSource: bookingData.creationSource ?? null,
+    orgId: eventType.team?.parentId ?? null,
+    deps,
+  });
+
+  return {
+    message: "Success",
+    meetingTokenId: instantMeetingToken.id,
+    bookingId: newBooking.id,
+    bookingUid: newBooking.uid,
+    expires: instantMeetingToken.expires,
+    userId: newBooking.userId,
+  } satisfies InstantBookingCreateResult;
+}
+
+async function fireBookingEvents({
+  booking,
+  bookerEmail,
+  bookerName,
+  eventType,
+  creationSource,
+  orgId,
+  deps,
+}: {
+  booking: { uid: string; startTime: Date; endTime: Date; status: BookingStatus; userId: number | null; attendees?: Array<{ id: number; email: string }> };
+  bookerEmail: string;
+  bookerName: string;
+  eventType: { id: number };
+  creationSource: string | null;
+  orgId: number | null;
+  deps: IInstantBookingCreateServiceDependencies;
+}) {
   try {
-    const orgId = eventType.team?.parentId ?? null;
     const isBookingAuditEnabled = orgId
       ? await deps.featuresRepository.checkIfTeamHasFeature(orgId, "booking-audit")
       : false;
 
     const actionSource: ActionSource = getAuditActionSource({
-      creationSource: bookingData.creationSource ?? null,
+      creationSource,
       eventTypeId: eventType.id,
       rescheduleUid: null,
     });
 
-    const bookerAttendeeId = newBooking.attendees?.find((a) => a.email === bookerEmail)?.id ?? null;
+    const bookerAttendeeId = booking.attendees?.find((a) => a.email === bookerEmail)?.id ?? null;
     const auditActor = getBookingAuditActorForNewBooking({
       bookerAttendeeId,
       actorUserUuid: null,
       bookerEmail,
-      bookerName: fullName,
+      bookerName,
       rescheduledBy: null,
       logger,
     });
@@ -379,20 +414,20 @@ export async function handler(
         config: { isDryRun: false },
         bookingFormData: { hashedLink: null },
         booking: {
-          uid: newBooking.uid,
-          startTime: newBooking.startTime,
-          endTime: newBooking.endTime,
-          status: newBooking.status,
-          userId: newBooking.userId,
+          uid: booking.uid,
+          startTime: booking.startTime,
+          endTime: booking.endTime,
+          status: booking.status,
+          userId: booking.userId,
         },
         organizationId: orgId,
       },
       actor: auditActor,
       auditData: buildBookingCreatedAuditData({
         booking: {
-          startTime: newBooking.startTime,
-          endTime: newBooking.endTime,
-          status: newBooking.status,
+          startTime: booking.startTime,
+          endTime: booking.endTime,
+          status: booking.status,
           userUuid: null,
         },
         attendeeSeatId: null,
@@ -404,15 +439,6 @@ export async function handler(
   } catch (error) {
     logger.error("Error firing booking audit event for instant booking", error);
   }
-
-  return {
-    message: "Success",
-    meetingTokenId: instantMeetingToken.id,
-    bookingId: newBooking.id,
-    bookingUid: newBooking.uid,
-    expires: instantMeetingToken.expires,
-    userId: newBooking.userId,
-  } satisfies InstantBookingCreateResult;
 }
 
 /**

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -441,7 +441,7 @@ async function fireBookingEvents({
           startTime: booking.startTime,
           endTime: booking.endTime,
           status: booking.status,
-          userUuid,
+          userUuid: null,
         },
         attendeeSeatId: null,
       }),

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -24,6 +24,7 @@ import { getFullName } from "@calcom/features/form-builder/utils";
 import { sendNotification } from "@calcom/features/notifications/sendNotification";
 import { sendGenericWebhookPayload } from "@calcom/features/webhooks/lib/sendPayload";
 import { WEBAPP_URL } from "@calcom/lib/constants";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import { isPrismaObjOrUndefined } from "@calcom/lib/isPrismaObj";
 import logger from "@calcom/lib/logger";
 import { getTranslation } from "@calcom/i18n/server";
@@ -176,7 +177,8 @@ const triggerBrowserNotifications = async (args: {
 
 export async function handler(
   bookingData: CreateInstantBookingData,
-  deps: IInstantBookingCreateServiceDependencies
+  deps: IInstantBookingCreateServiceDependencies,
+  userUuid?: string | null
 ) {
   // TODO: In a followup PR, we aim to remove prisma dependency and instead inject the repositories as dependencies.
   const { prismaClient: prisma } = deps;
@@ -188,11 +190,11 @@ export async function handler(
   };
 
   if (!eventType.team?.id) {
-    throw new Error("Only Team Event Types are supported for Instant Meeting");
+    throw ErrorWithCode.Factory.BadRequest("Only Team Event Types are supported for Instant Meeting");
   }
 
   if (!bookingData.creationSource) {
-    throw new Error("creationSource is required for instant bookings");
+    throw ErrorWithCode.Factory.BadRequest("creationSource is required for instant bookings");
   }
 
   const creationSource: CreationSource = bookingData.creationSource;
@@ -257,7 +259,7 @@ export async function handler(
   const calVideoMeeting = await createInstantMeetingWithCalVideo(dayjs.utc(reqBody.end).toISOString());
 
   if (!calVideoMeeting) {
-    throw new Error("Cal Video Meeting Creation Failed");
+    throw ErrorWithCode.Factory.InternalServerError("Cal Video Meeting Creation Failed");
   }
 
   const bookingReferenceToCreate = [
@@ -366,6 +368,7 @@ export async function handler(
     eventType,
     creationSource,
     orgId,
+    userUuid: userUuid ?? null,
     deps,
   });
 
@@ -386,6 +389,7 @@ async function fireBookingEvents({
   eventType,
   creationSource,
   orgId,
+  userUuid,
   deps,
 }: {
   booking: { uid: string; startTime: Date; endTime: Date; status: BookingStatus; userId: number | null; attendees?: Array<{ id: number; email: string }> };
@@ -394,6 +398,7 @@ async function fireBookingEvents({
   eventType: { id: number };
   creationSource: CreationSource;
   orgId: number | null;
+  userUuid: string | null;
   deps: IInstantBookingCreateServiceDependencies;
 }) {
   try {
@@ -410,7 +415,7 @@ async function fireBookingEvents({
     const bookerAttendeeId = booking.attendees?.find((a) => a.email === bookerEmail)?.id ?? null;
     const auditActor = getBookingAuditActorForNewBooking({
       bookerAttendeeId,
-      actorUserUuid: null,
+      actorUserUuid: userUuid,
       bookerEmail,
       bookerName,
       rescheduledBy: null,
@@ -436,7 +441,7 @@ async function fireBookingEvents({
           startTime: booking.startTime,
           endTime: booking.endTime,
           status: booking.status,
-          userUuid: null,
+          userUuid,
         },
         attendeeSeatId: null,
       }),
@@ -455,7 +460,7 @@ async function fireBookingEvents({
 export class InstantBookingCreateService implements IBookingCreateService {
   constructor(private readonly deps: IInstantBookingCreateServiceDependencies) {}
 
-  async createBooking(input: { bookingData: CreateInstantBookingData }): Promise<InstantBookingCreateResult> {
-    return handler(input.bookingData, this.deps);
+  async createBooking(input: { bookingData: CreateInstantBookingData; userUuid?: string | null }): Promise<InstantBookingCreateResult> {
+    return handler(input.bookingData, this.deps, input.userUuid);
   }
 }

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -5,6 +5,7 @@ import { v5 as uuidv5 } from "uuid";
 import dayjs from "@calcom/dayjs";
 import type { ActionSource } from "@calcom/features/booking-audit/lib/types/actionSource";
 import type {
+  CreateBookingMeta,
   CreateInstantBookingData,
   InstantBookingCreateResult,
 } from "@calcom/features/bookings/lib/dto/types";
@@ -25,6 +26,7 @@ import { sendNotification } from "@calcom/features/notifications/sendNotificatio
 import { sendGenericWebhookPayload } from "@calcom/features/webhooks/lib/sendPayload";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { ErrorWithCode } from "@calcom/lib/errors";
+import getOrgIdFromMemberOrTeamId from "@calcom/lib/getOrgIdFromMemberOrTeamId";
 import { isPrismaObjOrUndefined } from "@calcom/lib/isPrismaObj";
 import logger from "@calcom/lib/logger";
 import { getTranslation } from "@calcom/i18n/server";
@@ -178,7 +180,7 @@ const triggerBrowserNotifications = async (args: {
 export async function handler(
   bookingData: CreateInstantBookingData,
   deps: IInstantBookingCreateServiceDependencies,
-  userUuid?: string | null
+  bookingMeta?: CreateBookingMeta
 ) {
   // TODO: In a followup PR, we aim to remove prisma dependency and instead inject the repositories as dependencies.
   const { prismaClient: prisma } = deps;
@@ -193,7 +195,12 @@ export async function handler(
     throw ErrorWithCode.Factory.BadRequest("Only Team Event Types are supported for Instant Meeting");
   }
 
-  const creationSource: CreationSource = bookingData.creationSource ?? CreationSource.WEBAPP;
+  if (!bookingData.creationSource) {
+    throw ErrorWithCode.Factory.BadRequest("creationSource is required for instant bookings");
+  }
+
+  const creationSource: CreationSource = bookingData.creationSource;
+  const userUuid = bookingMeta?.userUuid ?? null;
 
   const schema = getBookingDataSchema({
     view: bookingData?.rescheduleUid ? "reschedule" : "booking",
@@ -331,7 +338,7 @@ export async function handler(
   });
 
   // Trigger Webhook
-  const orgId = eventType.team?.parentId ?? null;
+  const orgId = (await getOrgIdFromMemberOrTeamId({ teamId: eventType.team?.id })) ?? null;
   const webhookData = {
     triggerEvent: WebhookTriggerEvents.INSTANT_MEETING,
     uid: newBooking.uid,
@@ -456,7 +463,7 @@ async function fireBookingEvents({
 export class InstantBookingCreateService implements IBookingCreateService {
   constructor(private readonly deps: IInstantBookingCreateServiceDependencies) {}
 
-  async createBooking(input: { bookingData: CreateInstantBookingData; userUuid?: string | null }): Promise<InstantBookingCreateResult> {
-    return handler(input.bookingData, this.deps, input.userUuid);
+  async createBooking(input: { bookingData: CreateInstantBookingData; bookingMeta?: CreateBookingMeta }): Promise<InstantBookingCreateResult> {
+    return handler(input.bookingData, this.deps, input.bookingMeta);
   }
 }

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -178,7 +178,7 @@ const triggerBrowserNotifications = async (args: {
 };
 
 export async function handler(
-  bookingData: CreateInstantBookingData,
+  bookingData: CreateInstantBookingData & Required<Pick<CreateInstantBookingData, "creationSource">>,
   deps: IInstantBookingCreateServiceDependencies,
   bookingMeta?: CreateBookingMeta
 ) {
@@ -195,11 +195,7 @@ export async function handler(
     throw ErrorWithCode.Factory.BadRequest("Only Team Event Types are supported for Instant Meeting");
   }
 
-  if (!bookingData.creationSource) {
-    throw ErrorWithCode.Factory.BadRequest("creationSource is required for instant bookings");
-  }
-
-  const creationSource: CreationSource = bookingData.creationSource;
+  const creationSource = bookingData.creationSource;
   const userUuid = bookingMeta?.userUuid ?? null;
 
   const schema = getBookingDataSchema({
@@ -463,7 +459,7 @@ async function fireBookingEvents({
 export class InstantBookingCreateService implements IBookingCreateService {
   constructor(private readonly deps: IInstantBookingCreateServiceDependencies) {}
 
-  async createBooking(input: { bookingData: CreateInstantBookingData; bookingMeta?: CreateBookingMeta }): Promise<InstantBookingCreateResult> {
+  async createBooking(input: { bookingData: CreateInstantBookingData & Required<Pick<CreateInstantBookingData, "creationSource">>; bookingMeta?: CreateBookingMeta }): Promise<InstantBookingCreateResult> {
     return handler(input.bookingData, this.deps, input.bookingMeta);
   }
 }

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -24,7 +24,6 @@ import { getFullName } from "@calcom/features/form-builder/utils";
 import { sendNotification } from "@calcom/features/notifications/sendNotification";
 import { sendGenericWebhookPayload } from "@calcom/features/webhooks/lib/sendPayload";
 import { WEBAPP_URL } from "@calcom/lib/constants";
-import getOrgIdFromMemberOrTeamId from "@calcom/lib/getOrgIdFromMemberOrTeamId";
 import { isPrismaObjOrUndefined } from "@calcom/lib/isPrismaObj";
 import logger from "@calcom/lib/logger";
 import { getTranslation } from "@calcom/i18n/server";
@@ -45,9 +44,10 @@ const handleInstantMeetingWebhookTrigger = async (args: {
   eventTypeId: number;
   webhookData: Record<string, unknown>;
   teamId: number;
+  orgId: number;
   prismaClient: PrismaClient;
 }) => {
-  const orgId = (await getOrgIdFromMemberOrTeamId({ teamId: args.teamId })) ?? 0;
+  const orgId = args.orgId;
   const { prismaClient: prisma } = args;
   try {
     const eventTrigger = WebhookTriggerEvents.INSTANT_MEETING;
@@ -327,6 +327,7 @@ export async function handler(
   });
 
   // Trigger Webhook
+  const orgId = eventType.team?.parentId ?? null;
   const webhookData = {
     triggerEvent: WebhookTriggerEvents.INSTANT_MEETING,
     uid: newBooking.uid,
@@ -341,6 +342,7 @@ export async function handler(
     eventTypeId: eventType.id,
     webhookData,
     teamId: eventType.team?.id,
+    orgId: orgId ?? 0,
     prismaClient: prisma,
   });
 
@@ -357,7 +359,7 @@ export async function handler(
     bookerName: fullName,
     eventType,
     creationSource: bookingData.creationSource ?? null,
-    orgId: eventType.team?.parentId ?? null,
+    orgId,
     deps,
   });
 

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4568,6 +4568,7 @@
   "location_applied_to_hosts_other": "Location applied to {{count}} hosts",
   "booking_audit_action": {
     "created": "Booked with {{host}}",
+    "created_awaiting_host": "Booked (awaiting host)",
     "created_with_seat": "Seat Booked with {{host}}",
     "cancelled": "Cancelled",
     "rescheduled": "Rescheduled {{oldDate}} -> <0>{{newDate}}</0>",

--- a/packages/trpc/server/routers/loggedInViewer/connectAndJoin.handler.test.ts
+++ b/packages/trpc/server/routers/loggedInViewer/connectAndJoin.handler.test.ts
@@ -1,0 +1,208 @@
+import { prisma } from "@calcom/prisma/__mocks__/prisma";
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { BookingStatus } from "@calcom/prisma/enums";
+import type { TrpcSessionUser } from "@calcom/trpc/server/types";
+
+import { Handler } from "./connectAndJoin.handler";
+
+vi.mock("@calcom/prisma", () => ({
+  prisma,
+}));
+
+vi.mock("@calcom/emails/email-manager", () => ({
+  sendScheduledEmailsAndSMS: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@calcom/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers", () => ({
+  scheduleNoShowTriggers: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@calcom/i18n/server", () => ({
+  getTranslation: vi.fn().mockResolvedValue((key: string) => key),
+}));
+
+vi.mock("@calcom/features/eventtypes/di/EventTypeService.container", () => ({
+  getEventTypeService: vi.fn(() => ({
+    shouldHideBrandingForEventType: vi.fn().mockResolvedValue(false),
+  })),
+}));
+
+vi.mock("@calcom/features/bookings/lib/getCalEventResponses", () => ({
+  getCalEventResponses: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@calcom/features/di/containers/FeaturesRepository");
+vi.mock("@calcom/features/bookings/di/BookingEventHandlerService.container");
+
+const MOCK_BOOKING_UID = "booking-uid-123";
+const MOCK_USER_UUID = "user-uuid-456";
+const MOCK_ORG_ID = 100;
+const MOCK_TOKEN = "instant-meeting-token";
+
+function createMockUser(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 1,
+    uuid: MOCK_USER_UUID,
+    email: "host@example.com",
+    name: "Host User",
+    username: "hostuser",
+    timeZone: "UTC",
+    timeFormat: 12,
+    locale: "en",
+    organization: { id: MOCK_ORG_ID },
+    organizationId: MOCK_ORG_ID,
+    ...overrides,
+  } as unknown as NonNullable<TrpcSessionUser>;
+}
+
+function mockPrismaForSuccessfulJoin({ oldStatus = BookingStatus.AWAITING_HOST } = {}) {
+  prisma.user.findUnique.mockResolvedValue({
+    hideBranding: false,
+    profiles: [],
+  } as any);
+
+  prisma.instantMeetingToken.findUnique.mockResolvedValue({
+    expires: new Date(Date.now() + 60_000),
+    teamId: 1,
+    booking: {
+      id: 10,
+      status: oldStatus,
+      user: { id: 99 },
+    },
+  } as any);
+
+  prisma.booking.update.mockResolvedValue({
+    id: 10,
+    uid: MOCK_BOOKING_UID,
+    title: "Instant Meeting",
+    description: null,
+    customInputs: {},
+    startTime: new Date("2026-04-04T10:00:00Z"),
+    endTime: new Date("2026-04-04T10:45:00Z"),
+    location: "integrations:daily",
+    userId: 1,
+    status: BookingStatus.ACCEPTED,
+    responses: {},
+    metadata: { videoCallUrl: "https://daily.co/mock-meeting" },
+    attendees: [
+      {
+        name: "Attendee",
+        email: "attendee@example.com",
+        timeZone: "UTC",
+        locale: "en",
+      },
+    ],
+    references: [
+      {
+        type: "daily_video",
+        meetingId: "MOCK_ID",
+        meetingPassword: "MOCK_PASS",
+        meetingUrl: "https://daily.co/mock-meeting",
+      },
+    ],
+    eventTypeId: 1,
+    eventType: {
+      id: 1,
+      owner: null,
+      teamId: 1,
+      title: "Instant Meeting",
+      slug: "instant-meeting",
+      requiresConfirmation: false,
+      currency: "usd",
+      length: 45,
+      description: null,
+      price: 0,
+      bookingFields: null,
+      disableGuests: false,
+      metadata: null,
+      hideOrganizerEmail: false,
+      customInputs: [],
+      parentId: null,
+      customReplyToEmail: null,
+      team: {
+        id: 1,
+        name: "Test Team",
+        hideBranding: false,
+        parent: null,
+      },
+    },
+  } as any);
+}
+
+describe("connectAndJoin.handler", () => {
+  const mockOnBookingAccepted = vi.fn().mockResolvedValue(undefined);
+  const mockCheckIfTeamHasFeature = vi.fn();
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const { getBookingEventHandlerService } = await import(
+      "@calcom/features/bookings/di/BookingEventHandlerService.container"
+    );
+    vi.mocked(getBookingEventHandlerService).mockReturnValue({
+      onBookingAccepted: mockOnBookingAccepted,
+    } as any);
+
+    const { getFeaturesRepository } = await import("@calcom/features/di/containers/FeaturesRepository");
+    vi.mocked(getFeaturesRepository).mockReturnValue({
+      checkIfTeamHasFeature: mockCheckIfTeamHasFeature,
+    } as any);
+  });
+
+  describe("booking audit event", () => {
+    it("should fire booking accepted audit event with correct data", async () => {
+      mockCheckIfTeamHasFeature.mockResolvedValue(true);
+      mockPrismaForSuccessfulJoin({ oldStatus: BookingStatus.AWAITING_HOST });
+
+      await Handler({
+        ctx: { user: createMockUser() },
+        input: { token: MOCK_TOKEN },
+      });
+
+      expect(mockCheckIfTeamHasFeature).toHaveBeenCalledWith(MOCK_ORG_ID, "booking-audit");
+
+      expect(mockOnBookingAccepted).toHaveBeenCalledTimes(1);
+      expect(mockOnBookingAccepted).toHaveBeenCalledWith({
+        bookingUid: MOCK_BOOKING_UID,
+        actor: { identifiedBy: "user", userUuid: MOCK_USER_UUID },
+        organizationId: MOCK_ORG_ID,
+        auditData: {
+          status: { old: BookingStatus.AWAITING_HOST, new: BookingStatus.ACCEPTED },
+        },
+        source: "WEBAPP",
+        isBookingAuditEnabled: true,
+      });
+    });
+
+    it("should pass isBookingAuditEnabled=false when feature is disabled", async () => {
+      mockCheckIfTeamHasFeature.mockResolvedValue(false);
+      mockPrismaForSuccessfulJoin();
+
+      await Handler({
+        ctx: { user: createMockUser() },
+        input: { token: MOCK_TOKEN },
+      });
+
+      expect(mockOnBookingAccepted).toHaveBeenCalledTimes(1);
+      expect(mockOnBookingAccepted).toHaveBeenCalledWith(
+        expect.objectContaining({ isBookingAuditEnabled: false })
+      );
+    });
+
+    it("should not throw when audit event fails", async () => {
+      mockCheckIfTeamHasFeature.mockResolvedValue(true);
+      mockOnBookingAccepted.mockRejectedValue(new Error("Audit handler failure"));
+      mockPrismaForSuccessfulJoin();
+
+      const result = await Handler({
+        ctx: { user: createMockUser() },
+        input: { token: MOCK_TOKEN },
+      });
+
+      expect(result.meetingUrl).toBe("https://daily.co/mock-meeting");
+      expect(mockOnBookingAccepted).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/trpc/server/routers/loggedInViewer/connectAndJoin.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/connectAndJoin.handler.ts
@@ -1,12 +1,15 @@
 import { sendScheduledEmailsAndSMS } from "@calcom/emails/email-manager";
+import { getBookingEventHandlerService } from "@calcom/features/bookings/di/BookingEventHandlerService.container";
 import { getCalEventResponses } from "@calcom/features/bookings/lib/getCalEventResponses";
 import { scheduleNoShowTriggers } from "@calcom/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers";
+import { getFeaturesRepository } from "@calcom/features/di/containers/FeaturesRepository";
 import {
   type EventTypeBrandingData,
   getEventTypeService,
 } from "@calcom/features/eventtypes/di/EventTypeService.container";
-import { isPrismaObjOrUndefined } from "@calcom/lib/isPrismaObj";
 import { getTranslation } from "@calcom/i18n/server";
+import { isPrismaObjOrUndefined } from "@calcom/lib/isPrismaObj";
+import logger from "@calcom/lib/logger";
 import { getTimeFormatStringFromUserTimeFormat } from "@calcom/lib/timeFormat";
 import { prisma } from "@calcom/prisma";
 import { BookingStatus } from "@calcom/prisma/enums";
@@ -163,6 +166,13 @@ export const Handler = async ({ ctx, input }: Options) => {
     },
   });
 
+  await fireBookingAcceptedAuditEvent({
+    bookingUid: updatedBooking.uid,
+    actorUserUuid: user.uuid,
+    organizationId: user.organizationId,
+    oldStatus: instantMeetingToken.booking.status,
+  });
+
   const locationVideoCallUrl = bookingMetadataSchema.parse(updatedBooking.metadata || {})?.videoCallUrl;
 
   if (!locationVideoCallUrl) {
@@ -282,3 +292,36 @@ export const Handler = async ({ ctx, input }: Options) => {
 
   return { isBookingAlreadyAcceptedBySomeoneElse, meetingUrl: locationVideoCallUrl };
 };
+
+async function fireBookingAcceptedAuditEvent({
+  bookingUid,
+  actorUserUuid,
+  organizationId,
+  oldStatus,
+}: {
+  bookingUid: string;
+  actorUserUuid: string;
+  organizationId: number | null;
+  oldStatus: BookingStatus;
+}) {
+  try {
+    const featuresRepository = getFeaturesRepository();
+    const isBookingAuditEnabled = organizationId
+      ? await featuresRepository.checkIfTeamHasFeature(organizationId, "booking-audit")
+      : false;
+
+    const bookingEventHandlerService = getBookingEventHandlerService();
+    await bookingEventHandlerService.onBookingAccepted({
+      bookingUid,
+      actor: { identifiedBy: "user", userUuid: actorUserUuid },
+      organizationId,
+      auditData: {
+        status: { old: oldStatus, new: BookingStatus.ACCEPTED },
+      },
+      source: "WEBAPP",
+      isBookingAuditEnabled,
+    });
+  } catch (error) {
+    logger.error("Error firing booking accepted audit for instant meeting", error);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

- Fixes #22832

`RegularBookingService` and `RecurringBookingService` both emit audit events through `BookingEventHandlerService` when bookings are created or rescheduled. `InstantBookingCreateService` was the only booking service missing this integration.

this wires up `BookingEventHandlerService.onBookingCreated()` in the instant booking flow, following the exact same pattern used in `RegularBookingService`. the audit call is wrapped in try/catch so audit failures never break the booking flow.

## Visual Demo (For contributors especially)

N/A — backend-only change, no UI impact. audit events are written to the `BookingAudit` table behind the `booking-audit` feature flag.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. enable the `booking-audit` feature flag for an organization
2. create an instant meeting event type for a team
3. book an instant meeting as an external user
4. verify a row is created in the `BookingAudit` table with `action = CREATED` and the correct `bookingUid`
5. verify the booking itself still works normally (audit is fire-and-forget, shouldn't affect the booking flow)

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
