### PR TITLE
fix: load dayjs utc plugin before timezone plugin

### DIFF
--- a/packages/dayjs/index.ts
+++ b/packages/dayjs/index.ts
@@ -18,9 +18,9 @@ dayjs.extend(isBetween);
 dayjs.extend(isToday);
 dayjs.extend(localizedFormat);
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
 dayjs.extend(timeZone);
 dayjs.extend(toArray);
-dayjs.extend(utc);
 dayjs.extend(minmax);
 dayjs.extend(duration);
 


### PR DESCRIPTION
## What does this PR do?
Fixes the Day.js plugin loading order in [packages/dayjs/index.ts](cci:7://file:///Users/pro/cal.com/packages/dayjs/index.ts:0:0-0:0) to correctly handle timezone formatting.

Day.js requires the `utc` plugin to be loaded **before** the `timezone` plugin to correctly apply timezone offsets during formatting (see [Day.js documentation](https://day.js.org/docs/en/plugin/timezone)).

This fixes an issue where the Bookings Dashboard displayed UTC time but labeled it with the user's timezone.

ref #28193

## Visual Demo
N/A - fixing a formatting behavior.

## How was this tested?
Locally verified that `dayjs('2024-01-01T06:45:00Z').tz('Asia/Kolkata').format('h:mm A z')` now correctly outputs `12:15 PM IST` instead of `12:15 PM z`. Also ran `yarn test` and `yarn build --filter=@calcom/dayjs` successfully.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
