### PR TITLE
fix: resolve 'length is outside of buffer bounds' error on Node.js 22+

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "vitest-mock-extended": "3.1.0"
   },
   "resolutions": {
+    "pg": "^8.16.0",
     "@isaacs/brace-expansion": "5.0.1",
     "types-ramda": "0.29.4",
     "@apidevtools/json-schema-ref-parser": "9.0.9",

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,6 +27,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31733,17 +31733,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-cloudflare@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "pg-cloudflare@npm:1.2.5"
-  checksum: 10/13181a5d8243758bc6651426368097c89a2ff226d2ed8119f2777b15eea5e22953b5605b3d4861e68cd2109e1b08d3eea143e495bcefccaf7a0c8f70b69a0b51
+"pg-cloudflare@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "pg-cloudflare@npm:1.3.0"
+  checksum: 10/04007ebbd314bdc8e5983d5d0f71a942f1915d2312ed84894d55475010559665bcbb9941d55523d36be6386cd83490dffb5b1ea98ffbbc82a140ef5dfb68ab8d
   languageName: node
   linkType: hard
 
-"pg-connection-string@npm:^2.9.0":
-  version: 2.9.1
-  resolution: "pg-connection-string@npm:2.9.1"
-  checksum: 10/40e9e9cd752121e72bff18d83e6c7ecda9056426815a84294de018569a319293c924704c8b7f0604fdc588835c7927647dea4f3c87a014e715bcbb17d794e9f0
+"pg-connection-string@npm:^2.11.0":
+  version: 2.11.0
+  resolution: "pg-connection-string@npm:2.11.0"
+  checksum: 10/0333bb1b7ddeac6fa5262920f82a983222c600d21ef14fdc5254b0d3cbb1763030d20c1e8e3c20fa767a6eda8f4b4773550954c06f3e072e5288b6fa9e9cae13
   languageName: node
   linkType: hard
 
@@ -31761,19 +31761,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-pool@npm:^3.10.0":
-  version: 3.10.1
-  resolution: "pg-pool@npm:3.10.1"
+"pg-pool@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "pg-pool@npm:3.12.0"
   peerDependencies:
     pg: ">=8.0"
-  checksum: 10/b389a714be59ebe53ec412cbff513191cc0b7a203faa5d26416b6a038cafdfe30fbf1a5936b77bb76109c49bd7c4a116870a5a46a45796b1b34c96f016d7fbe2
+  checksum: 10/81a4220b89ba28034c51db0a7e231a8c1555ddb3cf8bacde0acd092fb26473763a335629ffcf5153059dd8f406d39610e384fd9176d34359a3d1498b4c5b95cd
   languageName: node
   linkType: hard
 
-"pg-protocol@npm:*, pg-protocol@npm:^1.10.0":
+"pg-protocol@npm:*":
   version: 1.10.3
   resolution: "pg-protocol@npm:1.10.3"
   checksum: 10/31da85319084c03f403efee7accce9786964df82a7feb60e6bd77b71f1e622c74a2a644a2bc434389d0ab92e5abdeedea69ebdb53b1897d9f01d2a1f51a8a2fe
+  languageName: node
+  linkType: hard
+
+"pg-protocol@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "pg-protocol@npm:1.12.0"
+  checksum: 10/0f5d8a5dbef39ef4d06686910ad61599b8d26c4505e76af2f6da3a1a1028c312f61678fae5e5012d477fe318b5ebc8507a828c087973b22e5fd4ec1e7394101a
   languageName: node
   linkType: hard
 
@@ -31805,14 +31812,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg@npm:8.16.0, pg@npm:^8.11.3":
-  version: 8.16.0
-  resolution: "pg@npm:8.16.0"
+"pg@npm:^8.16.0":
+  version: 8.19.0
+  resolution: "pg@npm:8.19.0"
   dependencies:
-    pg-cloudflare: "npm:^1.2.5"
-    pg-connection-string: "npm:^2.9.0"
-    pg-pool: "npm:^3.10.0"
-    pg-protocol: "npm:^1.10.0"
+    pg-cloudflare: "npm:^1.3.0"
+    pg-connection-string: "npm:^2.11.0"
+    pg-pool: "npm:^3.12.0"
+    pg-protocol: "npm:^1.12.0"
     pg-types: "npm:2.2.0"
     pgpass: "npm:1.0.5"
   peerDependencies:
@@ -31823,7 +31830,7 @@ __metadata:
   peerDependenciesMeta:
     pg-native:
       optional: true
-  checksum: 10/706ba6bbc79c397ae32ab144db2cc4e962a2dbad759ba539be0269731298efca8e0dbcd4de4ad14fb6e8b54c830b82f5da7d94ae4c32d853dea7e541b3a05f60
+  checksum: 10/0d552512b6c65c20b4054a203632f8ad51f6c5e60b8aaf65f5dc9f07a698da1e8974ca3918964999ea783c370bda9d230e662d2bab333b3968a28086923934e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

Fixes #28231

This resolves the `"length" is outside of buffer bounds` (`ERR_BUFFER_OUT_OF_BOUNDS`) Internal Server Error that occurs when making a `POST` request to `/v2/bookings` on Node.js v22.7.0+.

### Root Cause

The `pg` (node-postgres) library versions prior to `8.13.0` had a bug where they passed an out-of-bounds length to `Buffer.from()`. Node.js v22.7.0 introduced stricter `Buffer` validation that catches this, causing crashes during Prisma database queries (e.g., after booking creation via `@prisma/adapter-pg` which resolved `pg@8.11.14`).

Bookings were still being created because the initial Prisma `$transaction` succeeded, but subsequent queries (fetching relations, syncing calendars, etc.) triggered the `pg` buffer reading logic that crashed with a `500 Internal Server Error`.

### Fix

Added a yarn resolution to force `pg` to `^8.16.0` across the entire monorepo. This resolves `pg` to `8.19.0` in the lockfile, which includes the upstream fix for the buffer bounds issue.

```diff
  "resolutions": {
+   "pg": "^8.16.0",
    "@isaacs/brace-expansion": "5.0.1",
```

### How was this tested?

- Verified `yarn.lock` resolves `pg` to `8.19.0` for all workspaces (including `@prisma/adapter-pg` and `@calcom/kysely`)
- Ran `yarn install` successfully
- Confirmed the app boots without the buffer error

### Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] I have updated the developer documentation, if necessary