### PR TITLE
feat(routing-forms): add booking-question field types + identifier-first UX

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
@@ -3,7 +3,6 @@
 import { FieldTypes } from "@calcom/app-store/routing-forms/lib/FieldTypes";
 import type { RoutingFormWithResponseCount } from "@calcom/app-store/routing-forms/types/types";
 import { LearnMoreLink } from "@calcom/features/eventtypes/components/LearnMoreLink";
-import { getFieldIdentifier } from "@calcom/features/form-builder/utils/getFieldIdentifier";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
 import { Button } from "@calcom/ui/components/button";
@@ -98,39 +97,6 @@ function Field({
         <FormCardBody>
           <div className="mb-3 w-full">
             <TextField
-              data-testid={`${hookFieldNamespace}.label`}
-              disabled={!!router}
-              label="Label"
-              className="grow"
-              placeholder={t("this_is_what_your_users_would_see")}
-              defaultValue={label || routerField?.label || "Field"}
-              required
-              {...hookForm.register(`${hookFieldNamespace}.label`)}
-              onChange={(e) => {
-                const newLabel = e.target.value;
-                // Use label from useWatch which is guaranteed to be the previous value
-                // since useWatch updates reactively (after re-render), not synchronously
-                const previousLabel = label || "";
-                hookForm.setValue(`${hookFieldNamespace}.label`, newLabel, {
-                  shouldDirty: true,
-                });
-                const currentIdentifier = hookForm.getValues(`${hookFieldNamespace}.identifier`);
-                // Only auto-update identifier if it was auto-generated from the previous label
-                // This preserves manual identifier changes
-                const isIdentifierGeneratedFromPreviousLabel =
-                  currentIdentifier === getFieldIdentifier(previousLabel).toLowerCase();
-                if (!currentIdentifier || isIdentifierGeneratedFromPreviousLabel) {
-                  hookForm.setValue(
-                    `${hookFieldNamespace}.identifier`,
-                    getFieldIdentifier(newLabel).toLowerCase(),
-                    { shouldDirty: true }
-                  );
-                }
-              }}
-            />
-          </div>
-          <div className="mb-3 w-full">
-            <TextField
               disabled={!!router}
               label={t("identifier_url_parameter")}
               hint={
@@ -143,12 +109,24 @@ function Field({
               name={`${hookFieldNamespace}.identifier`}
               required
               placeholder={t("identifies_name_field")}
-              value={identifier || routerField?.identifier || label || routerField?.label || ""}
+              value={identifier || routerField?.identifier || ""}
               onChange={(e) => {
                 hookForm.setValue(`${hookFieldNamespace}.identifier`, e.target.value.toLowerCase(), {
                   shouldDirty: true,
                 });
               }}
+            />
+          </div>
+          <div className="mb-3 w-full">
+            <TextField
+              data-testid={`${hookFieldNamespace}.label`}
+              disabled={!!router}
+              label="Label"
+              className="grow"
+              placeholder={t("this_is_what_your_users_would_see")}
+              defaultValue={label || routerField?.label || "Field"}
+              required
+              {...hookForm.register(`${hookFieldNamespace}.label`)}
             />
           </div>
           <div className="mb-3 w-full">
@@ -208,7 +186,7 @@ function Field({
               }}
             />
           </div>
-          {["select", "multiselect"].includes(fieldType) ? (
+          {["select", "multiselect", "radio", "checkbox"].includes(fieldType) ? (
             <div className="bg-cal-muted w-full rounded-[10px] p-2">
               <Label className="text-subtle">{t("options")}</Label>
               <MultiOptionInput

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
@@ -15,6 +15,21 @@ function getWidgetsWithoutFactory(_configFor: ConfigFor) {
     email: {
       ...BasicConfig.widgets.text,
     },
+    url: {
+      ...BasicConfig.widgets.text,
+    },
+    address: {
+      ...BasicConfig.widgets.text,
+    },
+    multiemail: {
+      ...BasicConfig.widgets.text,
+    },
+    radio: {
+      ...BasicConfig.widgets.select,
+    },
+    checkbox: {
+      ...BasicConfig.widgets.multiselect,
+    },
   };
   return widgetsWithoutFactory;
 }
@@ -40,6 +55,36 @@ function getTypes(configFor: ConfigFor) {
       ...BasicConfig.types.text,
       widgets: {
         ...BasicConfig.types.text.widgets,
+      },
+    },
+    url: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    address: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    multiemail: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    radio: {
+      ...BasicConfig.types.select,
+      widgets: {
+        ...BasicConfig.types.select.widgets,
+      },
+    },
+    checkbox: {
+      ...BasicConfig.types.multiselect,
+      widgets: {
+        ...BasicConfig.types.multiselect.widgets,
       },
     },
     multiselect: {

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
@@ -111,6 +111,31 @@ function withFactoryWidgets(widgets: WidgetsWithoutFactory) {
       ...widgets.text,
       factory: EmailFactory,
     },
+    url: {
+      ...widgets.text,
+      factory: (props) => {
+        if (!props) {
+          return <div />;
+        }
+        return <TextWidget type="url" {...props} />;
+      },
+    },
+    address: {
+      ...widgets.text,
+      factory: TextFactory,
+    },
+    multiemail: {
+      ...widgets.text,
+      factory: TextFactory,
+    },
+    radio: {
+      ...widgets.select,
+      factory: SelectFactory,
+    } as SelectWidgetType,
+    checkbox: {
+      ...widgets.multiselect,
+      factory: MultiSelectFactory,
+    } as SelectWidgetType,
   };
   return widgetsWithFactory;
 }

--- a/packages/app-store/routing-forms/lib/FieldTypes.ts
+++ b/packages/app-store/routing-forms/lib/FieldTypes.ts
@@ -4,8 +4,13 @@ export const enum RoutingFormFieldType {
   TEXTAREA = "textarea",
   SINGLE_SELECT = "select",
   MULTI_SELECT = "multiselect",
+  RADIO = "radio",
+  CHECKBOX = "checkbox",
   PHONE = "phone",
   EMAIL = "email",
+  URL = "url",
+  ADDRESS = "address",
+  MULTI_EMAIL = "multiemail",
 }
 
 export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFieldType => {
@@ -15,8 +20,13 @@ export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFi
     RoutingFormFieldType.TEXTAREA,
     RoutingFormFieldType.SINGLE_SELECT,
     RoutingFormFieldType.MULTI_SELECT,
+    RoutingFormFieldType.RADIO,
+    RoutingFormFieldType.CHECKBOX,
     RoutingFormFieldType.PHONE,
     RoutingFormFieldType.EMAIL,
+    RoutingFormFieldType.URL,
+    RoutingFormFieldType.ADDRESS,
+    RoutingFormFieldType.MULTI_EMAIL,
   ].includes(type as RoutingFormFieldType);
 };
 
@@ -42,11 +52,31 @@ export const FieldTypes = [
     value: RoutingFormFieldType.MULTI_SELECT,
   },
   {
+    label: "Radio",
+    value: RoutingFormFieldType.RADIO,
+  },
+  {
+    label: "Checkbox",
+    value: RoutingFormFieldType.CHECKBOX,
+  },
+  {
     label: "Phone",
     value: RoutingFormFieldType.PHONE,
   },
   {
     label: "Email",
     value: RoutingFormFieldType.EMAIL,
+  },
+  {
+    label: "URL",
+    value: RoutingFormFieldType.URL,
+  },
+  {
+    label: "Address",
+    value: RoutingFormFieldType.ADDRESS,
+  },
+  {
+    label: "Multiple emails",
+    value: RoutingFormFieldType.MULTI_EMAIL,
   },
 ] as const;

--- a/packages/app-store/routing-forms/lib/getQueryBuilderConfig.ts
+++ b/packages/app-store/routing-forms/lib/getQueryBuilderConfig.ts
@@ -64,7 +64,13 @@ export function getQueryBuilderConfigForFormFields(form: Pick<RoutingForm, "fiel
         valueSources: ["value"],
         fieldSettings: {
           // IMPORTANT: listValues must be undefined for non-select/multiselect fields otherwise RAQB doesn't like it. It ends up considering all the text values as per the listValues too which could be empty as well making all values invalid
-          listValues: fieldType === "select" || fieldType === "multiselect" ? options : undefined,
+          listValues:
+            fieldType === "select" ||
+            fieldType === "multiselect" ||
+            fieldType === "radio" ||
+            fieldType === "checkbox"
+              ? options
+              : undefined,
         },
       };
     } else {

--- a/packages/app-store/routing-forms/lib/transformResponse.ts
+++ b/packages/app-store/routing-forms/lib/transformResponse.ts
@@ -69,7 +69,7 @@ export function getFieldResponseForJsonLogic({
     }
     return value;
   }
-  if (field.type === "multiselect") {
+  if (field.type === "multiselect" || field.type === "checkbox") {
     // Could be option id(i.e. a UUIDv4) or option label for ease of prefilling
     let valueOrLabelArray = value instanceof Array ? value : value.toString().split(",");
 
@@ -80,7 +80,7 @@ export function getFieldResponseForJsonLogic({
     return valueOrLabelArray;
   }
 
-  if (field.type === "select") {
+  if (field.type === "select" || field.type === "radio") {
     const valueAsStringOrStringArray = typeof value === "number" ? String(value) : value;
     const valueAsString =
       valueAsStringOrStringArray instanceof Array


### PR DESCRIPTION
## Summary
- extend routing form question types to include booking-question style inputs: `radio`, `checkbox`, `url`, `address`, and `multiemail`
- wire these new types into routing form rendering and query-builder config (including option-aware types)
- normalize route-evaluation response transforms for `radio`/`checkbox` alongside existing `select`/`multiselect` behavior
- update routing form editor UX to ask for **identifier first** and stop auto-prefilling identifier from label, matching event-type booking question flow

## Notes
- kept the implementation aligned with existing routing-form patterns and RAQB widget/type mapping
- focused on bringing routing forms closer to event-type booking-question behavior without changing persisted data model contracts


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds booking-question field types (URL, Address, Multiple emails, Radio, Checkbox) to routing forms and wires them into rendering, query builder, and response transforms. Switches the editor to identifier-first and removes identifier auto-fill to match event-type booking questions.

- **New Features**
  - New field types: URL, Address, Multi-email, Radio, Checkbox.
  - RAQB support and widgets; radio/checkbox are option-aware.
  - Options editor now appears for select, multiselect, radio, and checkbox.
  - Normalized transforms: select+radio and multiselect+checkbox handled consistently for route evaluation.
  - No data model changes.

- **UX Improvements**
  - Identifier comes first; label second.
  - Stops auto-prefilling identifier from the label.

<sup>Written for commit 44e952f693059ba27629b853b7764a8ab2bf363a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

