### PR TITLE
fix: remove unreachable code in deleteDomain function

### DIFF
--- a/packages/lib/domainManager/organization.ts
+++ b/packages/lib/domainManager/organization.ts
@@ -24,7 +24,6 @@ export const deleteDomain = async (slug: string) => {
     isDnsRecordDeleted = await deleteDnsRecord(domain);
   }
   return isDomainDeleted && isDnsRecordDeleted;
-  return false;
 };
 
 export const createDomain = async (slug: string) => {


### PR DESCRIPTION
## What does this PR do?
Removes an unreachable `return false;` statement in the [deleteDomain](cci:1://file:///Users/pro/cal.com/packages/lib/domainManager/organization.ts:10:0-26:2) function 
in [packages/lib/domainManager/organization.ts](cci:7://file:///Users/pro/cal.com/packages/lib/domainManager/organization.ts:0:0-0:0).

The function had:
```ts
return isDomainDeleted && isDnsRecordDeleted;
return false; // ← unreachable, never executes
