### PR TITLE
fix: warn for unsaved changes on event type setup page

### DIFF
--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -326,6 +326,8 @@ const EventTypeWeb = ({
   // Intercept in-app navigation when form has unsaved changes
   useEffect(() => {
     const originalPushState = window.history.pushState.bind(window.history);
+    const originalReplaceState = window.history.replaceState.bind(window.history);
+    const currentPageUrl = window.location.href;
 
     window.history.pushState = function (state: unknown, title: string, url?: string | URL | null) {
       if (formIsDirtyRef.current && url) {
@@ -336,8 +338,32 @@ const EventTypeWeb = ({
       originalPushState(state, title, url);
     };
 
+    window.history.replaceState = function (state: unknown, title: string, url?: string | URL | null) {
+      if (formIsDirtyRef.current && url) {
+        const newUrl = new URL(url.toString(), window.location.origin);
+        if (newUrl.pathname !== window.location.pathname) {
+          unsavedChangesPendingUrl.current = url.toString();
+          setIsOpenUnsavedChangesDialog(true);
+          return;
+        }
+      }
+      originalReplaceState(state, title, url);
+    };
+
+    const handlePopState = () => {
+      if (formIsDirtyRef.current) {
+        unsavedChangesPendingUrl.current = window.location.href;
+        originalPushState(null, "", currentPageUrl);
+        setIsOpenUnsavedChangesDialog(true);
+      }
+    };
+
+    window.addEventListener("popstate", handlePopState);
+
     return () => {
       window.history.pushState = originalPushState;
+      window.history.replaceState = originalReplaceState;
+      window.removeEventListener("popstate", handlePopState);
     };
   }, []);
 

--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -519,14 +519,18 @@ const EventTypeWeb = ({
           isOpen={isOpenUnsavedChangesDialog}
           setIsOpen={setIsOpenUnsavedChangesDialog}
           onDiscard={() => {
-            formIsDirtyRef.current = false;
-            if (unsavedChangesPendingUrl.current) {
-              appRouter.push(unsavedChangesPendingUrl.current);
+            const pendingUrl = unsavedChangesPendingUrl.current;
+            unsavedChangesPendingUrl.current = null;
+            if (pendingUrl) {
+              formIsDirtyRef.current = false;
+              appRouter.push(pendingUrl);
             } else if (hadPriorHistoryRef.current) {
               // Back button: go back past the extra history entry and the current page
+              formIsDirtyRef.current = false;
               window.history.go(-2);
             } else {
               // Direct entry (no prior history): navigate to parent page
+              formIsDirtyRef.current = false;
               appRouter.push("/event-types");
             }
           }}

--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -301,6 +301,19 @@ const EventTypeWeb = ({
     },
   });
 
+  // Warn before closing/refreshing the page with unsaved changes
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (form.formState.isDirty) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [form.formState.isDirty]);
+
   useEffect(() => {
     const timeout = setTimeout(() => {
       const Components = [

--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -324,51 +324,42 @@ const EventTypeWeb = ({
   }, [form.formState.isDirty]);
 
   // Intercept in-app navigation when form has unsaved changes
-  const currentPageUrlRef = useRef(typeof window !== "undefined" ? window.location.href : "");
-
   useEffect(() => {
-    const originalPushState = window.history.pushState.bind(window.history);
-    const originalReplaceState = window.history.replaceState.bind(window.history);
-    currentPageUrlRef.current = window.location.href;
+    const handleClick = (e: MouseEvent) => {
+      if (!formIsDirtyRef.current) return;
 
-    window.history.pushState = function (state: unknown, title: string, url?: string | URL | null) {
-      if (formIsDirtyRef.current && url) {
-        unsavedChangesPendingUrl.current = url.toString();
-        setIsOpenUnsavedChangesDialog(true);
-        return;
-      }
-      originalPushState(state, title, url);
-      currentPageUrlRef.current = window.location.href;
-    };
+      const target = (e.target as HTMLElement).closest("a");
+      if (!target) return;
 
-    window.history.replaceState = function (state: unknown, title: string, url?: string | URL | null) {
-      if (formIsDirtyRef.current && url) {
-        const newUrl = new URL(url.toString(), window.location.origin);
-        if (newUrl.pathname !== window.location.pathname) {
-          unsavedChangesPendingUrl.current = url.toString();
-          setIsOpenUnsavedChangesDialog(true);
-          return;
-        }
-      }
-      originalReplaceState(state, title, url);
-      currentPageUrlRef.current = window.location.href;
+      const href = target.getAttribute("href");
+      if (!href || href.startsWith("#") || href.startsWith("http") || href.startsWith("mailto:")) return;
+
+      // Only intercept internal navigation to different pages
+      if (href === window.location.pathname) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      unsavedChangesPendingUrl.current = href;
+      setIsOpenUnsavedChangesDialog(true);
     };
 
     const handlePopState = () => {
       if (formIsDirtyRef.current) {
-        unsavedChangesPendingUrl.current = window.location.href;
-        originalPushState(null, "", currentPageUrlRef.current);
+        // Push current URL back to prevent leaving the page
+        window.history.pushState(null, "", window.location.href);
+        unsavedChangesPendingUrl.current = "/event-types";
         setIsOpenUnsavedChangesDialog(true);
-      } else {
-        currentPageUrlRef.current = window.location.href;
       }
     };
 
+    // Add extra history entry so back button triggers popstate instead of leaving
+    window.history.pushState(null, "", window.location.href);
+
+    document.addEventListener("click", handleClick, true);
     window.addEventListener("popstate", handlePopState);
 
     return () => {
-      window.history.pushState = originalPushState;
-      window.history.replaceState = originalReplaceState;
+      document.removeEventListener("click", handleClick, true);
       window.removeEventListener("popstate", handlePopState);
     };
   }, []);

--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -150,6 +150,7 @@ const EventTypeWeb = ({
   const [isOpenUnsavedChangesDialog, setIsOpenUnsavedChangesDialog] = useState(false);
   const unsavedChangesPendingUrl = useRef<string | null>(null);
   const formIsDirtyRef = useRef(false);
+  const skipPopStateRef = useRef(false);
   const { eventType, locationOptions, team, teamMembers, destinationCalendar } = rest;
   const [slugExistsChildrenDialogOpen, setSlugExistsChildrenDialogOpen] = useState<ChildrenEventType[]>([]);
   const { data: eventTypeApps, isPending: isPendingApps } = trpc.viewer.apps.integrations.useQuery({
@@ -328,8 +329,14 @@ const EventTypeWeb = ({
     const handleClick = (e: MouseEvent) => {
       if (!formIsDirtyRef.current) return;
 
+      // Don't intercept modifier clicks (new tab/window)
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+
       const target = (e.target as HTMLElement).closest("a");
       if (!target) return;
+
+      // Don't intercept links with target attribute (e.g. target="_blank")
+      if (target.getAttribute("target")) return;
 
       const href = target.getAttribute("href");
       if (!href || href.startsWith("#") || href.startsWith("http") || href.startsWith("mailto:")) return;
@@ -344,11 +351,19 @@ const EventTypeWeb = ({
     };
 
     const handlePopState = () => {
+      if (skipPopStateRef.current) {
+        skipPopStateRef.current = false;
+        return;
+      }
       if (formIsDirtyRef.current) {
         // Push current URL back to prevent leaving the page
         window.history.pushState(null, "", window.location.href);
-        unsavedChangesPendingUrl.current = "/event-types";
+        unsavedChangesPendingUrl.current = null;
         setIsOpenUnsavedChangesDialog(true);
+      } else {
+        // Form is clean — continue back navigation past the extra history entry
+        skipPopStateRef.current = true;
+        window.history.back();
       }
     };
 
@@ -504,6 +519,9 @@ const EventTypeWeb = ({
             formIsDirtyRef.current = false;
             if (unsavedChangesPendingUrl.current) {
               appRouter.push(unsavedChangesPendingUrl.current);
+            } else {
+              // Back button: go back past the extra history entry and the current page
+              window.history.go(-2);
             }
           }}
         />

--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -151,6 +151,7 @@ const EventTypeWeb = ({
   const unsavedChangesPendingUrl = useRef<string | null>(null);
   const formIsDirtyRef = useRef(false);
   const skipPopStateRef = useRef(false);
+  const hadPriorHistoryRef = useRef(window.history.length > 1);
   const { eventType, locationOptions, team, teamMembers, destinationCalendar } = rest;
   const [slugExistsChildrenDialogOpen, setSlugExistsChildrenDialogOpen] = useState<ChildrenEventType[]>([]);
   const { data: eventTypeApps, isPending: isPendingApps } = trpc.viewer.apps.integrations.useQuery({
@@ -519,9 +520,12 @@ const EventTypeWeb = ({
             formIsDirtyRef.current = false;
             if (unsavedChangesPendingUrl.current) {
               appRouter.push(unsavedChangesPendingUrl.current);
-            } else {
+            } else if (hadPriorHistoryRef.current) {
               // Back button: go back past the extra history entry and the current page
               window.history.go(-2);
+            } else {
+              // Direct entry (no prior history): navigate to parent page
+              appRouter.push("/event-types");
             }
           }}
         />

--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { usePathname, useRouter as useAppRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { z } from "zod";
 
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
@@ -26,6 +26,7 @@ import { revalidateEventTypeEditPage } from "@calcom/web/app/(use-page-wrapper)/
 
 import type { ChildrenEventType } from "@calcom/features/eventtypes/components/ChildrenEventTypeSelect";
 import { EventType as EventTypeComponent } from "./EventType";
+import UnsavedChangesDialog from "./dialogs/UnsavedChangesDialog";
 import { useEventTypeForm } from "@calcom/atoms/event-types/hooks/useEventTypeForm";
 import { useHandleRouteChange } from "@calcom/atoms/event-types/hooks/useHandleRouteChange";
 import { useTabsNavigations } from "@calcom/atoms/event-types/hooks/useTabsNavigations";
@@ -146,6 +147,9 @@ const EventTypeWeb = ({
   const leaveWithoutAssigningHosts = useRef(false);
   const [isOpenAssignmentWarnDialog, setIsOpenAssignmentWarnDialog] = useState<boolean>(false);
   const [pendingRoute, setPendingRoute] = useState("");
+  const [isOpenUnsavedChangesDialog, setIsOpenUnsavedChangesDialog] = useState(false);
+  const unsavedChangesPendingUrl = useRef<string | null>(null);
+  const formIsDirtyRef = useRef(false);
   const { eventType, locationOptions, team, teamMembers, destinationCalendar } = rest;
   const [slugExistsChildrenDialogOpen, setSlugExistsChildrenDialogOpen] = useState<ChildrenEventType[]>([]);
   const { data: eventTypeApps, isPending: isPendingApps } = trpc.viewer.apps.integrations.useQuery({
@@ -301,6 +305,11 @@ const EventTypeWeb = ({
     },
   });
 
+  // Keep ref in sync with form dirty state
+  useEffect(() => {
+    formIsDirtyRef.current = form.formState.isDirty;
+  }, [form.formState.isDirty]);
+
   // Warn before closing/refreshing the page with unsaved changes
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
@@ -313,6 +322,24 @@ const EventTypeWeb = ({
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
   }, [form.formState.isDirty]);
+
+  // Intercept in-app navigation when form has unsaved changes
+  useEffect(() => {
+    const originalPushState = window.history.pushState.bind(window.history);
+
+    window.history.pushState = function (state: unknown, title: string, url?: string | URL | null) {
+      if (formIsDirtyRef.current && url) {
+        unsavedChangesPendingUrl.current = url.toString();
+        setIsOpenUnsavedChangesDialog(true);
+        return;
+      }
+      originalPushState(state, title, url);
+    };
+
+    return () => {
+      window.history.pushState = originalPushState;
+    };
+  }, []);
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -446,6 +473,16 @@ const EventTypeWeb = ({
           pendingRoute={pendingRoute}
           leaveWithoutAssigningHosts={leaveWithoutAssigningHosts}
           id={eventType.id}
+        />
+        <UnsavedChangesDialog
+          isOpen={isOpenUnsavedChangesDialog}
+          setIsOpen={setIsOpenUnsavedChangesDialog}
+          onDiscard={() => {
+            formIsDirtyRef.current = false;
+            if (unsavedChangesPendingUrl.current) {
+              appRouter.push(unsavedChangesPendingUrl.current);
+            }
+          }}
         />
       </>
     </EventTypeComponent>

--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -151,7 +151,7 @@ const EventTypeWeb = ({
   const unsavedChangesPendingUrl = useRef<string | null>(null);
   const formIsDirtyRef = useRef(false);
   const skipPopStateRef = useRef(false);
-  const hadPriorHistoryRef = useRef(window.history.length > 1);
+  const hadPriorHistoryRef = useRef(false);
   const { eventType, locationOptions, team, teamMembers, destinationCalendar } = rest;
   const [slugExistsChildrenDialogOpen, setSlugExistsChildrenDialogOpen] = useState<ChildrenEventType[]>([]);
   const { data: eventTypeApps, isPending: isPendingApps } = trpc.viewer.apps.integrations.useQuery({
@@ -327,6 +327,8 @@ const EventTypeWeb = ({
 
   // Intercept in-app navigation when form has unsaved changes
   useEffect(() => {
+    hadPriorHistoryRef.current = window.history.length > 1;
+
     const handleClick = (e: MouseEvent) => {
       if (!formIsDirtyRef.current) return;
 

--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -324,10 +324,12 @@ const EventTypeWeb = ({
   }, [form.formState.isDirty]);
 
   // Intercept in-app navigation when form has unsaved changes
+  const currentPageUrlRef = useRef(typeof window !== "undefined" ? window.location.href : "");
+
   useEffect(() => {
     const originalPushState = window.history.pushState.bind(window.history);
     const originalReplaceState = window.history.replaceState.bind(window.history);
-    const currentPageUrl = window.location.href;
+    currentPageUrlRef.current = window.location.href;
 
     window.history.pushState = function (state: unknown, title: string, url?: string | URL | null) {
       if (formIsDirtyRef.current && url) {
@@ -336,6 +338,7 @@ const EventTypeWeb = ({
         return;
       }
       originalPushState(state, title, url);
+      currentPageUrlRef.current = window.location.href;
     };
 
     window.history.replaceState = function (state: unknown, title: string, url?: string | URL | null) {
@@ -348,13 +351,16 @@ const EventTypeWeb = ({
         }
       }
       originalReplaceState(state, title, url);
+      currentPageUrlRef.current = window.location.href;
     };
 
     const handlePopState = () => {
       if (formIsDirtyRef.current) {
         unsavedChangesPendingUrl.current = window.location.href;
-        originalPushState(null, "", currentPageUrl);
+        originalPushState(null, "", currentPageUrlRef.current);
         setIsOpenUnsavedChangesDialog(true);
+      } else {
+        currentPageUrlRef.current = window.location.href;
       }
     };
 

--- a/apps/web/modules/event-types/components/dialogs/UnsavedChangesDialog.tsx
+++ b/apps/web/modules/event-types/components/dialogs/UnsavedChangesDialog.tsx
@@ -1,0 +1,42 @@
+import type { Dispatch, SetStateAction } from "react";
+
+import { Dialog } from "@calcom/features/components/controlled-dialog";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button } from "@calcom/ui/components/button";
+import { DialogContent, DialogFooter } from "@calcom/ui/components/dialog";
+
+interface UnsavedChangesDialogProps {
+    isOpen: boolean;
+    setIsOpen: Dispatch<SetStateAction<boolean>>;
+    onDiscard: () => void;
+}
+
+const UnsavedChangesDialog = ({ isOpen, setIsOpen, onDiscard }: UnsavedChangesDialogProps) => {
+    const { t } = useLocale();
+
+    return (
+        <Dialog open={isOpen} onOpenChange={setIsOpen}>
+            <DialogContent
+                title={t("leave_without_saving")}
+                description={t("leave_without_saving_event_description")}
+                Icon="circle-alert"
+                type="confirmation">
+                <DialogFooter className="mt-6">
+                    <Button onClick={() => setIsOpen(false)} color="minimal">
+                        {t("go_back")}
+                    </Button>
+                    <Button
+                        onClick={() => {
+                            setIsOpen(false);
+                            onDiscard();
+                        }}
+                        color="destructive">
+                        {t("discard")}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default UnsavedChangesDialog;

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -28,7 +28,6 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
-  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -28,6 +28,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -3652,6 +3652,7 @@
   "save_changes": "Save changes",
   "leave_without_saving": "Leave without saving",
   "leave_without_saving_description": "Are you sure you want to leave without saving changes to your routing form?",
+  "leave_without_saving_event_description": "You have unsaved changes. Are you sure you want to leave?",
   "something_unexpected_occurred": "Something unexpected occurred",
   "500_error_message": "It's not you, it's us.",
   "dry_run_mode_active": "You are doing a test booking.",


### PR DESCRIPTION
Summary
Added a "beforeunload" event handler to the event type setup page that warns users when they attempt to close or refresh the browser tab with unsaved form changes.

Fixes #10180

Changes Made
  - Added "useEffect" with "beforeunload" listener in "EventTypeWebWrapper.tsx"
  - Uses existing "form.formState.isDirty" from React Hook Form to detect unsaved changes
  - Warning only appears when the form has been modified
  
How it was tested

- Edited event type fields (title, duration, etc.) without saving
- Attempted to close/refresh the tab → browser warning appeared
- Saved the form → warning no longer appears
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
