### PR TITLE
perf: batch DB operations in createAttributesScenario to avoid CI timeout

### DIFF
--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
@@ -179,13 +179,17 @@ async function createAttributesScenario(params: {
 
   const users = await prisma.user.findMany({
     where: { email: { in: userDataList.map((u) => u.email) } },
-    select: { id: true },
+    select: { id: true, email: true },
   });
 
-  createdResources.users.push(...users.map((u) => u.id));
+  // findMany doesn't guarantee order, so re-sort to match userDataList index
+  const emailToUser = new Map(users.map((u) => [u.email, u]));
+  const orderedUsers = userDataList.map((ud) => emailToUser.get(ud.email)!);
+
+  createdResources.users.push(...orderedUsers.map((u) => u.id));
 
   await prisma.membership.createMany({
-    data: users.map((user) => ({
+    data: orderedUsers.map((user) => ({
       userId: user.id,
       teamId: testFixtures.org.id,
       role: "MEMBER" as const,
@@ -195,7 +199,7 @@ async function createAttributesScenario(params: {
 
   const orgMemberships = await prisma.membership.findMany({
     where: {
-      userId: { in: users.map((u) => u.id) },
+      userId: { in: orderedUsers.map((u) => u.id) },
       teamId: testFixtures.org.id,
     },
     select: { id: true, userId: true },
@@ -204,7 +208,7 @@ async function createAttributesScenario(params: {
   createdResources.memberships.push(...orgMemberships.map((m) => m.id));
 
   await prisma.membership.createMany({
-    data: users.map((user) => ({
+    data: orderedUsers.map((user) => ({
       userId: user.id,
       teamId: testFixtures.team.id,
       role: "MEMBER" as const,
@@ -214,7 +218,7 @@ async function createAttributesScenario(params: {
 
   const teamMemberships = await prisma.membership.findMany({
     where: {
-      userId: { in: users.map((u) => u.id) },
+      userId: { in: orderedUsers.map((u) => u.id) },
       teamId: testFixtures.team.id,
     },
     select: { id: true },
@@ -225,8 +229,8 @@ async function createAttributesScenario(params: {
   const userIdToOrgMembershipId = new Map(orgMemberships.map((m) => [m.userId, m.id]));
 
   const attributeAssignments: { memberId: number; attributeOptionId: string }[] = [];
-  for (let i = 0; i < users.length; i++) {
-    const orgMembershipId = userIdToOrgMembershipId.get(users[i].id);
+  for (let i = 0; i < orderedUsers.length; i++) {
+    const orgMembershipId = userIdToOrgMembershipId.get(orderedUsers[i].id);
     if (!orgMembershipId) continue;
     const member = teamMembersWithAttributeOptionValuePerAttribute[i];
     for (const [attrId, value] of Object.entries(member.attributes)) {
@@ -256,7 +260,7 @@ async function createAttributesScenario(params: {
     createdResources.attributeToUsers.push(...createdAssignments.map((a) => a.id));
   }
 
-  const createdUsers = users.map((user) => ({
+  const createdUsers = orderedUsers.map((user) => ({
     userId: user.id,
     orgMembershipId: userIdToOrgMembershipId.get(user.id)!,
   }));

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
@@ -167,40 +167,99 @@ async function createAttributesScenario(params: {
     }
   }
 
-  const createdUsers: { userId: number; orgMembershipId: number }[] = [];
+  const numMembers = teamMembersWithAttributeOptionValuePerAttribute.length;
+  const timestamp = Date.now();
 
-  for (const member of teamMembersWithAttributeOptionValuePerAttribute) {
-    let userId: number;
-    if (member.userId) {
-      userId = member.userId;
-      const user = await createTestUser();
-      userId = user.id;
-    } else {
-      const user = await createTestUser();
-      userId = user.id;
-    }
+  const userDataList = Array.from({ length: numMembers }, (_, i) => ({
+    email: `test-user-${timestamp}-${i}@example.com`,
+    username: `test-user-${timestamp}-${i}`,
+  }));
 
-    const { orgMembership } = await createTestMemberships({
-      userId,
-      orgId: testFixtures.org.id,
+  await prisma.user.createMany({ data: userDataList });
+
+  const users = await prisma.user.findMany({
+    where: { email: { in: userDataList.map((u) => u.email) } },
+    select: { id: true },
+  });
+
+  createdResources.users.push(...users.map((u) => u.id));
+
+  await prisma.membership.createMany({
+    data: users.map((user) => ({
+      userId: user.id,
+      teamId: testFixtures.org.id,
+      role: "MEMBER" as const,
+      accepted: true,
+    })),
+  });
+
+  const orgMemberships = await prisma.membership.findMany({
+    where: {
+      userId: { in: users.map((u) => u.id) },
+      teamId: testFixtures.org.id,
+    },
+    select: { id: true, userId: true },
+  });
+
+  createdResources.memberships.push(...orgMemberships.map((m) => m.id));
+
+  await prisma.membership.createMany({
+    data: users.map((user) => ({
+      userId: user.id,
       teamId: testFixtures.team.id,
-    });
+      role: "MEMBER" as const,
+      accepted: true,
+    })),
+  });
 
+  const teamMemberships = await prisma.membership.findMany({
+    where: {
+      userId: { in: users.map((u) => u.id) },
+      teamId: testFixtures.team.id,
+    },
+    select: { id: true },
+  });
+
+  createdResources.memberships.push(...teamMemberships.map((m) => m.id));
+
+  const userIdToOrgMembershipId = new Map(orgMemberships.map((m) => [m.userId, m.id]));
+
+  const attributeAssignments: { memberId: number; attributeOptionId: string }[] = [];
+  for (let i = 0; i < users.length; i++) {
+    const orgMembershipId = userIdToOrgMembershipId.get(users[i].id);
+    if (!orgMembershipId) continue;
+    const member = teamMembersWithAttributeOptionValuePerAttribute[i];
     for (const [attrId, value] of Object.entries(member.attributes)) {
       const values = Array.isArray(value) ? value : [value];
       for (const v of values) {
         const optionId = optionValueToId.get(`${attrId}:${v}`);
         if (optionId) {
-          await createTestAttributeAssignment({
-            orgMembershipId: orgMembership.id,
+          attributeAssignments.push({
+            memberId: orgMembershipId,
             attributeOptionId: optionId,
           });
         }
       }
     }
-
-    createdUsers.push({ userId, orgMembershipId: orgMembership.id });
   }
+
+  if (attributeAssignments.length > 0) {
+    await prisma.attributeToUser.createMany({ data: attributeAssignments });
+
+    const createdAssignments = await prisma.attributeToUser.findMany({
+      where: {
+        memberId: { in: orgMemberships.map((m) => m.id) },
+      },
+      select: { id: true },
+    });
+
+    createdResources.attributeToUsers.push(...createdAssignments.map((a) => a.id));
+  }
+
+  const createdUsers = users.map((user) => ({
+    userId: user.id,
+    orgMembershipId: userIdToOrgMembershipId.get(user.id)!,
+  }));
 
   return { createdAttributes, createdUsers };
 }
@@ -232,97 +291,6 @@ async function createHugeAttributesOfTypeSingleSelect(params: {
 
   const assignedAttributeOptionIdForEachMember = 1;
 
-  // Create attributes in parallel (these are few, so individual creates are fine)
-  await Promise.all(
-    attributes.map((attr) =>
-      createTestAttribute({
-        orgId: testFixtures.org.id,
-        ...attr,
-      })
-    )
-  );
-
-  // Batch create users instead of one-by-one to avoid timeout on slow CI
-  const userDataList = Array.from({ length: numTeamMembers }, (_, i) => ({
-    email: `perf-test-user-${timestamp}-${i}@example.com`,
-    username: `perf-test-user-${timestamp}-${i}`,
-  }));
-
-  await prisma.user.createMany({ data: userDataList });
-
-  const users = await prisma.user.findMany({
-    where: { email: { in: userDataList.map((u) => u.email) } },
-    select: { id: true },
-  });
-
-  createdResources.users.push(...users.map((u) => u.id));
-
-  // Batch create org memberships
-  await prisma.membership.createMany({
-    data: users.map((user) => ({
-      userId: user.id,
-      teamId: testFixtures.org.id,
-      role: "MEMBER" as const,
-      accepted: true,
-    })),
-  });
-
-  const orgMemberships = await prisma.membership.findMany({
-    where: {
-      userId: { in: users.map((u) => u.id) },
-      teamId: testFixtures.org.id,
-    },
-    select: { id: true, userId: true },
-  });
-
-  createdResources.memberships.push(...orgMemberships.map((m) => m.id));
-
-  // Batch create team memberships
-  await prisma.membership.createMany({
-    data: users.map((user) => ({
-      userId: user.id,
-      teamId: testFixtures.team.id,
-      role: "MEMBER" as const,
-      accepted: true,
-    })),
-  });
-
-  const teamMemberships = await prisma.membership.findMany({
-    where: {
-      userId: { in: users.map((u) => u.id) },
-      teamId: testFixtures.team.id,
-    },
-    select: { id: true },
-  });
-
-  createdResources.memberships.push(...teamMemberships.map((m) => m.id));
-
-  // Batch create attribute assignments
-  const userIdToOrgMembershipId = new Map(orgMemberships.map((m) => [m.userId, m.id]));
-
-  const attributeAssignments: { memberId: number; attributeOptionId: string }[] = [];
-  for (const user of users) {
-    const orgMembershipId = userIdToOrgMembershipId.get(user.id);
-    if (!orgMembershipId) continue;
-    for (let j = 0; j < numAttributesUsedPerTeamMember; j++) {
-      attributeAssignments.push({
-        memberId: orgMembershipId,
-        attributeOptionId: attributes[j].options[assignedAttributeOptionIdForEachMember].id,
-      });
-    }
-  }
-
-  await prisma.attributeToUser.createMany({ data: attributeAssignments });
-
-  const createdAssignments = await prisma.attributeToUser.findMany({
-    where: {
-      memberId: { in: orgMemberships.map((m) => m.id) },
-    },
-    select: { id: true },
-  });
-
-  createdResources.attributeToUsers.push(...createdAssignments.map((a) => a.id));
-
   const teamMembersWithAttributeOptionValuePerAttribute = Array.from({ length: numTeamMembers }, (_, _i) => ({
     attributes: Object.fromEntries(
       Array.from({ length: numAttributesUsedPerTeamMember }, (_, j) => [
@@ -331,6 +299,11 @@ async function createHugeAttributesOfTypeSingleSelect(params: {
       ])
     ),
   }));
+
+  await createAttributesScenario({
+    attributes,
+    teamMembersWithAttributeOptionValuePerAttribute,
+  });
 
   return {
     attributes,
@@ -1336,7 +1309,7 @@ describe("findTeamMembersMatchingAttributeLogic", () => {
           timeTaken,
         });
         expect(totalTimeTaken).toBeLessThan(5000);
-      }, 60000);
+      }, 120000);
     });
   });
 

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
@@ -232,7 +232,98 @@ async function createHugeAttributesOfTypeSingleSelect(params: {
 
   const assignedAttributeOptionIdForEachMember = 1;
 
-  const teamMembersWithAttributeOptionValuePerAttribute = Array.from({ length: numTeamMembers }, (_, i) => ({
+  // Create attributes in parallel (these are few, so individual creates are fine)
+  await Promise.all(
+    attributes.map((attr) =>
+      createTestAttribute({
+        orgId: testFixtures.org.id,
+        ...attr,
+      })
+    )
+  );
+
+  // Batch create users instead of one-by-one to avoid timeout on slow CI
+  const userDataList = Array.from({ length: numTeamMembers }, (_, i) => ({
+    email: `perf-test-user-${timestamp}-${i}@example.com`,
+    username: `perf-test-user-${timestamp}-${i}`,
+  }));
+
+  await prisma.user.createMany({ data: userDataList });
+
+  const users = await prisma.user.findMany({
+    where: { email: { in: userDataList.map((u) => u.email) } },
+    select: { id: true },
+  });
+
+  createdResources.users.push(...users.map((u) => u.id));
+
+  // Batch create org memberships
+  await prisma.membership.createMany({
+    data: users.map((user) => ({
+      userId: user.id,
+      teamId: testFixtures.org.id,
+      role: "MEMBER" as const,
+      accepted: true,
+    })),
+  });
+
+  const orgMemberships = await prisma.membership.findMany({
+    where: {
+      userId: { in: users.map((u) => u.id) },
+      teamId: testFixtures.org.id,
+    },
+    select: { id: true, userId: true },
+  });
+
+  createdResources.memberships.push(...orgMemberships.map((m) => m.id));
+
+  // Batch create team memberships
+  await prisma.membership.createMany({
+    data: users.map((user) => ({
+      userId: user.id,
+      teamId: testFixtures.team.id,
+      role: "MEMBER" as const,
+      accepted: true,
+    })),
+  });
+
+  const teamMemberships = await prisma.membership.findMany({
+    where: {
+      userId: { in: users.map((u) => u.id) },
+      teamId: testFixtures.team.id,
+    },
+    select: { id: true },
+  });
+
+  createdResources.memberships.push(...teamMemberships.map((m) => m.id));
+
+  // Batch create attribute assignments
+  const userIdToOrgMembershipId = new Map(orgMemberships.map((m) => [m.userId, m.id]));
+
+  const attributeAssignments: { memberId: number; attributeOptionId: string }[] = [];
+  for (const user of users) {
+    const orgMembershipId = userIdToOrgMembershipId.get(user.id);
+    if (!orgMembershipId) continue;
+    for (let j = 0; j < numAttributesUsedPerTeamMember; j++) {
+      attributeAssignments.push({
+        memberId: orgMembershipId,
+        attributeOptionId: attributes[j].options[assignedAttributeOptionIdForEachMember].id,
+      });
+    }
+  }
+
+  await prisma.attributeToUser.createMany({ data: attributeAssignments });
+
+  const createdAssignments = await prisma.attributeToUser.findMany({
+    where: {
+      memberId: { in: orgMemberships.map((m) => m.id) },
+    },
+    select: { id: true },
+  });
+
+  createdResources.attributeToUsers.push(...createdAssignments.map((a) => a.id));
+
+  const teamMembersWithAttributeOptionValuePerAttribute = Array.from({ length: numTeamMembers }, (_, _i) => ({
     attributes: Object.fromEntries(
       Array.from({ length: numAttributesUsedPerTeamMember }, (_, j) => [
         attributes[j].id,
@@ -240,11 +331,6 @@ async function createHugeAttributesOfTypeSingleSelect(params: {
       ])
     ),
   }));
-
-  await createAttributesScenario({
-    attributes,
-    teamMembersWithAttributeOptionValuePerAttribute,
-  });
 
   return {
     attributes,

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
@@ -167,40 +167,99 @@ async function createAttributesScenario(params: {
     }
   }
 
-  const createdUsers: { userId: number; orgMembershipId: number }[] = [];
+  const numMembers = teamMembersWithAttributeOptionValuePerAttribute.length;
+  const timestamp = Date.now();
 
-  for (const member of teamMembersWithAttributeOptionValuePerAttribute) {
-    let userId: number;
-    if (member.userId) {
-      userId = member.userId;
-      const user = await createTestUser();
-      userId = user.id;
-    } else {
-      const user = await createTestUser();
-      userId = user.id;
-    }
+  const userDataList = Array.from({ length: numMembers }, (_, i) => ({
+    email: `test-user-${timestamp}-${i}@example.com`,
+    username: `test-user-${timestamp}-${i}`,
+  }));
 
-    const { orgMembership } = await createTestMemberships({
-      userId,
-      orgId: testFixtures.org.id,
+  await prisma.user.createMany({ data: userDataList });
+
+  const users = await prisma.user.findMany({
+    where: { email: { in: userDataList.map((u) => u.email) } },
+    select: { id: true },
+  });
+
+  createdResources.users.push(...users.map((u) => u.id));
+
+  await prisma.membership.createMany({
+    data: users.map((user) => ({
+      userId: user.id,
+      teamId: testFixtures.org.id,
+      role: "MEMBER" as const,
+      accepted: true,
+    })),
+  });
+
+  const orgMemberships = await prisma.membership.findMany({
+    where: {
+      userId: { in: users.map((u) => u.id) },
+      teamId: testFixtures.org.id,
+    },
+    select: { id: true, userId: true },
+  });
+
+  createdResources.memberships.push(...orgMemberships.map((m) => m.id));
+
+  await prisma.membership.createMany({
+    data: users.map((user) => ({
+      userId: user.id,
       teamId: testFixtures.team.id,
-    });
+      role: "MEMBER" as const,
+      accepted: true,
+    })),
+  });
 
+  const teamMemberships = await prisma.membership.findMany({
+    where: {
+      userId: { in: users.map((u) => u.id) },
+      teamId: testFixtures.team.id,
+    },
+    select: { id: true },
+  });
+
+  createdResources.memberships.push(...teamMemberships.map((m) => m.id));
+
+  const userIdToOrgMembershipId = new Map(orgMemberships.map((m) => [m.userId, m.id]));
+
+  const attributeAssignments: { memberId: number; attributeOptionId: string }[] = [];
+  for (let i = 0; i < users.length; i++) {
+    const orgMembershipId = userIdToOrgMembershipId.get(users[i].id);
+    if (!orgMembershipId) continue;
+    const member = teamMembersWithAttributeOptionValuePerAttribute[i];
     for (const [attrId, value] of Object.entries(member.attributes)) {
       const values = Array.isArray(value) ? value : [value];
       for (const v of values) {
         const optionId = optionValueToId.get(`${attrId}:${v}`);
         if (optionId) {
-          await createTestAttributeAssignment({
-            orgMembershipId: orgMembership.id,
+          attributeAssignments.push({
+            memberId: orgMembershipId,
             attributeOptionId: optionId,
           });
         }
       }
     }
-
-    createdUsers.push({ userId, orgMembershipId: orgMembership.id });
   }
+
+  if (attributeAssignments.length > 0) {
+    await prisma.attributeToUser.createMany({ data: attributeAssignments });
+
+    const createdAssignments = await prisma.attributeToUser.findMany({
+      where: {
+        memberId: { in: orgMemberships.map((m) => m.id) },
+      },
+      select: { id: true },
+    });
+
+    createdResources.attributeToUsers.push(...createdAssignments.map((a) => a.id));
+  }
+
+  const createdUsers = users.map((user) => ({
+    userId: user.id,
+    orgMembershipId: userIdToOrgMembershipId.get(user.id)!,
+  }));
 
   return { createdAttributes, createdUsers };
 }
@@ -232,7 +291,7 @@ async function createHugeAttributesOfTypeSingleSelect(params: {
 
   const assignedAttributeOptionIdForEachMember = 1;
 
-  const teamMembersWithAttributeOptionValuePerAttribute = Array.from({ length: numTeamMembers }, (_, i) => ({
+  const teamMembersWithAttributeOptionValuePerAttribute = Array.from({ length: numTeamMembers }, (_, _i) => ({
     attributes: Object.fromEntries(
       Array.from({ length: numAttributesUsedPerTeamMember }, (_, j) => [
         attributes[j].id,
@@ -1250,7 +1309,7 @@ describe("findTeamMembersMatchingAttributeLogic", () => {
           timeTaken,
         });
         expect(totalTimeTaken).toBeLessThan(5000);
-      }, 60000);
+      }, 120000);
     });
   });
 

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
@@ -53,42 +53,6 @@ const createTestTeam = async (overrides: { parentId: number }) => {
   return team;
 };
 
-const createTestUser = async (overrides?: { email?: string; username?: string }) => {
-  const timestamp = Date.now() + Math.random();
-  const user = await prisma.user.create({
-    data: {
-      email: overrides?.email ?? `test-user-${timestamp}@example.com`,
-      username: overrides?.username ?? `test-user-${timestamp}`,
-    },
-  });
-  createdResources.users.push(user.id);
-  return user;
-};
-
-const createTestMemberships = async (params: { userId: number; orgId: number; teamId: number }) => {
-  const orgMembership = await prisma.membership.create({
-    data: {
-      userId: params.userId,
-      teamId: params.orgId,
-      role: "MEMBER",
-      accepted: true,
-    },
-  });
-  createdResources.memberships.push(orgMembership.id);
-
-  const teamMembership = await prisma.membership.create({
-    data: {
-      userId: params.userId,
-      teamId: params.teamId,
-      role: "MEMBER",
-      accepted: true,
-    },
-  });
-  createdResources.memberships.push(teamMembership.id);
-
-  return { orgMembership, teamMembership };
-};
-
 const createTestAttribute = async (params: {
   orgId: number;
   id: string;
@@ -122,23 +86,6 @@ const createTestAttribute = async (params: {
   return attribute;
 };
 
-const createTestAttributeAssignment = async (params: {
-  orgMembershipId: number;
-  attributeOptionId: string;
-}) => {
-  const assignment = await prisma.attributeToUser.create({
-    data: {
-      memberId: params.orgMembershipId,
-      attributeOptionId: params.attributeOptionId,
-    },
-  });
-  createdResources.attributeToUsers.push(assignment.id);
-  return assignment;
-};
-
-/**
- * Batch-create users and return them in the same order as the input list.
- */
 const createTestUsers = async (userDataList: { email: string; username: string }[]) => {
   await prisma.user.createMany({ data: userDataList });
 
@@ -147,7 +94,6 @@ const createTestUsers = async (userDataList: { email: string; username: string }
     select: { id: true, email: true },
   });
 
-  // findMany doesn't guarantee order, so re-sort to match input order
   const emailToUser = new Map(users.map((u) => [u.email, u]));
   const orderedUsers = userDataList.map((ud) => emailToUser.get(ud.email)!);
 
@@ -155,10 +101,6 @@ const createTestUsers = async (userDataList: { email: string; username: string }
   return orderedUsers;
 };
 
-/**
- * Batch-create org and team memberships for all users.
- * Returns a map of userId → orgMembershipId.
- */
 const createTestMembershipsForUsers = async (params: {
   userIds: number[];
   orgId: number;
@@ -202,9 +144,6 @@ const createTestMembershipsForUsers = async (params: {
   return { userIdToOrgMembershipId };
 };
 
-/**
- * Batch-create attribute assignments for users based on a per-member attribute map.
- */
 const createTestAttributeAssignments = async (params: {
   orderedUserIds: number[];
   userIdToOrgMembershipId: Map<number, number>;

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
@@ -1313,7 +1313,7 @@ describe("findTeamMembersMatchingAttributeLogic", () => {
           timeTaken,
         });
         expect(totalTimeTaken).toBeLessThan(5000);
-      }, 120000);
+      }, 60000);
     });
   });
 

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
@@ -167,99 +167,40 @@ async function createAttributesScenario(params: {
     }
   }
 
-  const numMembers = teamMembersWithAttributeOptionValuePerAttribute.length;
-  const timestamp = Date.now();
+  const createdUsers: { userId: number; orgMembershipId: number }[] = [];
 
-  const userDataList = Array.from({ length: numMembers }, (_, i) => ({
-    email: `test-user-${timestamp}-${i}@example.com`,
-    username: `test-user-${timestamp}-${i}`,
-  }));
+  for (const member of teamMembersWithAttributeOptionValuePerAttribute) {
+    let userId: number;
+    if (member.userId) {
+      userId = member.userId;
+      const user = await createTestUser();
+      userId = user.id;
+    } else {
+      const user = await createTestUser();
+      userId = user.id;
+    }
 
-  await prisma.user.createMany({ data: userDataList });
-
-  const users = await prisma.user.findMany({
-    where: { email: { in: userDataList.map((u) => u.email) } },
-    select: { id: true },
-  });
-
-  createdResources.users.push(...users.map((u) => u.id));
-
-  await prisma.membership.createMany({
-    data: users.map((user) => ({
-      userId: user.id,
-      teamId: testFixtures.org.id,
-      role: "MEMBER" as const,
-      accepted: true,
-    })),
-  });
-
-  const orgMemberships = await prisma.membership.findMany({
-    where: {
-      userId: { in: users.map((u) => u.id) },
-      teamId: testFixtures.org.id,
-    },
-    select: { id: true, userId: true },
-  });
-
-  createdResources.memberships.push(...orgMemberships.map((m) => m.id));
-
-  await prisma.membership.createMany({
-    data: users.map((user) => ({
-      userId: user.id,
+    const { orgMembership } = await createTestMemberships({
+      userId,
+      orgId: testFixtures.org.id,
       teamId: testFixtures.team.id,
-      role: "MEMBER" as const,
-      accepted: true,
-    })),
-  });
+    });
 
-  const teamMemberships = await prisma.membership.findMany({
-    where: {
-      userId: { in: users.map((u) => u.id) },
-      teamId: testFixtures.team.id,
-    },
-    select: { id: true },
-  });
-
-  createdResources.memberships.push(...teamMemberships.map((m) => m.id));
-
-  const userIdToOrgMembershipId = new Map(orgMemberships.map((m) => [m.userId, m.id]));
-
-  const attributeAssignments: { memberId: number; attributeOptionId: string }[] = [];
-  for (let i = 0; i < users.length; i++) {
-    const orgMembershipId = userIdToOrgMembershipId.get(users[i].id);
-    if (!orgMembershipId) continue;
-    const member = teamMembersWithAttributeOptionValuePerAttribute[i];
     for (const [attrId, value] of Object.entries(member.attributes)) {
       const values = Array.isArray(value) ? value : [value];
       for (const v of values) {
         const optionId = optionValueToId.get(`${attrId}:${v}`);
         if (optionId) {
-          attributeAssignments.push({
-            memberId: orgMembershipId,
+          await createTestAttributeAssignment({
+            orgMembershipId: orgMembership.id,
             attributeOptionId: optionId,
           });
         }
       }
     }
+
+    createdUsers.push({ userId, orgMembershipId: orgMembership.id });
   }
-
-  if (attributeAssignments.length > 0) {
-    await prisma.attributeToUser.createMany({ data: attributeAssignments });
-
-    const createdAssignments = await prisma.attributeToUser.findMany({
-      where: {
-        memberId: { in: orgMemberships.map((m) => m.id) },
-      },
-      select: { id: true },
-    });
-
-    createdResources.attributeToUsers.push(...createdAssignments.map((a) => a.id));
-  }
-
-  const createdUsers = users.map((user) => ({
-    userId: user.id,
-    orgMembershipId: userIdToOrgMembershipId.get(user.id)!,
-  }));
 
   return { createdAttributes, createdUsers };
 }
@@ -291,6 +232,97 @@ async function createHugeAttributesOfTypeSingleSelect(params: {
 
   const assignedAttributeOptionIdForEachMember = 1;
 
+  // Create attributes in parallel (these are few, so individual creates are fine)
+  await Promise.all(
+    attributes.map((attr) =>
+      createTestAttribute({
+        orgId: testFixtures.org.id,
+        ...attr,
+      })
+    )
+  );
+
+  // Batch create users instead of one-by-one to avoid timeout on slow CI
+  const userDataList = Array.from({ length: numTeamMembers }, (_, i) => ({
+    email: `perf-test-user-${timestamp}-${i}@example.com`,
+    username: `perf-test-user-${timestamp}-${i}`,
+  }));
+
+  await prisma.user.createMany({ data: userDataList });
+
+  const users = await prisma.user.findMany({
+    where: { email: { in: userDataList.map((u) => u.email) } },
+    select: { id: true },
+  });
+
+  createdResources.users.push(...users.map((u) => u.id));
+
+  // Batch create org memberships
+  await prisma.membership.createMany({
+    data: users.map((user) => ({
+      userId: user.id,
+      teamId: testFixtures.org.id,
+      role: "MEMBER" as const,
+      accepted: true,
+    })),
+  });
+
+  const orgMemberships = await prisma.membership.findMany({
+    where: {
+      userId: { in: users.map((u) => u.id) },
+      teamId: testFixtures.org.id,
+    },
+    select: { id: true, userId: true },
+  });
+
+  createdResources.memberships.push(...orgMemberships.map((m) => m.id));
+
+  // Batch create team memberships
+  await prisma.membership.createMany({
+    data: users.map((user) => ({
+      userId: user.id,
+      teamId: testFixtures.team.id,
+      role: "MEMBER" as const,
+      accepted: true,
+    })),
+  });
+
+  const teamMemberships = await prisma.membership.findMany({
+    where: {
+      userId: { in: users.map((u) => u.id) },
+      teamId: testFixtures.team.id,
+    },
+    select: { id: true },
+  });
+
+  createdResources.memberships.push(...teamMemberships.map((m) => m.id));
+
+  // Batch create attribute assignments
+  const userIdToOrgMembershipId = new Map(orgMemberships.map((m) => [m.userId, m.id]));
+
+  const attributeAssignments: { memberId: number; attributeOptionId: string }[] = [];
+  for (const user of users) {
+    const orgMembershipId = userIdToOrgMembershipId.get(user.id);
+    if (!orgMembershipId) continue;
+    for (let j = 0; j < numAttributesUsedPerTeamMember; j++) {
+      attributeAssignments.push({
+        memberId: orgMembershipId,
+        attributeOptionId: attributes[j].options[assignedAttributeOptionIdForEachMember].id,
+      });
+    }
+  }
+
+  await prisma.attributeToUser.createMany({ data: attributeAssignments });
+
+  const createdAssignments = await prisma.attributeToUser.findMany({
+    where: {
+      memberId: { in: orgMemberships.map((m) => m.id) },
+    },
+    select: { id: true },
+  });
+
+  createdResources.attributeToUsers.push(...createdAssignments.map((a) => a.id));
+
   const teamMembersWithAttributeOptionValuePerAttribute = Array.from({ length: numTeamMembers }, (_, _i) => ({
     attributes: Object.fromEntries(
       Array.from({ length: numAttributesUsedPerTeamMember }, (_, j) => [
@@ -299,11 +331,6 @@ async function createHugeAttributesOfTypeSingleSelect(params: {
       ])
     ),
   }));
-
-  await createAttributesScenario({
-    attributes,
-    teamMembersWithAttributeOptionValuePerAttribute,
-  });
 
   return {
     attributes,
@@ -1309,7 +1336,7 @@ describe("findTeamMembersMatchingAttributeLogic", () => {
           timeTaken,
         });
         expect(totalTimeTaken).toBeLessThan(5000);
-      }, 120000);
+      }, 60000);
     });
   });
 

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
@@ -170,7 +170,7 @@ const createTestAttributeAssignments = async (params: {
   if (assignments.length > 0) {
     await prisma.attributeToUser.createMany({ data: assignments });
 
-    const orgMembershipIds = [...new Set(assignments.map((a) => a.memberId))];
+    const orgMembershipIds = Array.from(new Set(assignments.map((a) => a.memberId)));
     const created = await prisma.attributeToUser.findMany({
       where: { memberId: { in: orgMembershipIds } },
       select: { id: true },

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
@@ -136,6 +136,111 @@ const createTestAttributeAssignment = async (params: {
   return assignment;
 };
 
+/**
+ * Batch-create users and return them in the same order as the input list.
+ */
+const createTestUsers = async (userDataList: { email: string; username: string }[]) => {
+  await prisma.user.createMany({ data: userDataList });
+
+  const users = await prisma.user.findMany({
+    where: { email: { in: userDataList.map((u) => u.email) } },
+    select: { id: true, email: true },
+  });
+
+  // findMany doesn't guarantee order, so re-sort to match input order
+  const emailToUser = new Map(users.map((u) => [u.email, u]));
+  const orderedUsers = userDataList.map((ud) => emailToUser.get(ud.email)!);
+
+  createdResources.users.push(...orderedUsers.map((u) => u.id));
+  return orderedUsers;
+};
+
+/**
+ * Batch-create org and team memberships for all users.
+ * Returns a map of userId → orgMembershipId.
+ */
+const createTestMembershipsForUsers = async (params: {
+  userIds: number[];
+  orgId: number;
+  teamId: number;
+}) => {
+  const { userIds, orgId, teamId } = params;
+
+  await prisma.membership.createMany({
+    data: userIds.map((userId) => ({
+      userId,
+      teamId: orgId,
+      role: "MEMBER" as const,
+      accepted: true,
+    })),
+  });
+
+  const orgMemberships = await prisma.membership.findMany({
+    where: { userId: { in: userIds }, teamId: orgId },
+    select: { id: true, userId: true },
+  });
+
+  createdResources.memberships.push(...orgMemberships.map((m) => m.id));
+
+  await prisma.membership.createMany({
+    data: userIds.map((userId) => ({
+      userId,
+      teamId,
+      role: "MEMBER" as const,
+      accepted: true,
+    })),
+  });
+
+  const teamMemberships = await prisma.membership.findMany({
+    where: { userId: { in: userIds }, teamId },
+    select: { id: true },
+  });
+
+  createdResources.memberships.push(...teamMemberships.map((m) => m.id));
+
+  const userIdToOrgMembershipId = new Map(orgMemberships.map((m) => [m.userId, m.id]));
+  return { userIdToOrgMembershipId };
+};
+
+/**
+ * Batch-create attribute assignments for users based on a per-member attribute map.
+ */
+const createTestAttributeAssignments = async (params: {
+  orderedUserIds: number[];
+  userIdToOrgMembershipId: Map<number, number>;
+  membersAttributes: Record<string, string | string[]>[];
+  optionValueToId: Map<string, string>;
+}) => {
+  const { orderedUserIds, userIdToOrgMembershipId, membersAttributes, optionValueToId } = params;
+
+  const assignments: { memberId: number; attributeOptionId: string }[] = [];
+  for (let i = 0; i < orderedUserIds.length; i++) {
+    const orgMembershipId = userIdToOrgMembershipId.get(orderedUserIds[i]);
+    if (!orgMembershipId) continue;
+    for (const [attrId, value] of Object.entries(membersAttributes[i])) {
+      const values = Array.isArray(value) ? value : [value];
+      for (const v of values) {
+        const optionId = optionValueToId.get(`${attrId}:${v}`);
+        if (optionId) {
+          assignments.push({ memberId: orgMembershipId, attributeOptionId: optionId });
+        }
+      }
+    }
+  }
+
+  if (assignments.length > 0) {
+    await prisma.attributeToUser.createMany({ data: assignments });
+
+    const orgMembershipIds = [...new Set(assignments.map((a) => a.memberId))];
+    const created = await prisma.attributeToUser.findMany({
+      where: { memberId: { in: orgMembershipIds } },
+      select: { id: true },
+    });
+
+    createdResources.attributeToUsers.push(...created.map((a) => a.id));
+  }
+};
+
 async function createAttributesScenario(params: {
   attributes: {
     id: string;
@@ -175,90 +280,20 @@ async function createAttributesScenario(params: {
     username: `test-user-${timestamp}-${i}`,
   }));
 
-  await prisma.user.createMany({ data: userDataList });
+  const orderedUsers = await createTestUsers(userDataList);
 
-  const users = await prisma.user.findMany({
-    where: { email: { in: userDataList.map((u) => u.email) } },
-    select: { id: true, email: true },
+  const { userIdToOrgMembershipId } = await createTestMembershipsForUsers({
+    userIds: orderedUsers.map((u) => u.id),
+    orgId: testFixtures.org.id,
+    teamId: testFixtures.team.id,
   });
 
-  // findMany doesn't guarantee order, so re-sort to match userDataList index
-  const emailToUser = new Map(users.map((u) => [u.email, u]));
-  const orderedUsers = userDataList.map((ud) => emailToUser.get(ud.email)!);
-
-  createdResources.users.push(...orderedUsers.map((u) => u.id));
-
-  await prisma.membership.createMany({
-    data: orderedUsers.map((user) => ({
-      userId: user.id,
-      teamId: testFixtures.org.id,
-      role: "MEMBER" as const,
-      accepted: true,
-    })),
+  await createTestAttributeAssignments({
+    orderedUserIds: orderedUsers.map((u) => u.id),
+    userIdToOrgMembershipId,
+    membersAttributes: teamMembersWithAttributeOptionValuePerAttribute.map((m) => m.attributes),
+    optionValueToId,
   });
-
-  const orgMemberships = await prisma.membership.findMany({
-    where: {
-      userId: { in: orderedUsers.map((u) => u.id) },
-      teamId: testFixtures.org.id,
-    },
-    select: { id: true, userId: true },
-  });
-
-  createdResources.memberships.push(...orgMemberships.map((m) => m.id));
-
-  await prisma.membership.createMany({
-    data: orderedUsers.map((user) => ({
-      userId: user.id,
-      teamId: testFixtures.team.id,
-      role: "MEMBER" as const,
-      accepted: true,
-    })),
-  });
-
-  const teamMemberships = await prisma.membership.findMany({
-    where: {
-      userId: { in: orderedUsers.map((u) => u.id) },
-      teamId: testFixtures.team.id,
-    },
-    select: { id: true },
-  });
-
-  createdResources.memberships.push(...teamMemberships.map((m) => m.id));
-
-  const userIdToOrgMembershipId = new Map(orgMemberships.map((m) => [m.userId, m.id]));
-
-  const attributeAssignments: { memberId: number; attributeOptionId: string }[] = [];
-  for (let i = 0; i < orderedUsers.length; i++) {
-    const orgMembershipId = userIdToOrgMembershipId.get(orderedUsers[i].id);
-    if (!orgMembershipId) continue;
-    const member = teamMembersWithAttributeOptionValuePerAttribute[i];
-    for (const [attrId, value] of Object.entries(member.attributes)) {
-      const values = Array.isArray(value) ? value : [value];
-      for (const v of values) {
-        const optionId = optionValueToId.get(`${attrId}:${v}`);
-        if (optionId) {
-          attributeAssignments.push({
-            memberId: orgMembershipId,
-            attributeOptionId: optionId,
-          });
-        }
-      }
-    }
-  }
-
-  if (attributeAssignments.length > 0) {
-    await prisma.attributeToUser.createMany({ data: attributeAssignments });
-
-    const createdAssignments = await prisma.attributeToUser.findMany({
-      where: {
-        memberId: { in: orgMemberships.map((m) => m.id) },
-      },
-      select: { id: true },
-    });
-
-    createdResources.attributeToUsers.push(...createdAssignments.map((a) => a.id));
-  }
 
   const createdUsers = orderedUsers.map((user) => ({
     userId: user.id,

--- a/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
+++ b/packages/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic.integration-test.ts
@@ -232,98 +232,7 @@ async function createHugeAttributesOfTypeSingleSelect(params: {
 
   const assignedAttributeOptionIdForEachMember = 1;
 
-  // Create attributes in parallel (these are few, so individual creates are fine)
-  await Promise.all(
-    attributes.map((attr) =>
-      createTestAttribute({
-        orgId: testFixtures.org.id,
-        ...attr,
-      })
-    )
-  );
-
-  // Batch create users instead of one-by-one to avoid timeout on slow CI
-  const userDataList = Array.from({ length: numTeamMembers }, (_, i) => ({
-    email: `perf-test-user-${timestamp}-${i}@example.com`,
-    username: `perf-test-user-${timestamp}-${i}`,
-  }));
-
-  await prisma.user.createMany({ data: userDataList });
-
-  const users = await prisma.user.findMany({
-    where: { email: { in: userDataList.map((u) => u.email) } },
-    select: { id: true },
-  });
-
-  createdResources.users.push(...users.map((u) => u.id));
-
-  // Batch create org memberships
-  await prisma.membership.createMany({
-    data: users.map((user) => ({
-      userId: user.id,
-      teamId: testFixtures.org.id,
-      role: "MEMBER" as const,
-      accepted: true,
-    })),
-  });
-
-  const orgMemberships = await prisma.membership.findMany({
-    where: {
-      userId: { in: users.map((u) => u.id) },
-      teamId: testFixtures.org.id,
-    },
-    select: { id: true, userId: true },
-  });
-
-  createdResources.memberships.push(...orgMemberships.map((m) => m.id));
-
-  // Batch create team memberships
-  await prisma.membership.createMany({
-    data: users.map((user) => ({
-      userId: user.id,
-      teamId: testFixtures.team.id,
-      role: "MEMBER" as const,
-      accepted: true,
-    })),
-  });
-
-  const teamMemberships = await prisma.membership.findMany({
-    where: {
-      userId: { in: users.map((u) => u.id) },
-      teamId: testFixtures.team.id,
-    },
-    select: { id: true },
-  });
-
-  createdResources.memberships.push(...teamMemberships.map((m) => m.id));
-
-  // Batch create attribute assignments
-  const userIdToOrgMembershipId = new Map(orgMemberships.map((m) => [m.userId, m.id]));
-
-  const attributeAssignments: { memberId: number; attributeOptionId: string }[] = [];
-  for (const user of users) {
-    const orgMembershipId = userIdToOrgMembershipId.get(user.id);
-    if (!orgMembershipId) continue;
-    for (let j = 0; j < numAttributesUsedPerTeamMember; j++) {
-      attributeAssignments.push({
-        memberId: orgMembershipId,
-        attributeOptionId: attributes[j].options[assignedAttributeOptionIdForEachMember].id,
-      });
-    }
-  }
-
-  await prisma.attributeToUser.createMany({ data: attributeAssignments });
-
-  const createdAssignments = await prisma.attributeToUser.findMany({
-    where: {
-      memberId: { in: orgMemberships.map((m) => m.id) },
-    },
-    select: { id: true },
-  });
-
-  createdResources.attributeToUsers.push(...createdAssignments.map((a) => a.id));
-
-  const teamMembersWithAttributeOptionValuePerAttribute = Array.from({ length: numTeamMembers }, (_, _i) => ({
+  const teamMembersWithAttributeOptionValuePerAttribute = Array.from({ length: numTeamMembers }, (_, i) => ({
     attributes: Object.fromEntries(
       Array.from({ length: numAttributesUsedPerTeamMember }, (_, j) => [
         attributes[j].id,
@@ -331,6 +240,11 @@ async function createHugeAttributesOfTypeSingleSelect(params: {
       ])
     ),
   }));
+
+  await createAttributesScenario({
+    attributes,
+    teamMembersWithAttributeOptionValuePerAttribute,
+  });
 
   return {
     attributes,


### PR DESCRIPTION
ci failure: https://github.com/calcom/cal.com/actions/runs/22773565595/job/66061673841?pr=28319
<img width="829" height="271" alt="Screenshot 2026-03-07 at 11 03 33 PM" src="https://github.com/user-attachments/assets/2a263108-c2e1-4fb9-9e23-7e803a7287b2" />


 ## Problem: test time out

  The integration test setup was creating database records **one at a time in a loop**, causing:
  - ~5,200 database round-trips for the performance test scenario (400 team members × 10 attributes)
  - Each round-trip adds network latency (~5-10ms)
  - Total setup time exceeded CI timeout threshold


  Loop of N iterations × 4 DB calls each  →  4 batch calls total
           (5,200 calls)                         (8 calls)


###   BEFORE:

- Created database records one-by-one inside a loop using prisma.create() — each iteration made separate DB calls for user, memberships, and attribute assignments.

```
    Users:               400 × 1 create     = 400 calls
    Org Memberships:     400 × 1 create     = 400 calls
    Team Memberships:    400 × 1 create     = 400 calls
    Attr Assignments:    400 × 10 create    = 4,000 calls
    ─────────────────────────────────────────────────────
    TOTAL:                                    5,200 calls


```
<img width="838" height="109" alt="Screenshot 2026-03-07 at 11 15 09 PM" src="https://github.com/user-attachments/assets/958087b9-7935-4ebc-8439-070eefdd1c14" />

###  AFTER:

- Collect all data first, then insert everything at once using prisma.createMany() — one batch call per entity type regardless of how many records.

```
    Users:               1 createMany + 1 findMany = 2 calls
    Org Memberships:     1 createMany + 1 findMany = 2 calls
    Team Memberships:    1 createMany + 1 findMany = 2 calls
    Attr Assignments:    1 createMany + 1 findMany = 2 calls
    ─────────────────────────────────────────────────────
    TOTAL:                                           8 calls
```
<img width="868" height="100" alt="Screenshot 2026-03-07 at 11 15 40 PM" src="https://github.com/user-attachments/assets/6010e6f9-c35a-4e36-ad94-1230ed9d420c" />


  ## Changes

  - **Removed**: `createTestUser`, `createTestMemberships`, `createTestAttributeAssignment` (single-record helpers)
  - **Added**: `createTestUsers`, `createTestMembershipsForUsers`, `createTestAttributeAssignments` (batch helpers)
  - **Refactored**: `createAttributesScenario` to use batch helpers
  - Preserved deterministic user ordering for test assertions




