### PR TITLE
fix: skip queued-response API call when cal.isBookingDryRun=true is set

### DIFF
--- a/packages/embeds/embed-core/playground/lib/playground-init.ts
+++ b/packages/embeds/embed-core/playground/lib/playground-init.ts
@@ -8,6 +8,7 @@ window.params = {
   email: emailQueryParam,
   formId: url.searchParams.get("param.formId"),
   disablePrerender: url.searchParams.get("param.disablePrerender") === "true",
+  dryRun: url.searchParams.get("param.dryRun") === "true",
 };
 
 window.generateRandomHexColor = function generateRandomHexColor() {

--- a/packages/embeds/embed-core/playwright/tests/routing-prerender.e2e.ts
+++ b/packages/embeds/embed-core/playwright/tests/routing-prerender.e2e.ts
@@ -1,20 +1,19 @@
-import type { Page } from "@playwright/test";
-import { expect } from "@playwright/test";
-
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { SchedulingType } from "@calcom/prisma/enums";
-import { test } from "@calcom/web/playwright/lib/fixtures";
 import type { Fixtures } from "@calcom/web/playwright/lib/fixtures";
+import { test } from "@calcom/web/playwright/lib/fixtures";
 import { doOnOrgDomain } from "@calcom/web/playwright/lib/testUtils";
-
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { expectHostsToBe } from "../lib/pages/bookingSuccessPage";
 import {
-  getEmbedIframe,
   bookEvent,
+  expectActualFormResponseConnectedToQueuedFormResponse,
   expectEmbedIFrameToBeVisible,
   getAllFormResponses,
-  expectActualFormResponseConnectedToQueuedFormResponse,
+  getEmbedIframe,
   getLatestQueuedFormResponse,
+  getQueuedFormResponse,
 } from "../lib/testUtils";
 
 // in parallel mode sometimes handleNewBooking endpoint throws "No available users found" error, this never happens in serial mode.
@@ -111,6 +110,81 @@ test.describe("Prerender Headless Router", () => {
         hosts: expectedRoutedTeamMembers.map((user) => ({ email: user.email })),
         frame: prerenderedIframe,
       });
+    });
+  });
+
+  test("should skip queued-response API call when cal.isBookingDryRun=true is passed in modal config but not in prerender", async ({
+    page,
+    embeds,
+    users,
+  }) => {
+    const userFixture = await users.create(
+      { username: "routing-forms" },
+      {
+        hasTeam: true,
+        isOrg: true,
+        hasSubteam: true,
+        schedulingType: SchedulingType.ROUND_ROBIN,
+        seedRoutingFormWithAttributeRouting: true,
+        seedRoutingForms: true,
+      }
+    );
+
+    const orgMembership = await userFixture.getOrgMembership();
+    const teamMembership = await userFixture.getFirstTeamMembership();
+    const routingForm = userFixture.routingForms[0];
+
+    const calNamespace = "routingFormFullPrerender";
+    // Note: param.dryRun=true causes the modal config to include cal.isBookingDryRun=true
+    // but prerender does NOT include it - this is the partial dry-run scenario
+    await embeds.gotoPlayground({
+      calNamespace,
+      url: `/embed/routing-playground.html?only=ns:${calNamespace}&param.formId=${routingForm.id}&calOrigin=${WEBAPP_URL}&cal.embed.logging=1&param.dryRun=true`,
+    });
+
+    await doOnOrgDomain({ orgSlug: orgMembership.team.slug, page }, async ({ page }) => {
+      await fillRoutingRequiredAttributes(page, {
+        skills: "JavaScript",
+        location: "London",
+        email: "embed-user@example.com",
+      });
+
+      const expectedRoutedTeamMembers = [teamMembership.user];
+      // Prerender happens without dry-run, so a real queuedFormResponseId is created
+      const { prerenderedIframe, queuedFormResponseId } = await expectPrerenderedRoutedTeamBookingPage({
+        page,
+        calNamespace,
+        calLink: `/team/${teamMembership.team.slug}/team-javascript`,
+        embeds,
+        routedTeamMemberIds: expectedRoutedTeamMembers.map((user) => user.id),
+        routingForm,
+      });
+
+      // Track whether the queued-response API call is made
+      let queuedResponseApiCalled = false;
+      await page.route("**/queued-response", (route) => {
+        queuedResponseApiCalled = true;
+        route.continue();
+      });
+
+      await fillRestOfTheFormAndSubmit(page);
+      await expectEmbedIFrameToBeVisible({ calNamespace, page });
+
+      // Give enough time for the connect method to execute (which would call recordResponseIfQueued)
+      // The connect method runs after the modal opens and the iframe is ready
+      await page.waitForTimeout(3000);
+
+      // The queued-response API should NOT have been called because cal.isBookingDryRun=true
+      // was passed in the modal config, and our fix detects this from the URL query param
+      expect(queuedResponseApiCalled).toBe(false);
+
+      // Verify no actual form response was created from the queued response
+      const queuedFormResponseFromDb = await getQueuedFormResponse(queuedFormResponseId);
+      expect(queuedFormResponseFromDb?.actualResponse).toBeNull();
+
+      // Verify no form responses were recorded at all
+      const allFormResponses = await getAllFormResponses(routingForm.id);
+      expect(allFormResponses.length).toBe(0);
     });
   });
 });

