### PR TITLE
fix: prevent attendee email leak in ICS attachment for seated event workflow reminders

### DIFF
--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -8,9 +8,9 @@ import generateIcsString from "@calcom/emails/lib/generateIcsString";
 import { getCalEventResponses } from "@calcom/features/bookings/lib/getCalEventResponses";
 import { BookingSeatRepository } from "@calcom/features/bookings/repositories/BookingSeatRepository";
 import { getBookerBaseUrl } from "@calcom/features/ee/organizations/lib/getBookerUrlServer";
+import { getTranslation } from "@calcom/i18n/server";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
-import { getTranslation } from "@calcom/i18n/server";
 import { getTimeFormatStringFromUserTimeFormat } from "@calcom/lib/timeFormat";
 import prisma from "@calcom/prisma";
 import { SchedulingType, WorkflowActions, WorkflowTemplates } from "@calcom/prisma/enums";
@@ -336,6 +336,14 @@ async function handler(req: NextRequest) {
 
           const attendees = await Promise.all(attendeePromises);
 
+          // For seated events with EMAIL_ATTENDEE, only include the target attendee in the ICS
+          // to prevent leaking other attendees' emails via the calendar attachment.
+          const isSeatedAttendeeEmail =
+            reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE && reminder.seatReferenceId;
+          const icsAttendees = isSeatedAttendeeEmail
+            ? attendees.filter((a) => a.email === targetAttendee?.email)
+            : attendees;
+
           const event = {
             ...booking,
             startTime: dayjs(booking.startTime).utc().format(),
@@ -347,17 +355,16 @@ async function handler(req: NextRequest) {
               timeZone: booking.user?.timeZone ?? "",
               language: { translate: t, locale: booking.user?.locale ?? "en" },
             },
-            attendees,
+            attendees: icsAttendees,
             location: bookingMetadataSchema.parse(booking.metadata || {})?.videoCallUrl || booking.location,
             title: booking.title || booking.eventType?.title || "",
           };
 
           const customReplyTo = reminder.booking?.eventType?.customReplyToEmail;
-              const fallbackReplyTo =
-                reminder.booking?.userPrimaryEmail ?? reminder.booking?.user?.email;
-              const replyTo = reminder.booking?.eventType?.hideOrganizerEmail
-                ? customReplyTo
-                : customReplyTo ?? fallbackReplyTo;
+          const fallbackReplyTo = reminder.booking?.userPrimaryEmail ?? reminder.booking?.user?.email;
+          const replyTo = reminder.booking?.eventType?.hideOrganizerEmail
+            ? customReplyTo
+            : (customReplyTo ?? fallbackReplyTo);
 
           const mailData = {
             subject: emailContent.emailSubject,
@@ -374,8 +381,8 @@ async function handler(req: NextRequest) {
                 ]
               : undefined,
             sender: reminder.workflowStep.sender,
-          ...(replyTo ? { replyTo } : {}),
-        };
+            ...(replyTo ? { replyTo } : {}),
+          };
 
           if (isSendgridEnabled) {
             sendEmailPromises.push(
@@ -451,8 +458,7 @@ async function handler(req: NextRequest) {
         if (emailContent.emailSubject.length > 0 && !emailBodyEmpty && sendTo) {
           const batchId = isSendgridEnabled ? await getBatchId() : undefined;
           const customReplyTo = reminder.booking?.eventType?.customReplyToEmail;
-          const fallbackReplyTo =
-            reminder.booking?.userPrimaryEmail || reminder.booking?.user?.email;
+          const fallbackReplyTo = reminder.booking?.userPrimaryEmail || reminder.booking?.user?.email;
           const replyTo = reminder.booking?.eventType?.hideOrganizerEmail
             ? customReplyTo
             : customReplyTo || fallbackReplyTo;

--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -336,8 +336,8 @@ async function handler(req: NextRequest) {
 
           const attendees = await Promise.all(attendeePromises);
 
-          // For seated events with EMAIL_ATTENDEE, only include the target attendee in the ICS
-          // to prevent leaking other attendees' emails via the calendar attachment.
+          // Email clients display ICS ATTENDEE fields in the "To:" header, so for seated events
+          // we must filter to only the target attendee to avoid leaking other attendees' emails.
           const isSeatedAttendeeEmail =
             reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE && reminder.seatReferenceId;
           const icsAttendees = isSeatedAttendeeEmail

--- a/packages/features/ee/workflows/lib/service/EmailWorkflowService.test.ts
+++ b/packages/features/ee/workflows/lib/service/EmailWorkflowService.test.ts
@@ -59,8 +59,12 @@ const mockWorkflowReminderRepository: Pick<WorkflowReminderRepository, "findById
   findByIdIncludeStepAndWorkflow: vi.fn(),
 };
 
-const mockBookingSeatRepository: Pick<BookingSeatRepository, "getByUidIncludeAttendee"> = {
+const mockBookingSeatRepository: Pick<
+  BookingSeatRepository,
+  "getByUidIncludeAttendee" | "getByReferenceUidWithAttendeeDetails"
+> = {
   getByUidIncludeAttendee: vi.fn(),
+  getByReferenceUidWithAttendeeDetails: vi.fn(),
 };
 
 describe("EmailWorkflowService", () => {
@@ -602,6 +606,128 @@ describe("EmailWorkflowService", () => {
       });
 
       expect(result.attachments).toBeUndefined();
+    });
+  });
+
+  describe("generateEmailPayloadForEvtWorkflow - Seated event ICS attendee filtering", () => {
+    const mockSeatedBookingInfo = {
+      uid: "booking-seated-123",
+      bookerUrl: "https://cal.com",
+      title: "Seated Event Meeting",
+      startTime: "2024-12-01T10:00:00Z",
+      endTime: "2024-12-01T11:00:00Z",
+      organizer: {
+        name: "Organizer Name",
+        email: "organizer@example.com",
+        timeZone: "UTC",
+        language: { locale: "en" },
+        timeFormat: "h:mma",
+      },
+      attendees: [
+        {
+          name: "Attendee One",
+          email: "attendee1@example.com",
+          timeZone: "UTC",
+          language: { locale: "en" },
+        },
+        {
+          name: "Attendee Two",
+          email: "attendee2@example.com",
+          timeZone: "America/New_York",
+          language: { locale: "en" },
+        },
+        {
+          name: "Attendee Three",
+          email: "attendee3@example.com",
+          timeZone: "Europe/London",
+          language: { locale: "en" },
+        },
+      ],
+    };
+
+    test("should only include target attendee in ICS for seated event with EMAIL_ATTENDEE", async () => {
+      const generateIcsString = (await import("@calcom/emails/lib/generateIcsString")).default;
+
+      vi.mocked(mockBookingSeatRepository.getByReferenceUidWithAttendeeDetails).mockResolvedValue({
+        attendee: {
+          name: "Attendee Two",
+          email: "attendee2@example.com",
+          phoneNumber: null,
+          timeZone: "America/New_York",
+          locale: "en",
+        },
+      });
+
+      await emailWorkflowService.generateEmailPayloadForEvtWorkflow({
+        evt: mockSeatedBookingInfo,
+        sendTo: ["attendee2@example.com"],
+        seatReferenceUid: "seat-ref-123",
+        hideBranding: false,
+        emailSubject: "Test Subject",
+        emailBody: "Test Body",
+        sender: "Cal.com",
+        action: WorkflowActions.EMAIL_ATTENDEE,
+        template: WorkflowTemplates.CUSTOM,
+        includeCalendarEvent: true,
+        triggerEvent: WorkflowTriggerEvents.BEFORE_EVENT,
+      });
+
+      // Verify generateIcsString was called with only the target attendee
+      expect(generateIcsString).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({
+            attendees: expect.arrayContaining([expect.objectContaining({ email: "attendee2@example.com" })]),
+          }),
+        })
+      );
+
+      // Verify other attendees are NOT in the ICS
+      const icsCall = vi.mocked(generateIcsString).mock.calls[0][0];
+      expect(icsCall.event.attendees).toHaveLength(1);
+      expect(icsCall.event.attendees[0].email).toBe("attendee2@example.com");
+    });
+
+    test("should include all attendees in ICS for non-seated event with EMAIL_ATTENDEE", async () => {
+      const generateIcsString = (await import("@calcom/emails/lib/generateIcsString")).default;
+
+      await emailWorkflowService.generateEmailPayloadForEvtWorkflow({
+        evt: mockSeatedBookingInfo,
+        sendTo: ["attendee1@example.com"],
+        hideBranding: false,
+        emailSubject: "Test Subject",
+        emailBody: "Test Body",
+        sender: "Cal.com",
+        action: WorkflowActions.EMAIL_ATTENDEE,
+        template: WorkflowTemplates.CUSTOM,
+        includeCalendarEvent: true,
+        triggerEvent: WorkflowTriggerEvents.BEFORE_EVENT,
+        // No seatReferenceUid = non-seated event
+      });
+
+      const icsCall = vi.mocked(generateIcsString).mock.calls[0][0];
+      expect(icsCall.event.attendees).toHaveLength(3);
+    });
+
+    test("should include all attendees in ICS for seated event with EMAIL_HOST", async () => {
+      const generateIcsString = (await import("@calcom/emails/lib/generateIcsString")).default;
+
+      await emailWorkflowService.generateEmailPayloadForEvtWorkflow({
+        evt: mockSeatedBookingInfo,
+        sendTo: ["organizer@example.com"],
+        seatReferenceUid: "seat-ref-123",
+        hideBranding: false,
+        emailSubject: "Test Subject",
+        emailBody: "Test Body",
+        sender: "Cal.com",
+        action: WorkflowActions.EMAIL_HOST,
+        template: WorkflowTemplates.CUSTOM,
+        includeCalendarEvent: true,
+        triggerEvent: WorkflowTriggerEvents.BEFORE_EVENT,
+      });
+
+      // EMAIL_HOST should still include all attendees even for seated events
+      const icsCall = vi.mocked(generateIcsString).mock.calls[0][0];
+      expect(icsCall.event.attendees).toHaveLength(3);
     });
   });
 

