### PR TITLE
fix: use zero-decimal-aware conversion for no-show fee acknowledgment text

### DIFF
--- a/packages/features/ee/payments/components/Payment.tsx
+++ b/packages/features/ee/payments/components/Payment.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import getStripe from "@calcom/app-store/stripepayment/lib/client";
 import { useBookingSuccessRedirect } from "@calcom/features/bookings/lib/bookingSuccessRedirect";
 import { WEBAPP_URL } from "@calcom/lib/constants";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { EventType, Payment } from "@calcom/prisma/client";
@@ -83,7 +84,7 @@ export const PaymentFormComponent = (
         <div className="bg-cal-info mb-5 mt-2 rounded-md p-3">
           <CheckboxField
             description={t("acknowledge_booking_no_show_fee", {
-              amount: props.payment.amount / 100,
+              amount: convertFromSmallestToPresentableCurrencyUnit(props.payment.amount, props.payment.currency),
               formatParams: { amount: { currency: props.payment.currency } },
             })}
             onChange={(e) => setHoldAcknowledged(e.target.checked)}


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect amount display in the no-show fee acknowledgment checkbox for zero-decimal currencies (e.g. JPY, KRW).

### Bug

When a host sets a no-show fee in a zero-decimal currency like JPY (¥1,000), the HOLD payment acknowledgment text incorrectly showed ¥10 instead of ¥1,000.

**Before:** `このイベントに出席しなかった場合、不参加費用として ￥10 が私のカードに請求されることに同意します。`
**After:** `このイベントに出席しなかった場合、不参加費用として ￥1,000 が私のカードに請求されることに同意します。`

### Root Cause

`Payment.tsx` hardcoded `amount / 100` to convert from Stripe's smallest currency unit. For zero-decimal currencies (JPY, KRW, etc.), Stripe stores the amount already in the base unit, so dividing by 100 results in a 100x smaller value.

### Fix

Replace `props.payment.amount / 100` with the existing `convertFromSmallestToPresentableCurrencyUnit` utility from `@calcom/lib/currencyConversions`, which already correctly handles zero-decimal currencies.

```diff
- amount: props.payment.amount / 100,
+ amount: convertFromSmallestToPresentableCurrencyUnit(props.payment.amount, props.payment.currency),
```

## How to reproduce

1. Install a Stripe integration and set currency to JPY
2. Create an event type with a no-show fee (e.g. ¥1,000) using HOLD payment
3. Open the booking/payment page
4. Observe the acknowledgment text shows ¥10 instead of ¥1,000

## Checklist

- [x] `yarn type-check:ci` passes
- [x] No new dependencies added
- [x] Uses existing utility (`convertFromSmallestToPresentableCurrencyUnit`) for consistency