### PR TITLE
fix: resolve invalid DOM nesting in DataTable SeparatorRowRenderer

### DIFF
--- a/apps/web/modules/data-table/components/DataTable.tsx
+++ b/apps/web/modules/data-table/components/DataTable.tsx
@@ -284,16 +284,25 @@ type RowToRender<TData> = {
   virtualItem?: VirtualItem;
 };
 
-function SeparatorRowRenderer({ separator, className }: { separator: SeparatorRow; className?: string }) {
+function SeparatorRowRenderer({
+  separator,
+  className,
+  colSpan,
+}: {
+  separator: SeparatorRow;
+  className?: string;
+  colSpan: number;
+}) {
   return (
-    <div
+    <TableCell
+      colSpan={colSpan}
       className={classNames(
         "bg-cal-muted text-emphasis w-full px-3 py-2 font-semibold",
         separator.className,
         className
       )}>
       {separator.label}
-    </div>
+    </TableCell>
   );
 }
 
@@ -384,7 +393,11 @@ function DataTableBody<TData>({
                 }),
               }}
               className="hover:bg-subtle border-muted flex w-full border-b">
-              <SeparatorRowRenderer separator={row.original as SeparatorRow} className={separatorClassName} />
+              <SeparatorRowRenderer
+                separator={row.original as SeparatorRow}
+                className={separatorClassName}
+                colSpan={table.getAllColumns().length}
+              />
             </TableRow>
           );
         }

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,6 +27,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,7 +27,6 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
-  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",


### PR DESCRIPTION
## What does this PR do?

Fixes #28184

The `SeparatorRowRenderer` in the DataTable component rendered a `<div>` directly inside a `<TableRow>` (`<tr>`), which is invalid HTML — a `<tr>` can only contain `<td>` or `<th>` elements. This caused React hydration warnings and accessibility issues.

### Changes
- Replace `<div>` with `<TableCell>` in `SeparatorRowRenderer`
- Add `colSpan` prop to span all table columns
- Pass `table.getAllColumns().length` as the `colSpan` value at the call site

<!-- Please remove all options that are not relevant -->
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Navigate to any page using DataTable with separator rows (e.g., bookings list grouped by date)
2. Open browser DevTools and verify no DOM nesting warnings in console
3. Inspect the separator row — it should be `<tr><td colspan="N">...</td></tr>` instead of `<tr><div>...</div></tr>`

## Mandatory Tasks

- [x] I have self-reviewed the code in this PR
- [x] I have added the relevant tests (if applicable)
- [x] I have updated the documentation (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)