--- a/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
+++ b/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
@@ -576,10 +576,8 @@ export class EmailWorkflowService {
       })
     );
 
-    // For EMAIL_ATTENDEE with seated events, only include the target attendee in the ICS
-    // to prevent leaking other attendees' emails via the calendar attachment.
-    // Email clients (Outlook, Apple Mail) display ICS ATTENDEE fields in the "To:" header,
-    // so including all attendees would expose everyone's email to each recipient.
+    // Email clients display ICS ATTENDEE fields in the "To:" header, so for seated events
+    // we must filter to only the target attendee to avoid leaking other attendees' emails.
     const isEmailAttendeeSeatedEvent = action === WorkflowActions.EMAIL_ATTENDEE && seatReferenceUid;
     const icsAttendees = isEmailAttendeeSeatedEvent
       ? processedAttendees.filter((a) => a.email === attendeeToBeUsedInMail.email)

--- a/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
+++ b/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
@@ -8,10 +8,10 @@ import { preprocessNameFieldDataWithVariant } from "@calcom/features/form-builde
 import { getHideBranding } from "@calcom/features/profile/lib/hideBranding";
 import { getSubmitterEmail } from "@calcom/features/tasker/tasks/triggerFormSubmittedNoEvent/formSubmissionValidation";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+import { getTranslation } from "@calcom/i18n/server";
 import { getVideoCallUrlFromCalEvent } from "@calcom/lib/CalEventParser";
 import { SENDER_NAME, WEBSITE_URL } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
