### PR TITLE
fix(schedules): align slots to viewer timezone

### DIFF
--- a/packages/features/schedules/lib/slots.ts
+++ b/packages/features/schedules/lib/slots.ts
@@ -19,6 +19,7 @@ export type GetSlots = {
   datesOutOfOffice?: IOutOfOfficeData;
   showOptimizedSlots?: boolean | null;
   datesOutOfOfficeTimeZone?: string;
+  timeZone?: string;
 };
 export type TimeFrame = { userIds?: number[]; startTime: number; endTime: number };
 
@@ -239,6 +240,7 @@ const getSlots = ({
   datesOutOfOffice,
   showOptimizedSlots,
   datesOutOfOfficeTimeZone,
+  timeZone,
 }: GetSlots): {
   time: Dayjs;
   userIds?: number[];
@@ -252,7 +254,7 @@ const getSlots = ({
     dateRanges,
     frequency,
     eventLength,
-    timeZone: getTimeZone(inviteeDate),
+    timeZone: timeZone ?? getTimeZone(inviteeDate),
     minimumBookingNotice,
     offsetStart,
     datesOutOfOffice,

--- a/packages/features/schedules/lib/timezone.test.ts
+++ b/packages/features/schedules/lib/timezone.test.ts
@@ -1,0 +1,52 @@
+import dayjs from "@calcom/dayjs";
+import getSlots from "./slots";
+
+describe("Timezone Slot Alignment", () => {
+  beforeAll(() => {
+    vi.setSystemTime(dayjs.utc("2023-12-31T00:00:00Z").toDate());
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it("aligns slots to the hour in Asia/Kolkata (UTC+5:30) when availability starts at half hour in that timezone", async () => {
+    // Availability: 9:00 UTC - 11:00 UTC
+    // In IST (UTC+5:30): 14:30 - 16:30
+    // Start is aligned to UTC hour (9:00), but NOT aligned to IST hour (14:30)
+    const startUTC = dayjs.utc("2024-01-01T09:00:00Z");
+    const endUTC = dayjs.utc("2024-01-01T11:00:00Z");
+    
+    // Viewer timezone: Asia/Kolkata
+    const timeZone = "Asia/Kolkata";
+    
+    const slots = getSlots({
+      inviteeDate: dayjs.tz("2024-01-01T00:00:00", timeZone),
+      frequency: 60,
+      minimumBookingNotice: 0,
+      eventLength: 60,
+      dateRanges: [{ start: startUTC, end: endUTC }],
+      timeZone: timeZone,
+      offsetStart: 0,
+    });
+
+    // If the fix is working, the logic converts slotStartTime to IST (14:30), 
+    // detects it's not aligned to interval (60), and rounds it up to 15:00 IST.
+    
+    // 15:00 IST is 09:30 UTC.
+    // 15:00 IST to 16:00 IST (1 hour) fits in 14:30-16:30.
+    
+    // If the fix is NOT working (calculation in UTC):
+    // 09:00 UTC. Aligned to interval (60) in UTC. No rounding.
+    // Returns 09:00 UTC = 14:30 IST.
+    
+    console.log("Slots found:", slots.map(s => s.time.tz(timeZone).format()));
+
+    // We expect the fix to enforce alignment to the viewer's timezone
+    expect(slots.length).toBeGreaterThan(0);
+    const firstSlot = slots[0].time.tz(timeZone);
+    
+    expect(firstSlot.minute()).toBe(0);
+    expect(firstSlot.hour()).toBe(15);
+  });
+});

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1290,6 +1290,7 @@ export class AvailableSlotsService {
       datesOutOfOffice: !isTeamEvent ? allUsersAvailability[0]?.datesOutOfOffice : undefined,
       showOptimizedSlots: eventType.showOptimizedSlots,
       datesOutOfOfficeTimeZone: !isTeamEvent ? allUsersAvailability[0]?.timeZone : undefined,
+      timeZone: input.timeZone,
     });
 
     let availableTimeSlots: typeof timeSlots = [];


### PR DESCRIPTION
- Pass the viewer's timezone to the slot generation logic.
- Update the `getSlots` function to prioritize the viewer's timezone.
- Ensure slots align correctly with the viewer's local hour.