### PR TITLE
fix: resolve 7 unresolved PR review comments from #28155

### DIFF
--- a/apps/web/modules/event-types/components/AddMembersWithSwitch.tsx
+++ b/apps/web/modules/event-types/components/AddMembersWithSwitch.tsx
@@ -305,6 +305,16 @@ export function AddMembersWithSwitch({
   const { t } = useLocale();
   const { setValue } = useFormContext<FormValues>();
 
+  const {
+    assignRRMembersUsingSegment,
+    setAssignRRMembersUsingSegment,
+    rrSegmentQueryValue,
+    setRrSegmentQueryValue,
+  } = useSegmentState();
+
+  // Only fetch search results when the member selector is actually rendered
+  const shouldShowMemberSelector = !assignAllTeamMembers && !assignRRMembersUsingSegment;
+
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebounce(search, 300);
 
@@ -316,14 +326,8 @@ export function AddMembersWithSwitch({
   } = useSearchTeamMembers({
     teamId,
     search: debouncedSearch,
-    enabled: true,
+    enabled: shouldShowMemberSelector,
   });
-  const {
-    assignRRMembersUsingSegment,
-    setAssignRRMembersUsingSegment,
-    rrSegmentQueryValue,
-    setRrSegmentQueryValue,
-  } = useSegmentState();
 
   const assignmentState = getAssignmentState({
     assignAllTeamMembers,

--- a/apps/web/modules/event-types/components/EditWeightsForAllTeamMembers.tsx
+++ b/apps/web/modules/event-types/components/EditWeightsForAllTeamMembers.tsx
@@ -237,6 +237,8 @@ export const EditWeightsForAllTeamMembers = ({
         })),
         "team-members-weights.csv"
       );
+    } catch {
+      showToast(t("error_downloading_csv"), "error");
     } finally {
       setIsDownloading(false);
     }

--- a/apps/web/modules/event-types/components/locations/HostLocations.tsx
+++ b/apps/web/modules/event-types/components/locations/HostLocations.tsx
@@ -732,13 +732,16 @@ const useHostLocationHandlers = (
   hosts: Host[],
   serverHosts: Host[],
   setHosts: (serverHosts: Host[], newHosts: Host[]) => void,
+  clearAllHostLocations: () => void,
   eventTypeId: number
 ) => {
   const handleToggle = (checked: boolean) => {
     formMethods.setValue("enablePerHostLocations", checked, { shouldDirty: true });
     if (!checked) {
-      // Use setHosts from context instead of form setValue for performance
-      setHosts(serverHosts, hosts.map((host) => ({ ...host, location: null })));
+      // Set the clearAllHostLocations flag so the backend bulk-deletes all
+      // HostLocation rows on save. This handles all hosts, not just the
+      // currently loaded page from pagination.
+      clearAllHostLocations();
     }
   };
 
@@ -819,7 +822,7 @@ export const HostLocations = ({ eventTypeId, locationOptions }: HostLocationsPro
   const isOrg = !!session.data?.user?.org?.id;
   const enablePerHostLocations = formMethods.watch("enablePerHostLocations");
   // Use hosts from context for mutations, paginated query for data
-  const { setHosts, pendingChanges } = useHosts();
+  const { setHosts, clearAllHostLocations, pendingChanges } = useHosts();
 
   const { hosts, serverHosts } = usePaginatedAssignmentHosts({
     eventTypeId,
@@ -829,7 +832,7 @@ export const HostLocations = ({ eventTypeId, locationOptions }: HostLocationsPro
 
   const { hostDataMap, fullLocationOptions, containerRef, isLoading, isFetchingNextPage } =
     useHostLocationsData(eventTypeId, enablePerHostLocations, locationOptions);
-  const { handleToggle, handleLocationChange } = useHostLocationHandlers(formMethods, hosts, serverHosts, setHosts, eventTypeId);
+  const { handleToggle, handleLocationChange } = useHostLocationHandlers(formMethods, hosts, serverHosts, setHosts, clearAllHostLocations, eventTypeId);
   const { handleMassApply, isPending } = useMassApplyMutation(eventTypeId, hosts, serverHosts, setHosts, () =>
     setIsMassApplyDialogOpen(false)
   );

--- a/packages/features/eventtypes/components/CheckedTeamSelect.tsx
+++ b/packages/features/eventtypes/components/CheckedTeamSelect.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, useEffect } from "react";
 import type { Options, Props } from "react-select";
 
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
-import { useFetchMoreOnScroll } from "@calcom/features/eventtypes/lib/useFetchMoreOnScroll";
+
 import type { Host, SelectClassNames } from "@calcom/features/eventtypes/lib/types";
 import { getHostsFromOtherGroups } from "@calcom/lib/bookings/hostGroupUtils";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -89,16 +89,35 @@ export const CheckedTeamSelect = ({
 
   const valueFromGroup = groupId ? value.filter((host) => host.groupId === groupId) : value;
 
+  // Use a callback ref so that when the scroll container mounts/unmounts
+  // (due to conditional rendering when valueFromGroup is empty), we trigger
+  // a re-render that lets useFetchMoreOnScroll attach its scroll listener.
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [scrollContainerNode, setScrollContainerNode] = useState<HTMLDivElement | null>(null);
+  const scrollContainerCallbackRef = useCallback((node: HTMLDivElement | null) => {
+    scrollContainerRef.current = node;
+    setScrollContainerNode(node);
+  }, []);
+
   const stableFetchNextPage = useCallback(() => {
     fetchNextPageSelected?.();
   }, [fetchNextPageSelected]);
-  useFetchMoreOnScroll(
-    scrollContainerRef,
-    hasNextPageSelected ?? false,
-    isFetchingNextPageSelected ?? false,
-    stableFetchNextPage
-  );
+
+  // Attach scroll listener to fetch more when scrolling near the bottom
+  const hasNextPage = hasNextPageSelected ?? false;
+  const isFetchingNext = isFetchingNextPageSelected ?? false;
+  useEffect(() => {
+    if (!scrollContainerNode || !hasNextPage || isFetchingNext) return;
+    const handleScroll = () => {
+      const { scrollHeight, scrollTop, clientHeight } = scrollContainerNode;
+      if (scrollHeight - scrollTop - clientHeight < 100) {
+        stableFetchNextPage();
+      }
+    };
+    scrollContainerNode.addEventListener("scroll", handleScroll);
+    return () => scrollContainerNode.removeEventListener("scroll", handleScroll);
+  }, [scrollContainerNode, hasNextPage, isFetchingNext, stableFetchNextPage]);
+
   const rowVirtualizer = useVirtualizer({
     count: valueFromGroup.length,
     estimateSize: () => 44,
@@ -142,7 +161,7 @@ export const CheckedTeamSelect = ({
       />
       {valueFromGroup.length >= 1 && (
         <div
-          ref={scrollContainerRef}
+          ref={scrollContainerCallbackRef}
           className={classNames(
             "mb-4 mt-3 overflow-y-auto rounded-md",
             "border-subtle border",

--- a/packages/features/eventtypes/lib/HostsContext.tsx
+++ b/packages/features/eventtypes/lib/HostsContext.tsx
@@ -10,6 +10,7 @@ type HostsContextValue = {
   updateHost: (userId: number, changes: Partial<Omit<Host, "userId">>) => void;
   removeHost: (userId: number) => void;
   clearAllHosts: (newHosts?: Host[]) => void;
+  clearAllHostLocations: () => void;
   setHosts: (serverHosts: Host[], newHosts: Host[]) => void;
   pendingChanges: PendingHostChanges;
 };

--- a/packages/features/eventtypes/lib/types.ts
+++ b/packages/features/eventtypes/lib/types.ts
@@ -70,6 +70,7 @@ export type PendingHostChanges = {
   hostsToUpdate: HostUpdate[];
   hostsToRemove: number[]; // userIds
   clearAllHosts?: boolean; // When true, backend computes delta: keeps hosts in hostsToAdd, removes all others
+  clearAllHostLocations?: boolean; // When true, backend deletes all HostLocation rows for this event type
 };
 
 // Delta-based children tracking for managed event types
@@ -293,8 +294,8 @@ export type HostInput = {
 export type HostUpdateInput = {
   userId: number;
   isFixed?: boolean;
-  priority?: number | null;
-  weight?: number | null;
+  priority?: number;
+  weight?: number;
   scheduleId?: number | null;
   groupId?: string | null;
   location?: HostLocationInput | null;
@@ -305,10 +306,11 @@ export type PendingHostChangesInput = {
   hostsToUpdate: HostUpdateInput[];
   hostsToRemove: number[];
   clearAllHosts?: boolean;
+  clearAllHostLocations?: boolean;
 };
 
 export type PendingChildrenChangesInput = {
-  childrenToAdd: { owner: { id: number; name: string; email: string }; hidden: boolean }[];
+  childrenToAdd: { owner: { id: number; name: string; email: string; eventTypeSlugs: string[] }; hidden: boolean }[];
   childrenToRemove: number[];
   childrenToUpdate: { userId: number; hidden?: boolean }[];
   clearAllChildren?: boolean;

--- a/packages/features/eventtypes/lib/useHostsForEventType.ts
+++ b/packages/features/eventtypes/lib/useHostsForEventType.ts
@@ -162,6 +162,11 @@ export function useHostsForEventType() {
         return;
       }
 
+      // Guard against duplicate removals (e.g. double-click)
+      if (current.hostsToRemove.includes(userId)) {
+        return;
+      }
+
       // Otherwise add to hostsToRemove and clean up hostsToUpdate
       setPendingChanges(
         {
@@ -191,6 +196,18 @@ export function useHostsForEventType() {
     },
     [setPendingChanges]
   );
+
+  // Set the clearAllHostLocations flag so the backend bulk-deletes all HostLocation rows on save
+  const clearAllHostLocations = useCallback(() => {
+    const current: PendingHostChanges = getValues("pendingHostChanges") ?? DEFAULT_PENDING_CHANGES;
+    setPendingChanges(
+      {
+        ...current,
+        clearAllHostLocations: true,
+      },
+      { shouldDirty: true }
+    );
+  }, [getValues, setPendingChanges]);
 
   // Set all hosts (replaces current state) - used for bulk operations
   // Compares newHosts against serverHosts (from paginated query) instead of initialHosts
@@ -250,9 +267,10 @@ export function useHostsForEventType() {
       updateHost,
       removeHost,
       clearAllHosts,
+      clearAllHostLocations,
       setHosts,
       pendingChanges,
     }),
-    [addHost, updateHost, removeHost, clearAllHosts, setHosts, pendingChanges]
+    [addHost, updateHost, removeHost, clearAllHosts, clearAllHostLocations, setHosts, pendingChanges]
   );
 }

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -667,6 +667,7 @@
   "password": "Password",
   "password_updated_successfully": "Password updated successfully",
   "password_has_been_changed": "Your password has been successfully changed.",
+  "error_downloading_csv": "Error downloading CSV. Please try again.",
   "error_changing_password": "Error changing password",
   "session_timeout_changed": "Your session configuration has been updated successfully.",
   "session_timeout_change_error": "Error updating session configuration",

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
@@ -484,7 +484,14 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
     if (pendingHostChanges) {
       // New delta path: process changes directly
       let { hostsToAdd, hostsToUpdate, hostsToRemove } = pendingHostChanges;
-      const { clearAllHosts } = pendingHostChanges;
+      const { clearAllHosts, clearAllHostLocations } = pendingHostChanges;
+
+      // When clearAllHostLocations is true, bulk-delete all host locations for this event type
+      if (clearAllHostLocations) {
+        await ctx.prisma.hostLocation.deleteMany({
+          where: { eventTypeId: id },
+        });
+      }
 
       // When clearAllHosts is true, compute delta: keep hosts in hostsToAdd, remove all others
       if (clearAllHosts) {

--- a/packages/trpc/server/routers/viewer/eventTypes/types.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/types.ts
@@ -94,8 +94,8 @@ const hostSchema: z.ZodType<HostInput> = z.object({
 const hostUpdateSchema: z.ZodType<HostUpdateInput> = z.object({
   userId: z.number(),
   isFixed: z.boolean().optional(),
-  priority: z.number().min(0).max(4).optional().nullable(),
-  weight: z.number().min(0).optional().nullable(),
+  priority: z.number().min(0).max(4).optional(),
+  weight: z.number().min(0).optional(),
   scheduleId: z.number().optional().nullable(),
   groupId: z.string().optional().nullable(),
   location: hostLocationSchema.optional().nullable(),
@@ -106,6 +106,7 @@ const pendingHostChangesSchema: z.ZodType<PendingHostChangesInput> = z.object({
   hostsToUpdate: z.array(hostUpdateSchema),
   hostsToRemove: z.array(z.number()),
   clearAllHosts: z.boolean().optional(),
+  clearAllHostLocations: z.boolean().optional(),
 });
 
 const hostGroupSchema: z.ZodType<HostGroupInput> = z.object({
@@ -130,6 +131,7 @@ const pendingChildrenChangesSchema: z.ZodType<PendingChildrenChangesInput> = z.o
         id: z.number(),
         name: z.string(),
         email: z.string(),
+        eventTypeSlugs: z.array(z.string()),
       }),
       hidden: z.boolean(),
     })


### PR DESCRIPTION
## What does this PR do?

Addresses 7 unresolved review comments from Cubic/Devin on PR #28155 (event type assignment improvements):

1. **Duplicate `hostsToRemove` guard** (`useHostsForEventType.ts`): `removeHost` now checks `hostsToRemove.includes(userId)` before appending, preventing double-removals from corrupting `effectiveHostCount`.


2. **`clearAllHostLocations` delta flag** (multiple files): Added flag to `PendingHostChanges` that triggers backend bulk-delete of all `HostLocation` rows. Frontend now calls `clearAllHostLocations()` when disabling per-host locations instead of clearing only paginated hosts client-side.

3. **Gate `useSearchTeamMembers`** (`AddMembersWithSwitch.tsx`): Query now only runs when member selector UI is shown (`!assignAllTeamMembers && !assignRRMembersUsingSegment`), preventing wasteful queries.

4. **CSV download error handling** (`EditWeightsForAllTeamMembers.tsx`): Added `catch` block with `error_downloading_csv` toast for `handleDownloadCsv`.

5. **Scroll listener fix** (`CheckedTeamSelect.tsx`): Replaced ref-based `useFetchMoreOnScroll` with callback ref + `useEffect` pattern so scroll listener attaches even when list starts empty and first item is added later.

6. **Type alignment** (`types.ts` + Zod): Removed `| null` from `priority`/`weight` in `HostUpdateInput` to match `HostUpdate` (optional only, not nullable).

7. **`eventTypeSlugs` field** (`types.ts` + Zod): Added `eventTypeSlugs: string[]` to `PendingChildrenChangesInput.childrenToAdd.owner` to align frontend and backend types.

## Mandatory Tasks

- [x] I have self-reviewed the code.
- [x] N/A - No documentation changes required (internal refactoring + bug fixes).
- [ ] **⚠️ No automated tests added** - changes span multiple integration points (delta handling, Zod validation, React hooks). Manual testing + CI required.

## How should this be tested?

### Prerequisites
- Event type with team assignment enabled
- Multiple team members available
- Event type with per-host locations enabled

### Test scenarios:

**Comment 2 (duplicate removal guard):**
1. Add a host to an event type
2. Rapidly double-click the "Remove" button
3. ✅ Expected: Host removed once; no console errors about negative host counts

**Comment 3 (clearAllHostLocations):**
1. Enable per-host locations on event with 50+ hosts
2. Navigate to page 2 of hosts (paginated view)
3. Disable per-host locations toggle
4. Save event type
5. ✅ Expected: ALL host locations deleted (verify in DB), not just first 20

**Comment 7 (query gating):**
1. Open event type with "Assign all team members" enabled
2. Open browser Network tab
3. ✅ Expected: No `searchTeamMembers` query fired (since selector hidden)

**Comment 10 (CSV error handling):**
1. Disconnect network
2. Click "Download CSV" in weight editor
3. ✅ Expected: Toast shows "Error downloading CSV"

**Comment 11 (scroll listener):**
1. Create event with 0 hosts assigned
2. Assign first host
3. Scroll selected hosts list
4. ✅ Expected: Pagination loads next page (if 20+ hosts selected)

**Comments 42 & 43 (type alignment):**
- ✅ CI should pass with no Zod validation errors
- Manual: Add managed children and verify URL preview works for unsaved children

## Checklist

- [x] Read the contributing guide
- [x] Code follows style guidelines
- [x] Added clarifying comments for complex logic (clearAllHostLocations bulk delete, callback ref pattern)
- [x] Verified no new biome warnings introduced (54 warnings are pre-existing)
- [x] PR is focused (<100 lines changed across 10 files)

---

**⚠️ Review focus areas:**

1. **`eventTypeSlugs` Zod schema** (`types.ts:134`): Now **required** in `childrenToAdd`. Verify all frontend code constructing this includes `eventTypeSlugs: []` or actual slugs.

2. **`clearAllHostLocations` bulk delete** (`update.handler.ts:490-494`): Deletes ALL host locations for event type when flag set. Confirm this is correct (no partial preservation needed).

3. **`priority`/`weight` nullability** (`types.ts:296-297`): Removed `| null`. Verify no code path sends `null` for these fields.

4. **Hook reordering** (`AddMembersWithSwitch.tsx:308-336`): `useSegmentState()` moved before `useSearchTeamMembers`. Confirm this doesn't break React hooks rules (looks fine, but double-check).

---

**Link to Devin Session:** https://app.devin.ai/sessions/94028006a2414e4fbee1b27d820e5d96  
**Requested by:** @joeauyeung
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
