### PR TITLE
fix(dx): align local Postgres DB defaults with DATABASE_URL (#28106)

### DIFF
--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,6 +27,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,7 +27,6 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
-  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/prisma/docker-compose.yml
+++ b/packages/prisma/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: "cal-saml"
+      POSTGRES_DB: "calendso"
       POSTGRES_PASSWORD: ""
       POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:


### PR DESCRIPTION
## What does this PR do?

### Fix: Align local Postgres DB defaults (`POSTGRES_DB` vs `DATABASE_URL`) (#28106)

**Problem:**
Running `yarn workspace @calcom/prisma dx` spins up a local Postgres Docker container with the default database name `cal-saml`, while the app's `.env.example` and main `docker-compose.yml` point to `calendso`. This mismatch causes connection errors during local onboarding on clean volumes.

**Changes:**

- Aligned `POSTGRES_DB` in `packages/prisma/docker-compose.yml` to `calendso` to match the `.env` default.
- This ensures that local development setup works out-of-the-box without having to discover hidden DB-name differences.

## How should this be tested?

1. Clean your local docker volumes or run `yarn workspace @calcom/prisma db-nuke`.
2. Run `yarn workspace @calcom/prisma dx`.
3. Verify that the initialized database is named `calendso` and the application connects cleanly via the default `DATABASE_URL`.

Fixes #28106
