### PR TITLE
fix: remove shallow routing from app category navigation

### DIFF
--- a/packages/app-store/_components/AppCategoryNavigation.tsx
+++ b/packages/app-store/_components/AppCategoryNavigation.tsx
@@ -44,14 +44,12 @@ const AppCategoryNavigation = ({
         <VerticalTabs
           tabs={appCategories}
           sticky
-          linkShallow
           itemClassname={classNames?.verticalTabsItem}
         />
       </div>
       <div className="block xl:hidden">
         <HorizontalTabs
           tabs={appCategories}
-          linkShallow
           scrollActiveTabIntoView
         />
       </div>


### PR DESCRIPTION
## Summary

Fixes #28298 — Installed Apps sub-navigation links (Calendar, Conferencing, Analytics, etc.) are unresponsive on first click.

## Root cause

`AppCategoryNavigation` passes `linkShallow` to both `VerticalTabs` and `HorizontalTabs`. In Next.js, [shallow routing](https://nextjs.org/docs/pages/building-your-application/routing/linking-and-navigating#shallow-routing) only updates the URL without re-running data fetching methods when the **path stays the same** and only query parameters change.

Since the installed apps page navigates between different **path segments** (`/apps/installed/calendar` → `/apps/installed/conferencing`), shallow routing prevents the page from actually re-rendering on the first click. A second click works because by then the URL has already changed.

## Fix

Remove `linkShallow` from both `VerticalTabs` and `HorizontalTabs` in `AppCategoryNavigation`. This is a focused **2-line deletion in a single file**.

> **Note:** A previous PR #28304 addressed this among 3 other unrelated issues and was rejected for being too large (96 files changed). This PR is scoped to only this specific bug.

## Test plan

- [ ] Navigate to `/apps/installed`
- [ ] Click any sub-navigation link (Calendar, Conferencing, Analytics, AI, etc.)
- [ ] Verify the page navigates on the **first** click (not requiring a double-click)
- [ ] Verify both desktop (vertical tabs) and mobile (horizontal tabs) layouts work correctly
- [ ] Verify the `/apps` page (non-installed) still works correctly (it uses `useQueryParam` which is unaffected)