### PR TITLE
fix: make general settings switches optimistic and independent

### DIFF
--- a/apps/web/modules/ee/organizations/components/DisableAutofillOnBookingPageSwitch.tsx
+++ b/apps/web/modules/ee/organizations/components/DisableAutofillOnBookingPageSwitch.tsx
@@ -20,15 +20,43 @@ export const DisableAutofillOnBookingPageSwitch = ({ currentOrg }: GeneralViewPr
   );
 
   const mutation = trpc.viewer.organizations.update.useMutation({
-    onSuccess: async (_data, variables) => {
-      setDisableAutofillOnBookingPageActive(!!variables.disableAutofillOnBookingPage);
+    onMutate: async ({ disableAutofillOnBookingPage }) => {
+      await utils.viewer.organizations.listCurrent.cancel();
+      const previousValue =
+        !!utils.viewer.organizations.listCurrent.getData()?.organizationSettings.disableAutofillOnBookingPage;
+
+      setDisableAutofillOnBookingPageActive(!!disableAutofillOnBookingPage);
+      utils.viewer.organizations.listCurrent.setData(undefined, (previousOrg) => {
+        if (!previousOrg) return previousOrg;
+        return {
+          ...previousOrg,
+          organizationSettings: {
+            ...previousOrg.organizationSettings,
+            disableAutofillOnBookingPage: !!disableAutofillOnBookingPage,
+          },
+        };
+      });
+
+      return { previousValue };
+    },
+    onSuccess: async () => {
       showToast(t("settings_updated_successfully"), "success");
     },
-    onError: () => {
+    onError: (_error, _variables, context) => {
+      if (context) {
+        utils.viewer.organizations.listCurrent.setData(undefined, (previousOrg) => {
+          if (!previousOrg) return previousOrg;
+          return {
+            ...previousOrg,
+            organizationSettings: {
+              ...previousOrg.organizationSettings,
+              disableAutofillOnBookingPage: context.previousValue,
+            },
+          };
+        });
+        setDisableAutofillOnBookingPageActive(context.previousValue);
+      }
       showToast(t("error_updating_settings"), "error");
-    },
-    onSettled: () => {
-      utils.viewer.organizations.listCurrent.invalidate();
     },
   });
 
@@ -37,7 +65,6 @@ export const DisableAutofillOnBookingPageSwitch = ({ currentOrg }: GeneralViewPr
       <SettingsToggle
         toggleSwitchAtTheEnd={true}
         title={t("disable_autofill_on_booking_page")}
-        disabled={mutation?.isPending}
         description={t("disable_autofill_on_booking_page_description")}
         checked={disableAutofillOnBookingPageActive}
         onCheckedChange={(checked) => {

--- a/apps/web/modules/ee/organizations/components/DisablePhoneOnlySMSNotificationsSwitch.tsx
+++ b/apps/web/modules/ee/organizations/components/DisablePhoneOnlySMSNotificationsSwitch.tsx
@@ -20,14 +20,43 @@ export const DisablePhoneOnlySMSNotificationsSwitch = ({ currentOrg }: GeneralVi
   );
 
   const mutation = trpc.viewer.organizations.update.useMutation({
+    onMutate: async ({ disablePhoneOnlySMSNotifications }) => {
+      await utils.viewer.organizations.listCurrent.cancel();
+      const previousValue =
+        !!utils.viewer.organizations.listCurrent.getData()?.organizationSettings.disablePhoneOnlySMSNotifications;
+
+      setDisablePhoneOnlySMSNotificationsActive(disablePhoneOnlySMSNotifications);
+      utils.viewer.organizations.listCurrent.setData(undefined, (previousOrg) => {
+        if (!previousOrg) return previousOrg;
+        return {
+          ...previousOrg,
+          organizationSettings: {
+            ...previousOrg.organizationSettings,
+            disablePhoneOnlySMSNotifications,
+          },
+        };
+      });
+
+      return { previousValue };
+    },
     onSuccess: async () => {
       showToast(t("settings_updated_successfully"), "success");
     },
-    onError: () => {
+    onError: (_error, _variables, context) => {
+      if (context) {
+        utils.viewer.organizations.listCurrent.setData(undefined, (previousOrg) => {
+          if (!previousOrg) return previousOrg;
+          return {
+            ...previousOrg,
+            organizationSettings: {
+              ...previousOrg.organizationSettings,
+              disablePhoneOnlySMSNotifications: context.previousValue,
+            },
+          };
+        });
+        setDisablePhoneOnlySMSNotificationsActive(context.previousValue);
+      }
       showToast(t("error_updating_settings"), "error");
-    },
-    onSettled: () => {
-      utils.viewer.organizations.listCurrent.invalidate();
     },
   });
 
@@ -36,14 +65,12 @@ export const DisablePhoneOnlySMSNotificationsSwitch = ({ currentOrg }: GeneralVi
       <SettingsToggle
         toggleSwitchAtTheEnd={true}
         title={t("organization_disable_phone_only_sms_notifications_switch_title")}
-        disabled={mutation?.isPending}
         description={t("organization_disable_phone_only_sms_notifications_switch_description")}
         checked={disablePhoneOnlySMSNotificationsActive}
         onCheckedChange={(checked) => {
           mutation.mutate({
             disablePhoneOnlySMSNotifications: checked,
           });
-          setDisablePhoneOnlySMSNotificationsActive(checked);
         }}
         switchContainerClassName="mt-6"
       />

--- a/apps/web/modules/ee/organizations/components/LockEventTypeSwitch.tsx
+++ b/apps/web/modules/ee/organizations/components/LockEventTypeSwitch.tsx
@@ -32,13 +32,40 @@ export const LockEventTypeSwitch = ({ currentOrg }: GeneralViewProps) => {
   );
   const [showModal, setShowModal] = useState(false);
   const { t } = useLocale();
+  const utils = trpc.useUtils();
 
   const mutation = trpc.viewer.organizations.update.useMutation({
+    onMutate: async ({ lockEventTypeCreation }) => {
+      if (typeof lockEventTypeCreation === "undefined") return;
+
+      await utils.viewer.organizations.listCurrent.cancel();
+      const previousValue = utils.viewer.organizations.listCurrent.getData();
+
+      setLockEventTypeCreationForUsers(lockEventTypeCreation);
+      utils.viewer.organizations.listCurrent.setData(undefined, (previousOrg) => {
+        if (!previousOrg) return previousOrg;
+        return {
+          ...previousOrg,
+          organizationSettings: {
+            ...previousOrg.organizationSettings,
+            lockEventTypeCreationForUsers: lockEventTypeCreation,
+          },
+        };
+      });
+
+      return { previousValue };
+    },
     onSuccess: async () => {
       reset(getValues());
       showToast(t("settings_updated_successfully"), "success");
     },
-    onError: () => {
+    onError: (_error, _variables, context) => {
+      if (context?.previousValue) {
+        utils.viewer.organizations.listCurrent.setData(undefined, context.previousValue);
+        setLockEventTypeCreationForUsers(
+          !!context.previousValue.organizationSettings.lockEventTypeCreationForUsers
+        );
+      }
       showToast(t("error_updating_settings"), "error");
     },
   });
@@ -75,9 +102,9 @@ export const LockEventTypeSwitch = ({ currentOrg }: GeneralViewProps) => {
               lockEventTypeCreation: checked,
             });
           } else {
+            setLockEventTypeCreationForUsers(true);
             setShowModal(true);
           }
-          setLockEventTypeCreationForUsers(checked);
         }}
         switchContainerClassName="mt-6"
       />
@@ -86,8 +113,10 @@ export const LockEventTypeSwitch = ({ currentOrg }: GeneralViewProps) => {
           open={showModal}
           onOpenChange={(e) => {
             if (!e) {
+              const latestOrg = utils.viewer.organizations.listCurrent.getData();
               setLockEventTypeCreationForUsers(
-                !!currentOrg.organizationSettings.lockEventTypeCreationForUsers
+                latestOrg?.organizationSettings.lockEventTypeCreationForUsers ??
+                  !!currentOrg.organizationSettings.lockEventTypeCreationForUsers
               );
               setShowModal(false);
             }

--- a/apps/web/modules/ee/organizations/components/NoSlotsNotificationSwitch.tsx
+++ b/apps/web/modules/ee/organizations/components/NoSlotsNotificationSwitch.tsx
@@ -18,14 +18,43 @@ export const NoSlotsNotificationSwitch = ({ currentOrg }: GeneralViewProps) => {
   );
 
   const mutation = trpc.viewer.organizations.update.useMutation({
+    onMutate: async ({ adminGetsNoSlotsNotification }) => {
+      await utils.viewer.organizations.listCurrent.cancel();
+      const previousValue =
+        !!utils.viewer.organizations.listCurrent.getData()?.organizationSettings.adminGetsNoSlotsNotification;
+
+      setNotificationActive(adminGetsNoSlotsNotification);
+      utils.viewer.organizations.listCurrent.setData(undefined, (previousOrg) => {
+        if (!previousOrg) return previousOrg;
+        return {
+          ...previousOrg,
+          organizationSettings: {
+            ...previousOrg.organizationSettings,
+            adminGetsNoSlotsNotification,
+          },
+        };
+      });
+
+      return { previousValue };
+    },
     onSuccess: async () => {
       showToast(t("settings_updated_successfully"), "success");
     },
-    onError: () => {
+    onError: (_error, _variables, context) => {
+      if (context) {
+        utils.viewer.organizations.listCurrent.setData(undefined, (previousOrg) => {
+          if (!previousOrg) return previousOrg;
+          return {
+            ...previousOrg,
+            organizationSettings: {
+              ...previousOrg.organizationSettings,
+              adminGetsNoSlotsNotification: context.previousValue,
+            },
+          };
+        });
+        setNotificationActive(context.previousValue);
+      }
       showToast(t("error_updating_settings"), "error");
-    },
-    onSettled: () => {
-      utils.viewer.organizations.listCurrent.invalidate();
     },
   });
 
@@ -34,14 +63,12 @@ export const NoSlotsNotificationSwitch = ({ currentOrg }: GeneralViewProps) => {
       <SettingsToggle
         toggleSwitchAtTheEnd={true}
         title={t("organization_no_slots_notification_switch_title")}
-        disabled={mutation?.isPending}
         description={t("organization_no_slots_notification_switch_description")}
         checked={notificationActive}
         onCheckedChange={(checked) => {
           mutation.mutate({
             adminGetsNoSlotsNotification: checked,
           });
-          setNotificationActive(checked);
         }}
         switchContainerClassName="mt-6"
       />


### PR DESCRIPTION
## What does this PR do?

This PR makes the organization settings switches feel instant and independent. Each toggle now updates immediately in the UI (optimistic update), while the server update runs in the background. If the server rejects the change, the switch rolls back cleanly and shows an error toast.

This removes the “global loading / laggy feel” where one switch blocks the others.

- Fixes #28330
- Fixes CAL-28330

## Visual Demo (For contributors especially)

### Video Demo (if applicable):

- Before: [https://github.com/user-attachments/assets/df7a8b03-e6f2-4c03-bea5-284a7b4a7261](https://github.com/user-attachments/assets/df7a8b03-e6f2-4c03-bea5-284a7b4a7261)

- After: https://github.com/user-attachments/assets/6cb8b563-34e3-4cdf-80a3-32fa118f0501


## Mandatory Tasks (DO NOT REMOVE)

- [x]  I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x]  I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x]  I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Environment variables: standard local [[Cal.com](http://cal.com/)](http://cal.com/) setup for org settings. No new env vars required.
- Minimal test data: an org account with access to `Settings → Organization → General`.
- Steps:
    1. Open `Settings → Organization → General`.
    2. Toggle `No slots notification`.
    3. Immediately toggle `Disable phone-only SMS notifications`.
    4. Immediately toggle `Disable autofill on booking page`.
- Expected:
    - Each switch flips instantly on click.
    - Other switches are not blocked while one is saving.
    - If network fails, the switch reverts and error toast appears.
    - On success, settings stay consistent after refresh.