### PR TITLE
fix: update PostgreSQL volume mount path for Postgres 18 compatibility

### DIFF
--- a/packages/prisma/docker-compose.yml
+++ b/packages/prisma/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "5450:5432" # expose pg on port 5450 to not collide with pg from elsewhere
     restart: always
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql
     environment:
       POSTGRES_DB: "cal-saml"
       POSTGRES_PASSWORD: ""


### PR DESCRIPTION
## What does this PR do?
Fixes the PostgreSQL container volume mount path in [packages/prisma/docker-compose.yml](cci:7://file:///Users/pro/cal.com/packages/prisma/docker-compose.yml:0:0-0:0).

Postgres 18 changed its data directory from `/var/lib/postgresql/data` to `/var/lib/postgresql/18/main` (see [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)). The volume must mount at `/var/lib/postgresql` for data to persist.

- Fixes #28281

## Visual Demo
N/A — infrastructure change, no UI impact.

## How was this tested?
After applying the fix, `docker compose -f packages/prisma/docker-compose.yml up` starts Postgres successfully and data persists across restarts.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
