### PR TITLE
fix: increase Node.js memory limit for start script to prevent heap o…

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "build:docker": "yarn workspace @calcom/platform-constants build && yarn workspace @calcom/platform-enums build && yarn workspace @calcom/platform-utils build && yarn workspace @calcom/platform-types build && yarn workspace @calcom/platform-libraries build && yarn workspace @calcom/trpc build:server",
     "format": "biome format --write src test",
-    "start": "nest start",
+    "start": "NODE_OPTIONS='--max-old-space-size=4096' nest start",
     "dev:build:watch": "concurrently --names \"libraries,lru-fix,constants,enums,utils,types\" \"yarn _dev:build:watch:libraries\" \"yarn _dev:build:watch:libraries:lru-fix\" \"yarn _dev:build:watch:constants\" \"yarn _dev:build:watch:enums\" \"yarn _dev:build:watch:utils\" \"yarn _dev:build:watch:types\"",
     "_dev:build:watch:libraries": "yarn workspace @calcom/platform-libraries build:watch",
     "_dev:build:watch:libraries:lru-fix": "yarn workspace @calcom/platform-libraries watch-lru-fix",


### PR DESCRIPTION
from the issue 
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory #28233

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Node.js memory limit to 4 GB in the API v2 start script to prevent heap out-of-memory crashes during NestJS startup.

- **Bug Fixes**
  - apps/api/v2/package.json: set NODE_OPTIONS="--max-old-space-size=4096" for the start command to avoid "Ineffective mark-compacts near heap limit" errors.

<sup>Written for commit 4efd18c5c4fba740bf14e130dc0ae196d7a0ccf2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

