### PR TITLE
fix: sign OAuth state for Stripe and Dub integrations

### DIFF
--- a/apps/web/playwright/oauth/oauth-csrf-protection.e2e.ts
+++ b/apps/web/playwright/oauth/oauth-csrf-protection.e2e.ts
@@ -1,20 +1,8 @@
-import { createHmac, randomUUID } from "node:crypto";
-import process from "node:process";
 import { expect } from "@playwright/test";
+import { signOAuthState } from "@calcom/app-store/_utils/oauth/encodeOAuthState";
 import { WEBAPP_URL } from "@calcom/lib/constants";
+import type { IntegrationOAuthCallbackState } from "@calcom/app-store/types";
 import { test } from "../lib/fixtures";
-
-/**
- * Signs an OAuth state with HMAC-SHA256 nonce, mirroring the server's signOAuthState.
- * Requires NEXTAUTH_SECRET to match the running server's secret.
- */
-function signState(state: Record<string, unknown>, userId: number): string {
-  const secret = process.env.NEXTAUTH_SECRET;
-  if (!secret) throw new Error("NEXTAUTH_SECRET not available in test environment");
-  const nonce = randomUUID();
-  const nonceHash = createHmac("sha256", secret).update(`${nonce}:${userId}`).digest("hex");
-  return JSON.stringify({ ...state, nonce, nonceHash });
-}
 
 function buildUnsignedState(overrides: Record<string, unknown> = {}): string {
   return JSON.stringify({
@@ -54,12 +42,12 @@ test.describe("OAuth CSRF Protection", () => {
       await user.apiLogin();
 
       // Use absolute URLs — getSafeRedirectUrl requires them
-      const validState = signState(
+      const validState = signOAuthState(
         {
           returnTo: `${WEBAPP_URL}/apps/installed/payment`,
           onErrorReturnTo: `${WEBAPP_URL}/apps`,
           fromApp: true,
-        },
+        } as IntegrationOAuthCallbackState,
         user.id
       );
 
@@ -76,8 +64,8 @@ test.describe("OAuth CSRF Protection", () => {
       await user.apiLogin();
 
       // Attacker signed this state with their own userId
-      const wrongUserState = signState(
-        { onErrorReturnTo: `${WEBAPP_URL}/apps/specific-path`, fromApp: true },
+      const wrongUserState = signOAuthState(
+        { onErrorReturnTo: `${WEBAPP_URL}/apps/specific-path`, fromApp: true } as IntegrationOAuthCallbackState,
         999999
       );
 
@@ -117,8 +105,8 @@ test.describe("OAuth CSRF Protection", () => {
       await user.apiLogin();
 
       // Use absolute URL — getSafeRedirectUrl requires it
-      const validState = signState(
-        { onErrorReturnTo: `${WEBAPP_URL}/apps/installed`, fromApp: true },
+      const validState = signOAuthState(
+        { onErrorReturnTo: `${WEBAPP_URL}/apps/installed`, fromApp: true } as IntegrationOAuthCallbackState,
         user.id
       );
 

--- a/apps/web/playwright/oauth/oauth-csrf-protection.e2e.ts
+++ b/apps/web/playwright/oauth/oauth-csrf-protection.e2e.ts
@@ -1,0 +1,138 @@
+import { createHmac, randomUUID } from "node:crypto";
+import process from "node:process";
+import { expect } from "@playwright/test";
+import { WEBAPP_URL } from "@calcom/lib/constants";
+import { test } from "../lib/fixtures";
+
+/**
+ * Signs an OAuth state with HMAC-SHA256 nonce, mirroring the server's signOAuthState.
+ * Requires NEXTAUTH_SECRET to match the running server's secret.
+ */
+function signState(state: Record<string, unknown>, userId: number): string {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) throw new Error("NEXTAUTH_SECRET not available in test environment");
+  const nonce = randomUUID();
+  const nonceHash = createHmac("sha256", secret).update(`${nonce}:${userId}`).digest("hex");
+  return JSON.stringify({ ...state, nonce, nonceHash });
+}
+
+function buildUnsignedState(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    returnTo: "https://attacker.example.com/controlled",
+    onErrorReturnTo: "https://attacker.example.com/error",
+    fromApp: true,
+    ...overrides,
+  });
+}
+
+test.afterEach(async ({ users }) => {
+  await users.deleteAll();
+});
+
+test.describe("OAuth CSRF Protection", () => {
+  test.describe("Stripe callback - user cancellation flow", () => {
+    const CALLBACK = "/api/integrations/stripepayment/callback";
+
+    test("rejects unsigned state and falls back to default redirect", async ({ page, users }) => {
+      const user = await users.create();
+      await user.apiLogin();
+
+      await page.goto(
+        `${CALLBACK}?error=access_denied&state=${encodeURIComponent(buildUnsignedState())}`
+      );
+
+      await page.waitForURL((url) => !url.pathname.startsWith("/api/"));
+      const finalUrl = page.url();
+
+      // Unsigned state → decodeOAuthState returns undefined → default redirect
+      expect(finalUrl).not.toContain("attacker");
+      expect(finalUrl).toContain("/apps/installed");
+    });
+
+    test("honors valid signed state and redirects to onErrorReturnTo", async ({ page, users }) => {
+      const user = await users.create();
+      await user.apiLogin();
+
+      // Use absolute URLs — getSafeRedirectUrl requires them
+      const validState = signState(
+        {
+          returnTo: `${WEBAPP_URL}/apps/installed/payment`,
+          onErrorReturnTo: `${WEBAPP_URL}/apps`,
+          fromApp: true,
+        },
+        user.id
+      );
+
+      await page.goto(
+        `${CALLBACK}?error=access_denied&state=${encodeURIComponent(validState)}`
+      );
+
+      await page.waitForURL((url) => !url.pathname.startsWith("/api/"));
+      expect(page.url()).toContain("/apps");
+    });
+
+    test("rejects state signed with a different userId", async ({ page, users }) => {
+      const user = await users.create();
+      await user.apiLogin();
+
+      // Attacker signed this state with their own userId
+      const wrongUserState = signState(
+        { onErrorReturnTo: `${WEBAPP_URL}/apps/specific-path`, fromApp: true },
+        999999
+      );
+
+      await page.goto(
+        `${CALLBACK}?error=access_denied&state=${encodeURIComponent(wrongUserState)}`
+      );
+
+      await page.waitForURL((url) => !url.pathname.startsWith("/api/"));
+      const finalUrl = page.url();
+
+      // HMAC verification fails → state is undefined → default redirect
+      expect(finalUrl).not.toContain("specific-path");
+      expect(finalUrl).toContain("/apps/installed");
+    });
+
+    test("returns 401 without session", async ({ page }) => {
+      const response = await page.goto(`${CALLBACK}?code=test_code`);
+      expect(response?.status()).toBe(401);
+    });
+  });
+
+  test.describe("Dub callback - missing code flow", () => {
+    const CALLBACK = "/api/integrations/dub/callback";
+
+    test("blocks unsigned state — returns error instead of redirect", async ({ page, users }) => {
+      const user = await users.create();
+      await user.apiLogin();
+
+      const response = await page.goto(`${CALLBACK}?state=${encodeURIComponent(buildUnsignedState())}`);
+
+      // State decoding fails (no nonce) → state undefined → no onErrorReturnTo → error
+      expect(response?.status()).toBeGreaterThanOrEqual(400);
+    });
+
+    test("redirects to onErrorReturnTo with valid signed state", async ({ page, users }) => {
+      const user = await users.create();
+      await user.apiLogin();
+
+      // Use absolute URL — getSafeRedirectUrl requires it
+      const validState = signState(
+        { onErrorReturnTo: `${WEBAPP_URL}/apps/installed`, fromApp: true },
+        user.id
+      );
+
+      await page.goto(`${CALLBACK}?state=${encodeURIComponent(validState)}`);
+
+      // Valid state decoded → onErrorReturnTo present → redirect
+      await page.waitForURL((url) => !url.pathname.startsWith("/api/"));
+      expect(page.url()).toContain("/apps/installed");
+    });
+
+    test("returns error without session", async ({ page }) => {
+      const response = await page.goto(`${CALLBACK}?code=test_code`);
+      // Without session: HttpError(401) thrown — Next.js may return 401 or 500
+      expect(response?.status()).toBeGreaterThanOrEqual(400);
+    });
+  });
+});

--- a/packages/app-store/_utils/oauth/decodeOAuthState.test.ts
+++ b/packages/app-store/_utils/oauth/decodeOAuthState.test.ts
@@ -1,0 +1,170 @@
+import { createHmac, randomUUID } from "node:crypto";
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { decodeOAuthState } from "./decodeOAuthState";
+
+const TEST_SECRET = "test-nextauth-secret";
+const TEST_USER_ID = 42;
+
+function buildRequest({
+  state,
+  userId,
+}: {
+  state?: Record<string, unknown> | string;
+  userId?: number | null;
+}): Parameters<typeof decodeOAuthState>[0] {
+  const query: Record<string, string> = {};
+  if (state !== undefined) {
+    query.state = typeof state === "string" ? state : JSON.stringify(state);
+  }
+  return {
+    query,
+    session: userId !== null ? { user: { id: userId ?? TEST_USER_ID } } : undefined,
+  } as Parameters<typeof decodeOAuthState>[0];
+}
+
+function signNonce(nonce: string, userId: number, secret: string = TEST_SECRET): string {
+  return createHmac("sha256", secret).update(`${nonce}:${userId}`).digest("hex");
+}
+
+function buildStateWithValidNonce(
+  extra: Record<string, unknown> = {}
+): Record<string, unknown> & { nonce: string; nonceHash: string } {
+  const nonce = randomUUID();
+  const nonceHash = signNonce(nonce, TEST_USER_ID);
+  return { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true, nonce, nonceHash, ...extra };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("decodeOAuthState", () => {
+  describe("when state query param is missing or not a string", () => {
+    it("returns undefined for missing state", () => {
+      const req = buildRequest({ state: undefined });
+      delete (req.query as Record<string, unknown>).state;
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+
+    it("returns undefined for non-string state", () => {
+      const req = { query: { state: 123 }, session: { user: { id: TEST_USER_ID } } } as unknown as Parameters<
+        typeof decodeOAuthState
+      >[0];
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+  });
+
+  describe("nonce-exempt apps", () => {
+    const exemptApps = ["basecamp3", "webex", "tandem"];
+
+    it.each(exemptApps)("returns state without nonce verification for exempt app: %s", (slug) => {
+      const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      const result = decodeOAuthState(req, slug);
+      expect(result).toEqual(stateObj);
+    });
+
+    it("returns state for exempt app even when nonce fields are missing", () => {
+      const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req, "basecamp3")).toEqual(stateObj);
+    });
+  });
+
+  describe("formerly exempt apps now require nonce (stripe, dub)", () => {
+    it.each(["stripe", "dub"])("rejects %s state without nonce even when slug is passed", (slug) => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req, slug)).toBeUndefined();
+    });
+
+    it.each(["stripe", "dub"])("accepts %s state with valid nonce", (slug) => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const stateObj = buildStateWithValidNonce();
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req, slug)).toEqual(stateObj);
+    });
+  });
+
+  describe("mandatory nonce verification (non-exempt apps)", () => {
+    it("returns undefined when nonce is missing", () => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+
+    it("returns undefined when nonceHash is missing", () => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true, nonce: randomUUID() };
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+
+    it("returns undefined when userId is missing", () => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const stateObj = buildStateWithValidNonce();
+      const req = buildRequest({ state: stateObj, userId: null });
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+
+    it("returns undefined when NEXTAUTH_SECRET is not set", () => {
+      vi.stubEnv("NEXTAUTH_SECRET", "");
+      const stateObj = buildStateWithValidNonce();
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+
+    it("returns state when nonce and HMAC are valid", () => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const stateObj = buildStateWithValidNonce();
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      const result = decodeOAuthState(req);
+      expect(result).toEqual(stateObj);
+    });
+
+    it("returns undefined when nonceHash is tampered", () => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const stateObj = buildStateWithValidNonce();
+      stateObj.nonceHash = "deadbeef".repeat(8);
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+
+    it("returns undefined when nonce is tampered", () => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const stateObj = buildStateWithValidNonce();
+      stateObj.nonce = randomUUID();
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+
+    it("returns undefined when signed with a different userId", () => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const nonce = randomUUID();
+      const nonceHash = signNonce(nonce, 999);
+      const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true, nonce, nonceHash };
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+
+    it("returns undefined when signed with a different secret", () => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const nonce = randomUUID();
+      const nonceHash = createHmac("sha256", "wrong-secret").update(`${nonce}:${TEST_USER_ID}`).digest("hex");
+      const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true, nonce, nonceHash };
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+
+    it("prevents CSRF bypass by stripping nonce fields from non-exempt app", () => {
+      vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+      const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+      const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+      expect(decodeOAuthState(req)).toBeUndefined();
+    });
+  });
+});

--- a/packages/app-store/_utils/oauth/decodeOAuthState.test.ts
+++ b/packages/app-store/_utils/oauth/decodeOAuthState.test.ts
@@ -38,6 +38,7 @@ function buildStateWithValidNonce(
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("decodeOAuthState", () => {

--- a/packages/app-store/_utils/oauth/decodeOAuthState.ts
+++ b/packages/app-store/_utils/oauth/decodeOAuthState.ts
@@ -3,7 +3,7 @@ import process from "node:process";
 import type { NextApiRequest } from "next";
 import type { IntegrationOAuthCallbackState } from "../../types";
 
-const NONCE_EXEMPT_APPS = new Set(["stripe", "basecamp3", "dub", "webex", "tandem"]);
+const NONCE_EXEMPT_APPS = new Set(["basecamp3", "webex", "tandem"]);
 
 export function decodeOAuthState(req: NextApiRequest, appSlug?: string) {
   if (typeof req.query.state !== "string") {
@@ -28,6 +28,7 @@ export function decodeOAuthState(req: NextApiRequest, appSlug?: string) {
     .digest();
   const actual = Buffer.from(state.nonceHash, "hex");
   if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    console.warn("[OAuth] State nonce verification failed");
     return undefined;
   }
 

--- a/packages/app-store/_utils/oauth/encodeOAuthState.test.ts
+++ b/packages/app-store/_utils/oauth/encodeOAuthState.test.ts
@@ -26,6 +26,7 @@ function buildRequest({
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("encodeOAuthState", () => {

--- a/packages/app-store/_utils/oauth/encodeOAuthState.test.ts
+++ b/packages/app-store/_utils/oauth/encodeOAuthState.test.ts
@@ -1,0 +1,144 @@
+import { createHmac } from "node:crypto";
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { encodeOAuthState, signOAuthState } from "./encodeOAuthState";
+
+const TEST_SECRET = "test-nextauth-secret";
+const TEST_USER_ID = 42;
+
+function buildRequest({
+  state,
+  userId,
+}: {
+  state?: Record<string, unknown> | string;
+  userId?: number | null;
+}): Parameters<typeof encodeOAuthState>[0] {
+  const query: Record<string, string> = {};
+  if (state !== undefined) {
+    query.state = typeof state === "string" ? state : JSON.stringify(state);
+  }
+  return {
+    query,
+    session: userId !== null ? { user: { id: userId ?? TEST_USER_ID } } : undefined,
+  } as Parameters<typeof encodeOAuthState>[0];
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("encodeOAuthState", () => {
+  it("returns undefined when state query param is missing", () => {
+    const req = buildRequest({ state: undefined });
+    delete (req.query as Record<string, unknown>).state;
+    expect(encodeOAuthState(req)).toBeUndefined();
+  });
+
+  it("returns JSON string preserving original state fields", () => {
+    vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+    const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+    const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+    const result = encodeOAuthState(req);
+    expect(result).toBeDefined();
+    const parsed = JSON.parse(result!);
+    expect(parsed.returnTo).toBe("/apps");
+    expect(parsed.onErrorReturnTo).toBe("/error");
+    expect(parsed.fromApp).toBe(true);
+  });
+
+  it("injects nonce and nonceHash when userId and secret are available", () => {
+    vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+    const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+    const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+    const result = encodeOAuthState(req);
+    const parsed = JSON.parse(result!);
+    expect(parsed.nonce).toBeDefined();
+    expect(typeof parsed.nonce).toBe("string");
+    expect(parsed.nonceHash).toBeDefined();
+    expect(typeof parsed.nonceHash).toBe("string");
+  });
+
+  it("produces a valid HMAC that matches manual computation", () => {
+    vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+    const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+    const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+    const result = encodeOAuthState(req);
+    const parsed = JSON.parse(result!);
+    const expectedHash = createHmac("sha256", TEST_SECRET)
+      .update(`${parsed.nonce}:${TEST_USER_ID}`)
+      .digest("hex");
+    expect(parsed.nonceHash).toBe(expectedHash);
+  });
+
+  it("does not inject nonce when userId is missing", () => {
+    vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+    const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+    const req = buildRequest({ state: stateObj, userId: null });
+    const result = encodeOAuthState(req);
+    const parsed = JSON.parse(result!);
+    expect(parsed.nonce).toBeUndefined();
+    expect(parsed.nonceHash).toBeUndefined();
+  });
+
+  it("does not inject nonce when NEXTAUTH_SECRET is not set", () => {
+    vi.stubEnv("NEXTAUTH_SECRET", "");
+    const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+    const req = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+    const result = encodeOAuthState(req);
+    const parsed = JSON.parse(result!);
+    expect(parsed.nonce).toBeUndefined();
+    expect(parsed.nonceHash).toBeUndefined();
+  });
+
+  it("generates unique nonces per call", () => {
+    vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+    const stateObj = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true };
+    const req1 = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+    const req2 = buildRequest({ state: stateObj, userId: TEST_USER_ID });
+    const result1 = JSON.parse(encodeOAuthState(req1)!);
+    const result2 = JSON.parse(encodeOAuthState(req2)!);
+    expect(result1.nonce).not.toBe(result2.nonce);
+    expect(result1.nonceHash).not.toBe(result2.nonceHash);
+  });
+});
+
+describe("signOAuthState", () => {
+  it("signs state with nonce and nonceHash when secret is present", () => {
+    vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+    const state = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true as const };
+    const result = JSON.parse(signOAuthState(state, TEST_USER_ID));
+    expect(result.nonce).toBeDefined();
+    expect(typeof result.nonce).toBe("string");
+    expect(result.nonceHash).toBeDefined();
+    expect(typeof result.nonceHash).toBe("string");
+    expect(result.returnTo).toBe("/apps");
+  });
+
+  it("returns JSON without nonce when NEXTAUTH_SECRET is empty", () => {
+    vi.stubEnv("NEXTAUTH_SECRET", "");
+    const state = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true as const };
+    const result = JSON.parse(signOAuthState(state, TEST_USER_ID));
+    expect(result.nonce).toBeUndefined();
+    expect(result.nonceHash).toBeUndefined();
+    expect(result.returnTo).toBe("/apps");
+  });
+
+  it("produces HMAC that matches manual computation", () => {
+    vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+    const state = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true as const };
+    const result = JSON.parse(signOAuthState(state, TEST_USER_ID));
+    const expectedHash = createHmac("sha256", TEST_SECRET)
+      .update(`${result.nonce}:${TEST_USER_ID}`)
+      .digest("hex");
+    expect(result.nonceHash).toBe(expectedHash);
+  });
+
+  it("does not mutate the input state object", () => {
+    vi.stubEnv("NEXTAUTH_SECRET", TEST_SECRET);
+    const state = { returnTo: "/apps", onErrorReturnTo: "/error", fromApp: true as const };
+    signOAuthState(state, TEST_USER_ID);
+    expect((state as Record<string, unknown>).nonce).toBeUndefined();
+    expect((state as Record<string, unknown>).nonceHash).toBeUndefined();
+  });
+});

--- a/packages/app-store/_utils/oauth/encodeOAuthState.ts
+++ b/packages/app-store/_utils/oauth/encodeOAuthState.ts
@@ -3,6 +3,18 @@ import process from "node:process";
 import type { NextApiRequest } from "next";
 import type { IntegrationOAuthCallbackState } from "../../types";
 
+/** Like encodeOAuthState, but takes userId directly instead of reading from req.session.
+ *  Needed in getServerSideProps where the session shape differs from NextApiRequest. */
+export function signOAuthState(state: IntegrationOAuthCallbackState, userId: number): string {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    return JSON.stringify(state);
+  }
+  const nonce = randomUUID();
+  const nonceHash = createHmac("sha256", secret).update(`${nonce}:${userId}`).digest("hex");
+  return JSON.stringify({ ...state, nonce, nonceHash });
+}
+
 export function encodeOAuthState(req: NextApiRequest) {
   if (typeof req.query.state !== "string") {
     return undefined;
@@ -10,12 +22,9 @@ export function encodeOAuthState(req: NextApiRequest) {
   const state: IntegrationOAuthCallbackState = JSON.parse(req.query.state);
 
   const userId = req.session?.user?.id;
-  if (userId && process.env.NEXTAUTH_SECRET) {
-    state.nonce = randomUUID();
-    state.nonceHash = createHmac("sha256", process.env.NEXTAUTH_SECRET)
-      .update(`${state.nonce}:${userId}`)
-      .digest("hex");
+  if (!userId) {
+    return JSON.stringify(state);
   }
 
-  return JSON.stringify(state);
+  return signOAuthState(state, userId);
 }

--- a/packages/app-store/dub/api/add.ts
+++ b/packages/app-store/dub/api/add.ts
@@ -1,10 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { WEBAPP_URL } from "@calcom/lib/constants";
 import { HttpError } from "@calcom/lib/http-error";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";
 import { defaultResponder } from "@calcom/lib/server/defaultResponder";
 
 import getParsedAppKeysFromSlug from "../../_utils/getParsedAppKeysFromSlug";
+import { signOAuthState } from "@calcom/app-store/_utils/oauth/encodeOAuthState";
+import type { IntegrationOAuthCallbackState } from "@calcom/app-store/types";
 import { dubAppKeysSchema, scopeString } from "../lib/utils";
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -28,9 +31,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   url.searchParams.append("redirect_uri", redirect_uris);
   url.searchParams.append("response_type", "code");
   url.searchParams.append("scope", scopeString);
-  if (typeof teamId === "string" && !Number.isNaN(Number(teamId))) {
-    url.searchParams.append("state", JSON.stringify({ teamId: Number(teamId) }));
-  }
+
+  const oauthState: IntegrationOAuthCallbackState = {
+    onErrorReturnTo: `${WEBAPP_URL}/apps/installed`,
+    fromApp: true,
+    ...(typeof teamId === "string" && !Number.isNaN(Number(teamId)) ? { teamId: Number(teamId) } : {}),
+  };
+  url.searchParams.append("state", signOAuthState(oauthState, loggedInUser.id));
   const oauthUrl = url.toString();
 
   return res.status(200).json({ url: oauthUrl });

--- a/packages/app-store/dub/api/callback.ts
+++ b/packages/app-store/dub/api/callback.ts
@@ -1,9 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { getSafeRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
 import { HttpError } from "@calcom/lib/http-error";
-
+import type { NextApiRequest, NextApiResponse } from "next";
 import getInstalledAppPath from "../../_utils/getInstalledAppPath";
 import getParsedAppKeysFromSlug from "../../_utils/getParsedAppKeysFromSlug";
 import createOAuthAppCredential from "../../_utils/oauth/createOAuthAppCredential";
@@ -13,7 +11,7 @@ import { dubAppKeysSchema } from "../lib/utils";
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { code } = req.query;
 
-  const state = decodeOAuthState(req, "dub");
+  const state = decodeOAuthState(req);
 
   if (typeof code !== "string") {
     if (state?.onErrorReturnTo || state?.returnTo) {

--- a/packages/app-store/stripepayment/api/add.ts
+++ b/packages/app-store/stripepayment/api/add.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";
 
+import { encodeOAuthState } from "@calcom/app-store/_utils/oauth/encodeOAuthState";
 import { getStripeAppKeys } from "../lib/getStripeAppKeys";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -35,7 +36,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         country: process.env.NEXT_PUBLIC_IS_E2E ? "US" : undefined,
       },
       redirect_uri,
-      state: typeof req.query.state === "string" ? req.query.state : undefined,
+      state: encodeOAuthState(req),
     };
     /** stringify is being dumb here */
     const params = z.record(z.any()).parse(stripeConnectParams);

--- a/packages/app-store/stripepayment/api/callback.ts
+++ b/packages/app-store/stripepayment/api/callback.ts
@@ -10,14 +10,17 @@ import stripe from "../lib/server";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { code, error, error_description } = req.query;
-  const state = decodeOAuthState(req, "stripe");
+  const state = decodeOAuthState(req);
 
   if (error) {
+    // User cancels flow
     if (error === "access_denied") {
-      return res.redirect(getSafeRedirectUrl(state?.onErrorReturnTo) ?? "/apps/installed/payment");
+      const safeReturnTo = getSafeRedirectUrl(state?.onErrorReturnTo) ?? "/apps/installed/payment";
+      return res.redirect(safeReturnTo);
     }
     const query = stringify({ error, error_description });
-    return res.redirect(`/apps/installed?${query}`);
+    res.redirect(`/apps/installed?${query}`);
+    return;
   }
 
   if (!req.session?.user?.id) {
@@ -30,9 +33,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   });
 
   const data: StripeData = { ...response, default_currency: "" };
-  if (response.stripe_user_id) {
-    const account = await stripe.accounts.retrieve(response.stripe_user_id);
-    data.default_currency = account.default_currency;
+  if (response["stripe_user_id"]) {
+    const account = await stripe.accounts.retrieve(response["stripe_user_id"]);
+    data["default_currency"] = account.default_currency;
   }
 
   await createOAuthAppCredential(

--- a/packages/app-store/stripepayment/pages/setup/__tests__/_getServerSideProps.test.ts
+++ b/packages/app-store/stripepayment/pages/setup/__tests__/_getServerSideProps.test.ts
@@ -1,5 +1,5 @@
 import type { GetServerSidePropsContext } from "next";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock dependencies before imports
 vi.mock("@calcom/features/auth/lib/getServerSession", () => ({
@@ -50,6 +50,7 @@ function createMockContext(overrides: Partial<GetServerSidePropsContext> = {}): 
 describe("Stripe Setup Page getServerSideProps", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv("NEXTAUTH_SECRET", "test-nextauth-secret");
     mockGetStripeAppKeys.mockResolvedValue({
       client_id: "ca_test_client_id",
       payment_fee_fixed: 0,
@@ -57,6 +58,10 @@ describe("Stripe Setup Page getServerSideProps", () => {
       public_key: "pk_test",
       webhook_secret: "whsec_test",
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe("Slug validation", () => {
@@ -117,7 +122,7 @@ describe("Stripe Setup Page getServerSideProps", () => {
       const ctx = createMockContext();
       const testUuid = "550e8400-e29b-41d4-a716-446655440000";
       mockGetServerSession.mockResolvedValue({
-        user: { uuid: testUuid },
+        user: { id: 42, uuid: testUuid },
         hasValidLicense: true,
         upId: "test",
         expires: "2024-12-31",
@@ -137,7 +142,7 @@ describe("Stripe Setup Page getServerSideProps", () => {
   describe("OAuth redirect construction", () => {
     beforeEach(() => {
       mockGetServerSession.mockResolvedValue({
-        user: { uuid: "550e8400-e29b-41d4-a716-446655440000" },
+        user: { id: 42, uuid: "550e8400-e29b-41d4-a716-446655440000" },
         hasValidLicense: true,
         upId: "test",
         expires: "2024-12-31",
@@ -235,6 +240,22 @@ describe("Stripe Setup Page getServerSideProps", () => {
       expect(state.onErrorReturnTo).toBe("/settings/integrations");
     });
 
+    it("should include nonce and nonceHash in state for CSRF protection", async () => {
+      const ctx = createMockContext();
+
+      const result = await getServerSideProps(ctx);
+
+      const redirect = (result as { redirect: { destination: string; permanent: boolean } }).redirect;
+      const stateMatch = redirect.destination.match(/state=([^&]+)/);
+      expect(stateMatch).toBeTruthy();
+      const stateStr = decodeURIComponent(stateMatch![1]);
+      const state = JSON.parse(stateStr);
+      expect(state.nonce).toBeDefined();
+      expect(typeof state.nonce).toBe("string");
+      expect(state.nonceHash).toBeDefined();
+      expect(typeof state.nonceHash).toBe("string");
+    });
+
     it("should handle user with null name", async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         email: "user@example.com",
@@ -253,7 +274,7 @@ describe("Stripe Setup Page getServerSideProps", () => {
   describe("Error handling", () => {
     beforeEach(() => {
       mockGetServerSession.mockResolvedValue({
-        user: { uuid: "550e8400-e29b-41d4-a716-446655440000" },
+        user: { id: 42, uuid: "550e8400-e29b-41d4-a716-446655440000" },
         hasValidLicense: true,
         upId: "test",
         expires: "2024-12-31",
@@ -282,7 +303,7 @@ describe("Stripe Setup Page getServerSideProps", () => {
   describe("E2E mode", () => {
     beforeEach(() => {
       mockGetServerSession.mockResolvedValue({
-        user: { uuid: "550e8400-e29b-41d4-a716-446655440000" },
+        user: { id: 42, uuid: "550e8400-e29b-41d4-a716-446655440000" },
         hasValidLicense: true,
         upId: "test",
         expires: "2024-12-31",

--- a/packages/app-store/stripepayment/pages/setup/_getServerSideProps.ts
+++ b/packages/app-store/stripepayment/pages/setup/_getServerSideProps.ts
@@ -8,6 +8,7 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";
 
 import type { IntegrationOAuthCallbackState } from "@calcom/app-store/types";
+import { signOAuthState } from "@calcom/app-store/_utils/oauth/encodeOAuthState";
 import { getStripeAppKeys } from "../../lib/getStripeAppKeys";
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
@@ -16,7 +17,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 
   const session = await getServerSession({ req: ctx.req });
 
-  if (!session?.user?.uuid) {
+  if (!session?.user?.id || !session?.user?.uuid) {
     return {
       redirect: {
         destination: "/auth/login",
@@ -63,7 +64,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
         country: process.env.NEXT_PUBLIC_IS_E2E ? "US" : undefined,
       },
       redirect_uri,
-      state: JSON.stringify(state),
+      state: signOAuthState(state, session.user.id),
     };
 
     const params = z.record(z.any()).parse(stripeConnectParams);


### PR DESCRIPTION
## What does this PR do?

Continues the work from #28083, which added HMAC-signed nonce verification to OAuth state. Stripe and Dub were left exempt and this PR completes their migration, signing the state in both apps' authorization flows and removing their exemptions

### Changes

| File | Change |
|---|---|
| `encodeOAuthState.ts` | Add `signOAuthState()` for SSR contexts where `req.session` isn't available |
| `encodeOAuthState.ts` | Refactor `encodeOAuthState()` to delegate to `signOAuthState()` |
| `decodeOAuthState.ts` | Remove `"stripe"` and `"dub"` from `NONCE_EXEMPT_APPS` |
| `decodeOAuthState.ts` | Add `console.warn` on HMAC mismatch for debugging |
| `stripepayment/api/add.ts` | Replace raw state passthrough with `encodeOAuthState(req)` |
| `stripepayment/pages/setup/_getServerSideProps.ts` | Replace `JSON.stringify(state)` with `signOAuthState(state, userId)` |
| `stripepayment/pages/setup/_getServerSideProps.ts` | Add `session.user.id` check alongside existing `uuid` check |
| `stripepayment/api/callback.ts` | Remove `"stripe"` slug from `decodeOAuthState` call |
| `dub/api/add.ts` | Always send signed state (previously omitted when no `teamId`) |
| `dub/api/callback.ts` | Remove `"dub"` slug from `decodeOAuthState` call |

### What does NOT change

- **`createOAuthAppCredential.ts`**: keeps its internal `decodeOAuthState(req)` call; double-decode elimination is a separate refactor;
- **Other 12 OAuth callbacks** (hubspot, zoom, salesforce, etc.): untouched; they already go through `encodeOAuthState` in their add handlers
- **Exempt apps** (basecamp3, webex, tandem): remain exempt; none send `teamId` in state so the behavior is unchanged

### Updates since last revision

Addressed Cubic AI review feedback (all three issues had confidence 9/10):

| File | Change |
|---|---|
| `oauth-csrf-protection.e2e.ts` | Replace duplicated `signState` helper with imported `signOAuthState` from production code, so e2e tests validate the actual signer |
| `decodeOAuthState.test.ts` | Add `vi.unstubAllEnvs()` in `afterEach` to prevent `NEXTAUTH_SECRET` leaking across tests |
| `encodeOAuthState.test.ts` | Add `vi.unstubAllEnvs()` in `afterEach` — `vi.restoreAllMocks()` does not reset `vi.stubEnv` values |

## How should this be tested?

**Unit tests (47 passing):**
```bash
TZ=UTC yarn vitest run packages/app-store/_utils/oauth/encodeOAuthState.test.ts
TZ=UTC yarn vitest run packages/app-store/_utils/oauth/decodeOAuthState.test.ts
TZ=UTC yarn vitest run packages/app-store/stripepayment/pages/setup/__tests__/_getServerSideProps.test.ts
```

E2E tests (7 passing):
```PLAYWRIGHT_HEADLESS=1 yarn e2e apps/web/playwright/oauth/oauth-csrf-protection.e2e.ts```

Type check:
```yarn type-check:ci```

Manual verification (Stripe Connect):
1. Install Stripe via Apps → state in authorize URL contains nonce and nonceHash
2. Complete OAuth flow → redirects back successfully
3. Visit callback with unsigned state → rejected, falls back to /apps/installed

## Human Review Checklist

- [ ] Verify the e2e test's import of `signOAuthState` from `@calcom/app-store/_utils/oauth/encodeOAuthState` resolves correctly in the Playwright environment
- [ ] Confirm the `as IntegrationOAuthCallbackState` casts in e2e test are safe (objects contain `onErrorReturnTo` + `fromApp` matching the type)
- [ ] Verify `stripepayment/api/callback.ts` bracket notation change (`response["stripe_user_id"]`) is intentional and not a regression

## Mandatory Tasks


- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a https://cal.com/docs.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

---

**Link to Devin Session:** https://app.devin.ai/sessions/53b56e1c21744f9d86606cb3055eefed  
**Requested by:** bot_apk (apk@cognition.ai)