### PR TITLE
fix: slot-past-validation-timezone

### DIFF
--- a/packages/lib/isOutOfBounds.tsx
+++ b/packages/lib/isOutOfBounds.tsx
@@ -43,9 +43,16 @@ export function calculatePeriodLimits({
   _skipRollingWindowCheck,
 }: Pick<
   EventType,
-  "periodType" | "periodDays" | "periodCountCalendarDays" | "periodStartDate" | "periodEndDate"
+  | "periodType"
+  | "periodDays"
+  | "periodCountCalendarDays"
+  | "periodStartDate"
+  | "periodEndDate"
 > & {
-  allDatesWithBookabilityStatusInBookerTz: Record<string, { isBookable: boolean }> | null;
+  allDatesWithBookabilityStatusInBookerTz: Record<
+    string,
+    { isBookable: boolean }
+  > | null;
   eventUtcOffset: number;
   bookerUtcOffset: number;
   _skipRollingWindowCheck?: boolean;
@@ -119,7 +126,10 @@ export function calculatePeriodLimits({
       // New format: 2024-01-20T00:00:00.000Z (time is exactly midnight UTC)
       // Old format: 2024-01-19T20:00:00.000Z (time is not midnight UTC - it's midnight in some browser timezone)
       const isNewFormat = (date: dayjs.Dayjs) =>
-        date.hour() === 0 && date.minute() === 0 && date.second() === 0 && date.millisecond() === 0;
+        date.hour() === 0 &&
+        date.minute() === 0 &&
+        date.second() === 0 &&
+        date.millisecond() === 0;
 
       let startOfRangeStartDayInEventTz: dayjs.Dayjs;
       let endOfRangeEndDayInEventTz: dayjs.Dayjs;
@@ -146,8 +156,12 @@ export function calculatePeriodLimits({
       } else {
         // Old format: dates were stored as browser timezone midnight converted to UTC
         // Convert to event timezone and take start/end of day (legacy behavior)
-        startOfRangeStartDayInEventTz = dayjs(periodStartDate).utcOffset(eventUtcOffset).startOf("day");
-        endOfRangeEndDayInEventTz = dayjs(periodEndDate).utcOffset(eventUtcOffset).endOf("day");
+        startOfRangeStartDayInEventTz = dayjs(periodStartDate)
+          .utcOffset(eventUtcOffset)
+          .startOf("day");
+        endOfRangeEndDayInEventTz = dayjs(periodEndDate)
+          .utcOffset(eventUtcOffset)
+          .endOf("day");
       }
 
       return {
@@ -177,11 +191,17 @@ export function getRollingWindowEndDate({
    */
   startDateInBookerTz: dayjs.Dayjs;
   daysNeeded: number;
-  allDatesWithBookabilityStatusInBookerTz: Record<string, { isBookable: boolean }>;
+  allDatesWithBookabilityStatusInBookerTz: Record<
+    string,
+    { isBookable: boolean }
+  >;
   countNonBusinessDays: boolean | null;
 }) {
   const log = logger.getSubLogger({ prefix: ["getRollingWindowEndDate"] });
-  log.debug("called:", safeStringify({ startDay: startDateInBookerTz.format(), daysNeeded }));
+  log.debug(
+    "called:",
+    safeStringify({ startDay: startDateInBookerTz.format(), daysNeeded })
+  );
   let counter = 1;
   let rollingEndDay: ReturnType<typeof startDateInBookerTz.startOf> | undefined;
   const startOfStartDayInEventTz = startDateInBookerTz.startOf("day");
@@ -200,7 +220,9 @@ export function getRollingWindowEndDate({
 
     const onlyDateOfIterationDay = startOfIterationDay.format("YYYY-MM-DD");
 
-    const isBookable = !!allDatesWithBookabilityStatusInBookerTz[onlyDateOfIterationDay]?.isBookable;
+    const isBookable =
+      !!allDatesWithBookabilityStatusInBookerTz[onlyDateOfIterationDay]
+        ?.isBookable;
 
     if (isBookable) {
       bookableDaysCount++;
@@ -229,7 +251,9 @@ export function getRollingWindowEndDate({
    * We can't just return null(if rollingEndDay couldn't be obtained) and allow days farther than ROLLING_WINDOW_PERIOD_MAX_DAYS_TO_CHECK to be booked as that would mean there is no future limit
    * The future limit talks in terms of days so we take the end of the day here to consider the entire day
    */
-  const endOfLastDayOfWindowInBookerTz = (rollingEndDay ?? startOfIterationDay).endOf("day");
+  const endOfLastDayOfWindowInBookerTz = (
+    rollingEndDay ?? startOfIterationDay
+  ).endOf("day");
   log.debug("Returning rollingEndDay", endOfLastDayOfWindowInBookerTz.format());
 
   return endOfLastDayOfWindowInBookerTz;
@@ -243,16 +267,25 @@ export function getRollingWindowEndDate({
 export function isTimeOutOfBounds({
   time,
   minimumBookingNotice,
+  eventUtcOffset,
 }: {
   time: dayjs.ConfigType;
   minimumBookingNotice?: number;
+  eventUtcOffset?: number;
 }) {
   const date = dayjs(time);
 
   guardAgainstBookingInThePast(date.toDate());
 
   if (minimumBookingNotice) {
-    const minimumBookingStartDate = dayjs().add(minimumBookingNotice, "minutes");
+    const currentTimeInHostTz =
+      eventUtcOffset !== undefined
+        ? dayjs().utcOffset(eventUtcOffset)
+        : dayjs();
+    const minimumBookingStartDate = currentTimeInHostTz.add(
+      minimumBookingNotice,
+      "minutes"
+    );
     if (date.isBefore(minimumBookingStartDate)) {
       return true;
     }
@@ -268,15 +301,21 @@ export function isTimeOutOfBounds({
 export function getPastTimeAndMinimumBookingNoticeBoundsStatus({
   time,
   minimumBookingNotice,
+  eventUtcOffset,
 }: {
   time: dayjs.ConfigType;
   minimumBookingNotice?: number;
+  eventUtcOffset?: number;
 }): {
   isOutOfBounds: boolean;
   reason: "minBookNoticeViolation" | "slotInPast" | null;
 } {
   try {
-    const isOutOfBounds = isTimeOutOfBounds({ time, minimumBookingNotice });
+    const isOutOfBounds = isTimeOutOfBounds({
+      time,
+      minimumBookingNotice,
+      eventUtcOffset,
+    });
     return {
       isOutOfBounds,
       reason: isOutOfBounds ? "minBookNoticeViolation" : null,
@@ -310,7 +349,8 @@ export function isTimeViolatingFutureLimit({
   const dateObj = new Date(time);
   if (periodLimits.endOfRollingPeriodEndDayInBookerTz) {
     const isAfterRollingEndDay =
-      dateObj.valueOf() > periodLimits.endOfRollingPeriodEndDayInBookerTz.valueOf();
+      dateObj.valueOf() >
+      periodLimits.endOfRollingPeriodEndDayInBookerTz.valueOf();
 
     if (isAfterRollingEndDay)
       log.warn(
@@ -318,15 +358,21 @@ export function isTimeViolatingFutureLimit({
         safeStringify({
           formattedDate: dateObj.toISOString(),
           isAfterRollingEndDay,
-          endOfRollingPeriodEndDayTs: periodLimits.endOfRollingPeriodEndDayInBookerTz.valueOf(),
+          endOfRollingPeriodEndDayTs:
+            periodLimits.endOfRollingPeriodEndDayInBookerTz.valueOf(),
         })
       );
     return isAfterRollingEndDay;
   }
 
-  if (periodLimits.startOfRangeStartDayInEventTz && periodLimits.endOfRangeEndDayInEventTz) {
-    const isBeforeRangeStart = dateObj.valueOf() < periodLimits.startOfRangeStartDayInEventTz.valueOf();
-    const isAfterRangeEnd = dateObj.valueOf() > periodLimits.endOfRangeEndDayInEventTz.valueOf();
+  if (
+    periodLimits.startOfRangeStartDayInEventTz &&
+    periodLimits.endOfRangeEndDayInEventTz
+  ) {
+    const isBeforeRangeStart =
+      dateObj.valueOf() < periodLimits.startOfRangeStartDayInEventTz.valueOf();
+    const isAfterRangeEnd =
+      dateObj.valueOf() > periodLimits.endOfRangeEndDayInEventTz.valueOf();
     if (isBeforeRangeStart || isAfterRangeEnd)
       log.warn(
         "Booking is out of bounds due to range start and end.",
@@ -334,8 +380,11 @@ export function isTimeViolatingFutureLimit({
           formattedDate: dateObj.toISOString(),
           isBeforeRangeStart,
           isAfterRangeEnd,
-          startOfRangeStartDayInEventTz: periodLimits.startOfRangeStartDayInEventTz.toDate().toISOString(),
-          endOfRangeEndDayInEventTz: periodLimits.endOfRangeEndDayInEventTz.toDate().toISOString(),
+          startOfRangeStartDayInEventTz:
+            periodLimits.startOfRangeStartDayInEventTz.toDate().toISOString(),
+          endOfRangeEndDayInEventTz: periodLimits.endOfRangeEndDayInEventTz
+            .toDate()
+            .toISOString(),
         })
       );
     return isBeforeRangeStart || isAfterRangeEnd;
@@ -355,7 +404,11 @@ export default function isOutOfBounds(
     bookerUtcOffset,
   }: Pick<
     EventType,
-    "periodType" | "periodDays" | "periodCountCalendarDays" | "periodStartDate" | "periodEndDate"
+    | "periodType"
+    | "periodDays"
+    | "periodCountCalendarDays"
+    | "periodStartDate"
+    | "periodEndDate"
   > & {
     eventUtcOffset: number;
     bookerUtcOffset: number;
@@ -363,7 +416,11 @@ export default function isOutOfBounds(
   minimumBookingNotice?: number
 ) {
   const log = logger.getSubLogger({ prefix: ["isOutOfBounds"] });
-  const isOutOfBoundsByTime = isTimeOutOfBounds({ time, minimumBookingNotice });
+  const isOutOfBoundsByTime = isTimeOutOfBounds({
+    time,
+    minimumBookingNotice,
+    eventUtcOffset,
+  });
   const periodLimits = calculatePeriodLimits({
     periodType,
     periodDays,
@@ -390,7 +447,10 @@ export default function isOutOfBounds(
   }
 
   if (isOutOfBoundsByPeriod) {
-    log.warn("Booking is out of bounds due to period restrictions", safeStringify({ periodLimits }));
+    log.warn(
+      "Booking is out of bounds due to period restrictions",
+      safeStringify({ periodLimits })
+    );
     return true;
   }
 

--- a/packages/trpc/server/routers/viewer/slots/isAvailable.handler.ts
+++ b/packages/trpc/server/routers/viewer/slots/isAvailable.handler.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest } from "next";
 
 import { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import { PrismaSelectedSlotRepository } from "@calcom/features/selectedSlots/repositories/PrismaSelectedSlotRepository";
+import { getUTCOffsetByTimezone } from "@calcom/lib/date-fns";
 import { HttpError } from "@calcom/lib/http-error";
 import { getPastTimeAndMinimumBookingNoticeBoundsStatus } from "@calcom/lib/isOutOfBounds";
 import type { PrismaClient } from "@calcom/prisma";
@@ -33,11 +34,14 @@ export const isAvailableHandler = async ({
 
   // Get event type details for time bounds validation
   const eventTypeRepo = new EventTypeRepository(ctx.prisma);
-  const eventType = await eventTypeRepo.findByIdMinimal({ id: eventTypeId });
+  const eventType = await eventTypeRepo.findForSlots({ id: eventTypeId });
 
   if (!eventType) {
     throw new HttpError({ statusCode: 404, message: "Event type not found" });
   }
+
+  const eventTimeZone = eventType.timeZone || eventType?.schedule?.timeZone;
+  const eventUtcOffset = eventTimeZone ? (getUTCOffsetByTimezone(eventTimeZone) ?? 0) : 0;
 
   // Check each slot's availability
   // Without uid, we must not check for reserved slots because if uuid isn't set in cookie yet, but it is going to be through reserveSlot request soon, we could consider the slot as reserved accidentally.
@@ -70,6 +74,7 @@ export const isAvailableHandler = async ({
     const timeStatus = getPastTimeAndMinimumBookingNoticeBoundsStatus({
       time: slot.utcStartIso,
       minimumBookingNotice: eventType.minimumBookingNotice,
+      eventUtcOffset,
     });
 
     return {

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1535,6 +1535,7 @@ export class AvailableSlotsService {
             isOutOfBounds = isTimeOutOfBounds({
               time: slot.time,
               minimumBookingNotice: eventType.minimumBookingNotice,
+              eventUtcOffset,
             });
           } catch (error) {
             if (error instanceof BookingDateInPastError) {


### PR DESCRIPTION
closes: #27676

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where booking slots were marked as past using the
server/local time instead of the event's timezone.

When the booker was ahead in timezone (e.g. IST) and the host was
behind (e.g. PST), remaining slots for the host’s current day
were incorrectly marked as unavailable.

- Fixes #27676 
- Fixes CAL-7176

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
