### PR TITLE
fix: use docker postgres:18 for pg_dump/psql to fix CI version mismatch

### DIFF
--- a/.github/actions/cache-db/action.yml
+++ b/.github/actions/cache-db/action.yml
@@ -32,14 +32,16 @@ runs:
       shell: bash
     - name: Postgres Dump Backup
       if: steps.cache-db.outputs.cache-hit != 'true'
-      uses: tj-actions/pg-dump@v2.3
-      with:
-        database_url: ${{ inputs.DATABASE_URL }}
-        path: ${{ inputs.path }}
-        options: "-O"
+      run: |
+        mkdir -p $(dirname "${{ inputs.path }}")
+        docker run --rm --network host \
+          -v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }} \
+          postgres:18 pg_dump "${{ inputs.DATABASE_URL }}" -O -f ${{ inputs.path }}
+      shell: bash
     - name: Postgres Backup Restore
       if: steps.cache-db.outputs.cache-hit == 'true'
-      uses: tj-actions/pg-restore@v4.5
-      with:
-        database_url: ${{ inputs.DATABASE_URL }}
-        backup_file: ${{ inputs.path }}
+      run: |
+        docker run --rm -i --network host \
+          -v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }} \
+          postgres:18 psql "${{ inputs.DATABASE_URL }}" -f ${{ inputs.path }}
+      shell: bash


### PR DESCRIPTION
## What does this PR do?

Fixes the "Setup Database" CI job failure caused by a `pg_dump` version mismatch after the recent PostgreSQL 13 → 18 upgrade (#28252).

The `tj-actions/pg-dump` and `tj-actions/pg-restore` actions use the host runner's `pg_dump`/`psql` binaries (v16 on Ubuntu 24.04), which refuse to operate against a Postgres 18 server:

```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 18.3; pg_dump version: 16.11
```

This PR replaces those third-party actions with `docker run` commands using the `postgres:18` image directly, ensuring the client tools always match the server version. 

**Changes:**
- Replaced `tj-actions/pg-dump@v2.3` with `docker run postgres:18 pg_dump ...`
- Replaced `tj-actions/pg-restore@v4.5` with `docker run postgres:18 psql ... -f`
- Both commands use `--network host` to reach the Postgres service and volume-mount the workspace for file access

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — CI-only change, no docs needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — this fix is validated by the CI pipeline itself passing.

## How should this be tested?

This is a CI infrastructure fix. Verification:
1. The "Setup Database" job in this PR's CI run should pass (specifically the "Postgres Dump Backup" and "Postgres Backup Restore" steps).
2. Any downstream jobs that depend on the database setup should also pass.

No environment variables or test data changes are needed.

## Human Review Checklist

- [ ] Verify `--network host` allows the Docker container to reach the Postgres service container on `localhost:5432`
- [ ] Confirm `postgres:18` image is available/cached on CI runners (it is — visible in CI runner logs)
- [ ] Verify the volume mount `-v ${{ github.workspace }}:${{ github.workspace }}` correctly persists the backup file

---
Link to Devin Session: https://app.devin.ai/sessions/fa48ae55ffc64935b66d16beb8bda41b
Requested by: Dhairyashil (dhairyashil@cal.com) (@dhairyashiil)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