--- a/packages/embeds/embed-core/routing-playground.html
+++ b/packages/embeds/embed-core/routing-playground.html
@@ -228,6 +228,7 @@
                 calOrigin: window.calOrigin,
                 config: {
                   "cal.embed.pageType": "team.event.booking.slots",
+                  ...(window.params.dryRun ? { "cal.isBookingDryRun": "true" } : {}),
                 },
               });
             }

--- a/packages/embeds/embed-core/src/embed-iframe/__tests__/utils.test.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/__tests__/utils.test.ts
@@ -1,8 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sdkActionManager } from "../../sdk-event";
 import { embedStore } from "../lib/embedStore";
-import { keepParentInformedAboutDimensionChanges } from "../lib/utils";
+import { keepParentInformedAboutDimensionChanges, recordResponseIfQueued } from "../lib/utils";
 import { fakeCurrentDocumentUrl } from "./test-utils";
 
 type DimensionEvent = {
@@ -226,5 +225,87 @@ describe("keepParentInformedAboutDimensionChanges", () => {
       expect(windowLoadEvents.length).toBe(1);
       expect(embedStore.windowLoadEventFired).toBe(true);
     });
+  });
+});
+
+describe("recordResponseIfQueued", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    global.fetch = fetchSpy;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should return null when no queuedFormResponseId is present", async () => {
+    fakeCurrentDocumentUrl({ params: {} });
+    const result = await recordResponseIfQueued({ field1: "value1" });
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("should return 0 when queuedFormResponseId is the dry-run UUID", async () => {
+    fakeCurrentDocumentUrl({
+      params: { "cal.queuedFormResponseId": "00000000-0000-0000-0000-000000000000" },
+    });
+    const result = await recordResponseIfQueued({ field1: "value1" });
+    expect(result).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("should return 0 and skip the API call when cal.isBookingDryRun=true is set", async () => {
+    fakeCurrentDocumentUrl({
+      params: {
+        "cal.queuedFormResponseId": "some-real-queued-id",
+        "cal.isBookingDryRun": "true",
+      },
+    });
+    const result = await recordResponseIfQueued({ field1: "value1" });
+    expect(result).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("should make the API call when queuedFormResponseId is present and not in dry-run mode", async () => {
+    fakeCurrentDocumentUrl({
+      params: { "cal.queuedFormResponseId": "some-real-queued-id" },
+    });
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { formResponseId: 42 } }),
+    });
+    const result = await recordResponseIfQueued({ form: "form-id", field1: "value1" });
+    expect(result).toBe(42);
+    expect(fetchSpy).toHaveBeenCalledWith("/api/routing-forms/queued-response", {
+      method: "POST",
+      body: JSON.stringify({ queuedFormResponseId: "some-real-queued-id", params: { field1: "value1" } }),
+    });
+  });
+
+  it("should return null when the API call fails", async () => {
+    fakeCurrentDocumentUrl({
+      params: { "cal.queuedFormResponseId": "some-real-queued-id" },
+    });
+    fetchSpy.mockResolvedValue({ ok: false });
+    const result = await recordResponseIfQueued({ field1: "value1" });
+    expect(result).toBeNull();
+  });
+
+  it("should not skip the API call when cal.isBookingDryRun is not 'true'", async () => {
+    fakeCurrentDocumentUrl({
+      params: {
+        "cal.queuedFormResponseId": "some-real-queued-id",
+        "cal.isBookingDryRun": "false",
+      },
+    });
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { formResponseId: 99 } }),
+    });
+    const result = await recordResponseIfQueued({ field1: "value1" });
+    expect(result).toBe(99);
+    expect(fetchSpy).toHaveBeenCalled();
   });
 });

