### PR TITLE
fix: remove TeamsCTA from teams loading skeleton

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/skeleton.tsx
@@ -1,19 +1,13 @@
 "use client";
 
-import { ShellMainAppDir } from "app/(use-page-wrapper)/(main-nav)/ShellMainAppDir";
-import { TeamsCTA } from "app/(use-page-wrapper)/(main-nav)/teams/CTA";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-
+import { ShellMainAppDir } from "app/(use-page-wrapper)/(main-nav)/ShellMainAppDir";
 import SkeletonLoaderTeamList from "~/ee/teams/components/SkeletonloaderTeamList";
 
 export const TeamsListSkeleton = () => {
   const { t } = useLocale();
   return (
-    <ShellMainAppDir
-      heading={t("teams")}
-      subtitle={t("create_manage_teams_collaborative")}
-      CTA={<TeamsCTA />}>
+    <ShellMainAppDir heading={t("teams")} subtitle={t("create_manage_teams_collaborative")}>
       <SkeletonLoaderTeamList />
     </ShellMainAppDir>
   );

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -173,10 +173,7 @@ test.describe("Teams - NonOrg", () => {
     await page.goto("/teams");
 
     await test.step("Can create team with same name", async () => {
-      // Click the new team button
-      const newTeamButton = page.locator("[data-testid=new-team-btn]");
-      await expect(newTeamButton).toHaveCount(1);
-      await newTeamButton.click();
+      await page.locator("[data-testid=new-team-btn]").click();
       await page.waitForLoadState("networkidle");
       // Fill team name input (new onboarding-v3 style flow)
       await page.locator('[data-testid="team-name-input"]').fill(uniqueName);

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -173,9 +173,10 @@ test.describe("Teams - NonOrg", () => {
     await page.goto("/teams");
 
     await test.step("Can create team with same name", async () => {
-      // Click the new team button (use .first() to avoid strict mode violation
-      // if the streaming SSR skeleton CTA briefly coexists with the page CTA)
-      await page.locator("[data-testid=new-team-btn]").first().click();
+      // Click the new team button
+      const newTeamButton = page.locator("[data-testid=new-team-btn]");
+      await expect(newTeamButton).toHaveCount(1);
+      await newTeamButton.click();
       await page.waitForLoadState("networkidle");
       // Fill team name input (new onboarding-v3 style flow)
       await page.locator('[data-testid="team-name-input"]').fill(uniqueName);

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -1,9 +1,7 @@
-import { expect } from "@playwright/test";
-
 import { IS_TEAM_BILLING_ENABLED } from "@calcom/lib/constants";
 import { prisma } from "@calcom/prisma";
 import { SchedulingType } from "@calcom/prisma/enums";
-
+import { expect } from "@playwright/test";
 import { test, todo } from "./lib/fixtures";
 import {
   bookTimeSlot,
@@ -175,8 +173,9 @@ test.describe("Teams - NonOrg", () => {
     await page.goto("/teams");
 
     await test.step("Can create team with same name", async () => {
-      // Click the new team button
-      await page.locator("[data-testid=new-team-btn]").click();
+      // Click the new team button (use .first() to avoid strict mode violation
+      // if the streaming SSR skeleton CTA briefly coexists with the page CTA)
+      await page.locator("[data-testid=new-team-btn]").first().click();
       await page.waitForLoadState("networkidle");
       // Fill team name input (new onboarding-v3 style flow)
       await page.locator('[data-testid="team-name-input"]').fill(uniqueName);


### PR DESCRIPTION

ci failure 1: https://github.com/calcom/cal.com/actions/runs/22792132011/job/66121206332?pr=28319#step:12:108
ci failure 2:https://github.com/calcom/cal.com/actions/runs/22801759841/job/66144602635?pr=28320#step:12:110
<img width="880" height="166" alt="Screenshot 2026-03-07 at 2 04 45 PM" src="https://github.com/user-attachments/assets/a970d223-c7ce-40dc-a36e-1997493adcd7" />


### problem: 
-  The E2E test failed because two elements with data-testid="new-team-btn" existed in the DOM simultaneously.
- The first button came from skeleton.tsx, which renders <TeamsCTA /> while the page is loading. The second button came from page.tsx (via server-page.tsx), which also renders <TeamsCTA /> when the actual content loads. During the transition from skeleton to real page, both buttons briefly coexisted in the DOM, causing Playwright's strict mode to fail when trying to click a single element.


- also as all users don't have team plan, having TeamsCTA in skeleton also allows users to bypass upgrade banner, so only show this +new team button for users with team plan (don't show during skeleton)

### solution: 
Remove the CTA from the skeleton so only the actual page renders the button for only users with team plan otherwise we'll show upgrade banner. 
