### PR TITLE
docs: use --affected flag for type-check to only check changed packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ You are a senior Cal.com engineer working in a Yarn/Turbo monorepo. You prioriti
 - Use `ErrorWithCode` for errors in non-tRPC files (services, repositories, utilities); use `TRPCError` only in tRPC routers
 - Use conventional commits: `feat:`, `fix:`, `refactor:`
 - Create PRs in draft mode by default
-- Run `yarn type-check:ci --force` before concluding CI failures are unrelated to your changes
+- Run `yarn type-check:ci --affected` to type-check only packages affected by your branch changes
+- Use `yarn type-check:ci --force` only when you need a full check (e.g. comparing branches)
 - Import directly from source files, not barrel files (e.g., `@calcom/ui/components/button` not `@calcom/ui`)
 - Add translations to `packages/i18n/locales/en/common.json` for all UI strings
 - Use `date-fns` or native `Date` instead of Day.js when timezone awareness isn't needed
@@ -80,7 +81,8 @@ When a task requires extensive changes, break it into multiple PRs:
 See [agents/commands.md](agents/commands.md) for full reference. Key commands:
 
 ```bash
-yarn type-check:ci --force  # Type check (always run before pushing)
+yarn type-check:ci --affected  # Type check only affected packages (recommended before pushing)
+yarn type-check:ci --force     # Type check all packages ignoring cache (for full verification)
 yarn biome check --write .  # Lint and format
 TZ=UTC yarn test            # Run unit tests
 yarn prisma generate        # Regenerate types after schema changes
@@ -90,7 +92,7 @@ yarn prisma generate        # Regenerate types after schema changes
 ## Boundaries
 
 ### Always do
-- Run type check on changed files before committing
+- Run type check on affected packages before committing (`--affected`)
 - Run relevant tests before pushing
 - Use `select` in Prisma queries
 - Follow conventional commits for PR titles
@@ -210,7 +212,7 @@ import { ProfileRepository } from "@calcom/features/profile/repositories/Profile
 ## PR Checklist
 
 - [ ] Title follows conventional commits: `feat(scope): description`
-- [ ] Type check passes: `yarn type-check:ci --force`
+- [ ] Type check passes: `yarn type-check:ci --affected`
 - [ ] Lint passes: `yarn lint:fix`
 - [ ] Relevant tests pass
 - [ ] Diff is small and focused (<500 lines, <10 files)

--- a/agents/commands.md
+++ b/agents/commands.md
@@ -20,6 +20,8 @@
 - `yarn lint:fix` - Run Biome and apply safe fixes
 - `yarn lint:report` - Generate Biome lint report
 - `yarn type-check` - Run TypeScript type checking
+- `yarn type-check:ci --affected` - Type check only packages affected by changes on the current branch (recommended for local development)
+- `yarn type-check:ci --force` - Type check all packages ignoring cache (use for full verification or comparing branches)
 - `yarn format` - Format code with Biome
 
 ## Testing Commands

--- a/agents/rules/ci-check-failures.md
+++ b/agents/rules/ci-check-failures.md
@@ -30,4 +30,4 @@ These errors are related to SAML database misconfiguration on CI and should be i
 
 ## Before Blaming CI
 
-Always run type checks locally using `yarn type-check:ci --force` before concluding that CI failures are unrelated to your changes. Even if errors appear in files you haven't directly modified, your changes might still be causing type issues through dependencies or type inference.
+Always run type checks locally using `yarn type-check:ci --affected` before concluding that CI failures are unrelated to your changes. The `--affected` flag ensures only packages changed on the current branch (compared to `main`) are checked. Even if errors appear in files you haven't directly modified, your changes might still be causing type issues through dependencies or type inference. If you need a full check across all packages, use `yarn type-check:ci --force`.

--- a/agents/rules/ci-check-failures.md
+++ b/agents/rules/ci-check-failures.md
@@ -30,4 +30,4 @@ These errors are related to SAML database misconfiguration on CI and should be i
 
 ## Before Blaming CI
 
-Always run type checks locally using `yarn type-check:ci --affected` before concluding that CI failures are unrelated to your changes. The `--affected` flag ensures only packages changed on the current branch (compared to `main`) are checked. Even if errors appear in files you haven't directly modified, your changes might still be causing type issues through dependencies or type inference. If you need a full check across all packages, use `yarn type-check:ci --force`.
+Always run type checks locally using `yarn type-check:ci --affected` before concluding that CI failures are unrelated to your changes. The `--affected` flag scopes checks to packages Turbo detects as affected on the current branch (compared to `main`), though in some cases it may include more packages than expected. Even if errors appear in files you haven't directly modified, your changes might still be causing type issues through dependencies or type inference. If you need a full check across all packages, use `yarn type-check:ci --force`.

--- a/agents/rules/ci-git-workflow.md
+++ b/agents/rules/ci-git-workflow.md
@@ -15,7 +15,7 @@ Waiting for CI checks on unpushed local commits is backwards - the CI runs on th
 
 **Proper sequence:**
 1. Commit locally
-2. Run local checks (`yarn type-check:ci --force`, `yarn biome check --write .`)
+2. Run local checks (`yarn type-check:ci --affected`, `yarn biome check --write .`)
 3. Push to remote
 4. Monitor CI status
 

--- a/agents/rules/ci-type-check-first.md
+++ b/agents/rules/ci-type-check-first.md
@@ -11,9 +11,11 @@ tags: ci, typescript, type-check, workflow
 
 When working on the Cal.com repository, prioritize fixing type issues before addressing failing tests.
 
-1. Run `yarn type-check:ci --force` first
+1. Run `yarn type-check:ci --affected` first (only checks packages affected by your changes)
 2. Fix all TypeScript errors
 3. Then run tests with `TZ=UTC yarn test`
+
+> **Note:** The `--affected` flag uses Turbo's built-in git diff detection (`...[main...HEAD]`) to only type-check packages that have changed on the current branch compared to `main`. This is significantly faster than checking the entire monorepo.
 
 ## Why Type Check First
 
@@ -24,7 +26,7 @@ Type errors are often the root cause of test failures. Fixing types first:
 
 ## Comparing Branches
 
-Compare type check results between the main branch and your feature branch to confirm whether you've introduced new type errors:
+If you need to do a full comparison between branches (e.g. to confirm whether errors are pre-existing), use `--force` to ignore cache:
 
 ```bash
 # On your branch

