### PR TITLE
feat: Add BigBlueButton video conferencing integration

### DIFF
--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -112,7 +112,11 @@ import zoho_bigin_config_json from "./zoho-bigin/config.json";
 import zohocalendar_config_json from "./zohocalendar/config.json";
 import zohocrm_config_json from "./zohocrm/config.json";
 import { metadata as zoomvideo__metadata_ts } from "./zoomvideo/_metadata";
+import { metadata as bigbluebuttonvideo__metadata_ts } from "./bigbluebuttonvideo/_metadata";
+
+
 export const appStoreMetadata = {
+  bigbluebuttonvideo: bigbluebuttonvideo__metadata_ts,
   alby: alby_config_json,
   amie: amie_config_json,
   applecalendar: applecalendar__metadata_ts,

--- a/packages/app-store/bigbluebuttonvideo/_metadata.ts
+++ b/packages/app-store/bigbluebuttonvideo/_metadata.ts
@@ -1,0 +1,30 @@
+import type { AppMeta } from "@calcom/types/App";
+
+export const metadata = {
+  linkType: "dynamic",
+  name: "BigBlueButton",
+  description:
+    "BigBlueButton is an open-source web conferencing system for online learning. It provides real-time sharing of audio, video, slides, chat, and screen, and is designed for online classrooms with features like breakout rooms, polls, and whiteboard.",
+  type: "bigbluebutton_video",
+  categories: ["conferencing"],
+  variant: "conferencing",
+  logo: "icon.svg",
+  publisher: "Cal.com",
+  url: "https://bigbluebutton.org/",
+  category: "conferencing",
+  slug: "bigbluebutton",
+  title: "BigBlueButton",
+  email: "help@cal.com",
+  appData: {
+    location: {
+      default: false,
+      linkType: "dynamic",
+      type: "integrations:bigbluebutton",
+      label: "BigBlueButton",
+    },
+  },
+  dirName: "bigbluebuttonvideo",
+  isOAuth: false,
+} as AppMeta;
+
+export default metadata;

--- a/packages/app-store/bigbluebuttonvideo/index.ts
+++ b/packages/app-store/bigbluebuttonvideo/index.ts
@@ -1,0 +1,1 @@
+export * from "./_metadata";

--- a/packages/app-store/bigbluebuttonvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/bigbluebuttonvideo/lib/VideoApiAdapter.ts
@@ -1,0 +1,42 @@
+import crypto from "crypto";
+import { v4 as uuidv4 } from "uuid";
+import type { CalendarEvent } from "@calcom/types/Calendar";
+import type { PartialReference } from "@calcom/types/EventManager";
+import type { VideoApiAdapter, VideoCallData } from "@calcom/types/VideoApiAdapter";
+import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
+import { metadata } from "../_metadata";
+function generateBBBChecksum(apiCall: string, queryString: string, secret: string): string {
+  const stringToHash = apiCall + queryString + secret;
+  return crypto.createHash("sha1").update(stringToHash).digest("hex");
+}
+function buildBBBUrl(
+  host: string,
+  apiCall: string,
+  params: Record<string, string>,
+  secret: string
+): string {
+  const queryString = new URLSearchParams(params).toString();
+  const checksum = generateBBBChecksum(apiCall, queryString, secret);
+  return `${host}/bigbluebutton/api/${apiCall}?${queryString}&checksum=${checksum}`;
+}
+const BigBlueButtonVideoApiAdapter = (): VideoApiAdapter => {
+  return {
+    getAvailability: () => {
+      return Promise.resolve([]);
+    },
+    createMeeting: async (eventData: CalendarEvent): Promise<VideoCallData> => {
+      const appKeys = await getAppKeysFromSlug(metadata.slug);
+      const host = (appKeys.bbbHost as string) || "https://test.bigbluebutton.org";
+      const secret = (appKeys.bbbSecret as string) || "";
+      const meetingID = `cal-${uuidv4()}`;
+      const moderatorPW = crypto.randomBytes(8).toString("hex");
+      const attendeePW = crypto.randomBytes(8).toString("hex");
+      const createParams: Record<string, string> = {
+        name: eventData.title || "Cal.com Meeting",
+        meetingID: meetingID,
+        moderatorPW: moderatorPW,
+        attendeePW: attendeePW,
+        welcome: "Welcome to this Cal.com meeting powered by BigBlueButton!",
+        record: "true",
+        autoStartRecording: "false",allowStartStopRecording: "true",
+};

--- a/packages/app-store/bigbluebuttonvideo/lib/index.ts
+++ b/packages/app-store/bigbluebuttonvideo/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as VideoApiAdapter } from "./VideoApiAdapter";

--- a/packages/app-store/bigbluebuttonvideo/package.json
+++ b/packages/app-store/bigbluebuttonvideo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@calcom/bigbluebutton",
+  "version": "0.0.1",
+  "main": "./index.ts",
+  "dependencies": {
+    "@calcom/lib": "*",
+    "@calcom/types": "*"
+  },
+  "devDependencies": {
+    "@calcom/tsconfig": "*"
+  }
+}

--- a/packages/app-store/bigbluebuttonvideo/zod.ts
+++ b/packages/app-store/bigbluebuttonvideo/zod.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const appKeysSchema = z.object({
+  bbbHost: z.string().optional(),
+  bbbSecret: z.string().optional(),
+});

--- a/packages/packages/app-store/bigbluebuttonvideo/static/icon.svg
+++ b/packages/packages/app-store/bigbluebuttonvideo/static/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <rect width="100" height="100" rx="15" fill="#283D54"/>
+  <circle cx="35" cy="40" r="15" fill="#FFFFFF"/>
+  <path d="M20 75 Q35 55 50 75 T80 75" stroke="#FFFFFF" stroke-width="8" fill="none" stroke-linecap="round"/>
+  <circle cx="70" cy="35" r="12" fill="#4A90D9"/>
+  <rect x="58" y="48" width="24" height="20" rx="3" fill="#4A90D9"/>
+</svg>


### PR DESCRIPTION
/claim #1985

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds BigBlueButton as a new video conferencing provider with a dynamic location link and a VideoApiAdapter to create meetings. Implements Linear #1985 by registering the app in the store and wiring up meeting creation.

- **New Features**
  - New app: bigbluebuttonvideo (metadata, icon, package).
  - VideoApiAdapter to create meetings via the BigBlueButton API.
  - App keys schema for bbbHost and bbbSecret; falls back to test host if not set.
  - App store registration and exports for use under the “conferencing” variant.

<sup>Written for commit 57d10c4a4487dba49c123e38d233200be74a946b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

