### PR TITLE
chore: upgrade PostgreSQL from 13 to 18 in CI and docker-compose

### DIFF
--- a/.github/workflows/api-v1-production-build.yml
+++ b/.github/workflows/api-v1-production-build.yml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 30
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/api-v2-production-build.yml
+++ b/.github/workflows/api-v2-production-build.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/check-prisma-migrations.yml
+++ b/.github/workflows/check-prisma-migrations.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/e2e-app-store.yml
+++ b/.github/workflows/e2e-app-store.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/e2e-embed-react.yml
+++ b/.github/workflows/e2e-embed-react.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/setup-db.yml
+++ b/.github/workflows/setup-db.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/apps/api/v1/test/docker-compose.yml
+++ b/apps/api/v1/test/docker-compose.yml
@@ -1,7 +1,7 @@
 # The containers that compose the project
 services:
   db:
-    image: postgres:13
+    image: postgres:18
     restart: always
     container_name: integration-tests-prisma
     ports:

--- a/apps/web/test/docker-compose.yml
+++ b/apps/web/test/docker-compose.yml
@@ -1,7 +1,7 @@
 # The containers that compose the project
 services:
   db:
-    image: postgres:13
+    image: postgres:18
     restart: always
     container_name: integration-tests-prisma
     ports:

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1514,7 +1514,11 @@ export class BookingRepository implements IBookingRepository {
     `;
     }
 
-    return totalBookingTime.totalMinutes ?? 0;
+    // PostgreSQL 16+ returns `numeric` type from EXTRACT(EPOCH FROM ...) instead of `double precision`.
+    // Prisma maps `numeric` to a JavaScript Decimal object, which causes string concatenation
+    // instead of numeric addition when used with the `+` operator (e.g., Decimal(30) + 30 = "3030").
+    // Explicitly convert to a plain number to ensure correct arithmetic in all callers.
+    return Number(totalBookingTime.totalMinutes ?? 0);
   }
 
   async findOriginalRescheduledBookingUserId({ rescheduleUid }: { rescheduleUid: string }) {

--- a/packages/prisma/docker-compose.yml
+++ b/packages/prisma/docker-compose.yml
@@ -2,7 +2,7 @@
 # starts a postgres instance on port 5450 to use as a local db
 services:
   postgres:
-    image: postgres:13
+    image: postgres:18
     ports:
       - "5450:5432" # expose pg on port 5450 to not collide with pg from elsewhere
     restart: always

--- a/packages/prisma/docker-compose.yml
+++ b/packages/prisma/docker-compose.yml
@@ -1,5 +1,5 @@
 # this file is a helper to run Cal.com locally
-# starts a postgres instance on port 5450 to use as a local db
+# starts a postgres 18 instance on port 5450 to use as a local db
 services:
   postgres:
     image: postgres:18


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded PostgreSQL from 13 to 18 across CI and docker-compose to keep dev and test environments current. Also fixed booking duration math by casting Prisma Decimal to a number for PostgreSQL 16+.

- **Dependencies**
  - Bumped all GitHub Actions services and test/local docker-compose files to use postgres:18.

- **Bug Fixes**
  - In BookingRepository, cast totalMinutes to Number to avoid Decimal string concatenation and ensure correct arithmetic with PG 16+ returning numeric from EXTRACT(EPOCH).

<sup>Written for commit 267210a7afdbcd2a9a65836ef6c945330c1b9e75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

