### PR TITLE
feat: sync meeting-duration-date-selector-style

### DIFF
--- a/apps/web/modules/bookings/components/event-meta/Duration.tsx
+++ b/apps/web/modules/bookings/components/event-meta/Duration.tsx
@@ -112,7 +112,7 @@ export const EventDuration = ({
         </button>
       )}
       <ul
-        className="bg-default no-scrollbar flex max-w-full items-center gap-0.5 overflow-x-auto rounded-md p-1"
+        className="bg-default no-scrollbar flex max-w-full items-center gap-1 overflow-x-auto rounded-md p-1"
         onScroll={(e) => calculateScroll(e)}
         ref={ref}>
         {durations
@@ -125,8 +125,8 @@ export const EventDuration = ({
               onClick={() => setSelectedDuration(duration)}
               ref={(el) => (itemRefs.current[duration] = el)}
               className={classNames(
-                selectedDuration === duration ? "bg-emphasis" : "hover:text-emphasis",
-                "text-default cursor-pointer rounded-[4px] px-3 py-1.5 text-sm leading-tight transition"
+                selectedDuration === duration ? "bg-brand-default text-brand" : "text-emphasis bg-emphasis hover:border-brand-default",
+                "cursor-pointer rounded-[4px] border-2 border-transparent px-3 py-1.5 text-sm leading-tight transition"
               )}>
               <div className="w-max">{getDurationFormatted(duration, t)}</div>
             </li>


### PR DESCRIPTION
## What does this PR do?

This PR synchronizes the visual styling of the meeting duration selector with the date selector component in the booking UI.

- Fixes #28275 
- Fixes CAL-7278

| Before | After |
|--------|--------|
| <img width="810" height="544" alt="image" src="https://github.com/user-attachments/assets/2ea8afc4-a2b7-4e15-84b3-f94c6eda4240" /> | <img width="837" height="539" alt="image" src="https://github.com/user-attachments/assets/3eea3945-7db8-4b7c-a443-e2fe8bb19c87" /> | 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas