### PR TITLE
feat: add sun/moon icon to time slots for AM/PM distinction

### DIFF
--- a/apps/web/modules/bookings/components/AvailableTimes.tsx
+++ b/apps/web/modules/bookings/components/AvailableTimes.tsx
@@ -1,28 +1,27 @@
 // We do not need to worry about importing framer-motion here as it is lazy imported in Booker.
-import * as HoverCard from "@radix-ui/react-hover-card";
-import { AnimatePresence, m } from "framer-motion";
-import { useMemo } from "react";
 
 import { getPaymentAppData } from "@calcom/app-store/_utils/payments/getPaymentAppData";
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import dayjs from "@calcom/dayjs";
 import type { IOutOfOfficeData } from "@calcom/features/availability/lib/getUserAvailability";
 import { useBookerStoreContext } from "@calcom/features/bookings/Booker/BookerStoreProvider";
-import { OutOfOfficeInSlots } from "./OutOfOfficeInSlots";
-import type { IUseBookingLoadingStates } from "../hooks/useBookings";
-import type { BookerEvent } from "@calcom/features/bookings/types";
-import type { Slot } from "~/schedules/lib/types";
+import { useBookerTime } from "@calcom/features/bookings/Booker/hooks/useBookerTime";
+import { getQueryParam } from "@calcom/features/bookings/Booker/utils/query-param";
+import { useCheckOverlapWithOverlay } from "@calcom/features/bookings/lib/useCheckOverlapWithOverlay";
+import type { BookerEvent, Slots } from "@calcom/features/bookings/types";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { localStorage } from "@calcom/lib/webstorage";
 import classNames from "@calcom/ui/classNames";
 import { Button } from "@calcom/ui/components/button";
+import { Icon } from "@calcom/ui/components/icon";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { CalendarX2Icon } from "@coss/ui/icons";
-
-import { useBookerTime } from "@calcom/features/bookings/Booker/hooks/useBookerTime";
-import { getQueryParam } from "@calcom/features/bookings/Booker/utils/query-param";
-import { useCheckOverlapWithOverlay } from "@calcom/features/bookings/lib/useCheckOverlapWithOverlay";
-import type { Slots } from "@calcom/features/bookings/types";
+import * as HoverCard from "@radix-ui/react-hover-card";
+import { AnimatePresence, m } from "framer-motion";
+import { useMemo } from "react";
+import type { Slot } from "~/schedules/lib/types";
+import type { IUseBookingLoadingStates } from "../hooks/useBookings";
+import { OutOfOfficeInSlots } from "./OutOfOfficeInSlots";
 import { SeatsAvailabilityText } from "./SeatsAvailabilityText";
 
 type TOnTimeSelect = (
@@ -122,6 +121,9 @@ const SlotItem = ({
   const isNearlyFull = slot.attendees && seatsPerTimeSlot && slot.attendees / seatsPerTimeSlot >= 0.83;
   const colorClass = isNearlyFull ? "bg-rose-600" : isHalfFull ? "bg-yellow-500" : "bg-emerald-400";
 
+  const slotHour = computedDateWithUsersTimezone.hour();
+  const isDaytime = slotHour >= 6 && slotHour < 18;
+
   const nowDate = dayjs();
   const usersTimezoneDate = nowDate.tz(timezone);
 
@@ -183,6 +185,10 @@ const SlotItem = ({
                 )}
               />
             )}
+            <Icon
+              name={isDaytime ? "sun" : "moon"}
+              className={classNames("h-4 w-4 shrink-0", isDaytime ? "text-yellow-500" : "text-blue-400")}
+            />
             {computedDateWithUsersTimezone.format(timeFormat)}
           </div>
           {bookingFull && <p className="text-sm">{t("booking_full")}</p>}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

  Adds a sun/moon icon next to time slots on the booking page to help users visually distinguish between daytime (6AM–5:59PM) and nighttime (6PM–5:59AM) slots at a glance.       

- Fixes #28086
- Fixes CAL-7247

#### Image Demo :

Before:
<img width="303" height="532" alt="Screenshot From 2026-03-07 13-01-52" src="https://github.com/user-attachments/assets/1e3c954d-c2b7-46cf-8e41-2449dcc41719" />

After:
<img width="315" height="546" alt="Screenshot From 2026-03-13 23-29-06" src="https://github.com/user-attachments/assets/66202f0e-5a43-41bc-94f9-45405071c726" />




## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sun/moon icons next to booking time slots so users can quickly tell daytime vs nighttime at a glance. Fulfills CAL-7247 by visually distinguishing AM/PM on the booking page.

- **New Features**
  - Shows a sun for 06:00–17:59 and a moon for 18:00–05:59.
  - Uses the viewer’s timezone to compute slot hour.

<sup>Written for commit 842202467360cd09ccabb7b803ae7f445620aa1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



