### PR TITLE
feat: add emoji picker to About editor

### DIFF
--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -31,6 +31,8 @@ import { Button } from "../../button";
 import { Dropdown, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../../dropdown";
 import { Icon } from "../../icon";
 import type { TextEditorProps } from "../types";
+import { Popover, PopoverContent, PopoverTrigger } from "../../popover";
+import EmojiPicker, { EmojiStyle } from "emoji-picker-react";
 import { AddVariablesDropdown } from "./AddVariablesDropdown";
 
 const LowPriority = 1;
@@ -453,6 +455,15 @@ export default function ToolbarPlugin(props: TextEditorProps) {
     [editor, isLink]
   );
 
+  const onEmojiClick = (emojiData: { emoji: string }) => {
+    editor.update(() => {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        selection.insertText(emojiData.emoji);
+      }
+    });
+  };
+
   if (!props.editable) return null;
   return (
     <div className="toolbar flex gap-1" ref={toolbarRef}>
@@ -537,6 +548,26 @@ export default function ToolbarPlugin(props: TextEditorProps) {
               {isLink && createPortal(<FloatingLinkEditor editor={editor} />, document.body)}{" "}
             </>
           )}
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                aria-label="Emoji"
+                color="minimal"
+                variant="icon"
+                type="button"
+                StartIcon="sparkles"
+              />
+            </PopoverTrigger>
+            <PopoverContent className="w-full border-none p-0" sideOffset={10}>
+              <EmojiPicker
+                onEmojiClick={onEmojiClick}
+                autoFocusSearch={false}
+                emojiStyle={EmojiStyle.NATIVE}
+                width={350}
+                height={400}
+              />
+            </PopoverContent>
+          </Popover>
         </div>
         {props.variables && (
           <div className={`${props.addVariableButtonTop ? "-mt-10" : ""} ml-auto`}>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -101,6 +101,7 @@
     "cmk": "0.1.1",
     "date-fns": "3.6.0",
     "downshift": "6.1.9",
+    "emoji-picker-react": "^4.0.0",
     "lexical": "0.9.0",
     "react-colorful": "5.6.1",
     "react-day-picker": "8.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3227,6 +3227,7 @@ __metadata:
     cmk: "npm:0.1.1"
     date-fns: "npm:3.6.0"
     downshift: "npm:6.1.9"
+    emoji-picker-react: "npm:^4.0.0"
     execa: "npm:9.3.0"
     fast-glob: "npm:3.3.2"
     fs-extra: "npm:11.3.2"
@@ -21428,6 +21429,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emoji-picker-react@npm:^4.0.0":
+  version: 4.18.0
+  resolution: "emoji-picker-react@npm:4.18.0"
+  dependencies:
+    flairup: "npm:1.0.0"
+  peerDependencies:
+    react: ">=16"
+  checksum: 10/a42192f5ee5310e44f759b79e567ceace63ae83d7b339ce18d562bedff5d0c91b229bf221ea7d64a7cd90608916cb5128fe03f032d1d155d6730443da1c0cd46
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^10.2.1, emoji-regex@npm:^10.3.0":
   version: 10.5.0
   resolution: "emoji-regex@npm:10.5.0"
@@ -23026,6 +23038,13 @@ __metadata:
     locate-path: "npm:^6.0.0"
     path-exists: "npm:^4.0.0"
   checksum: 10/07955e357348f34660bde7920783204ff5a26ac2cafcaa28bace494027158a97b9f56faaf2d89a6106211a8174db650dd9f503f9c0d526b1202d5554a00b9095
+  languageName: node
+  linkType: hard
+
+"flairup@npm:1.0.0":
+  version: 1.0.0
+  resolution: "flairup@npm:1.0.0"
+  checksum: 10/9125711da6effe146fa748fda4c293027a142bde7cc9264d6e515a5845c79181d6fdb63bb1254a5c364006b333a1083d06ac6ead0c2e3c28024c977363e19571
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

Adds an emoji picker to the rich-text editor used in the 'About' section of the user profile.

### The Problem
Users previously had to copy-paste or use system shortcuts to add emojis to their profile bio, which was inconsistent and lacked parity with other rich-text features.

### The Solution
- Integrated emoji-picker-react into the ToolbarPlugin.
- Added an emoji button (sparkles icon) that opens a Popover.
- Emojis are inserted at the current cursor position as plain Unicode text.
- No backend or schema changes required.

Fixes #27935