### PR TITLE
ci: use GitHub App token for fetching base OpenAPI spec in breaking changes check

### DIFF
--- a/.github/workflows/check-api-v2-breaking-changes.yml
+++ b/.github/workflows/check-api-v2-breaking-changes.yml
@@ -29,6 +29,14 @@ jobs:
     timeout-minutes: 10
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94
+        with:
+          app-id: ${{ secrets.CI_CAL_APP_ID }}
+          private-key: ${{ secrets.CI_CAL_APP_PRIVATE_KEY }}
+          repositories: 'cal.com'
+
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -55,13 +63,21 @@ jobs:
           yarn prisma generate
           yarn generate-swagger
 
+      - name: Get base OpenAPI spec from main
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
+          git fetch origin main --depth=1
+          git show origin/main:docs/api-reference/v2/openapi.json > /tmp/openapi-base.json
+
       - name: Check API v2 breaking changes
         run: |
           docker run --rm \
-            -v "$PWD:/work" -w /work \
+            -v "$PWD:/work" -v "/tmp/openapi-base.json:/work/openapi-base.json" -w /work \
             tufin/oasdiff:latest \
             breaking \
-            https://raw.githubusercontent.com/calcom/cal.com/refs/heads/main/docs/api-reference/v2/openapi.json \
+            openapi-base.json \
             docs/api-reference/v2/openapi.json \
             --fail-on ERR \
             --err-ignore .github/oasdiff-err-ignore.txt


### PR DESCRIPTION
## What does this PR do?

Updates the `check-api-v2-breaking-changes` workflow to use a GitHub App token (via `actions/create-github-app-token`) instead of fetching the base OpenAPI spec from `raw.githubusercontent.com`. This follows the same token generation pattern used in the `draft-release` workflow.

Changes:
- Adds a "Generate GitHub App token" step using `CI_CAL_APP_ID` / `CI_CAL_APP_PRIVATE_KEY` secrets (same as `draft-release.yml`)
- Adds a "Get base OpenAPI spec from main" step that uses the token to `git fetch origin main` and extracts the base `openapi.json` to `/tmp/openapi-base.json`
- Updates the oasdiff Docker step to mount and read the local base spec file instead of fetching from `raw.githubusercontent.com`

This resolves potential authentication/rate-limiting issues when fetching the base spec from GitHub.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — CI-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — this is a CI workflow change that will be verified when the workflow runs.

## How should this be tested?

This is a CI workflow change. To verify:
1. Open a PR that touches `docs/api-reference/v2/openapi.json` or API v2 code
2. Confirm the "Check API v2 breaking changes" job passes and correctly fetches the base spec via `git fetch` instead of `raw.githubusercontent.com`

## Human Review Checklist

- [ ] Verify the GitHub App (`CI_CAL_APP_ID`) has content read permissions on the `cal.com` repo
- [ ] Confirm the Docker volume mount (`-v "/tmp/openapi-base.json:/work/openapi-base.json"`) works correctly with oasdiff (local file vs previous URL approach)
- [ ] Note that `git remote set-url origin` is modified mid-job — this shouldn't affect anything since no subsequent steps use the origin, but worth being aware of

<!-- Link to Devin session: https://app.devin.ai/sessions/1e9870bb755f4411b1b8d1bd77bace91 -->
<!-- Requested by: @sean-brydon -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
