### PR TITLE
feat: add setting to change default home view

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,6 +3,8 @@ import { redirect } from "next/navigation";
 
 import { checkOnboardingRedirect } from "@calcom/features/auth/lib/onboardingUtils";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import prisma from "@calcom/prisma";
+import { userMetadata } from "@calcom/prisma/zod-utils";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
@@ -23,7 +25,13 @@ const RedirectPage = async () => {
     redirect(onboardingPath);
   }
 
-  redirect("/event-types");
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { metadata: true },
+  });
+  const metadata = userMetadata.parse(user?.metadata);
+  const defaultView = metadata?.defaultHomeView || "event-types";
+  redirect(`/${defaultView}`);
 };
 
 export default RedirectPage;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -29,8 +29,8 @@ const RedirectPage = async () => {
     where: { id: session.user.id },
     select: { metadata: true },
   });
-  const metadata = userMetadata.parse(user?.metadata);
-  const defaultView = metadata?.defaultHomeView || "event-types";
+  const parsed = userMetadata.safeParse(user?.metadata);
+  const defaultView = parsed.success ? (parsed.data?.defaultHomeView || "event-types") : "event-types";
   redirect(`/${defaultView}`);
 };
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,8 +3,6 @@ import { redirect } from "next/navigation";
 
 import { checkOnboardingRedirect } from "@calcom/features/auth/lib/onboardingUtils";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import prisma from "@calcom/prisma";
-import { userMetadata } from "@calcom/prisma/zod-utils";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
@@ -25,13 +23,7 @@ const RedirectPage = async () => {
     redirect(onboardingPath);
   }
 
-  const user = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { metadata: true },
-  });
-  const parsed = userMetadata.safeParse(user?.metadata);
-  const defaultView = parsed.success ? (parsed.data?.defaultHomeView || "event-types") : "event-types";
-  redirect(`/${defaultView}`);
+  redirect(`/${session.user.defaultHomeView || "event-types"}`);
 };
 
 export default RedirectPage;

--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -6,6 +6,7 @@ import { formatLocalizedDateTime } from "@calcom/lib/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { localeOptions } from "@calcom/lib/i18n";
 import { nameOfDay } from "@calcom/lib/weekday";
+import { userMetadata as userMetadataSchema } from "@calcom/prisma/zod-utils";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
 import classNames from "@calcom/ui/classNames";
@@ -32,6 +33,10 @@ export type FormValues = {
     label: string | number;
   };
   weekStart: {
+    value: string;
+    label: string;
+  };
+  defaultHomeView: {
     value: string;
     label: string;
   };
@@ -99,6 +104,13 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
     { value: "Saturday", label: nameOfDay(localeProp, 6) },
   ];
 
