### PR TITLE
fix: use zero-decimal-aware conversion for cancel booking no-show fee text

### DIFF
--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -3,6 +3,7 @@
 import { sdkActionManager } from "@calcom/embed-core/embed-iframe";
 import { isCancellationReasonRequired } from "@calcom/features/bookings/lib/cancellationReason";
 import { shouldChargeNoShowCancellationFee } from "@calcom/features/bookings/lib/payment/shouldChargeNoShowCancellationFee";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useRefreshData } from "@calcom/lib/hooks/useRefreshData";
 import type { CancellationReasonRequirement } from "@calcom/prisma/enums";
@@ -310,7 +311,7 @@ export default function CancelBooking(props: Props) {
                   description={t("cancel_booking_acknowledge_no_show_fee", {
                     timeValue,
                     timeUnit,
-                    amount: booking.payment.amount / 100,
+                    amount: convertFromSmallestToPresentableCurrencyUnit(booking.payment.amount, booking.payment.currency),
                     formatParams: { amount: { currency: booking.payment.currency } },
                   })}
                   onChange={(e) => setAcknowledgeCancellationNoShowFee(e.target.checked)}


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect amount display in the cancellation no-show fee acknowledgment checkbox for zero-decimal currencies (e.g. JPY, KRW).

This is a companion fix to #28221 which fixed the same bug in the payment page.

### Bug

When a host charges a no-show fee from the bookings page (`/bookings/upcoming`), the cancellation confirmation popup incorrectly showed ¥10 instead of ¥1,000 for zero-decimal currencies like JPY.

### Root Cause

`CancelBooking.tsx` hardcoded `amount / 100` to convert from Stripe's smallest currency unit. For zero-decimal currencies (JPY, KRW, etc.), Stripe stores the amount already in the base unit, so dividing by 100 results in a 100x smaller value.

### Fix

Replace `booking.payment.amount / 100` with the existing `convertFromSmallestToPresentableCurrencyUnit` utility from `@calcom/lib/currencyConversions`.

```diff
- amount: booking.payment.amount / 100,
+ amount: convertFromSmallestToPresentableCurrencyUnit(booking.payment.amount, booking.payment.currency),
```

## Checklist

- [x] `yarn type-check:ci` passes
- [x] No new dependencies added
- [x] Uses existing utility (`convertFromSmallestToPresentableCurrencyUnit`) for consistency