### PR TITLE
fix: populate allFallbackRRHosts when segment matching reduces hosts

### DIFF
--- a/packages/features/bookings/lib/host-filtering/findQualifiedHostsWithDelegationCredentials.test.ts
+++ b/packages/features/bookings/lib/host-filtering/findQualifiedHostsWithDelegationCredentials.test.ts
@@ -1,12 +1,9 @@
 import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
-
-import { vi, it, describe, expect, afterEach } from "vitest";
-import type { Mock } from "vitest";
-
 import { getQualifiedHostsService } from "@calcom/features/di/containers/QualifiedHosts";
 import * as getRoutedUsers from "@calcom/features/users/lib/getRoutedUsers";
 import { RRResetInterval, SchedulingType } from "@calcom/prisma/enums";
-
+import type { Mock } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { filterHostsByLeadThreshold } from "./filterHostsByLeadThreshold";
 
 // Mock the filterHostsByLeadThreshold function
@@ -681,11 +678,125 @@ describe("findQualifiedHostsWithDelegationCredentials", async () => {
       routingFormResponse: null,
     });
 
-    // Verify the result
+    // Verify the result — segment matching reduced hosts (4 → 3), so fallback is the full pre-segment set
     expect(result).toEqual({
       qualifiedRRHosts: [hosts[2]],
-      allFallbackRRHosts: [hosts[1], hosts[2]],
+      allFallbackRRHosts: hosts,
       fixedHosts: [],
     });
+  });
+
+  it("should populate allFallbackRRHosts when segment matching reduces hosts even without fairness filtering", async () => {
+    // This reproduces the bug where segment matching narrows 100 hosts to 2,
+    // maxLeadThreshold is null (so fairness is a no-op), and allFallbackRRHosts
+    // was incorrectly left undefined — causing no_available_users_found_error
+    // when the segment-matched hosts weren't available.
+    const oneYearAgo = new Date();
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+    const hosts = [
+      {
+        isFixed: false,
+        createdAt: oneYearAgo,
+        weight: undefined,
+        priority: undefined,
+        user: {
+          email: "segment-matched-1@gmail.com",
+          id: 1,
+          credentials: [],
+          userLevelSelectedCalendars: [],
+        },
+      },
+      {
+        isFixed: false,
+        createdAt: oneYearAgo,
+        weight: undefined,
+        priority: undefined,
+        user: {
+          email: "segment-matched-2@gmail.com",
+          id: 2,
+          credentials: [],
+          userLevelSelectedCalendars: [],
+        },
+      },
+      {
+        isFixed: false,
+        createdAt: oneYearAgo,
+        weight: undefined,
+        priority: undefined,
+        user: {
+          email: "other-host-3@gmail.com",
+          id: 3,
+          credentials: [],
+          userLevelSelectedCalendars: [],
+        },
+      },
+      {
+        isFixed: false,
+        createdAt: oneYearAgo,
+        weight: undefined,
+        priority: undefined,
+        user: {
+          email: "other-host-4@gmail.com",
+          id: 4,
+          credentials: [],
+          userLevelSelectedCalendars: [],
+        },
+      },
+      {
+        isFixed: false,
+        createdAt: oneYearAgo,
+        weight: undefined,
+        priority: undefined,
+        user: {
+          email: "other-host-5@gmail.com",
+          id: 5,
+          credentials: [],
+          userLevelSelectedCalendars: [],
+        },
+      },
+    ];
+
+    // Segment matching reduces 5 hosts down to 2
+    vi.spyOn(getRoutedUsers, "findMatchingHostsWithEventSegment").mockImplementation(async () => [
+      hosts[0],
+      hosts[1],
+    ]);
+
+    // Fairness filter is a no-op (maxLeadThreshold is null, so filterHostsByLeadThreshold returns same hosts)
+    (filterHostsByLeadThreshold as Mock).mockResolvedValue([hosts[0], hosts[1]]);
+
+    const eventType = {
+      id: 1,
+      hosts,
+      users: [],
+      schedulingType: SchedulingType.ROUND_ROBIN,
+      maxLeadThreshold: null,
+      rescheduleWithSameRoundRobinHost: true,
+      assignAllTeamMembers: true,
+      assignRRMembersUsingSegment: false,
+      rrSegmentQueryValue: null,
+      isRRWeightsEnabled: false,
+      team: {
+        id: 1,
+        parentId: null,
+        rrResetInterval: RRResetInterval.MONTH,
+      },
+    };
+
+    const result = await qualifiedHostsService.findQualifiedHostsWithDelegationCredentials({
+      eventType,
+      routedTeamMemberIds: [],
+      rescheduleUid: null,
+      contactOwnerEmail: null,
+      routingFormResponse: null,
+    });
+
+    // qualifiedRRHosts should be the 2 segment-matched hosts
+    expect(result.qualifiedRRHosts).toEqual([hosts[0], hosts[1]]);
+    // allFallbackRRHosts should be ALL hosts (pre-segment set) so booking can
+    // fall back when the segment-matched hosts aren't available
+    expect(result.allFallbackRRHosts).toEqual(hosts);
+    expect(result.fixedHosts).toEqual([]);
   });
 });

