### PR TITLE
fix: wait for networkidle in locale e2e tests to avoid hydration race condition

### DIFF
--- a/apps/web/playwright/locale.e2e.ts
+++ b/apps/web/playwright/locale.e2e.ts
@@ -402,7 +402,7 @@ test.describe("authorized user sees changed translations (de->ar)", async () => 
     await test.step("should change the language and show Arabic translations", async () => {
       await page.goto("/settings/my-account/general");
 
-      await page.waitForLoadState("domcontentloaded");
+      await page.waitForLoadState("networkidle");
 
       await page.getByTestId("locale-select").click();
       await page.getByTestId("select-option-ar").click();
@@ -462,7 +462,7 @@ test.describe("authorized user sees changed translations (de->pt-BR) [locale1]",
 
     await test.step("should change the language and show Brazil-Portuguese translations", async () => {
       await page.goto("/settings/my-account/general");
-      await page.waitForLoadState("domcontentloaded");
+      await page.waitForLoadState("networkidle");
 
       await page.getByTestId("locale-select").click();
       await page.getByTestId("select-option-pt-BR").click();


### PR DESCRIPTION
## What does this PR do?

Fixes flaky locale E2E test failures where `getByTestId('locale-select')` resolved to 2 elements in Playwright strict mode.

ci link 1: https://github.com/calcom/cal.com/actions/runs/22842158041/job/66250594998?pr=28340#step:12:113
ci link 2: https://github.com/calcom/cal.com/actions/runs/22851659166/job/66281710111?pr=28305#step:12:125
<img width="994" height="301" alt="Screenshot 2026-03-09 at 1 34 09 PM" src="https://github.com/user-attachments/assets/a8f69925-738e-4a12-95f0-3f5b2a08800c" />


The `de->ar` and `de->pt-BR` locale change tests were failing because they used `waitForLoadState("domcontentloaded")`, which fires before React hydration completes. During Next.js App Router streaming, the server-rendered `locale-select` element can briefly coexist with its hydrated counterpart in the DOM, causing Playwright's strict mode to reject the ambiguous locator.

Switching to `waitForLoadState("networkidle")` ensures all JS has loaded and React hydration has settled before the test interacts with the select element.

## How should this be tested?

- Run the locale E2E tests: `PLAYWRIGHT_HEADLESS=1 yarn e2e locale.e2e.ts`
- The `de->ar` and `de->pt-BR` test cases (lines ~394 and ~455) should pass consistently without "resolved to 2 elements" errors.

---

[Link to Devin Session](https://app.devin.ai/sessions/9a6210d3f7764a2c8df92ee12e8b11cf)
Requested by: @romitg2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
