### PR TITLE
fix: match duration selector style to date selector style

### DIFF
--- a/apps/web/modules/bookings/components/event-meta/Duration.tsx
+++ b/apps/web/modules/bookings/components/event-meta/Duration.tsx
@@ -124,8 +124,10 @@ export const EventDuration = ({
               onClick={() => setSelectedDuration(duration)}
               ref={(el) => (itemRefs.current[duration] = el)}
               className={classNames(
-                selectedDuration === duration ? "bg-inverted text-inverted" : "hover:text-emphasis",
-                "text-default cursor-pointer rounded-[4px] px-3 py-1.5 text-sm leading-tight transition"
+                selectedDuration === duration
+                  ? "bg-inverted text-inverted"
+                  : "text-default hover:text-emphasis",
+                "cursor-pointer rounded-[4px] px-3 py-1.5 text-sm leading-tight transition"
               )}>
               <div className="w-max">{getDurationFormatted(duration, t)}</div>
             </li>

--- a/apps/web/modules/bookings/components/event-meta/Duration.tsx
+++ b/apps/web/modules/bookings/components/event-meta/Duration.tsx
@@ -1,14 +1,13 @@
-import type { TFunction } from "i18next";
-import { useEffect, useRef } from "react";
-
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import { useIsEmbed } from "@calcom/embed-core/embed-iframe";
-import { useShouldShowArrows } from "@calcom/web/modules/apps/components/AllApps";
 import { useBookerStoreContext } from "@calcom/features/bookings/Booker/BookerStoreProvider";
 import type { BookerEvent } from "@calcom/features/bookings/types";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
+import { useShouldShowArrows } from "@calcom/web/modules/apps/components/AllApps";
 import { ChevronLeftIcon, ChevronRightIcon } from "@coss/ui/icons";
+import type { TFunction } from "i18next";
+import { useEffect, useRef } from "react";
 
 /** Render X mins as X hours or X hours Y mins instead of in minutes once >= 60 minutes */
 export const getDurationFormatted = (mins: number | undefined, t: TFunction) => {
@@ -125,7 +124,7 @@ export const EventDuration = ({
               onClick={() => setSelectedDuration(duration)}
               ref={(el) => (itemRefs.current[duration] = el)}
               className={classNames(
-                selectedDuration === duration ? "bg-emphasis" : "hover:text-emphasis",
+                selectedDuration === duration ? "bg-inverted text-inverted" : "hover:text-emphasis",
                 "text-default cursor-pointer rounded-[4px] px-3 py-1.5 text-sm leading-tight transition"
               )}>
               <div className="w-max">{getDurationFormatted(duration, t)}</div>


### PR DESCRIPTION
## What does this PR do?
Updates the active duration pill in the booking page to use the same
style as the selected date in the calendar.

The selected duration previously used `bg-emphasis` (neutral grey).
This changes it to `bg-inverted text-inverted` to match the high-contrast
dark style used by the Date Selector's selected state.

Fixes #28275

## Visual Demo
Before: neutral grey pill for selected duration
After: high-contrast dark pill matching the date selector style

## How was this tested?
Verified styling by reviewing `Calendar.tsx` which uses `bg-inverted text-inverted`
for the day_selected modifier.

## Type of change
- [x] Bug fix / UI improvement
