### PR TITLE
fix(dx): align local Postgres DB name in packages/prisma docker-compose

### DIFF
--- a/packages/prisma/docker-compose.yml
+++ b/packages/prisma/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: "cal-saml"
+      POSTGRES_DB: "calendso"
       POSTGRES_PASSWORD: ""
       POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:


### PR DESCRIPTION
Fixes mismatch between packages/prisma/docker-compose.yml (cal-saml) and .env.example defaults (calendso). Changed POSTGRES_DB to calendso. Fixes #28106