### PR TITLE
Chore/linux machine

### DIFF
--- a/.github/workflows/porter-app-5348-caldotcom.yml
+++ b/.github/workflows/porter-app-5348-caldotcom.yml
@@ -1,0 +1,32 @@
+"on":
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+
+name: Deploy to caldotcom
+jobs:
+    porter-deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: Set Github tag
+              id: vars
+              run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+            - name: Setup porter
+              uses: porter-dev/setup-porter@v0.1.0
+            - name: Deploy stack
+              timeout-minutes: 30
+              run: porter apply
+              env:
+                PORTER_APP_NAME: caldotcom
+                PORTER_CLUSTER: "5348"
+                PORTER_DEPLOYMENT_TARGET_ID: fbd28a2c-3213-43b3-903b-b11ed9094385
+                PORTER_HOST: https://dashboard.porter.run
+                PORTER_PROJECT: "12178"
+                PORTER_TAG: ${{ steps.vars.outputs.sha_short }}
+                PORTER_TOKEN: ${{ secrets.PORTER_APP_12178_1170730211 }}
+                DOCKER_BUILDKIT: '1'
+                PORTER_BUILDKIT_ARGS: --platform linux/arm64
+                PORTER_BUILDKIT_PUSH_ARGS: --platform linux/arm64

--- a/.github/workflows/porter-app-5348-caldotcom.yml
+++ b/.github/workflows/porter-app-5348-caldotcom.yml
@@ -7,7 +7,7 @@
 name: Deploy to caldotcom
 jobs:
     porter-deploy:
-        runs-on: ubuntu-latest
+        runs-on: linux-arm64
         steps:
             - name: Checkout code
               uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a GitHub Actions workflow to deploy the caldotcom app with Porter using a linux-arm64 runner. It builds and pushes arm64 images, tags deploys with the short commit SHA, and runs on push to main or via manual dispatch.

<sup>Written for commit 9f6016e6cf77b0fcfb1e115039d4010ac060b4f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

