### PR TITLE
feat(reschedule): check guest availability when host reschedules

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -159,6 +159,7 @@ export type GetUserAvailabilityInitialData = {
     bookingLimits?: unknown;
     includeManagedEventsInLimits: boolean;
   } | null;
+  guestBusyTimes?: { start: Date; end: Date; title: string }[];
 };
 
 export type GetAvailabilityUser = GetUserAvailabilityInitialData["user"];
@@ -622,6 +623,12 @@ export class UserAvailabilityService {
       })),
       ...busyTimesFromLimits,
       ...busyTimesFromTeamLimits,
+      ...(initialData?.guestBusyTimes?.map((b) => ({
+        start: dayjs(b.start).toISOString(),
+        end: dayjs(b.end).toISOString(),
+        title: b.title || "Guest Booking",
+        source: "guest-busy-times" as const,
+      })) || []),
     ];
 
     log.debug(

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -2221,3 +2221,60 @@ export class BookingRepository implements IBookingRepository {
     });
   }
 }
+
+  /**
+   * Get accepted bookings for specific attendee emails within a date range.
+   * Used to check guest availability when host reschedules a booking.
+   */
+  async getAcceptedBookingsByAttendeeEmails({
+    emails,
+    startDate,
+    endDate,
+    excludedUid,
+  }: {
+    emails: string[];
+    startDate: Date;
+    endDate: Date;
+    excludedUid?: string;
+  }) {
+    const where: Prisma.BookingWhereInput = {
+      status: BookingStatus.ACCEPTED,
+      startTime: {
+        gte: startDate,
+      },
+      endTime: {
+        lte: endDate,
+      },
+      attendees: {
+        some: {
+          email: {
+            in: emails,
+          },
+        },
+      },
+    };
+
+    // Exclude the booking being rescheduled
+    if (excludedUid) {
+      where.uid = {
+        not: excludedUid,
+      };
+    }
+
+    return await this.prismaClient.booking.findMany({
+      where,
+      select: {
+        id: true,
+        uid: true,
+        startTime: true,
+        endTime: true,
+        title: true,
+        userId: true,
+        attendees: {
+          select: {
+            email: true,
+          },
+        },
+      },
+    });
+  }

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -850,6 +850,60 @@ export class AvailableSlotsService {
       this.getOOODates(startTimeDate, endTimeDate, allUserIds),
     ]);
 
+    // Get guest busy times when rescheduling
+    let guestBusyTimes: { start: Date; end: Date; title: string }[] = [];
+    if (input.rescheduleUid) {
+      try {
+        // Get the original booking with attendees
+        const originalBooking = await bookingRepo.findByUidIncludeEventTypeAttendeesAndUser({
+          bookingUid: input.rescheduleUid,
+        });
+
+        if (originalBooking && originalBooking.attendees && originalBooking.attendees.length > 0) {
+          // Collect host emails to exclude (organizer + event-type hosts)
+          const hostEmails = new Set<string>();
+          if (originalBooking.user?.email) {
+            hostEmails.add(originalBooking.user.email.toLowerCase());
+          }
+          if (originalBooking.userPrimaryEmail) {
+            hostEmails.add(originalBooking.userPrimaryEmail.toLowerCase());
+          }
+          if (originalBooking.eventType?.hosts) {
+            for (const host of originalBooking.eventType.hosts) {
+              if (host.user?.email) {
+                hostEmails.add(host.user.email.toLowerCase());
+              }
+            }
+          }
+
+          // Filter to get only guest emails (non-host attendees)
+          const guestEmails = originalBooking.attendees
+            .map((a) => a.email)
+            .filter((email) => !hostEmails.has(email.toLowerCase()));
+
+          if (guestEmails.length > 0) {
+            // Get guest's accepted bookings in the time window
+            const guestBookings = await bookingRepo.getAcceptedBookingsByAttendeeEmails({
+              emails: guestEmails,
+              startDate: startTimeDate,
+              endDate: endTimeDate,
+              excludedUid: input.rescheduleUid,
+            });
+
+            // Convert to busy times format
+            guestBusyTimes = guestBookings.map((booking) => ({
+              start: booking.startTime,
+              end: booking.endTime,
+              title: booking.title || "Guest Booking",
+            }));
+          }
+        }
+      } catch (error) {
+        // Non-fatal: if guest lookup fails, continue without guest availability
+        loggerWithEventDetails.warn("Failed to get guest availability for reschedule", { error });
+      }
+    }
+
     const bookingLimits =
       eventType?.bookingLimits &&
       typeof eventType?.bookingLimits === "object" &&
@@ -962,6 +1016,7 @@ export class AvailableSlotsService {
         eventTypeForLimits: eventType && (bookingLimits || durationLimits) ? eventType : null,
         teamBookingLimits: teamBookingLimitsMap,
         teamForBookingLimits: teamForBookingLimits,
+        guestBusyTimes: guestBusyTimes.length > 0 ? guestBusyTimes : undefined,
       },
     });
     /* We get all users working hours and busy slots */


### PR DESCRIPTION
## Summary

When a host reschedules a booking, the available slot picker now filters out time slots that conflict with the guests (non-host attendees) existing accepted bookings — preventing the host from accidentally double-booking a guest.

## Changes

1. **BookingRepository.ts** - Add `getAcceptedBookingsByAttendeeEmails()` to query bookings where any attendee is in a given email list
2. **slots/util.ts** - In `calculateHostsAndAvailabilities()`: fetch guest busy times when `rescheduleUid` is present; pass via `initialData.guestBusyTimes`
3. **getUserAvailability.ts** - Add `guestBusyTimes?` to `GetUserAvailabilityInitialData`; spread into `detailedBusyTimes`

## How it works

1. When `rescheduleUid` is present in `getSchedule`, look up the original booking attendees via `BookingRepository`
2. Filter out host emails (booking user + event-type hosts) to isolate guest-only emails
3. Query their accepted bookings in the slot search window, excluding the booking being rescheduled
4. Pass these as `guestBusyTimes` through `initialData` into `getUserAvailability`, where they are merged into `detailedBusyTimes`

Fixes #16378
/claim #28164