### PR TITLE
fix: replace fragile CSS selector with data-testid in locale E2E tests

### DIFF
--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import { revalidateSettingsGeneral } from "app/(use-page-wrapper)/settings/(settings-layout)/my-account/general/actions";
-import { useSession } from "next-auth/react";
-import { useState } from "react";
-import { Controller, useForm } from "react-hook-form";
-
-import { TimezoneSelect } from "@calcom/web/modules/timezone/components/TimezoneSelect";
-import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
+import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import { formatLocalizedDateTime } from "@calcom/lib/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { localeOptions } from "@calcom/lib/i18n";
@@ -16,15 +10,16 @@ import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
 import classNames from "@calcom/ui/classNames";
 import { Button } from "@calcom/ui/components/button";
-import { Form } from "@calcom/ui/components/form";
-import { Label } from "@calcom/ui/components/form";
-import { Select } from "@calcom/ui/components/form";
-import { SettingsToggle } from "@calcom/ui/components/form";
+import { Form, Label, Select, SettingsToggle } from "@calcom/ui/components/form";
+import { Icon } from "@calcom/ui/components/icon";
 import { showToast } from "@calcom/ui/components/toast";
 import { revalidateTravelSchedules } from "@calcom/web/app/cache/travelSchedule";
-
+import { TimezoneSelect } from "@calcom/web/modules/timezone/components/TimezoneSelect";
 import TravelScheduleModal from "@components/settings/TravelScheduleModal";
-import { Icon } from "@calcom/ui/components/icon";
+import { revalidateSettingsGeneral } from "app/(use-page-wrapper)/settings/(settings-layout)/my-account/general/actions";
+import { useSession } from "next-auth/react";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 
 export type FormValues = {
   locale: {
@@ -181,6 +176,7 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
                     options={localeOptions}
                     value={value}
                     onChange={onChange}
+                    data-testid="locale-select"
                   />
                 </>
               )}

--- a/apps/web/playwright/locale.e2e.ts
+++ b/apps/web/playwright/locale.e2e.ts
@@ -1,5 +1,4 @@
 import { expect } from "@playwright/test";
-
 import { test } from "./lib/fixtures";
 import { submitAndWaitForResponse } from "./lib/testUtils";
 
@@ -405,7 +404,7 @@ test.describe("authorized user sees changed translations (de->ar)", async () => 
 
       await page.waitForLoadState("domcontentloaded");
 
-      await page.locator(".bg-default > div > div:nth-child(2)").first().click();
+      await page.getByTestId("locale-select").click();
       await page.getByTestId("select-option-ar").click();
 
       await submitAndWaitForResponse(page, "/api/trpc/me/updateProfile?batch=1", {
@@ -465,8 +464,8 @@ test.describe("authorized user sees changed translations (de->pt-BR) [locale1]",
       await page.goto("/settings/my-account/general");
       await page.waitForLoadState("domcontentloaded");
 
-      await page.locator(".bg-default > div > div:nth-child(2)").first().click();
-      await page.locator("text=Português (Brasil)").click();
+      await page.getByTestId("locale-select").click();
+      await page.getByTestId("select-option-pt-BR").click();
 
       await submitAndWaitForResponse(page, "/api/trpc/me/updateProfile?batch=1", {
         action: () => page.click("[data-testid=general-submit-button]"),


### PR DESCRIPTION
## What does this PR do?

Fixes flaky locale E2E tests (`de->ar` and `de->pt-BR`) that intermittently fail due to a brittle CSS path selector (`.bg-default > div > div:nth-child(2)`) used to click the language dropdown on the general settings page.

CI link: https://github.com/calcom/cal.com/actions/runs/22797255454/job/66133803675?pr=28305

<img width="1201" height="586" alt="Screenshot 2026-03-07 at 7 10 01 PM" src="https://github.com/user-attachments/assets/057693e0-702a-4e17-a5d4-a0a0f7ce11e0" />

The root cause is that react-select's internal Input wrapper element (`<div data-value="" class="text-emphasis ...">`) overlaps the `singleValue` display and intercepts pointer events, causing a `TimeoutError`. This is a race condition dependent on render timing and CI machine load.

**Changes:**
- Add `data-testid="locale-select"` to the language `<Select>` in `general-view.tsx`
- Replace fragile CSS selectors with `getByTestId("locale-select")` in both failing tests
- Replace `text=Português (Brasil)` text selector with `getByTestId("select-option-pt-BR")` for consistency

> Note: Import reordering in `general-view.tsx` is auto-formatting by biome, not a functional change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Add the `ready-for-e2e` label to trigger E2E tests in CI
2. Verify the `locale.e2e.ts` tests pass, specifically:
   - `authorized user sees changed translations (de->ar) › should return correct translations and html attributes`
   - `authorized user sees changed translations (de->pt-BR) [locale1] › should return correct translations and html attributes`
3. These tests previously failed intermittently — they should now be stable since `getByTestId` clicks the `<span>` wrapper around the entire react-select control, avoiding the internal element overlap issue.

### Reviewer note

The `data-testid="locale-select"` prop is consumed by the `ControlComponent` in `packages/ui/components/form/select/components.tsx` (line 94), which places it on a `<span>` wrapping the react-select control. Please verify that clicking this `<span>` reliably opens the dropdown — this was not E2E tested locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings
- [x] My PR is small and focused (<10 lines changed, 2 files)

---

Link to Devin Session: https://app.devin.ai/sessions/7e19e154b3ba4886ae5aa72c2dca48e5  
Requested by: @romitg2