### PR TITLE
fix: use per-toggle loading state in general settings

### DIFF
--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -63,6 +63,7 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
   const { update } = useSession();
   const [isUpdateBtnLoading, setIsUpdateBtnLoading] = useState<boolean>(false);
   const [isTZScheduleOpen, setIsTZScheduleOpen] = useState<boolean>(false);
+  const [pendingToggles, setPendingToggles] = useState<Set<string>>(new Set());
 
   const mutation = trpc.viewer.me.updateProfile.useMutation({
     onSuccess: async (res) => {
@@ -88,6 +89,19 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
       setIsUpdateBtnLoading(false);
     },
   });
+
+  const mutateToggle = (key: string, data: Parameters<typeof mutation.mutate>[0]) => {
+    setPendingToggles((prev) => new Set(prev).add(key));
+    mutation.mutate(data, {
+      onSettled: () => {
+        setPendingToggles((prev) => {
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
+      },
+    });
+  };
 
   const timeFormatOptions = [
     { value: 12, label: t("12_hour") },
@@ -331,11 +345,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("dynamic_booking")}
           description={t("allow_dynamic_booking")}
-          disabled={mutation.isPending}
+          disabled={pendingToggles.has("allowDynamicBooking")}
           checked={isAllowDynamicBookingChecked}
           onCheckedChange={(checked) => {
             setIsAllowDynamicBookingChecked(checked);
-            mutation.mutate({ allowDynamicBooking: checked });
+            mutateToggle("allowDynamicBooking", { allowDynamicBooking: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -345,11 +359,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("seo_indexing")}
           description={t("allow_seo_indexing")}
-          disabled={mutation.isPending || user.organizationSettings?.allowSEOIndexing === false}
+          disabled={pendingToggles.has("allowSEOIndexing") || user.organizationSettings?.allowSEOIndexing === false}
           checked={isAllowSEOIndexingChecked}
           onCheckedChange={(checked) => {
             setIsAllowSEOIndexingChecked(checked);
-            mutation.mutate({ allowSEOIndexing: checked });
+            mutateToggle("allowSEOIndexing", { allowSEOIndexing: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -358,11 +372,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("monthly_digest_email")}
           description={t("monthly_digest_email_for_teams")}
-          disabled={mutation.isPending}
+          disabled={pendingToggles.has("receiveMonthlyDigestEmail")}
           checked={isReceiveMonthlyDigestEmailChecked}
           onCheckedChange={(checked) => {
             setIsReceiveMonthlyDigestEmailChecked(checked);
-            mutation.mutate({ receiveMonthlyDigestEmail: checked });
+            mutateToggle("receiveMonthlyDigestEmail", { receiveMonthlyDigestEmail: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -371,11 +385,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("require_booker_email_verification")}
           description={t("require_booker_email_verification_description")}
-          disabled={mutation.isPending}
+          disabled={pendingToggles.has("requiresBookerEmailVerification")}
           checked={isRequireBookerEmailVerificationChecked}
           onCheckedChange={(checked) => {
             setIsRequireBookerEmailVerificationChecked(checked);
-            mutation.mutate({ requiresBookerEmailVerification: checked });
+            mutateToggle("requiresBookerEmailVerification", { requiresBookerEmailVerification: checked });
           }}
           switchContainerClassName="mt-6"
         />

--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -86,7 +86,6 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
       await utils.viewer.me.invalidate();
       revalidateSettingsGeneral();
       revalidateTravelSchedules();
-      setIsUpdateBtnLoading(false);
     },
   });
 
@@ -175,12 +174,15 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           form={formMethods}
           handleSubmit={async (values) => {
             setIsUpdateBtnLoading(true);
-            mutation.mutate({
-              ...values,
-              locale: values.locale.value,
-              timeFormat: values.timeFormat.value,
-              weekStart: values.weekStart.value,
-            });
+            mutation.mutate(
+              {
+                ...values,
+                locale: values.locale.value,
+                timeFormat: values.timeFormat.value,
+                weekStart: values.weekStart.value,
+              },
+              { onSettled: () => setIsUpdateBtnLoading(false) }
+            );
           }}>
           <div className="border-subtle border-x border-y-0 px-4 py-8 sm:px-6">
             <Controller
@@ -359,7 +361,9 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("seo_indexing")}
           description={t("allow_seo_indexing")}
-          disabled={pendingToggles.has("allowSEOIndexing") || user.organizationSettings?.allowSEOIndexing === false}
+          disabled={
+            pendingToggles.has("allowSEOIndexing") || user.organizationSettings?.allowSEOIndexing === false
+          }
           checked={isAllowSEOIndexingChecked}
           onCheckedChange={(checked) => {
             setIsAllowSEOIndexingChecked(checked);

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,6 +27,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,7 +27,6 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
-  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",


### PR DESCRIPTION
## What does this PR do?

Fixes #28283

Toggling any setting on the General Settings page (dynamic booking, SEO indexing, monthly digest, booker email verification) disabled **all** toggles while the mutation was pending. This made the UI feel unresponsive when quickly toggling multiple settings.

### Changes
- Introduce `pendingToggles` state (`Set<string>`) to track which specific toggles have in-flight mutations
- Add `mutateToggle` helper that manages per-toggle pending state with `onSettled` cleanup
- Each toggle is now only disabled during its own mutation, leaving others interactive

<!-- Please remove all options that are not relevant -->
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Go to Settings → General
2. Toggle "Dynamic Booking" — verify only that toggle shows loading state
3. While it's saving, toggle "Monthly Digest Email" — verify it's still interactive
4. Verify all toggles save correctly and re-enable after their individual mutations complete
5. Test error case: if a mutation fails, verify the toggle re-enables

## Mandatory Tasks

- [x] I have self-reviewed the code in this PR
- [x] I have added the relevant tests (if applicable)
- [x] I have updated the documentation (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)