### PR TITLE
cal_Aditya

### DIFF
--- a/apps/web/modules/event-types/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/EventAdvancedTab.tsx
@@ -57,6 +57,10 @@ import {
 import { MultiplePrivateLinksController } from "@calcom/web/modules/event-types/components";
 import AddVerifiedEmail from "@calcom/web/modules/event-types/components/AddVerifiedEmail";
 import { LearnMoreLink } from "@calcom/features/eventtypes/components/LearnMoreLink";
+import { UpgradeTeamsBadgeWebWrapper as UpgradeTeamsBadge } from "@calcom/web/modules/billing/components/UpgradeTeamsBadgeWebWrapper";
+import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
+import { Avatar } from "@calcom/ui/components/avatar";
+import { Icon } from "@calcom/ui/components/icon";
 import type { Dispatch, SetStateAction } from "react";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
@@ -550,6 +554,28 @@ export const EventAdvancedTab = ({
   const closeEventNameTip = () => setShowEventNameTip(false);
 
   const [isEventTypeColorChecked, setIsEventTypeColorChecked] = useState(!!eventType.eventTypeColor);
+
+  const isTeamEventType = !!team;
+  const [addTeamMembersAsOptionalGuests, setAddTeamMembersAsOptionalGuests] = useState(
+    !!formMethods.getValues("metadata")?.addTeamMembersAsOptionalGuests
+  );
+
+  const teamMembersOptions = useMemo(() => {
+    if (!team?.members) return [];
+    return team.members
+      .filter((member) => member.accepted)
+      .map((member) => ({
+        value: String(member.user.id),
+        label: member.user.name || member.user.email || "",
+        avatar: getUserAvatarUrl(member.user),
+        email: member.user.email,
+      }));
+  }, [team?.members]);
+
+  const selectedOptionalGuests = useMemo(() => {
+    const ids = formMethods.getValues("metadata")?.optionalGuestUserIds || [];
+    return teamMembersOptions.filter((opt) => ids.includes(Number(opt.value)));
+  }, [teamMembersOptions, formMethods.getValues("metadata")?.optionalGuestUserIds]);
 
   const customReplyToEmail = formMethods.watch("customReplyToEmail");
 
@@ -1484,6 +1510,89 @@ export const EventAdvancedTab = ({
           </SettingsToggle>
         )}
       />
+      {isTeamEventType && (
+        <Controller
+          name="metadata"
+          render={({ field: { value: metadataValue, onChange: onMetadataChange } }) => (
+            <SettingsToggle
+              labelClassName="text-sm"
+              toggleSwitchAtTheEnd={true}
+              switchContainerClassName={classNames(
+                "border-subtle rounded-lg border py-6 px-4 sm:px-6",
+                addTeamMembersAsOptionalGuests && "rounded-b-none"
+              )}
+              title={t("add_team_members_as_optional_guests")}
+              Badge={<UpgradeTeamsBadge />}
+              description={t("add_team_members_as_optional_guests_description")}
+              checked={addTeamMembersAsOptionalGuests}
+              onCheckedChange={(checked) => {
+                setAddTeamMembersAsOptionalGuests(checked);
+                if (!checked) {
+                  onMetadataChange({
+                    ...metadataValue,
+                    addTeamMembersAsOptionalGuests: false,
+                    optionalGuestUserIds: [],
+                  });
+                } else {
+                  onMetadataChange({
+                    ...metadataValue,
+                    addTeamMembersAsOptionalGuests: true,
+                  });
+                }
+              }}>
+              <div className="border-subtle flex flex-col gap-4 rounded-b-lg border border-t-0 p-6">
+                <Select
+                  isMulti
+                  placeholder={t("select")}
+                  options={teamMembersOptions.filter(
+                    (opt) =>
+                      !(metadataValue?.optionalGuestUserIds || []).includes(Number(opt.value))
+                  )}
+                  value={[]}
+                  onChange={(selectedOptions) => {
+                    const newIds = selectedOptions.map((opt: { value: string }) => Number(opt.value));
+                    const currentIds = metadataValue?.optionalGuestUserIds || [];
+                    onMetadataChange({
+                      ...metadataValue,
+                      addTeamMembersAsOptionalGuests: true,
+                      optionalGuestUserIds: [...currentIds, ...newIds],
+                    });
+                  }}
+                />
+                <ul className={classNames("rounded-md", selectedOptionalGuests.length >= 1 && "border-subtle border")}>
+                  {selectedOptionalGuests.map((option, index) => (
+                    <li
+                      key={option.value}
+                      className={classNames(
+                        "flex px-3 py-2",
+                        index !== selectedOptionalGuests.length - 1 && "border-subtle border-b"
+                      )}>
+                      <Avatar size="sm" imageSrc={option.avatar} alt={option.label} />
+                      <p className="text-emphasis my-auto ms-3 text-sm">{option.label}</p>
+                      <div className="ml-auto flex items-center">
+                        <Icon
+                          name="x"
+                          className="my-auto ml-2 h-4 w-4 cursor-pointer"
+                          onClick={() => {
+                            const currentIds = metadataValue?.optionalGuestUserIds || [];
+                            onMetadataChange({
+                              ...metadataValue,
+                              addTeamMembersAsOptionalGuests: true,
+                              optionalGuestUserIds: currentIds.filter(
+                                (id: number) => id !== Number(option.value)
+                              ),
+                            });
+                          }}
+                        />
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </SettingsToggle>
+          )}
+        />
+      )}
       <Controller
         name="showOptimizedSlots"
         render={({ field: { onChange, value } }) => {

--- a/packages/app-store/exchange2013calendar/lib/CalendarService.ts
+++ b/packages/app-store/exchange2013calendar/lib/CalendarService.ts
@@ -77,7 +77,11 @@ class ExchangeCalendarService implements Calendar {
 
       if (event.team?.members) {
         event.team.members.forEach((member) => {
-          appointment.RequiredAttendees.Add(new Attendee(member.email));
+          if (member.isOptionalGuest) {
+            appointment.OptionalAttendees.Add(new Attendee(member.email));
+          } else {
+            appointment.RequiredAttendees.Add(new Attendee(member.email));
+          }
         });
       }
 
@@ -115,7 +119,11 @@ class ExchangeCalendarService implements Calendar {
       }
       if (event.team?.members) {
         event.team.members.forEach((member) => {
-          appointment.RequiredAttendees.Add(new Attendee(member.email));
+          if (member.isOptionalGuest) {
+            appointment.OptionalAttendees.Add(new Attendee(member.email));
+          } else {
+            appointment.RequiredAttendees.Add(new Attendee(member.email));
+          }
         });
       }
       appointment.Update(

--- a/packages/app-store/exchange2016calendar/lib/CalendarService.ts
+++ b/packages/app-store/exchange2016calendar/lib/CalendarService.ts
@@ -78,7 +78,11 @@ class ExchangeCalendarService implements Calendar {
 
       if (event.team?.members) {
         event.team.members.forEach((member) => {
-          appointment.RequiredAttendees.Add(new Attendee(member.email));
+          if (member.isOptionalGuest) {
+            appointment.OptionalAttendees.Add(new Attendee(member.email));
+          } else {
+            appointment.RequiredAttendees.Add(new Attendee(member.email));
+          }
         });
       }
 
@@ -116,7 +120,11 @@ class ExchangeCalendarService implements Calendar {
       }
       if (event.team?.members) {
         event.team.members.forEach((member) => {
-          appointment.RequiredAttendees.Add(new Attendee(member.email));
+          if (member.isOptionalGuest) {
+            appointment.OptionalAttendees.Add(new Attendee(member.email));
+          } else {
+            appointment.RequiredAttendees.Add(new Attendee(member.email));
+          }
         });
       }
       appointment.Update(

--- a/packages/app-store/exchangecalendar/lib/CalendarService.ts
+++ b/packages/app-store/exchangecalendar/lib/CalendarService.ts
@@ -65,8 +65,12 @@ class ExchangeCalendarService implements Calendar {
       appointment.RequiredAttendees.Add(new Attendee(attendee.email));
     });
     if (event.team?.members) {
-      event.team.members.forEach((member: Person) => {
-        appointment.RequiredAttendees.Add(new Attendee(member.email));
+      event.team.members.forEach((member) => {
+        if (member.isOptionalGuest) {
+          appointment.OptionalAttendees.Add(new Attendee(member.email));
+        } else {
+          appointment.RequiredAttendees.Add(new Attendee(member.email));
+        }
       });
     }
     return appointment
@@ -102,7 +106,11 @@ class ExchangeCalendarService implements Calendar {
     });
     if (event.team?.members) {
       event.team.members.forEach((member) => {
-        appointment.RequiredAttendees.Add(new Attendee(member.email));
+        if (member.isOptionalGuest) {
+          appointment.OptionalAttendees.Add(new Attendee(member.email));
+        } else {
+          appointment.RequiredAttendees.Add(new Attendee(member.email));
+        }
       });
     }
     return appointment

--- a/packages/app-store/feishucalendar/lib/CalendarService.ts
+++ b/packages/app-store/feishucalendar/lib/CalendarService.ts
@@ -420,7 +420,7 @@ class FeishuCalendarService implements Calendar {
       if (member.email !== this.credential.user?.email) {
         const attendee: FeishuEventAttendee = {
           type: "third_party",
-          is_optional: false,
+          is_optional: member.isOptionalGuest ?? false,
           third_party_email: member.email,
         };
         attendeeArray.push(attendee);

--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -168,6 +168,7 @@ class GoogleCalendarService implements Calendar {
             email: teamMemberDestinationCalendar?.externalId ?? m.email,
             displayName: m.name,
             responseStatus: "accepted",
+            ...(m.isOptionalGuest ? { optional: true } : {}),
           };
         });
       attendees.push(...teamAttendeesWithoutCurrentUser);

--- a/packages/app-store/larkcalendar/lib/CalendarService.ts
+++ b/packages/app-store/larkcalendar/lib/CalendarService.ts
@@ -420,7 +420,7 @@ class LarkCalendarService implements Calendar {
       if (member.email !== this.credential.user?.email) {
         const attendee: LarkEventAttendee = {
           type: "third_party",
-          is_optional: false,
+          is_optional: member.isOptionalGuest ?? false,
           third_party_email: member.email,
         };
         attendeeArray.push(attendee);

--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -535,7 +535,7 @@ class Office365CalendarService implements Calendar {
                     address: destinationCalendar?.externalId ?? member.email,
                     name: member.name,
                   },
-                  type: "required" as const,
+                  type: (member.isOptionalGuest ? "optional" : "required") as "optional" | "required",
                 };
               })
           : []),

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -291,6 +291,7 @@ export const buildEventForTeamEventType = async ({
   organizerUser,
   schedulingType,
   team,
+  optionalGuestUserIds,
 }: {
   existingEvent: Partial<CalendarEvent>;
   users: (Pick<User, "id" | "name" | "timeZone" | "locale" | "email"> & {
@@ -303,6 +304,8 @@ export const buildEventForTeamEventType = async ({
     id: number;
     name: string;
   } | null;
+  optionalGuestUserIds?: number[];
+  optionalGuestUsers?: Pick<User, "id" | "name" | "timeZone" | "locale" | "email">[];
 }) => {
   // not null assertion.
   if (!schedulingType) {
@@ -338,10 +341,34 @@ export const buildEventForTeamEventType = async ({
           translate: await getTranslation(user.locale ?? "en", "common"),
           locale: user.locale ?? "en",
         },
+        isOptionalGuest: optionalGuestUserIds?.includes(user.id) ?? false,
       };
     });
 
   const teamMembers = await Promise.all(teamMemberPromises);
+
+  // Add optional guest users who are not already in the filtered users list
+  if (optionalGuestUserIds?.length && optionalGuestUsers?.length) {
+    const existingUserIds = new Set(filteredUsers.map((u) => u.id));
+    const additionalOptionalGuests = optionalGuestUsers.filter(
+      (u) => !existingUserIds.has(u.id) && u.email !== organizerUser.email
+    );
+    const additionalGuestPromises = additionalOptionalGuests.map(async (user) => ({
+      id: user.id,
+      email: user.email ?? "",
+      name: user.name ?? "",
+      firstName: "",
+      lastName: "",
+      timeZone: user.timeZone,
+      language: {
+        translate: await getTranslation(user.locale ?? "en", "common"),
+        locale: user.locale ?? "en",
+      },
+      isOptionalGuest: true,
+    }));
+    const additionalGuests = await Promise.all(additionalGuestPromises);
+    teamMembers.push(...additionalGuests);
+  }
 
   const updatedEvt = CalendarEventBuilder.fromEvent(evt)
     ?.withDestinationCalendar([...(evt.destinationCalendar ?? []), ...teamDestinationCalendars])
@@ -1621,12 +1648,28 @@ async function handler(
   }
 
   if (isTeamEventType) {
+    const parsedMetadata = eventTypeMetaDataSchemaWithTypedApps.parse(eventType.metadata);
+    const optionalGuestUserIds = parsedMetadata?.addTeamMembersAsOptionalGuests
+      ? parsedMetadata.optionalGuestUserIds || []
+      : [];
+
+    // Fetch optional guest users who may not be in the scheduled users list
+    let optionalGuestUsers: Pick<User, "id" | "name" | "timeZone" | "locale" | "email">[] = [];
+    if (optionalGuestUserIds.length > 0) {
+      optionalGuestUsers = await deps.prismaClient.user.findMany({
+        where: { id: { in: optionalGuestUserIds } },
+        select: { id: true, name: true, timeZone: true, locale: true, email: true },
+      });
+    }
+
     const teamEvt = await buildEventForTeamEventType({
       existingEvent: evt,
       schedulingType: eventType.schedulingType,
       users,
       team: eventType.team,
       organizerUser,
+      optionalGuestUserIds,
+      optionalGuestUsers,
     });
 
     if (!teamEvt) {

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -3310,6 +3310,8 @@
   "creating_oauth_client_error": "An error occurred while creating the OAuth client, please try again later",
   "event_type_color": "Event type color",
   "event_type_color_description": "This is only used for event type & booking differentiation within the app. It is not displayed to bookers.",
+  "add_team_members_as_optional_guests": "Add team member as optional guests",
+  "add_team_members_as_optional_guests_description": "Adding a team member as an optional guest will always send an optional invite, but not check their availability",
   "mark_as_no_show_title": "Mark as no show",
   "x_marked_as_no_show": "{{x}} marked as no-show",
   "x_unmarked_as_no_show": "{{x}} unmarked as no-show",

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -383,7 +383,12 @@ const injectVTimezone = (
 };
 
 const mapAttendees = (attendees: AttendeeInCalendarEvent[] | TeamMember[]): Attendee[] =>
-  attendees.map(({ email, name }) => ({ name, email, partstat: "NEEDS-ACTION" }));
+  attendees.map((attendee) => ({
+    name: attendee.name,
+    email: attendee.email,
+    partstat: "NEEDS-ACTION",
+    ...("isOptionalGuest" in attendee && attendee.isOptionalGuest ? { role: "OPT-PARTICIPANT" as const } : {}),
+  }));
 
 export default abstract class BaseCalendarService implements Calendar {
   private url = "";

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -255,6 +255,8 @@ const _eventTypeMetaDataSchemaWithoutApps = z.object({
     })
     .optional(),
   bookerLayouts: bookerLayouts.optional(),
+  addTeamMembersAsOptionalGuests: z.boolean().optional(),
+  optionalGuestUserIds: z.array(z.number()).optional(),
 });
 
 export const eventTypeMetaDataSchemaWithUntypedApps = _eventTypeMetaDataSchemaWithoutApps.merge(

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -51,6 +51,7 @@ export type TeamMember = {
   phoneNumber?: string | null;
   timeZone: string;
   language: { translate: TFunction; locale: string };
+  isOptionalGuest?: boolean;
 };
 
 export type EventBusyDate = {


### PR DESCRIPTION
This PR implements the “Add team member as optional guests” event‑type setting requested in #18947 / CAL‑5091.
When enabled on a team event type, organizers can mark individual team members as optional guests ;they’ll still receive an invite, but:

their calendar availability is not checked
the invite is marked as optional in the underlying calendar provider
the UI shows an Upgrade to Teams badge and only appears for team event types
 Key changes
Metadata schema (packages/prisma/zod-utils.ts) extended with
addTeamMembersAsOptionalGuests and optionalGuestUserIds.
Translations added for new setting.
EventAdvancedTab UI updated with toggle, multi‑select and avatar list.
TeamMember type now includes isOptionalGuest.
RegularBookingService fetches/appends optional guest users and passes flag downstream.
Calendar integrations updated to respect isOptionalGuest:
