### PR TITLE
fix: strip avatar and profile from children payload in managed event type updates

### DIFF
--- a/packages/features/eventtypes/lib/childrenEventType.ts
+++ b/packages/features/eventtypes/lib/childrenEventType.ts
@@ -18,3 +18,21 @@ export type ChildrenEventType = {
   slug: string;
   hidden: boolean;
 };
+
+/**
+ * Extracts only the fields needed by the server from a ChildrenEventType array.
+ * Display-only fields (avatar, profile, username, membership) are stripped to
+ * avoid bloating the request payload — with many assigned users (~85+),
+ * sending full objects can push the request body over the 1MB server limit.
+ */
+export function stripChildrenForPayload(children: ChildrenEventType[]) {
+  return children.map((child) => ({
+    hidden: child.hidden,
+    owner: {
+      id: child.owner.id,
+      name: child.owner.name,
+      email: child.owner.email,
+      eventTypeSlugs: child.owner.eventTypeSlugs,
+    },
+  }));
+}

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.test.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+
+import type { ChildrenEventType } from "@calcom/features/eventtypes/lib/childrenEventType";
+import { MembershipRole } from "@calcom/prisma/enums";
+
+/**
+ * Extracts only the fields needed by the server from a ChildrenEventType array.
+ * This mirrors the stripping logic in useEventTypeForm's handleSubmit to ensure
+ * that display-only fields (avatar, profile, etc.) are not sent in the payload.
+ */
+function stripChildrenForPayload(children: ChildrenEventType[]) {
+  return children.map((child) => ({
+    hidden: child.hidden,
+    owner: {
+      id: child.owner.id,
+      name: child.owner.name,
+      email: child.owner.email,
+      eventTypeSlugs: child.owner.eventTypeSlugs,
+    },
+  }));
+}
+
+describe("useEventTypeForm - children payload stripping", () => {
+  it("should strip avatar, profile, username, and membership from children payload", () => {
+    const children: ChildrenEventType[] = [
+      {
+        value: "1",
+        label: "Alice",
+        created: true,
+        slug: "test-event",
+        hidden: false,
+        owner: {
+          id: 1,
+          name: "Alice",
+          email: "alice@example.com",
+          username: "alice",
+          avatar: "data:image/png;base64," + "A".repeat(50000), // Large base64 avatar
+          membership: MembershipRole.MEMBER,
+          eventTypeSlugs: ["meeting", "consultation"],
+          profile: {
+            id: 1,
+            username: "alice",
+            upId: "usr_1",
+            organizationId: null,
+            organization: null,
+          },
+        },
+      },
+      {
+        value: "2",
+        label: "Bob",
+        created: false,
+        slug: "test-event",
+        hidden: true,
+        owner: {
+          id: 2,
+          name: "Bob",
+          email: "bob@example.com",
+          username: "bob",
+          avatar: "https://example.com/avatars/bob.png",
+          membership: MembershipRole.OWNER,
+          eventTypeSlugs: [],
+          profile: {
+            id: 2,
+            username: "bob",
+            upId: "usr_2",
+            organizationId: 10,
+            organization: {
+              id: 10,
+              slug: "org",
+              name: "Org",
+              calVideoLogo: null,
+              bannerUrl: "",
+              isPlatform: false,
+            },
+          },
+        },
+      },
+    ];
+
+    const stripped = stripChildrenForPayload(children);
+
+    // Should only contain server-needed fields
+    expect(stripped).toEqual([
+      {
+        hidden: false,
+        owner: {
+          id: 1,
+          name: "Alice",
+          email: "alice@example.com",
+          eventTypeSlugs: ["meeting", "consultation"],
+        },
+      },
+      {
+        hidden: true,
+        owner: {
+          id: 2,
+          name: "Bob",
+          email: "bob@example.com",
+          eventTypeSlugs: [],
+        },
+      },
+    ]);
+
+    // Verify avatar is not present
+    for (const child of stripped) {
+      expect(child.owner).not.toHaveProperty("avatar");
+      expect(child.owner).not.toHaveProperty("profile");
+      expect(child.owner).not.toHaveProperty("username");
+      expect(child.owner).not.toHaveProperty("membership");
+    }
+  });
+
+  it("should significantly reduce payload size for large teams", () => {
+    // Simulate 85 users with base64 avatars (~10KB each)
+    const largeBase64Avatar = "data:image/png;base64," + "A".repeat(10000);
+
+    const children: ChildrenEventType[] = Array.from({ length: 85 }, (_, i) => ({
+      value: String(i + 1),
+      label: `User ${i + 1}`,
+      created: true,
+      slug: "managed-event",
+      hidden: false,
+      owner: {
+        id: i + 1,
+        name: `User ${i + 1}`,
+        email: `user${i + 1}@example.com`,
+        username: `user${i + 1}`,
+        avatar: largeBase64Avatar,
+        membership: MembershipRole.MEMBER,
+        eventTypeSlugs: ["event-a", "event-b"],
+        profile: {
+          id: i + 1,
+          username: `user${i + 1}`,
+          upId: `usr_${i + 1}`,
+          organizationId: 1,
+          organization: {
+            id: 1,
+            slug: "org",
+            name: "Large Org",
+            calVideoLogo: null,
+            bannerUrl: "",
+            isPlatform: false,
+          },
+        },
+      },
+    }));
+
+    const fullPayloadSize = JSON.stringify(children).length;
+    const strippedPayloadSize = JSON.stringify(stripChildrenForPayload(children)).length;
+
+    // The stripped payload should be dramatically smaller
+    expect(strippedPayloadSize).toBeLessThan(fullPayloadSize * 0.1);
+
+    // Full payload with 85 users and 10KB avatars should be around 850KB+
+    expect(fullPayloadSize).toBeGreaterThan(800000);
+
+    // Stripped payload should be well under 1MB
+    expect(strippedPayloadSize).toBeLessThan(100000);
+  });
+
+  it("should handle undefined children gracefully", () => {
+    const children: ChildrenEventType[] = [];
+    const stripped = stripChildrenForPayload(children);
+    expect(stripped).toEqual([]);
+  });
+});

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.test.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.test.ts
@@ -1,24 +1,8 @@
 import { describe, it, expect } from "vitest";
 
 import type { ChildrenEventType } from "@calcom/features/eventtypes/lib/childrenEventType";
+import { stripChildrenForPayload } from "@calcom/features/eventtypes/lib/childrenEventType";
 import { MembershipRole } from "@calcom/prisma/enums";
-
-/**
- * Extracts only the fields needed by the server from a ChildrenEventType array.
- * This mirrors the stripping logic in useEventTypeForm's handleSubmit to ensure
- * that display-only fields (avatar, profile, etc.) are not sent in the payload.
- */
-function stripChildrenForPayload(children: ChildrenEventType[]) {
-  return children.map((child) => ({
-    hidden: child.hidden,
-    owner: {
-      id: child.owner.id,
-      name: child.owner.name,
-      email: child.owner.email,
-      eventTypeSlugs: child.owner.eventTypeSlugs,
-    },
-  }));
-}
 
 describe("useEventTypeForm - children payload stripping", () => {
   it("should strip avatar, profile, username, and membership from children payload", () => {

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -287,8 +287,6 @@ export const useEventTypeForm = ({
     const updatedFields: Partial<FormValues> = {};
     Object.keys(dirtyFields).forEach((key) => {
       const typedKey = key as keyof typeof dirtyFields;
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
       updatedFields[typedKey] = undefined;
       const isDirty = isFieldDirty(typedKey);
       if (isDirty) {

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -3,6 +3,7 @@ import { locationsResolver } from "@calcom/app-store/locations";
 import { DEFAULT_BEGIN_MESSAGE, DEFAULT_PROMPT_VALUE } from "@calcom/features/calAIPhone/promptTemplates";
 import type { TemplateType } from "@calcom/features/calAIPhone/zod-utils";
 import { validateCustomEventName } from "@calcom/features/eventtypes/lib/eventNaming";
+import { stripChildrenForPayload } from "@calcom/features/eventtypes/lib/childrenEventType";
 import type {
   EventTypeSetupProps,
   EventTypeUpdateInput,
@@ -384,15 +385,7 @@ export const useEventTypeForm = ({
     // The full children objects contain avatar, profile, and other display-only
     // data that bloats the request payload. With many assigned users (~85+),
     // this can push the request body over the 1MB server limit.
-    const strippedChildren = children?.map((child) => ({
-      hidden: child.hidden,
-      owner: {
-        id: child.owner.id,
-        name: child.owner.name,
-        email: child.owner.email,
-        eventTypeSlugs: child.owner.eventTypeSlugs,
-      },
-    }));
+    const strippedChildren = children ? stripChildrenForPayload(children) : undefined;
 
     const payload = {
       ...rest,

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -1,23 +1,22 @@
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useMemo, useState, useEffect } from "react";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
-
 import checkForMultiplePaymentApps from "@calcom/app-store/_utils/payments/checkForMultiplePaymentApps";
 import { locationsResolver } from "@calcom/app-store/locations";
-import { DEFAULT_PROMPT_VALUE, DEFAULT_BEGIN_MESSAGE } from "@calcom/features/calAIPhone/promptTemplates";
+import { DEFAULT_BEGIN_MESSAGE, DEFAULT_PROMPT_VALUE } from "@calcom/features/calAIPhone/promptTemplates";
 import type { TemplateType } from "@calcom/features/calAIPhone/zod-utils";
 import { validateCustomEventName } from "@calcom/features/eventtypes/lib/eventNaming";
-import { sortHosts } from "@calcom/lib/bookings/hostGroupUtils";
 import type {
-  FormValues,
   EventTypeSetupProps,
   EventTypeUpdateInput,
+  FormValues,
 } from "@calcom/features/eventtypes/lib/types";
+import { sortHosts } from "@calcom/lib/bookings/hostGroupUtils";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { validateIntervalLimitOrder } from "@calcom/lib/intervalLimits/validateIntervalLimitOrder";
 import { validateBookerLayouts } from "@calcom/lib/validateBookerLayouts";
 import { eventTypeBookingFields as eventTypeBookingFieldsSchema } from "@calcom/prisma/zod-utils";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
 type Fields = z.infer<typeof eventTypeBookingFieldsSchema>;
 
@@ -288,12 +287,12 @@ export const useEventTypeForm = ({
     Object.keys(dirtyFields).forEach((key) => {
       const typedKey = key as keyof typeof dirtyFields;
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error
       updatedFields[typedKey] = undefined;
       const isDirty = isFieldDirty(typedKey);
       if (isDirty) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // @ts-expect-error
         updatedFields[typedKey] = values[typedKey];
       }
     });
@@ -381,6 +380,20 @@ export const useEventTypeForm = ({
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { availability, users, scheduleName, disabledCancelling, disabledRescheduling, ...rest } = input;
+    // Strip children down to only the fields the server schema expects.
+    // The full children objects contain avatar, profile, and other display-only
+    // data that bloats the request payload. With many assigned users (~85+),
+    // this can push the request body over the 1MB server limit.
+    const strippedChildren = children?.map((child) => ({
+      hidden: child.hidden,
+      owner: {
+        id: child.owner.id,
+        name: child.owner.name,
+        email: child.owner.email,
+        eventTypeSlugs: child.owner.eventTypeSlugs,
+      },
+    }));
+
     const payload = {
       ...rest,
       length,
@@ -402,7 +415,7 @@ export const useEventTypeForm = ({
       seatsShowAvailabilityCount,
       metadata,
       customInputs,
-      children,
+      children: strippedChildren,
       assignAllTeamMembers,
       multiplePrivateLinks: values.multiplePrivateLinks,
       disableCancelling: disabledCancelling,


### PR DESCRIPTION
## What does this PR do?

When assigning users to a large managed event type (~85+ users), the update request fails with a "Body exceeded 1mb limit" error. The root cause is that the full `ChildrenEventType` objects—including `avatar` (potentially large base64 data URLs), `profile`, `username`, and `membership`—are sent in the mutation payload, even though the server Zod schema (`childSchema`) only needs `owner.{id, name, email, eventTypeSlugs}` and `hidden`.

This PR strips the `children` array down to only server-required fields in `handleSubmit` before sending the mutation, while keeping the full data in form state for UI display (e.g., avatar rendering in `ChildrenEventTypeSelect`).

The stripping logic is extracted into a shared `stripChildrenForPayload` utility in `packages/features/eventtypes/lib/childrenEventType.ts`, which is imported by both the hook and the test file—avoiding code duplication.

## How should this be tested?

1. Create a managed event type in an organization with ~85+ team members
2. Assign all members to the managed event type
3. Save the event type — previously this would fail with "Body exceeded 1mb limit"; now it should succeed
4. Verify the assigned members list still displays correctly with avatars in the UI

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Human Review Checklist

- [ ] Verify the stripped fields (`owner.{id, name, email, eventTypeSlugs}`, `hidden`) match exactly what the server `childSchema` in `packages/trpc/server/routers/viewer/eventTypes/types.ts` expects
- [ ] Confirm the full `children` data (with avatars) is still available in react-hook-form state for UI rendering — note that `children` is extracted from `values` on line 303 (before dirty field filtering), while `strippedChildren` is only used for the outgoing payload
- [ ] Verify `stripChildrenForPayload` in `childrenEventType.ts` is correctly shared between the hook and the test file (no duplicated logic)

## Updates since last revision

- **Addressed Cubic AI review feedback (confidence 9/10):** Extracted inline stripping logic from `useEventTypeForm.ts` into a shared exported `stripChildrenForPayload()` function in `packages/features/eventtypes/lib/childrenEventType.ts`. The test file now imports and tests the actual production function instead of maintaining a mirrored copy.

---

> [Link to Devin session](https://app.devin.ai/sessions/ea196be4ae5c460cb932e42a16580a20)
> [Link to original Devin session](https://app.devin.ai/sessions/2b581d4d653f4d1bbc654c1c5de54f04)
> Requested by: @alishaz-polymath