### PR TITLE
fix: admin wizard crash and prisma enum generator path resolution

### DIFF
--- a/apps/web/modules/auth/setup-view.tsx
+++ b/apps/web/modules/auth/setup-view.tsx
@@ -30,16 +30,19 @@ export function Setup(props: PageProps) {
     props.hasValidLicense ? "EXISTING" : "FREE"
   );
 
+  const hasLicenseStep = !props.hasValidLicense && !hasPickedAGPLv3;
+
   const defaultStep = useMemo(() => {
     if (props.userCount > 0) {
-      if (!props.hasValidLicense && !hasPickedAGPLv3) {
+      if (hasLicenseStep) {
         return SETUP_VIEW_SETPS.LICENSE;
       } else {
-        return SETUP_VIEW_SETPS.APPS;
+        // License step is not shown, so apps step is at position 2 instead of 3
+        return SETUP_VIEW_SETPS.APPS - 1;
       }
     }
     return SETUP_VIEW_SETPS.ADMIN_USER;
-  }, [props.userCount, props.hasValidLicense, hasPickedAGPLv3]);
+  }, [props.userCount, hasLicenseStep]);
 
   const steps: WizardStep[] = [
     {
@@ -52,13 +55,7 @@ export function Setup(props: PageProps) {
             setIsPending(true);
           }}
           onSuccess={() => {
-            // If there's already a valid license or user picked AGPLv3, skip to apps step
-            if (props.hasValidLicense || hasPickedAGPLv3) {
-              nav.onNext();
-              nav.onNext(); // Skip license step
-            } else {
-              nav.onNext();
-            }
+            nav.onNext();
           }}
           onError={() => {
             setIsPending(false);
@@ -71,7 +68,7 @@ export function Setup(props: PageProps) {
   ];
 
   // Only show license selection step if there's no valid license already and AGPLv3 wasn't picked
-  if (!props.hasValidLicense && !hasPickedAGPLv3) {
+  if (hasLicenseStep) {
     steps.push({
       title: t("choose_a_license"),
       description: t("choose_license_description"),

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -2,6 +2,9 @@
   "name": "@calcom/prisma",
   "version": "0.0.0",
   "private": true,
+  "bin": {
+    "prisma-enum-generator": "./run-enum-generator.js"
+  },
   "scripts": {
     "clean": "rm -rf .turbo && rm -rf node_modules",
     "build": "ts-node --transpile-only ./auto-migrations.ts",

--- a/packages/prisma/run-enum-generator.js
+++ b/packages/prisma/run-enum-generator.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// Wrapper script for the enum generator that ensures correct path resolution
+// regardless of the current working directory (e.g., running prisma from repo root).
+// Prisma resolves providers starting with "./" relative to the schema file directory.
+require("ts-node").register({ transpileOnly: true });
+require("./enum-generator.ts");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -36,7 +36,7 @@ generator kysely {
 }
 
 generator enums {
-  provider = "ts-node --transpile-only ./enum-generator.ts"
+  provider = "./run-enum-generator.js"
 }
 
 enum SchedulingType {

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -36,7 +36,7 @@ generator kysely {
 }
 
 generator enums {
-  provider = "./run-enum-generator.js"
+  provider = "prisma-enum-generator"
 }
 
 enum SchedulingType {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2977,6 +2977,8 @@ __metadata:
     uuid: "npm:8.3.2"
     zod: "npm:3.25.76"
     zod-prisma-types: "npm:3.2.4"
+  bin:
+    prisma-enum-generator: ./run-enum-generator.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## What does this PR do?

Fixes two issues:

### 1. Admin Setup Wizard 500 Error

When creating the first admin user, a `TypeError: Cannot read properties of undefined (reading 'title')` crash occurs at `WizardForm.tsx:65`. 

**Root cause:** When `hasValidLicense` is `true`, the license step is excluded from the `steps` array (only 2 steps exist), but `defaultStep` still returns `SETUP_VIEW_SETPS.APPS` (hardcoded `3`). This causes `steps[3-1]` → `steps[2]` → `undefined` in `WizardForm.tsx`.

Additionally, the `onSuccess` handler called `nav.onNext()` twice to "skip" the license step — but since that step isn't in the array, the double call pushes past bounds.

**Fix:**
- Extracted `hasLicenseStep` for a single source of truth on the condition
- `defaultStep` now returns `SETUP_VIEW_SETPS.APPS - 1` (position 2) when the license step is absent
- Simplified `onSuccess` to a single `nav.onNext()` — since the license step is conditionally excluded from the array, there's nothing to skip

### 2. Prisma Enum Generator Not Directory-Safe

Running `npx prisma migrate reset` (or `generate`) from the repo root fails with `Cannot find module './enum-generator.ts'`.

**Root cause:** The `provider = "ts-node --transpile-only ./enum-generator.ts"` resolves `./enum-generator.ts` relative to CWD (repo root), not the schema file directory.

**Fix:** Created `run-enum-generator.js` wrapper in `packages/prisma/` and registered it as a bin entry (`prisma-enum-generator`) in the package's `package.json`. Changed the schema provider to `provider = "prisma-enum-generator"`, which Prisma finds via PATH (through `node_modules/.bin/`). The wrapper uses `require("./enum-generator.ts")` which Node resolves relative to the wrapper file's own directory — ensuring correct resolution regardless of CWD.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **No automated tests added — these are environment/integration issues requiring manual verification.**

## How should this be tested?

### Testing Admin Wizard Fix:
1. Set up a clean database with no users
2. Navigate to `/auth/setup`
3. Create the first admin user with `hasValidLicense=true` (or after picking AGPLv3 license)
4. Verify the wizard advances correctly without crashing
5. Check that it goes directly to the apps step (step 2) without showing license selection

### Testing Prisma Generator Fix:
1. Run `yarn install` to ensure the `prisma-enum-generator` bin symlink is created
2. From the **repo root**, run: `npx prisma generate`
3. Verify no "Cannot find module './enum-generator.ts'" error
4. From `packages/prisma/`, run: `npx prisma generate`
5. Verify both locations work and generate the enum files correctly

### Reviewer Checklist
- [x] Verify `defaultStep` arithmetic is correct for all `hasValidLicense` × `hasPickedAGPLv3` combinations (especially: `hasValidLicense=true` → steps=[ADMIN, APPS], defaultStep should be 2)
- [x] Confirm `require("./enum-generator.ts")` in the wrapper resolves relative to the file's directory, not CWD (this is standard Node.js `require` behavior)
- [x] Verify `yarn install` creates the `node_modules/.bin/prisma-enum-generator` symlink correctly

### Known Risks:
- **Risk: `SETUP_VIEW_SETPS.APPS - 1` arithmetic** — if someone adds more conditional steps in the future, this hardcoded math could break. Consider refactoring to dynamically compute step indices based on the actual steps array length.
- **Risk: No integration tests** — both fixes address runtime/environment issues that are hard to catch with unit tests alone.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is not too large (<500 lines and <10 files)

---

**Link to Devin Session:** https://app.devin.ai/sessions/7d59bb7c2b5e41d3a9fb8a095132fa31  
**Requested by:** @emrysal