### PR TITLE
feat: add unit tests for handleNewBooking functions and booking lib utilities

### DIFF
--- a/packages/features/bookings/lib/doesBookingRequireConfirmation.test.ts
+++ b/packages/features/bookings/lib/doesBookingRequireConfirmation.test.ts
@@ -1,0 +1,128 @@
+import dayjs from "@calcom/dayjs";
+import { describe, expect, it } from "vitest";
+import { doesBookingRequireConfirmation } from "./doesBookingRequireConfirmation";
+
+describe("doesBookingRequireConfirmation", () => {
+  it("returns true when requiresConfirmation is true and no threshold", () => {
+    const result = doesBookingRequireConfirmation({
+      booking: {
+        startTime: new Date("2025-06-01T10:00:00Z"),
+        eventType: {
+          requiresConfirmation: true,
+          metadata: null,
+        },
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when requiresConfirmation is false and no threshold", () => {
+    const result = doesBookingRequireConfirmation({
+      booking: {
+        startTime: new Date("2025-06-01T10:00:00Z"),
+        eventType: {
+          requiresConfirmation: false,
+          metadata: null,
+        },
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns undefined when eventType is null", () => {
+    const result = doesBookingRequireConfirmation({
+      booking: {
+        startTime: new Date("2025-06-01T10:00:00Z"),
+        eventType: null,
+      },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("overrides requiresConfirmation to false when booking is far enough in the future", () => {
+    const farFutureDate = dayjs().add(30, "days").toDate();
+
+    const result = doesBookingRequireConfirmation({
+      booking: {
+        startTime: farFutureDate,
+        eventType: {
+          requiresConfirmation: true,
+          metadata: {
+            requiresConfirmationThreshold: {
+              time: 24,
+              unit: "hours",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("keeps requiresConfirmation true when booking is within the threshold", () => {
+    const soonDate = dayjs().add(1, "hour").toDate();
+
+    const result = doesBookingRequireConfirmation({
+      booking: {
+        startTime: soonDate,
+        eventType: {
+          requiresConfirmation: true,
+          metadata: {
+            requiresConfirmationThreshold: {
+              time: 24,
+              unit: "hours",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("does not change false to true even with threshold", () => {
+    const soonDate = dayjs().add(1, "hour").toDate();
+
+    const result = doesBookingRequireConfirmation({
+      booking: {
+        startTime: soonDate,
+        eventType: {
+          requiresConfirmation: false,
+          metadata: {
+            requiresConfirmationThreshold: {
+              time: 24,
+              unit: "hours",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("handles minutes as threshold unit", () => {
+    const farFutureDate = dayjs().add(120, "minutes").toDate();
+
+    const result = doesBookingRequireConfirmation({
+      booking: {
+        startTime: farFutureDate,
+        eventType: {
+          requiresConfirmation: true,
+          metadata: {
+            requiresConfirmationThreshold: {
+              time: 60,
+              unit: "minutes",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/addVideoCallDataToEvent.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/addVideoCallDataToEvent.test.ts
@@ -1,0 +1,104 @@
+import type { BookingReference } from "@calcom/prisma/client";
+import type { CalendarEvent } from "@calcom/types/Calendar";
+import { describe, expect, it } from "vitest";
+import { addVideoCallDataToEvent } from "./addVideoCallDataToEvent";
+
+function makeBookingReference(overrides: Partial<BookingReference> = {}): BookingReference {
+  return {
+    id: 1,
+    type: "daily_video",
+    uid: "ref-uid-1",
+    meetingId: "meeting-123",
+    meetingPassword: "pass123",
+    meetingUrl: "https://daily.co/room-abc",
+    externalCalendarId: null,
+    deleted: false,
+    bookingId: null,
+    credentialId: null,
+    thirdPartyRecurringEventId: null,
+    ...overrides,
+  };
+}
+
+function makeCalendarEvent(): CalendarEvent {
+  return {
+    type: "30min",
+    title: "Test Meeting",
+    startTime: "2025-06-01T10:00:00Z",
+    endTime: "2025-06-01T10:30:00Z",
+    organizer: {
+      email: "organizer@example.com",
+      name: "Organizer",
+      timeZone: "UTC",
+      language: {
+        translate: ((key: string) => key) as unknown as CalendarEvent["organizer"]["language"]["translate"],
+        locale: "en",
+      },
+    },
+    attendees: [],
+    description: "",
+    language: "en",
+  } as unknown as CalendarEvent;
+}
+
+describe("addVideoCallDataToEvent", () => {
+  it("adds video call data from a video reference to the event", () => {
+    const refs = [
+      makeBookingReference({
+        type: "daily_video",
+        meetingId: "mtg-1",
+        meetingPassword: "pw",
+        meetingUrl: "https://daily.co/room",
+      }),
+    ];
+    const evt = makeCalendarEvent();
+
+    const result = addVideoCallDataToEvent(refs, evt);
+
+    expect(result.videoCallData).toEqual({
+      type: "daily_video",
+      id: "mtg-1",
+      password: "pw",
+      url: "https://daily.co/room",
+    });
+  });
+
+  it("does not set videoCallData when no video reference exists", () => {
+    const refs = [makeBookingReference({ type: "google_calendar" })];
+    const evt = makeCalendarEvent();
+
+    const result = addVideoCallDataToEvent(refs, evt);
+
+    expect(result.videoCallData).toBeUndefined();
+  });
+
+  it("picks the first video reference when multiple exist", () => {
+    const refs = [
+      makeBookingReference({ type: "daily_video", meetingUrl: "https://daily.co/first" }),
+      makeBookingReference({ type: "zoom_video", meetingUrl: "https://zoom.us/second" }),
+    ];
+    const evt = makeCalendarEvent();
+
+    const result = addVideoCallDataToEvent(refs, evt);
+
+    expect(result.videoCallData?.url).toBe("https://daily.co/first");
+  });
+
+  it("handles null meetingPassword", () => {
+    const refs = [makeBookingReference({ type: "daily_video", meetingPassword: null })];
+    const evt = makeCalendarEvent();
+
+    const result = addVideoCallDataToEvent(refs, evt);
+
+    expect(result.videoCallData?.password).toBeNull();
+  });
+
+  it("returns the same event object (mutates in place)", () => {
+    const refs = [makeBookingReference({ type: "daily_video" })];
+    const evt = makeCalendarEvent();
+
+    const result = addVideoCallDataToEvent(refs, evt);
+
+    expect(result).toBe(evt);
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/buildBookingEventAuditData.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/buildBookingEventAuditData.test.ts
@@ -1,0 +1,94 @@
+import { BookingStatus } from "@calcom/prisma/enums";
+import { describe, expect, it } from "vitest";
+import { buildBookingCreatedAuditData, buildBookingRescheduledAuditData } from "./buildBookingEventAuditData";
+
+describe("buildBookingCreatedAuditData", () => {
+  it("returns audit data with timestamps in milliseconds", () => {
+    const startTime = new Date("2025-06-01T10:00:00Z");
+    const endTime = new Date("2025-06-01T10:30:00Z");
+
+    const result = buildBookingCreatedAuditData({
+      booking: {
+        startTime,
+        endTime,
+        status: BookingStatus.ACCEPTED,
+        userUuid: "user-uuid-123",
+      },
+      attendeeSeatId: null,
+    });
+
+    expect(result).toEqual({
+      startTime: startTime.getTime(),
+      endTime: endTime.getTime(),
+      status: BookingStatus.ACCEPTED,
+      hostUserUuid: "user-uuid-123",
+      seatReferenceUid: null,
+    });
+  });
+
+  it("includes attendeeSeatId when provided", () => {
+    const result = buildBookingCreatedAuditData({
+      booking: {
+        startTime: new Date("2025-06-01T10:00:00Z"),
+        endTime: new Date("2025-06-01T10:30:00Z"),
+        status: BookingStatus.PENDING,
+        userUuid: null,
+      },
+      attendeeSeatId: "seat-ref-abc",
+    });
+
+    expect(result.seatReferenceUid).toBe("seat-ref-abc");
+  });
+
+  it("handles null userUuid", () => {
+    const result = buildBookingCreatedAuditData({
+      booking: {
+        startTime: new Date("2025-06-01T10:00:00Z"),
+        endTime: new Date("2025-06-01T10:30:00Z"),
+        status: BookingStatus.ACCEPTED,
+        userUuid: null,
+      },
+      attendeeSeatId: null,
+    });
+
+    expect(result.hostUserUuid).toBeNull();
+  });
+});
+
+describe("buildBookingRescheduledAuditData", () => {
+  it("returns old and new timestamps and rescheduled UID", () => {
+    const oldStart = new Date("2025-06-01T10:00:00Z");
+    const oldEnd = new Date("2025-06-01T10:30:00Z");
+    const newStart = new Date("2025-06-02T14:00:00Z");
+    const newEnd = new Date("2025-06-02T14:30:00Z");
+
+    const result = buildBookingRescheduledAuditData({
+      oldBooking: { startTime: oldStart, endTime: oldEnd },
+      newBooking: { startTime: newStart, endTime: newEnd, uid: "new-booking-uid" },
+    });
+
+    expect(result).toEqual({
+      startTime: {
+        old: oldStart.getTime(),
+        new: newStart.getTime(),
+      },
+      endTime: {
+        old: oldEnd.getTime(),
+        new: newEnd.getTime(),
+      },
+      rescheduledToUid: {
+        old: null,
+        new: "new-booking-uid",
+      },
+    });
+  });
+
+  it("sets old rescheduledToUid to null", () => {
+    const result = buildBookingRescheduledAuditData({
+      oldBooking: { startTime: new Date(), endTime: new Date() },
+      newBooking: { startTime: new Date(), endTime: new Date(), uid: "abc" },
+    });
+
+    expect(result.rescheduledToUid.old).toBeNull();
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/getCustomInputsResponses.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getCustomInputsResponses.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { getCustomInputsResponses } from "./getCustomInputsResponses";
+
+describe("getCustomInputsResponses", () => {
+  describe("when reqBody has customInputs", () => {
+    it("maps customInputs array to a label-value record", () => {
+      const reqBody = {
+        customInputs: [
+          { label: "Company Name", value: "Acme Corp" },
+          { label: "Notes", value: "Please call ahead" },
+        ],
+      };
+
+      const result = getCustomInputsResponses(reqBody, []);
+
+      expect(result).toEqual({
+        "Company Name": "Acme Corp",
+        Notes: "Please call ahead",
+      });
+    });
+
+    it("handles boolean custom input values", () => {
+      const reqBody = {
+        customInputs: [{ label: "Agree to Terms", value: true }],
+      };
+
+      const result = getCustomInputsResponses(reqBody, []);
+
+      expect(result).toEqual({ "Agree to Terms": true });
+    });
+  });
+
+  describe("when reqBody has responses (new format)", () => {
+    it("maps responses to custom input labels via slugified matching", () => {
+      const reqBody = {
+        responses: {
+          "company-name": { value: "Acme Corp" },
+        },
+      };
+      const eventTypeCustomInputs = [
+        {
+          id: 1,
+          eventTypeId: 1,
+          label: "Company Name",
+          type: "TEXT",
+          required: true,
+          placeholder: "",
+          options: null,
+          hasToBeCreated: true,
+        },
+      ];
+
+      const result = getCustomInputsResponses(
+        reqBody,
+        eventTypeCustomInputs as Parameters<typeof getCustomInputsResponses>[1]
+      );
+
+      expect(result).toEqual({
+        "Company Name": { value: "Acme Corp" },
+      });
+    });
+
+    it("ignores responses that do not match any custom input", () => {
+      const reqBody = {
+        responses: {
+          "unknown-field": { value: "ignored" },
+        },
+      };
+      const eventTypeCustomInputs = [
+        {
+          id: 1,
+          eventTypeId: 1,
+          label: "Company Name",
+          type: "TEXT",
+          required: true,
+          placeholder: "",
+          options: null,
+          hasToBeCreated: true,
+        },
+      ];
+
+      const result = getCustomInputsResponses(
+        reqBody,
+        eventTypeCustomInputs as Parameters<typeof getCustomInputsResponses>[1]
+      );
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("when reqBody has neither customInputs nor responses", () => {
+    it("returns an empty object", () => {
+      const result = getCustomInputsResponses({}, []);
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("when customInputs is empty array", () => {
+    it("falls back to responses mapping", () => {
+      const reqBody = {
+        customInputs: [],
+        responses: {
+          notes: { value: "test" },
+        },
+      };
+      const eventTypeCustomInputs = [
+        {
+          id: 1,
+          eventTypeId: 1,
+          label: "Notes",
+          type: "TEXTLONG",
+          required: false,
+          placeholder: "",
+          options: null,
+          hasToBeCreated: true,
+        },
+      ];
+
+      const result = getCustomInputsResponses(
+        reqBody,
+        eventTypeCustomInputs as Parameters<typeof getCustomInputsResponses>[1]
+      );
+
+      expect(result).toEqual({ Notes: { value: "test" } });
+    });
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/getVideoCallDetails.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getVideoCallDetails.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { getVideoCallDetails } from "./getVideoCallDetails";
+
+type VideoResult = Parameters<typeof getVideoCallDetails>[0]["results"][number];
+
+function makeVideoResult(overrides: Partial<VideoResult> = {}): VideoResult {
+  return {
+    type: "daily_video",
+    appName: "Daily.co",
+    success: true,
+    createdEvent: undefined,
+    updatedEvent: undefined,
+    originalEvent: undefined,
+    ...overrides,
+  } as VideoResult;
+}
+
+describe("getVideoCallDetails", () => {
+  it("returns videoCallUrl from hangoutLink when present", () => {
+    const result = makeVideoResult({
+      type: "google_calendar_video",
+      updatedEvent: {
+        hangoutLink: "https://meet.google.com/abc-def-ghi",
+        conferenceData: undefined,
+        entryPoints: undefined,
+      },
+    });
+
+    const { videoCallUrl } = getVideoCallDetails({ results: [result] });
+    expect(videoCallUrl).toBe("https://meet.google.com/abc-def-ghi");
+  });
+
+  it("returns videoCallUrl from updatedEvent.url when hangoutLink is absent", () => {
+    const result = makeVideoResult({
+      type: "daily_video",
+      updatedEvent: {
+        url: "https://daily.co/room123",
+        hangoutLink: undefined,
+        conferenceData: undefined,
+        entryPoints: undefined,
+      },
+    });
+
+    const { videoCallUrl } = getVideoCallDetails({ results: [result] });
+    expect(videoCallUrl).toBe("https://daily.co/room123");
+  });
+
+  it("returns undefined videoCallUrl when no video result exists", () => {
+    const result = makeVideoResult({
+      type: "google_calendar",
+      success: true,
+    });
+
+    const { videoCallUrl } = getVideoCallDetails({ results: [result] });
+    expect(videoCallUrl).toBeUndefined();
+  });
+
+  it("returns undefined videoCallUrl when video result was not successful", () => {
+    const result = makeVideoResult({
+      type: "daily_video",
+      success: false,
+    });
+
+    const { videoCallUrl } = getVideoCallDetails({ results: [result] });
+    expect(videoCallUrl).toBeUndefined();
+  });
+
+  it("extracts metadata from the video event", () => {
+    const conferenceData = { conferenceId: "123" };
+    const entryPoints = [{ entryPointType: "video", uri: "https://meet.google.com/abc" }];
+
+    const result = makeVideoResult({
+      type: "zoom_video",
+      updatedEvent: {
+        hangoutLink: "https://zoom.us/j/123",
+        conferenceData,
+        entryPoints,
+      },
+    });
+
+    const { metadata } = getVideoCallDetails({ results: [result] });
+    expect(metadata).toMatchObject({
+      hangoutLink: "https://zoom.us/j/123",
+      conferenceData,
+      entryPoints,
+    });
+  });
+
+  it("handles updatedEvent as an array", () => {
+    const result = makeVideoResult({
+      type: "daily_video",
+      updatedEvent: [
+        {
+          url: "https://daily.co/first-room",
+          hangoutLink: undefined,
+          conferenceData: undefined,
+          entryPoints: undefined,
+        },
+      ],
+    });
+
+    const { videoCallUrl } = getVideoCallDetails({ results: [result] });
+    expect(videoCallUrl).toBe("https://daily.co/first-room");
+  });
+
+  it("returns empty metadata when no video results", () => {
+    const { metadata } = getVideoCallDetails({ results: [] });
+    expect(metadata).toEqual({});
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/handleAppsStatus.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/handleAppsStatus.test.ts
@@ -1,0 +1,116 @@
+import type { AppsStatus } from "@calcom/types/Calendar";
+import { describe, expect, it } from "vitest";
+import { handleAppsStatus } from "./handleAppsStatus";
+
+function makeResult(
+  overrides: Partial<Parameters<typeof handleAppsStatus>[0][number]> = {}
+): Parameters<typeof handleAppsStatus>[0][number] {
+  return {
+    type: "daily_video",
+    appName: "Daily.co",
+    success: true,
+    calError: undefined,
+    calWarnings: [],
+    createdEvent: undefined,
+    updatedEvent: undefined,
+    originalEvent: undefined,
+    ...overrides,
+  } as Parameters<typeof handleAppsStatus>[0][number];
+}
+
+describe("handleAppsStatus", () => {
+  describe("when reqAppsStatus is undefined (first booking in series)", () => {
+    it("returns result status array mapped from event results", () => {
+      const results = [makeResult({ success: true })];
+      const booking = {} as Parameters<typeof handleAppsStatus>[1];
+
+      const status = handleAppsStatus(results, booking, undefined);
+
+      expect(status).toHaveLength(1);
+      expect(status[0]).toMatchObject({
+        appName: "Daily.co",
+        type: "daily_video",
+        success: 1,
+        failures: 0,
+      });
+    });
+
+    it("sets appsStatus on booking object", () => {
+      const results = [makeResult()];
+      const booking = {} as Parameters<typeof handleAppsStatus>[1];
+
+      handleAppsStatus(results, booking, undefined);
+
+      expect(booking?.appsStatus).toBeDefined();
+      expect(booking?.appsStatus).toHaveLength(1);
+    });
+
+    it("handles null booking gracefully", () => {
+      const results = [makeResult()];
+      const status = handleAppsStatus(results, null, undefined);
+
+      expect(status).toHaveLength(1);
+    });
+
+    it("maps failed results correctly", () => {
+      const results = [makeResult({ success: false, calError: "Connection failed" })];
+      const status = handleAppsStatus(results, null, undefined);
+
+      expect(status[0]).toMatchObject({
+        success: 0,
+        failures: 1,
+        errors: ["Connection failed"],
+      });
+    });
+  });
+
+  describe("when reqAppsStatus is provided (last booking in recurring series)", () => {
+    it("aggregates status from previous bookings with current results", () => {
+      const previousStatus: AppsStatus[] = [
+        {
+          appName: "Daily.co",
+          type: "daily_video",
+          success: 2,
+          failures: 0,
+          errors: [],
+          warnings: [],
+        },
+      ];
+      const results = [makeResult({ success: true })];
+
+      const status = handleAppsStatus(results, null, previousStatus);
+
+      expect(status).toHaveLength(1);
+      expect(status[0].success).toBe(3);
+    });
+
+    it("aggregates errors across bookings", () => {
+      const previousStatus: AppsStatus[] = [
+        {
+          appName: "Daily.co",
+          type: "daily_video",
+          success: 1,
+          failures: 1,
+          errors: ["First error"],
+          warnings: [],
+        },
+      ];
+      const results = [makeResult({ success: false, calError: "Second error" })];
+
+      const status = handleAppsStatus(results, null, previousStatus);
+
+      expect(status[0].errors).toEqual(["First error", "Second error"]);
+    });
+
+    it("handles multiple app types separately", () => {
+      const previousStatus: AppsStatus[] = [
+        { appName: "Daily.co", type: "daily_video", success: 1, failures: 0, errors: [], warnings: [] },
+      ];
+      const results = [makeResult({ type: "google_calendar", appName: "Google Calendar", success: true })];
+
+      const status = handleAppsStatus(results, null, previousStatus);
+
+      expect(status).toHaveLength(2);
+    });
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/handleCustomInputs.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/handleCustomInputs.test.ts
@@ -1,0 +1,88 @@
+import type { EventTypeCustomInput } from "@calcom/prisma/client";
+import { describe, expect, it } from "vitest";
+import { handleCustomInputs } from "./handleCustomInputs";
+
+function makeCustomInput(overrides: Partial<EventTypeCustomInput> = {}): EventTypeCustomInput {
+  return {
+    id: 1,
+    eventTypeId: 1,
+    label: "Company Name",
+    type: "TEXT",
+    required: true,
+    placeholder: "",
+    options: null,
+    hasToBeCreated: true,
+    ...overrides,
+  } as EventTypeCustomInput;
+}
+
+describe("handleCustomInputs", () => {
+  it("passes when all required inputs are provided", () => {
+    const eventTypeInputs = [makeCustomInput({ label: "Company Name", required: true })];
+    const reqInputs = [{ label: "Company Name", value: "Acme Corp" }];
+
+    expect(() => handleCustomInputs(eventTypeInputs, reqInputs)).not.toThrow();
+  });
+
+  it("throws when a required TEXT input is missing", () => {
+    const eventTypeInputs = [makeCustomInput({ label: "Company Name", required: true, type: "TEXT" })];
+    const reqInputs: { label: string; value: string | boolean }[] = [];
+
+    expect(() => handleCustomInputs(eventTypeInputs, reqInputs)).toThrow();
+  });
+
+  it("throws when a required TEXT input has empty value", () => {
+    const eventTypeInputs = [makeCustomInput({ label: "Company Name", required: true, type: "TEXT" })];
+    const reqInputs = [{ label: "Company Name", value: "" }];
+
+    expect(() => handleCustomInputs(eventTypeInputs, reqInputs)).toThrow();
+  });
+
+  it("does not throw for non-required inputs that are missing", () => {
+    const eventTypeInputs = [makeCustomInput({ label: "Notes", required: false, type: "TEXT" })];
+    const reqInputs: { label: string; value: string | boolean }[] = [];
+
+    expect(() => handleCustomInputs(eventTypeInputs, reqInputs)).not.toThrow();
+  });
+
+  it("throws when a required BOOL input is not true", () => {
+    const eventTypeInputs = [makeCustomInput({ label: "Agree to Terms", required: true, type: "BOOL" })];
+    const reqInputs = [{ label: "Agree to Terms", value: false }];
+
+    expect(() => handleCustomInputs(eventTypeInputs, reqInputs)).toThrow();
+  });
+
+  it("passes when a required BOOL input is true", () => {
+    const eventTypeInputs = [makeCustomInput({ label: "Agree to Terms", required: true, type: "BOOL" })];
+    const reqInputs = [{ label: "Agree to Terms", value: true }];
+
+    expect(() => handleCustomInputs(eventTypeInputs, reqInputs)).not.toThrow();
+  });
+
+  it("throws when a required PHONE input has an invalid phone number", () => {
+    const eventTypeInputs = [makeCustomInput({ label: "Phone", required: true, type: "PHONE" })];
+    const reqInputs = [{ label: "Phone", value: "not-a-phone" }];
+
+    expect(() => handleCustomInputs(eventTypeInputs, reqInputs)).toThrow();
+  });
+
+  it("passes when a required PHONE input has a valid phone number", () => {
+    const eventTypeInputs = [makeCustomInput({ label: "Phone", required: true, type: "PHONE" })];
+    const reqInputs = [{ label: "Phone", value: "+14155552671" }];
+
+    expect(() => handleCustomInputs(eventTypeInputs, reqInputs)).not.toThrow();
+  });
+
+  it("validates multiple required inputs", () => {
+    const eventTypeInputs = [
+      makeCustomInput({ id: 1, label: "Company", required: true, type: "TEXT" }),
+      makeCustomInput({ id: 2, label: "Agree", required: true, type: "BOOL" }),
+    ];
+    const reqInputs = [
+      { label: "Company", value: "Acme" },
+      { label: "Agree", value: true },
+    ];
+
+    expect(() => handleCustomInputs(eventTypeInputs, reqInputs)).not.toThrow();
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/validateEventLength.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/validateEventLength.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { validateEventLength } from "./validateEventLength";
+
+const mockLogger = {
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+} as unknown as Parameters<typeof validateEventLength>[0]["logger"];
+
+describe("validateEventLength", () => {
+  it("accepts a booking matching the event type length", () => {
+    expect(() =>
+      validateEventLength({
+        reqBodyStart: "2025-06-01T10:00:00Z",
+        reqBodyEnd: "2025-06-01T10:30:00Z",
+        eventTypeLength: 30,
+        logger: mockLogger,
+      })
+    ).not.toThrow();
+  });
+
+  it("throws HttpError when duration does not match event type length", () => {
+    expect(() =>
+      validateEventLength({
+        reqBodyStart: "2025-06-01T10:00:00Z",
+        reqBodyEnd: "2025-06-01T10:45:00Z",
+        eventTypeLength: 30,
+        logger: mockLogger,
+      })
+    ).toThrow("Invalid event length");
+  });
+
+  it("accepts a duration that matches one of the multiple duration options", () => {
+    expect(() =>
+      validateEventLength({
+        reqBodyStart: "2025-06-01T10:00:00Z",
+        reqBodyEnd: "2025-06-01T11:00:00Z",
+        eventTypeMultipleDuration: [30, 60, 90],
+        eventTypeLength: 30,
+        logger: mockLogger,
+      })
+    ).not.toThrow();
+  });
+
+  it("throws when duration does not match any multiple duration option", () => {
+    expect(() =>
+      validateEventLength({
+        reqBodyStart: "2025-06-01T10:00:00Z",
+        reqBodyEnd: "2025-06-01T10:45:00Z",
+        eventTypeMultipleDuration: [30, 60, 90],
+        eventTypeLength: 30,
+        logger: mockLogger,
+      })
+    ).toThrow("Invalid event length");
+  });
+
+  it("uses eventTypeLength when eventTypeMultipleDuration is empty", () => {
+    expect(() =>
+      validateEventLength({
+        reqBodyStart: "2025-06-01T10:00:00Z",
+        reqBodyEnd: "2025-06-01T10:30:00Z",
+        eventTypeMultipleDuration: [],
+        eventTypeLength: 30,
+        logger: mockLogger,
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts a 15-minute event for a 15-minute event type", () => {
+    expect(() =>
+      validateEventLength({
+        reqBodyStart: "2025-06-01T14:00:00Z",
+        reqBodyEnd: "2025-06-01T14:15:00Z",
+        eventTypeLength: 15,
+        logger: mockLogger,
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/features/bookings/lib/rating.test.ts
+++ b/packages/features/bookings/lib/rating.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_RATING,
+  getRatingEmoji,
+  MAX_RATING,
+  MIN_RATING,
+  RATING_OPTIONS,
+  validateRating,
+} from "./rating";
+
+describe("validateRating", () => {
+  it("returns the parsed number for a valid numeric rating", () => {
+    expect(validateRating(4)).toBe(4);
+  });
+
+  it("parses a string rating to a number", () => {
+    expect(validateRating("3")).toBe(3);
+  });
+
+  it("clamps ratings above MAX_RATING", () => {
+    expect(validateRating(10)).toBe(MAX_RATING);
+    expect(validateRating("99")).toBe(MAX_RATING);
+  });
+
+  it("clamps ratings below MIN_RATING", () => {
+    expect(validateRating(0)).toBe(DEFAULT_RATING);
+    expect(validateRating(-5)).toBe(MIN_RATING);
+  });
+
+  it("returns default for null", () => {
+    expect(validateRating(null)).toBe(DEFAULT_RATING);
+  });
+
+  it("returns default for undefined", () => {
+    expect(validateRating(undefined)).toBe(DEFAULT_RATING);
+  });
+
+  it("returns default for NaN string", () => {
+    expect(validateRating("not-a-number")).toBe(DEFAULT_RATING);
+  });
+
+  it("uses custom default value when provided", () => {
+    expect(validateRating(null, 1)).toBe(1);
+  });
+
+  it("returns exact boundary values", () => {
+    expect(validateRating(MIN_RATING)).toBe(MIN_RATING);
+    expect(validateRating(MAX_RATING)).toBe(MAX_RATING);
+  });
+});
+
+describe("getRatingEmoji", () => {
+  it("returns the correct emoji for each rating value", () => {
+    expect(getRatingEmoji(1)).toBe("😠");
+    expect(getRatingEmoji(2)).toBe("🙁");
+    expect(getRatingEmoji(3)).toBe("😐");
+    expect(getRatingEmoji(4)).toBe("😄");
+    expect(getRatingEmoji(5)).toBe("😍");
+  });
+
+  it("returns empty string for out-of-range values", () => {
+    expect(getRatingEmoji(0)).toBe("");
+    expect(getRatingEmoji(6)).toBe("");
+    expect(getRatingEmoji(-1)).toBe("");
+  });
+});
+
+describe("RATING_OPTIONS", () => {
+  it("has exactly 5 options", () => {
+    expect(RATING_OPTIONS).toHaveLength(5);
+  });
+
+  it("has sequential values from 1 to 5", () => {
+    const values = RATING_OPTIONS.map((opt) => opt.value);
+    expect(values).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe("constants", () => {
+  it("has correct boundary values", () => {
+    expect(MIN_RATING).toBe(1);
+    expect(MAX_RATING).toBe(5);
+    expect(DEFAULT_RATING).toBe(3);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds **66 unit tests** across **9 new test files** for previously untested functions in the booking engine (`packages/features/bookings/`). This is Phase 1 Batch 1 of a larger effort to increase test coverage for critical business logic in the handleNewBooking flow.

### Functions covered:

| File | Tests | What's tested |
|------|-------|---------------|
| `validateEventLength` | 6 | Duration validation against single and multiple duration options |
| `handleAppsStatus` | 7 | App status aggregation for single/recurring bookings, error accumulation |
| `handleCustomInputs` | 9 | Custom input validation for TEXT, BOOL, PHONE types; required vs optional |
| `getVideoCallDetails` | 7 | Video URL extraction from event results, metadata, array handling |
| `addVideoCallDataToEvent` | 5 | Video reference matching, data attachment, mutation behavior |
| `buildBookingEventAuditData` | 5 | Audit data construction for created and rescheduled bookings |
| `getCustomInputsResponses` | 6 | Response mapping for both old (`customInputs`) and new (`responses`) formats |
| `rating` | 14 | Rating validation/clamping, emoji lookup, constants, boundary values |
| `doesBookingRequireConfirmation` | 7 | Confirmation threshold logic with hours/minutes units, null eventType |

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — test-only changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the new tests with:

```bash
TZ=UTC yarn vitest run packages/features/bookings/lib/handleNewBooking/validateEventLength.test.ts packages/features/bookings/lib/handleNewBooking/handleAppsStatus.test.ts packages/features/bookings/lib/handleNewBooking/handleCustomInputs.test.ts packages/features/bookings/lib/handleNewBooking/getVideoCallDetails.test.ts packages/features/bookings/lib/handleNewBooking/addVideoCallDataToEvent.test.ts packages/features/bookings/lib/handleNewBooking/buildBookingEventAuditData.test.ts packages/features/bookings/lib/handleNewBooking/getCustomInputsResponses.test.ts packages/features/bookings/lib/rating.test.ts packages/features/bookings/lib/doesBookingRequireConfirmation.test.ts
```

All 66 tests pass locally. No environment variables or test data needed — these are pure unit tests with no database dependencies.

## Items for reviewer attention

- **Type casting in test helpers**: `makeCalendarEvent()` in `addVideoCallDataToEvent.test.ts` and `mockLogger` in `validateEventLength.test.ts` use `as unknown as <Type>` to build minimal test fixtures. This avoids constructing the full complex types while keeping tests focused.
- **Time-relative tests**: `doesBookingRequireConfirmation.test.ts` uses `dayjs().add(30, "days")` for future dates. These are stable but technically non-deterministic if run at exact threshold boundaries (extremely unlikely).
- **Coverage depth**: Tests cover happy paths and key edge cases. Some functions (like `handleAppsStatus` warnings aggregation) could have additional edge case coverage in future batches.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (N/A for test files)
- [x] I have checked if my changes generate no new warnings
- [x] My PR is appropriately sized (9 files, ~930 lines of test code)

---

**Link to Devin run:** https://app.devin.ai/sessions/cbb9b159425d4097bbcb850c030fffb1  
**Requested by:** @anikdhabal