+  const defaultHomeViewOptions = [
+    { value: "event-types", label: t("event_types") },
+    { value: "bookings", label: t("bookings") },
+  ];
+
+  const parsedMetadata = userMetadataSchema.parse(user.metadata);
+
   const formMethods = useForm<FormValues>({
     defaultValues: {
       locale: {
@@ -113,6 +125,13 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
       weekStart: {
         value: user.weekStart,
         label: weekStartOptions.find((option) => option.value === user.weekStart)?.label || "",
+      },
+      defaultHomeView: {
+        value: parsedMetadata?.defaultHomeView || "event-types",
+        label:
+          defaultHomeViewOptions.find(
+            (option) => option.value === (parsedMetadata?.defaultHomeView || "event-types")
+          )?.label || "",
       },
       travelSchedules:
         travelSchedules.map((schedule) => {
@@ -161,6 +180,7 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
               locale: values.locale.value,
               timeFormat: values.timeFormat.value,
               weekStart: values.weekStart.value,
+              metadata: { defaultHomeView: values.defaultHomeView.value as "event-types" | "bookings" },
             });
           }}>
           <div className="border-subtle border-x border-y-0 px-4 py-8 sm:px-6">
@@ -304,6 +324,26 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
                     options={weekStartOptions}
                     onChange={(event) => {
                       if (event) formMethods.setValue("weekStart", { ...event }, { shouldDirty: true });
+                    }}
+                  />
+                </>
+              )}
+            />
+            <Controller
+              name="defaultHomeView"
+              control={formMethods.control}
+              render={({ field: { value } }) => (
+                <>
+                  <Label className="text-emphasis mt-6">
+                    <>{t("default_home_view")}</>
+                  </Label>
+                  <p className="text-subtle mb-2 text-sm">{t("default_home_view_description")}</p>
+                  <Select
+                    value={value}
+                    options={defaultHomeViewOptions}
+                    onChange={(event) => {
+                      if (event)
+                        formMethods.setValue("defaultHomeView", { ...event }, { shouldDirty: true });
                     }}
                   />
                 </>

--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -5,6 +5,7 @@ import SectionBottomActions from "@calcom/features/settings/SectionBottomActions
 import { formatLocalizedDateTime } from "@calcom/lib/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { localeOptions } from "@calcom/lib/i18n";
+import { APP_NAME } from "@calcom/lib/constants";
 import { nameOfDay } from "@calcom/lib/weekday";
 import { userMetadata as userMetadataSchema } from "@calcom/prisma/zod-utils";
 import type { RouterOutputs } from "@calcom/trpc/react";
@@ -105,7 +106,7 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
   ];
 
   const defaultHomeViewOptions = [
-    { value: "event-types", label: t("event_types") },
+    { value: "event-types", label: t("event_types_page_title") },
     { value: "bookings", label: t("bookings") },
   ];
 
@@ -337,7 +338,7 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
                   <Label className="text-emphasis mt-6">
                     <>{t("default_home_view")}</>
                   </Label>
-                  <p className="text-subtle mb-2 text-sm">{t("default_home_view_description")}</p>
+                  <p className="text-subtle mb-2 text-sm">{t("default_home_view_description", { appName: APP_NAME })}</p>
                   <Select
                     value={value}
                     options={defaultHomeViewOptions}

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -28,7 +28,6 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
-  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -28,6 +28,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -639,6 +639,7 @@ export const getOptions = ({
             email: true,
             role: true,
             locale: true,
+            metadata: true,
             movedToProfileId: true,
             teams: {
               include: {
@@ -659,7 +660,9 @@ export const getOptions = ({
 
         // Check if the existingUser has any active teams
         const belongsToActiveTeam = checkIfUserBelongsToActiveTeam(existingUser);
-        const { teams: _teams, ...existingUserWithoutTeamsField } = existingUser;
+        const { teams: _teams, metadata: userMeta, ...existingUserWithoutTeamsField } = existingUser;
+        const parsedMetadata = userMetadata.safeParse(userMeta);
+        const defaultHomeView = parsedMetadata.success ? parsedMetadata.data?.defaultHomeView : undefined;
         const allProfiles = await ProfileRepository.findAllProfilesForUserIncludingMovedUser(existingUser);
         log.debug(
           "callbacks:jwt:autoMergeIdentities",
@@ -696,6 +699,7 @@ export const getOptions = ({
           upId,
           belongsToActiveTeam,
           orgAwareUsername: profileOrg ? profile.username : existingUser.username,
+          defaultHomeView: defaultHomeView ?? undefined,
           // All organizations in the token would be too big to store. It breaks the sessions request.
           // So, we just set the currently switched organization only here.
           // platform org user don't need profiles nor domains
@@ -975,6 +979,7 @@ export const getOptions = ({
           org: token?.org,
           locale: token.locale,
           inactiveAdminReason: token.inactiveAdminReason,
+          defaultHomeView: token.defaultHomeView,
         },
       };
       return calendsoSession;

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -588,6 +588,9 @@ export const getOptions = ({
           if (metadata?.sessionTimeout) {
             maxAge = metadata.sessionTimeout * 60;
           }
+          if (metadata?.defaultHomeView && token) {
+            token.defaultHomeView = metadata.defaultHomeView;
+          }
         }
       }
       return encode({ secret, token, maxAge });

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -1444,7 +1444,7 @@
   "error_404": "Error 404",
   "default": "Default",
   "default_home_view": "Default home page",
-  "default_home_view_description": "Choose which page to show when you open Cal.com",
+  "default_home_view_description": "Choose which page to show when you open {{appName}}",
   "set_to_default": "Set as default",
   "new_schedule_btn": "New schedule",
   "add_new_schedule": "Add a new schedule",

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -1443,6 +1443,8 @@
   "contact_sales": "Contact sales",
   "error_404": "Error 404",
   "default": "Default",
+  "default_home_view": "Default home page",
+  "default_home_view_description": "Choose which page to show when you open Cal.com",
   "set_to_default": "Set as default",
   "new_schedule_btn": "New schedule",
   "add_new_schedule": "Add a new schedule",

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -454,6 +454,7 @@ export const userMetadata = z
     sessionTimeout: z.number().optional(), // Minutes
     defaultConferencingApp: schemaDefaultConferencingApp.optional(),
     defaultBookerLayouts: bookerLayouts.optional(),
+    defaultHomeView: z.enum(["event-types", "bookings"]).optional(),
     emailChangeWaitingForVerification: z
       .string()
       .transform((data) => data.toLowerCase())

--- a/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts
+++ b/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts
@@ -7,11 +7,13 @@ import { bookerLayouts, userMetadata } from "@calcom/prisma/zod-utils";
 export type TUpdateUserMetadataAllowedKeys = {
   sessionTimeout?: number;
   defaultBookerLayouts?: z.infer<typeof bookerLayouts>;
+  defaultHomeView?: "event-types" | "bookings";
 };
 
 export const updateUserMetadataAllowedKeys: z.ZodType<TUpdateUserMetadataAllowedKeys> = z.object({
   sessionTimeout: z.number().optional(), // Minutes
   defaultBookerLayouts: bookerLayouts.optional(),
+  defaultHomeView: z.enum(["event-types", "bookings"]).optional(),
 });
 
 export type TUpdateProfileInputSchemaInput = {

--- a/packages/types/next-auth.d.ts
+++ b/packages/types/next-auth.d.ts
@@ -46,6 +46,7 @@ declare module "next-auth" {
     locale?: string | null;
     profile?: UserProfile;
     samlTenant?: string;
+    defaultHomeView?: "event-types" | "bookings";
   }
 }
 
@@ -78,5 +79,6 @@ declare module "next-auth/jwt" {
     orgAwareUsername?: PrismaUser["username"];
     organizationId?: number | null;
     locale?: string;
+    defaultHomeView?: "event-types" | "bookings";
   }
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                
  - Add a "Default home page" dropdown in General Settings (Event Types or Bookings)
  - Store preference in user metadata (`defaultHomeView`) — no DB migration needed
  - Root page redirect reads the preference and redirects accordingly

  Fixes #13778

  ## Changes
  - `packages/prisma/zod-utils.ts` — added `defaultHomeView` to userMetadata schema
  - `packages/trpc/server/routers/viewer/me/updateProfile.schema.ts` — allowed updating via API
  - `packages/i18n/locales/en/common.json` — added i18n keys
  - `apps/web/modules/settings/my-account/general-view.tsx` — added dropdown in Settings UI
  - `apps/web/app/page.tsx` — redirect based on user preference

  ## Approach
  Followed the same pattern as `defaultBookerLayouts` — user metadata JSON field, no DB migration. UI follows the `weekStart` dropdown pattern in General Settings.

  Previous PR #25419 used the same approach but was closed as stale.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