--- a/agents/rules/quality-pr-creation.md
+++ b/agents/rules/quality-pr-creation.md
@@ -31,6 +31,6 @@ Create pull requests in draft mode by default, so that a human reviewer can mark
 
 ## Before Pushing
 
-1. Run `yarn type-check:ci --force` to check types
+1. Run `yarn type-check:ci --affected` to check types on changed packages
 2. Run `yarn biome check --write .` to lint and format
 3. Run relevant tests locally

--- a/agents/rules/testing-incremental.md
+++ b/agents/rules/testing-incremental.md
@@ -15,7 +15,7 @@ This methodical approach makes it easier to identify and resolve specific issues
 
 ## Recommended Order
 
-1. Run `yarn type-check:ci --force` to identify TypeScript type errors
+1. Run `yarn type-check:ci --affected` to identify TypeScript type errors in changed packages
 2. Run `yarn test` to identify failing unit tests
 3. Address both type errors and failing tests before considering the task complete
 4. Type errors often need to be fixed first as they may be causing the test failures


### PR DESCRIPTION
## What does this PR do?

Updates all AI agent documentation (`AGENTS.md`, `agents/commands.md`, and rule files) to recommend `yarn type-check:ci --affected` instead of `yarn type-check:ci --force` as the default type-check command during local development.

The `--affected` flag uses Turbo's built-in git diff detection (`...[main...HEAD]`) to only type-check packages that have changed on the current branch compared to `main`, which is significantly faster than checking the entire monorepo.

`--force` is still documented for full verification use cases (e.g. comparing branches).

**Files updated:**
- `AGENTS.md` — Do list, commands block, boundaries, PR checklist
- `agents/commands.md` — Added both `--affected` and `--force` entries with descriptions
- `agents/rules/ci-type-check-first.md` — Default command + explanatory note
- `agents/rules/ci-check-failures.md` — "Before Blaming CI" section (with caveat that `--affected` may include more packages than expected in some cases)
- `agents/rules/ci-git-workflow.md` — Proper sequence
- `agents/rules/quality-pr-creation.md` — Before pushing checklist
- `agents/rules/testing-incremental.md` — Recommended order

## ⚠️ Important for review

There is a [known Turborepo issue](https://github.com/vercel/turborepo/discussions/11533) where `--affected` can mark ALL packages as affected when changes are in `packages/` (due to root dependency detection). Please verify that `--affected` behaves correctly in the cal.com monorepo before merging. If it doesn't scope correctly, the speedup benefit would be lost.

### Suggested verification
```bash
# On a feature branch with changes in a single package:
yarn type-check:ci --affected --dry-run
# Should list only the affected package(s), not the full monorepo
```

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — this only changes agent guides, not developer docs.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — documentation-only change.

## How should this be tested?

1. On a feature branch with changes in a single package, run `yarn type-check:ci --affected` and verify it only type-checks the affected package(s) rather than the entire monorepo.
2. Compare the output/timing against `yarn type-check:ci --force` to confirm the speedup.

## Checklist

- My code follows the style guidelines of this project
- I have checked if my changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/931d0862d5f64be18d3d3352deb9818d
Requested by: @eunjae-lee