### PR TITLE
fix: create user with team in teams page E2E test

### DIFF
--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -18,7 +18,7 @@ test.describe.configure({ mode: "parallel" });
 
 test.describe("Teams tests", () => {
   test("should render the /teams page", async ({ page, users, context }) => {
-    const user = await users.create();
+    const user = await users.create(undefined, { hasTeam: true });
 
     await user.apiLogin();
 


### PR DESCRIPTION
## What does this PR do?

Fixes the flaky/failing E2E test `should render the /teams page` by creating the test user with a team membership.

**Root cause:** PR #27650 introduced a `showHeader` flag in the teams server page that hides the "Teams" heading when a user has no teams (showing a fullscreen upgrade banner instead). That PR updated other tests in `teams.e2e.ts` to use `{ hasTeam: true }`, but missed this one. The test was already marked as "flaky" on #27650's CI run (failed 2/3 attempts, passed on final retry).

CI failure: https://github.com/calcom/cal.com/actions/runs/22761586303/job/66019417032?pr=28305#step:12:116
<img width="989" height="612" alt="Screenshot 2026-03-06 at 6 06 06 PM" src="https://github.com/user-attachments/assets/47d5cd80-2a30-4f4c-9404-d35af6f47049" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the E2E test shard containing `teams.e2e.ts` (shard 8/8). The `should render the /teams page` test should now pass consistently instead of failing or being marked as flaky.

```bash
yarn e2e teams.e2e.ts
```

## Human Review Checklist

- [ ] Verify that testing with a team-owning user still validates the original intent (that `/teams` page renders correctly)
- [ ] Consider whether a separate test should exist to verify the upgrade banner renders for users *without* teams

---

**Link to Devin Session:** https://app.devin.ai/sessions/73a2b1dc243c4eecb1bb677d4afc5ee6
**Requested by:** @romitg2