### PR TITLE
fix: display only the first assignment reason on routing page

### DIFF
--- a/packages/features/insights/services/InsightsRoutingBaseService.ts
+++ b/packages/features/insights/services/InsightsRoutingBaseService.ts
@@ -295,7 +295,16 @@ export class InsightsRoutingBaseService {
         rfrd."bookingUserName",
         rfrd."bookingUserEmail",
         rfrd."bookingUserAvatarUrl",
-        rfrd."bookingAssignmentReason",
+        COALESCE(
+          (
+            SELECT ar."reasonString"
+            FROM "AssignmentReason" ar
+            WHERE ar."bookingId" = rfrd."bookingId"
+            ORDER BY ar."createdAt" ASC
+            LIMIT 1
+          ),
+          ''
+        ) as "bookingAssignmentReason",
         rfrd."bookingStartTime",
         rfrd."bookingEndTime",
         rfrd."eventTypeId",

--- a/packages/prisma/migrations/20260304220000_use_first_assignment_reason_in_denormalized/migration.sql
+++ b/packages/prisma/migrations/20260304220000_use_first_assignment_reason_in_denormalized/migration.sql
@@ -1,0 +1,94 @@
+-- Update refresh function to explicitly get the FIRST assignment reason by createdAt
+CREATE OR REPLACE FUNCTION refresh_routing_form_response_denormalized(response_id INTEGER)
+RETURNS VOID AS $$
+BEGIN
+    -- Delete existing entry if any
+    DELETE FROM "RoutingFormResponseDenormalized" WHERE id = response_id;
+
+    -- Insert form response with all related data
+    INSERT INTO "RoutingFormResponseDenormalized" (
+        id,
+        "formId",
+        "formName",
+        "formTeamId",
+        "formUserId",
+        "bookingUid",
+        "bookingId",
+        "bookingStatus",
+        "bookingStatusOrder",
+        "bookingCreatedAt",
+        "bookingStartTime",
+        "bookingEndTime",
+        "bookingUserId",
+        "bookingUserName",
+        "bookingUserEmail",
+        "bookingUserAvatarUrl",
+        "bookingAssignmentReason",
+        "eventTypeId",
+        "eventTypeParentId",
+        "eventTypeSchedulingType",
+        "createdAt",
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content"
+    )
+    SELECT
+        r.id,
+        r."formId",
+        f.name as "formName",
+        f."teamId" as "formTeamId",
+        f."userId" as "formUserId",
+        b.uid as "bookingUid",
+        b.id as "bookingId",
+        b.status as "bookingStatus",
+        calculate_booking_status_order(b.status::text) as "bookingStatusOrder",
+        b."createdAt" as "bookingCreatedAt",
+        b."startTime" as "bookingStartTime",
+        b."endTime" as "bookingEndTime",
+        b."userId" as "bookingUserId",
+        u.name as "bookingUserName",
+        u.email as "bookingUserEmail",
+        u."avatarUrl" as "bookingUserAvatarUrl",
+        COALESCE(
+            (
+                SELECT ar."reasonString"
+                FROM "AssignmentReason" ar
+                WHERE ar."bookingId" = b.id
+                ORDER BY ar."createdAt" ASC
+                LIMIT 1
+            ),
+            ''
+        ) as "bookingAssignmentReason",
+        et.id as "eventTypeId",
+        et."parentId" as "eventTypeParentId",
+        et."schedulingType" as "eventTypeSchedulingType",
+        r."createdAt",
+        t.utm_source,
+        t.utm_medium,
+        t.utm_campaign,
+        t.utm_term,
+        t.utm_content
+    FROM "App_RoutingForms_FormResponse" r
+    INNER JOIN "App_RoutingForms_Form" f ON r."formId" = f.id
+    LEFT JOIN "Booking" b ON b.uid = r."routedToBookingUid"
+    LEFT JOIN "users" u ON b."userId" = u.id
+    LEFT JOIN "EventType" et ON b."eventTypeId" = et.id
+    LEFT JOIN "Tracking" t ON t."bookingId" = b.id
+    WHERE r.id = response_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Update trigger to only set assignment reason if not already set (preserve the first one)
+CREATE OR REPLACE FUNCTION trigger_refresh_routing_form_response_denormalized_assignment_reason()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Only update if there's no existing assignment reason (keep the first one)
+    UPDATE "RoutingFormResponseDenormalized" rfrd
+    SET "bookingAssignmentReason" = NEW."reasonString"
+    WHERE rfrd."bookingId" = NEW."bookingId"
+      AND (rfrd."bookingAssignmentReason" IS NULL OR rfrd."bookingAssignmentReason" = '');
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## What does this PR do?

Changes the routing form insights page to display only the **first** (earliest) assignment reason for each routing form submission, instead of the latest one.

Previously, the `bookingAssignmentReason` in the denormalized table was overwritten by a trigger each time a new `AssignmentReason` was inserted for a booking, causing the **last** assignment reason to be displayed. This PR ensures the **first** assignment reason (by `createdAt`) is shown instead.

### Changes:

1. **`InsightsRoutingBaseService.ts`** — Replaced `rfrd."bookingAssignmentReason"` with a correlated subquery that fetches the first assignment reason (`ORDER BY ar."createdAt" ASC LIMIT 1`) from the `AssignmentReason` table directly.

2. **New migration** — Updates two database functions:
   - `refresh_routing_form_response_denormalized`: Now uses explicit `ORDER BY ar."createdAt" ASC` when selecting the assignment reason (previously had `LIMIT 1` with no ordering, which was non-deterministic).
   - `trigger_refresh_routing_form_response_denormalized_assignment_reason`: Now only writes the assignment reason if the current value is `NULL` or empty, preserving the first one.

## ⚠️ Important review notes

- **Performance**: The `getTableData` query now includes a correlated subquery per row against the `AssignmentReason` table. Reviewers should evaluate whether this is acceptable at scale or if a backfill + reliance on the denormalized field would be preferable.
- **CSV download path**: `routing-events.ts` (`getRoutingFormPaginatedResponsesForDownload`) still reads `item.bookingAssignmentReason` from the denormalized field. For existing data that hasn't been refreshed, this could still show the last assignment reason. Reviewer should decide if this path also needs the subquery treatment.
- **No backfill for existing data**: The migration updates functions going forward but does not backfill existing `RoutingFormResponseDenormalized` rows. The subquery in `getTableData` ensures correct display regardless.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a booking through a routing form that triggers multiple assignment reasons (e.g., initial assignment + reassignment).
2. Navigate to the routing insights page and check the "Assignment Reason" column.
3. Verify it shows the **first** (original) assignment reason, not the latest one.
4. Verify the trigger behavior: insert a new `AssignmentReason` for an existing booking and confirm the denormalized field retains the first reason.

5. Test with and without existing data to validate both the subquery and trigger logic.

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings
- My PR is appropriately sized (<500 lines and <10 files)

---

**Link to Devin Session:** https://app.devin.ai/sessions/415b8ecfbc394712bc2f4734b35ce785  
**Requested by:** @joeauyeung
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