-import { getTranslation } from "@calcom/i18n/server";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import { prisma } from "@calcom/prisma";
 import {
@@ -576,6 +576,15 @@ export class EmailWorkflowService {
       })
     );
 
+    // For EMAIL_ATTENDEE with seated events, only include the target attendee in the ICS
+    // to prevent leaking other attendees' emails via the calendar attachment.
+    // Email clients (Outlook, Apple Mail) display ICS ATTENDEE fields in the "To:" header,
+    // so including all attendees would expose everyone's email to each recipient.
+    const isEmailAttendeeSeatedEvent = action === WorkflowActions.EMAIL_ATTENDEE && seatReferenceUid;
+    const icsAttendees = isEmailAttendeeSeatedEvent
+      ? processedAttendees.filter((a) => a.email === attendeeToBeUsedInMail.email)
+      : processedAttendees;
+
     const emailEvent = {
       ...evt,
       type: evt.eventType?.slug || "",
@@ -583,7 +592,7 @@ export class EmailWorkflowService {
         ...evt.organizer,
         language: { ...evt.organizer.language, translate: organizerT },
       },
-      attendees: processedAttendees,
+      attendees: icsAttendees,
       location: bookingMetadataSchema.safeParse(evt.metadata || {}).data?.videoCallUrl || evt.location,
     };
 
