### PR TITLE
feat(reschedule): check guest availability when host reschedules

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -148,6 +148,12 @@ export type GetUserAvailabilityInitialData = {
   })[];
   busyTimesFromLimitsBookings?: EventBusyDetails[];
   busyTimesFromLimits?: Map<number, EventBusyDetails[]>;
+  /**
+   * Busy times of guests (attendees who are not the host) from the booking being rescheduled.
+   * Injected by the slots service when `rescheduleUid` is present so that the availability
+   * calculation blocks any slot that conflicts with a guest's existing accepted booking.
+   */
+  guestBusyTimes?: EventBusyDetails[];
   eventTypeForLimits?: {
     id: number;
     bookingLimits?: unknown;
@@ -622,6 +628,8 @@ export class UserAvailabilityService {
       })),
       ...busyTimesFromLimits,
       ...busyTimesFromTeamLimits,
+      // Guest busy times from the booking being rescheduled: prevents double-booking guests.
+      ...(initialData?.guestBusyTimes ?? []),
     ];
 
     log.debug(

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -2220,4 +2220,45 @@ export class BookingRepository implements IBookingRepository {
       },
     });
   }
+
+  /**
+   * Returns accepted bookings whose attendee list contains at least one of the given emails,
+   * within the provided date range and excluding the booking with `excludedUid` (the booking
+   * being rescheduled). Used to surface guest conflicts when a host reschedules.
+   */
+  async getAcceptedBookingsByAttendeeEmails({
+    attendeeEmails,
+    startDate,
+    endDate,
+    excludedUid,
+  }: {
+    attendeeEmails: string[];
+    startDate: Date;
+    endDate: Date;
+    excludedUid?: string | null;
+  }) {
+    if (attendeeEmails.length === 0) return [];
+    return this.prismaClient.booking.findMany({
+      where: {
+        status: BookingStatus.ACCEPTED,
+        // Use overlap semantics: any booking whose time range intersects [startDate, endDate].
+        startTime: { lt: endDate },
+        endTime: { gt: startDate },
+        ...(excludedUid ? { uid: { not: excludedUid } } : {}),
+        attendees: {
+          some: {
+            email: { in: attendeeEmails },
+          },
+        },
+      },
+      select: {
+        id: true,
+        startTime: true,
+        endTime: true,
+        title: true,
+        uid: true,
+        userId: true,
+      },
+    });
+  }
 }

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -839,6 +839,44 @@ export class AvailableSlotsService {
     const allUserIds = Array.from(userIdAndEmailMap.keys());
 
     const bookingRepo = this.dependencies.bookingRepo;
+
+    // When rescheduling, collect accepted bookings of all guests (attendees who are not
+    // the host) so we can block slots that would double-book them.
+    let guestBusyTimes: EventBusyDetails[] = [];
+    if (input.rescheduleUid) {
+      const rescheduleBooking = await bookingRepo.findByUidIncludeEventTypeAttendeesAndUser({
+        bookingUid: input.rescheduleUid,
+      });
+      if (rescheduleBooking) {
+        // Host emails: the booking's user + any event-type host emails
+        const hostEmails = new Set<string>();
+        if (rescheduleBooking.user?.email) hostEmails.add(rescheduleBooking.user.email);
+        rescheduleBooking.eventType?.hosts?.forEach((h) => {
+          if (h.user.email) hostEmails.add(h.user.email);
+        });
+
+        // Guest emails = attendees that are NOT hosts
+        const guestEmails = rescheduleBooking.attendees
+          .map((a) => a.email)
+          .filter((email) => !hostEmails.has(email));
+
+        if (guestEmails.length > 0) {
+          const guestBookings = await bookingRepo.getAcceptedBookingsByAttendeeEmails({
+            attendeeEmails: guestEmails,
+            startDate: startTimeDate,
+            endDate: endTimeDate,
+            excludedUid: input.rescheduleUid,
+          });
+          guestBusyTimes = guestBookings.map((b) => ({
+            start: b.startTime.toISOString(),
+            end: b.endTime.toISOString(),
+            title: b.title ?? undefined,
+            source: "guest",
+          }));
+        }
+      }
+    }
+
     const [currentBookingsAllUsers, outOfOfficeDaysAllUsers] = await Promise.all([
       bookingRepo.findAllExistingBookingsForEventTypeBetween({
         startDate: startTimeDate,
@@ -962,6 +1000,7 @@ export class AvailableSlotsService {
         eventTypeForLimits: eventType && (bookingLimits || durationLimits) ? eventType : null,
         teamBookingLimits: teamBookingLimitsMap,
         teamForBookingLimits: teamForBookingLimits,
+        guestBusyTimes,
       },
     });
     /* We get all users working hours and busy slots */


### PR DESCRIPTION
When a host reschedules a booking, the slot picker now filters out time slots that conflict with the guests' (attendees') existing accepted bookings — preventing double-booking guests.

## Changes

### `packages/features/bookings/repositories/BookingRepository.ts`
- Add `getAcceptedBookingsByAttendeeEmails()` to query bookings where any attendee email appears in a given list, within a date range, excluding the booking being rescheduled
- Uses overlap semantics (`startTime < windowEnd AND endTime > windowStart`) for correct boundary detection

### `packages/trpc/server/routers/viewer/slots/util.ts`
- In `calculateHostsAndAvailabilities()`: when `rescheduleUid` is present, look up the original booking's attendees via `BookingRepository`
- Filter out host emails (booking owner + event type hosts) to isolate guest-only emails
- Fetch their accepted bookings in the slot search window, excluding the booking being rescheduled
- Pass as `guestBusyTimes` through `initialData`

### `packages/features/availability/lib/getUserAvailability.ts`
- Add optional `guestBusyTimes` field to `GetUserAvailabilityInitialData`
- Spread `guestBusyTimes` into `detailedBusyTimes` so guest conflicts block slot availability

## How it works
1. Host clicks reschedule → slot picker calls `getSchedule` with `rescheduleUid`
2. We look up the original booking's attendees and identify which are guests (not hosts)
3. We query all accepted bookings where those guest emails appear as attendees
4. Those bookings become busy times that block slots, just like host busy times

Fixes #16378
/claim #28164