### PR TITLE
fix: include org slug in organization invite email links

### DIFF
--- a/packages/features/ee/dsync/lib/inviteExistingUserToOrg.ts
+++ b/packages/features/ee/dsync/lib/inviteExistingUserToOrg.ts
@@ -13,7 +13,7 @@ const inviteExistingUserToOrg = async ({
   translation,
 }: {
   user: UserWithMembership;
-  org: { id: number; name: string; parent: { name: string } | null };
+  org: { id: number; name: string; slug: string | null; parent: { name: string } | null };
   translation: TFunction;
 }) => {
   await createAProfileForAnExistingUser({
@@ -47,6 +47,7 @@ const inviteExistingUserToOrg = async ({
     teamId: org.id,
     isAutoJoin: true,
     currentUserParentTeamName: org?.parent?.name,
+    orgSlug: org.slug,
   });
 };
 

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
@@ -304,6 +304,8 @@ const inviteMembers = async ({ ctx, input }: InviteMemberOptions) => {
 
   if (isTeamAnOrg) {
     await throwIfInviterCantAddOwnerToOrg();
+    // When inviting to an org, prefer the org's own slug over the inviter's profile org slug
+    orgSlug = team.slug || requestedSlugForTeam || orgSlug;
   }
 
   if (isPlatform) {


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where organization invite emails showed the new link as `cal.com/username` instead of `orgslug.cal.com/username`, causing confusion for invited users.

**Root cause (main invite flow):** In `inviteMember.handler.ts`, `orgSlug` was derived solely from `inviter.profile.organization`, which could be `null`. When null, `getOrgFullOrigin(null)` returns the base `WEBSITE_URL` (e.g. `cal.com`) without the org subdomain. The fix ensures that when inviting to an org, the org's own `team.slug` (or `requestedSlug`) is preferred.

**Root cause (DSYNC flow):** In `inviteExistingUserToOrg.ts`, the `orgSlug` parameter was not passed at all to `sendExistingUserTeamInviteEmails`, so it defaulted to `undefined` → treated as empty → no subdomain in link.

### Changes

1. **`inviteMember.handler.ts`** — When `isTeamAnOrg`, derive `orgSlug` from the team being invited to (`team.slug || requestedSlugForTeam`), falling back to the inviter's profile org slug. This mirrors what was already done in the `isPlatform` branch.
2. **`inviteExistingUserToOrg.ts`** — Added `slug` to the org type and passes `orgSlug: org.slug` to `sendExistingUserTeamInviteEmails`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Set up an organization with a slug (e.g. `tws`)
2. As an org admin, invite an existing Cal.com user to the organization
3. Check the invite email — the "new link" should show `tws.cal.com/username` (with org slug subdomain), not `cal.com/username`
4. Also verify DSYNC-provisioned user invites include the org slug in the link

## Human Review Checklist

- [ ] Verify the fallback chain `team.slug || requestedSlugForTeam || orgSlug` doesn't regress platform invite behavior (the `isPlatform` block runs after and would override anyway)
- [ ] Verify all callers of `inviteExistingUserToOrg` in the DSYNC path (`handleUserEvents.ts`) pass an `org` object that includes `slug` (it comes from `getTeamOrThrow` which includes it)
- [ ] Note: `handleUserEvents.ts` calls both `inviteExistingUserToOrg` (which now sends email) AND `sendExistingUserTeamInviteEmails` afterward — this is a **pre-existing** duplicate-email issue, not introduced here

---

[Link to Devin Session](https://app.devin.ai/sessions/03a0d791765c48d5b46fad6c33fd4ac4)
Requested by: @anikdhabal