@@ -608,9 +617,7 @@ export class EmailWorkflowService {
     const customReplyToEmail =
       evt?.eventType?.customReplyToEmail || (evt as CalendarEvent).customReplyToEmail;
 
-    const replyTo = evt.hideOrganizerEmail
-      ? customReplyToEmail
-      : customReplyToEmail || evt.organizer.email;
+    const replyTo = evt.hideOrganizerEmail ? customReplyToEmail : customReplyToEmail || evt.organizer.email;
 
     return {
       subject: emailContent.emailSubject,


### PR DESCRIPTION
## What does this PR do?

Fixes a privacy bug where workflow email reminders for **seated events** leaked all attendees' email addresses to each individual recipient.

**Root cause:** When generating the ICS calendar attachment for `EMAIL_ATTENDEE` workflow reminders, the code passed *all* event attendees to `generateIcsString`. Email clients (Outlook, Apple Mail, Gmail) parse ICS `ATTENDEE` fields and display them in the "To:" header — so every recipient could see every other attendee's email address.

**Fix:** For `EMAIL_ATTENDEE` actions on seated events (identified by `seatReferenceUid`/`seatReferenceId`), filter the ICS attendees to only include the specific attendee being emailed. Non-seated events and other actions (`EMAIL_HOST`, `EMAIL_ADDRESS`) are unchanged.

Applied in both:
- `EmailWorkflowService.generateEmailPayloadForEvtWorkflow` (tasker-based path)
- `scheduleEmailReminders` handler (deprecated SendGrid path)

#### Image Demo:

**Before** — all attendee emails visible in the "To:" field:
![before](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2N2VmNjZhZGZhYmEzZTllNTIxNGQ2ZmEiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi8zMjcwMTNlMC01NmEzLTQ3YWMtYjY1Ny0wMTA1OWRhNzEzYWUiLCJpYXQiOjE3NzI1NDU5MjgsImV4cCI6MTc3MzE1MDcyOH0.eJMUk7cjiQv8qn_NWHqEdtFa7eLNdR6u_LCMHByDjaY)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a seated event type with a workflow that sends an email reminder to attendees (e.g. `BEFORE_EVENT` trigger, 3 hours before) with "Include calendar event" enabled.
2. Have multiple different attendees book seats in the same time slot.
3. When the reminder fires, verify that each attendee's email only shows **their own email** in the "To:" field — not the other attendees' emails.
4. Verify non-seated events still show all attendees in the ICS as before.
5. Verify `EMAIL_HOST` reminders still include all attendees regardless.

Unit tests cover these scenarios:
```bash
TZ=UTC yarn vitest run packages/features/ee/workflows/lib/service/EmailWorkflowService.test.ts
```

## Human Review Checklist

- [ ] Verify `attendeeToBeUsedInMail` is always correctly populated when `seatReferenceUid` is present (the code fetches seat data via `getByReferenceUidWithAttendeeDetails` upstream)
- [ ] In the deprecated handler, `targetAttendee?.email` uses optional chaining — if `targetAttendee` is somehow null, the filter produces an empty attendees array for the ICS (safe fail, but worth confirming this edge case can't occur)
- [ ] Confirm filtering at the event object level (before passing to `generateIcsString`) is the correct approach

---

**Link to Devin Session:** https://app.devin.ai/sessions/8e08442c7be24c078bbce7d77a569ae6  
**Requested by:** @anikdhabal