--- a/packages/features/bookings/lib/host-filtering/findQualifiedHostsWithDelegationCredentials.ts
+++ b/packages/features/bookings/lib/host-filtering/findQualifiedHostsWithDelegationCredentials.ts
@@ -1,15 +1,14 @@
 import type { RoutingFormResponse } from "@calcom/features/bookings/lib/getLuckyUser";
 import type { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
+import type { EventType } from "@calcom/features/users/lib/getRoutedUsers";
 import {
   findMatchingHostsWithEventSegment,
   getNormalizedHostsWithDelegationCredentials,
 } from "@calcom/features/users/lib/getRoutedUsers";
-import type { EventType } from "@calcom/features/users/lib/getRoutedUsers";
 import { withReporting } from "@calcom/lib/sentryWrapper";
 import type { SelectedCalendar } from "@calcom/prisma/client";
 import { SchedulingType } from "@calcom/prisma/enums";
 import type { CredentialForCalendarService, CredentialPayload } from "@calcom/types/Credential";
-
 import { filterHostsByLeadThreshold } from "./filterHostsByLeadThreshold";
 import type { FilterHostsService } from "./filterHostsBySameRoundRobinHost";
 
@@ -240,13 +239,27 @@ export class QualifiedHostsService {
       };
     }
 
+    // Determine the appropriate fallback hosts.
+    // When segment matching reduces the host count (e.g. 100 hosts → 2), and those hosts
+    // aren't available, we need to fall back to the broader pre-segment set so the booking
+    // doesn't fail with no_available_users_found_error.
+    const segmentMatchingReducedHosts =
+      hostsAfterSegmentMatching.length < hostsAfterRescheduleWithSameRoundRobinHost.length;
+    const fairnessReducedHosts =
+      hostsAfterFairnessMatching.length !== hostsAfterRoutedTeamMemberIdsMatching.length;
+
+    let allFallbackRRHosts: typeof hostsAfterFairnessMatching | undefined;
+    if (segmentMatchingReducedHosts) {
+      // Segment matching narrowed hosts — fall back to the full pre-segment set
+      allFallbackRRHosts = hostsAfterRescheduleWithSameRoundRobinHost;
+    } else if (fairnessReducedHosts) {
+      // Only fairness filtering narrowed hosts — fall back to the pre-fairness set
+      allFallbackRRHosts = hostsAfterRoutedTeamMemberIdsMatching;
+    }
+
     return {
       qualifiedRRHosts: hostsAfterFairnessMatching,
-      // only if fairness filtering is active
-      allFallbackRRHosts:
-        hostsAfterFairnessMatching.length !== hostsAfterRoutedTeamMemberIdsMatching.length
-          ? hostsAfterRoutedTeamMemberIdsMatching
-          : undefined,
+      allFallbackRRHosts,
       fixedHosts,
     };
   }


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where booking a Round Robin event type with `segmentQueryValue` configured fails with `no_available_users_found_error` despite the slots API showing the time as available.

**Root cause:** When segment matching reduces the host pool (e.g. 100 hosts → 2), and `maxLeadThreshold` is null (so the fairness filter is a no-op), `allFallbackRRHosts` was left `undefined`. Without fallback hosts, if the segment-matched hosts aren't available at the requested time, the booking fails instead of trying the remaining hosts.

**Fix:** The final return in `_findQualifiedHostsWithDelegationCredentials` now also checks whether segment matching reduced the host count. If it did, `allFallbackRRHosts` is set to the full pre-segment host set (`hostsAfterRescheduleWithSameRoundRobinHost`), enabling the booking and slots flows to gracefully degrade.

### Key changes
- `findQualifiedHostsWithDelegationCredentials.ts`: Added `segmentMatchingReducedHosts` check alongside the existing `fairnessReducedHosts` check when determining `allFallbackRRHosts`
- Updated existing test expectation: when both segment matching AND fairness reduce hosts, the fallback is now the broader pre-segment set (not just the pre-fairness set)
- Added new test case that directly reproduces the reported bug scenario (segment narrows hosts, fairness is a no-op, fallback must still be populated)

## Human Review Checklist

- [ ] **Design decision**: When segment-matched hosts aren't available, the fallback bypasses segment matching entirely and falls back to ALL RR hosts. Is this the correct behavior, or should the fallback be scoped differently?
- [ ] **Early return paths not addressed**: Lines 183-188 (single segment match) and 205-220 (single routed team member after segment) also return without `allFallbackRRHosts` when segment matching reduced hosts. Should those paths also populate the fallback?
- [ ] **Updated test expectation**: The "fairness + segment + routing" test now expects `allFallbackRRHosts: hosts` (all 4 hosts) instead of `[hosts[1], hosts[2]]` (only routed subset). Verify this is intended.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Set up a Round Robin event type with 3+ hosts and a `segmentQueryValue` that matches only a subset of hosts
2. Set `maxLeadThreshold` to null (no fairness filtering)
3. Request slots — the segment-matched hosts' availability windows should appear
4. Attempt to book a time where the segment-matched hosts are NOT available but other hosts ARE available
5. **Expected**: Booking succeeds by falling back to the broader host pool
6. **Before this fix**: Booking fails with `no_available_users_found_error`

Unit tests cover the core logic. Integration/E2E testing would require complex setup (100+ hosts, segment query, specific working hours).

---

**Link to Devin run:** https://app.devin.ai/sessions/90561a952fd4430789c88c81a171f2fc  
**Requested by:** @joeauyeung