### PR TITLE
fix: align Prisma docker-compose DB name with env example

### DIFF
--- a/packages/prisma/docker-compose.yml
+++ b/packages/prisma/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: "cal-saml"
+      POSTGRES_DB: "calendso"
       POSTGRES_PASSWORD: ""
       POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:


### PR DESCRIPTION
## What does this PR do?

Fixes #28106

The Prisma `docker-compose.yml` uses `POSTGRES_DB: "cal-saml"` but `.env.example` defaults `DATABASE_URL` to `calendso`. This mismatch causes `yarn dx` to fail because migrations run against a database that doesn't match what Docker created.

Changes `POSTGRES_DB` from `"cal-saml"` to `"calendso"` to align with the env example.

<!-- Please remove all options that are not relevant -->
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Run `yarn dx` from a clean state
2. Verify the Docker Postgres container creates the `calendso` database
3. Verify migrations succeed without manual DB creation

## Mandatory Tasks

- [x] I have self-reviewed the code in this PR
- [x] I have added the relevant tests (if applicable)
- [x] I have updated the documentation (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)