### PR TITLE
fix: update broken Platform Starter Kit link in help cards

### DIFF
--- a/apps/web/lib/settings/platform/utils.ts
+++ b/apps/web/lib/settings/platform/utils.ts
@@ -78,8 +78,8 @@ export const helpCards: HelpCardInfo[] = [
       "If you are building a marketplace or platform from scratch, our Platform Starter Kit has everything you need.",
     variant: "basic",
     actionButton: {
-      href: "https://experts.cal.com",
-      child: "Try the Demo",
+      href: "https://github.com/calcom/examples",
+      child: "View Examples",
     },
   },
   {


### PR DESCRIPTION
## Summary
- The `experts.cal.com` demo site returns a **404** since the [`calcom/platform-starter-kit`](https://github.com/calcom/platform-starter-kit) repo was archived on Mar 31, 2025
- The archived repo directs users to [`github.com/calcom/examples`](https://github.com/calcom/examples) as the replacement
- Updated the "Try our Platform Starter Kit" help card in the platform settings dashboard to point to the examples repo instead

## Test plan
- [ ] Navigate to `/settings/platform` as a logged-in user
- [ ] Verify the "Try our Platform Starter Kit" card links to `https://github.com/calcom/examples`
- [ ] Verify the button text reads "View Examples"

🤖 Generated with [Claude Code](https://claude.com/claude-code)