### PR TITLE
fix: include seed files in cache-db key to prevent stale DB cache

### DIFF
--- a/.github/actions/cache-db-key/action.yml
+++ b/.github/actions/cache-db-key/action.yml
@@ -18,6 +18,6 @@ runs:
       env:
         CACHE_NAME: cache-db
         PATH_KEY: ${{ inputs.path }}
-        PRISMA_HASH: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
+        PRISMA_HASH: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts', 'scripts/seed*.ts') }}
       run: |
         echo "key=${CACHE_NAME}-${PATH_KEY}-${PRISMA_HASH}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What does this PR do?

Fixes integration test failures caused by a stale database cache in CI. 

The `cache-db-key` action generates a hash to decide whether to restore a cached seeded database or run a fresh `yarn db-seed`. Previously, the hash only included Prisma schema, migrations, and `packages/prisma/*.ts` — but **not the seed scripts themselves** (`scripts/seed.ts`, `scripts/seed-utils.ts`, `scripts/seed-app-store.ts`, etc.). When seed scripts were updated (e.g., adding new org members or changing seed data), the cache key didn't change, so CI kept restoring a stale database backup.

This caused 5 test failures across 4 test files in integration tests (e.g., org admin checks returning `false`, member counts returning `0` instead of expected values, 403s on org-admin endpoints) — identically across unrelated PRs.

**The fix:** Add `scripts/seed*.ts` to the `hashFiles()` input so any seed data change invalidates the cache and triggers a fresh `yarn db-seed`.

> **Note:** After merging, the existing stale cache entry should be manually deleted from [Actions Caches](https://github.com/calcom/cal.com/actions/caches) to immediately unblock PRs. Alternatively, it will be naturally superseded since the new hash will differ.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — CI-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. The fix is validated by the currently-failing integration tests passing after cache regeneration.

## How should this be tested?

1. After merge, verify the next CI run on any PR computes a **new** cache key (different from the current one).
2. Confirm integration tests pass on that run (cache miss → fresh `yarn db-seed` → all seed users present).
3. Optionally, manually delete the stale cache entry from [Actions Caches](https://github.com/calcom/cal.com/actions/caches) to speed things up.

## 🔍 Human Review Checklist

- [ ] Verify `scripts/seed*.ts` glob captures all files that influence seed data (currently: `seed.ts`, `seed-utils.ts`, `seed-app-store.ts`, `seed-huge-event-types.ts`, `seed-booking-audit.ts`, `seed-load-test-form-reponses.ts`)
- [ ] Confirm the glob doesn't accidentally match unrelated files in `scripts/`
- [ ] Accept one-time cache rebuild cost on the next CI run after merge

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings
- [x] My PR is small and focused

---

Link to Devin session: https://app.devin.ai/sessions/8bb3694ead7a42e4bff89b3b040192ee
Requested by: @Ryukemeister