--- a/packages/embeds/embed-core/src/embed-iframe/__tests__/utils.test.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/__tests__/utils.test.ts
@@ -229,14 +229,17 @@ describe("keepParentInformedAboutDimensionChanges", () => {
 });
 
 describe("recordResponseIfQueued", () => {
+  let originalFetch: typeof global.fetch;
   let fetchSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    originalFetch = global.fetch;
     fetchSpy = vi.fn();
-    global.fetch = fetchSpy;
+    global.fetch = fetchSpy as unknown as typeof global.fetch;
   });
 
   afterEach(() => {
+    global.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 

--- a/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
@@ -1,5 +1,5 @@
 import { sdkActionManager } from "../../sdk-event";
-import { type EmbedStore } from "../lib/embedStore";
+import type { EmbedStore } from "../lib/embedStore";
 
 export const isBrowser = typeof window !== "undefined";
 
@@ -104,13 +104,13 @@ export function keepParentInformedAboutDimensionChanges({ embedStore }: { embedS
     // Use, .height as that gives more accurate value in floating point. Also, do a ceil on the total sum so that whatever happens there is enough iframe size to avoid scroll.
     const contentHeight = Math.ceil(
       parseFloat(mainElementStyles.height) +
-      parseFloat(mainElementStyles.marginTop) +
-      parseFloat(mainElementStyles.marginBottom)
+        parseFloat(mainElementStyles.marginTop) +
+        parseFloat(mainElementStyles.marginBottom)
     );
     const contentWidth = Math.ceil(
       parseFloat(mainElementStyles.width) +
-      parseFloat(mainElementStyles.marginLeft) +
-      parseFloat(mainElementStyles.marginRight)
+        parseFloat(mainElementStyles.marginLeft) +
+        parseFloat(mainElementStyles.marginRight)
     );
 
     // During first render let iframe tell parent that how much is the expected height to avoid scroll.
@@ -163,6 +163,13 @@ export const recordResponseIfQueued = async (params: Record<string, string | str
   }
   // Corresponding dry run value for routingFormResponseId is 0
   if (queuedFormResponseId === "00000000-0000-0000-0000-000000000000") {
+    return 0;
+  }
+
+  // Detect dry-run mode from query param even when the prerender instruction didn't pass it
+  // but the actual embed modal opening call did. This avoids a partial dry-run where
+  // the queued-response API call would still fire.
+  if (url.searchParams.get("cal.isBookingDryRun") === "true") {
     return 0;
   }
   // form is formId and isn't acutal Form data

--- a/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
@@ -166,9 +166,7 @@ export const recordResponseIfQueued = async (params: Record<string, string | str
     return 0;
   }
 
-  // Detect dry-run mode from query param even when the prerender instruction didn't pass it
-  // but the actual embed modal opening call did. This avoids a partial dry-run where
-  // the queued-response API call would still fire.
+  // Handles partial dry-run: prerender doesn't have the flag but the modal opening call does
   if (url.searchParams.get("cal.isBookingDryRun") === "true") {
     return 0;
   }


### PR DESCRIPTION
## What does this PR do?

Fixes a partial dry-run issue where the `queued-response` API call still fires when `cal.isBookingDryRun=true` is passed to the embed modal opening call but not to the prerender instruction.

When prerender runs without `cal.isBookingDryRun=true`, it creates a real `queuedFormResponseId` (not the `00000000-...` sentinel UUID). When the modal is subsequently opened with `cal.isBookingDryRun=true` in the config, `recordResponseIfQueued` previously didn't detect dry-run mode because it only checked for the sentinel UUID — not the query param. This PR adds a check for the `cal.isBookingDryRun=true` query param before making the API call, returning `0` (dry-run value) to skip it.

### Changes

- **`utils.ts`**: Added early return in `recordResponseIfQueued` when `cal.isBookingDryRun=true` is detected in the URL search params
- **`utils.test.ts`**: Added 6 unit tests covering all branches of `recordResponseIfQueued`
- **`routing-prerender.e2e.ts`**: Added e2e test for the partial dry-run scenario (prerender without dry-run → modal with dry-run)
- **`playground-init.ts` / `routing-playground.html`**: Added `param.dryRun` support so the playground can conditionally pass `cal.isBookingDryRun` in the modal config

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Unit tests**: `TZ=UTC yarn vitest run packages/embeds/embed-core/src/embed-iframe/__tests__/utils.test.ts` — all 10 tests should pass
2. **E2E test** (requires running app + `ready-for-e2e` label): The new test navigates to the routing playground with `param.dryRun=true`, triggers prerender (which creates a real queued response), then opens the modal (which passes `cal.isBookingDryRun=true` in config). It asserts:
   - The `queued-response` API endpoint is **not** called
   - No actual form response is created in the database

## Human Review Checklist

- [ ] Verify e2e test passes when `ready-for-e2e` label is added — the e2e test was **not run locally** (requires full dev server + database)
- [ ] Evaluate whether `page.waitForTimeout(3000)` in the e2e test is sufficient or if a more deterministic wait condition exists for the connect phase
- [ ] The test file uses `fetchSpy as unknown as typeof global.fetch` to work around `vi.fn()` not matching fetch's overloaded signature — confirm this is acceptable

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized (<500 lines, <10 files)

---

**Devin run**: https://app.devin.ai/sessions/06673b3f28394a5caf0b52090c2c2948
**Requested by**: @hariombalhara