### PR TITLE
feat: disallow free email domains when creating OAuth clients

### DIFF
--- a/packages/trpc/server/routers/viewer/oAuth/submitClientForReview.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/submitClientForReview.handler.test.ts
@@ -1,9 +1,6 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
-
-import type { TFunction } from "i18next";
-
 import type { PrismaClient } from "@calcom/prisma";
-
+import type { TFunction } from "i18next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { submitClientForReviewHandler } from "./submitClientForReview.handler";
 
 const mocks = vi.hoisted(() => {
@@ -12,6 +9,7 @@ const mocks = vi.hoisted(() => {
     sendAdminOAuthClientNotification: vi.fn(),
     getTranslation: vi.fn(),
     generateSecret: vi.fn(),
+    checkIfFreeEmailDomain: vi.fn(),
   };
 });
 
@@ -34,12 +32,45 @@ vi.mock("@calcom/features/oauth/utils/generateSecret", () => ({
   generateSecret: mocks.generateSecret,
 }));
 
+vi.mock("@calcom/features/watchlist/lib/freeEmailDomainCheck/checkIfFreeEmailDomain", () => ({
+  checkIfFreeEmailDomain: mocks.checkIfFreeEmailDomain,
+}));
+
 describe("submitClientHandler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
+  it("throws an error when user has a free email domain", async () => {
+    mocks.checkIfFreeEmailDomain.mockResolvedValue(true);
+
+    const ctx = {
+      user: {
+        id: 42,
+        email: "submitter@gmail.com",
+        name: "Submitter Name",
+      },
+      prisma: {} as unknown as PrismaClient,
+    };
+
+    const input = {
+      name: "My Test Client",
+      purpose: "My test purpose",
+      redirectUri: "https://example.com/callback",
+      logo: "https://example.com/logo.png",
+      websiteUrl: "https://example.com",
+      enablePkce: false,
+    };
+
+    await expect(submitClientForReviewHandler({ ctx, input })).rejects.toThrow("Use a company email instead");
+
+    expect(mocks.checkIfFreeEmailDomain).toHaveBeenCalledWith({ email: "submitter@gmail.com" });
+    expect(mocks.createOAuthClient).not.toHaveBeenCalled();
+    expect(mocks.sendAdminOAuthClientNotification).not.toHaveBeenCalled();
+  });
+
   it("creates an OAuth client and sends the admin notification email with expected parameters", async () => {
+    mocks.checkIfFreeEmailDomain.mockResolvedValue(false);
     const t = ((key: string, vars?: Record<string, unknown>) => {
       if (key === "admin_oauth_notification_email_subject") {
         return `admin_oauth_notification_email_subject:${String(vars?.clientName ?? "")}`;

--- a/packages/trpc/server/routers/viewer/oAuth/submitClientForReview.handler.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/submitClientForReview.handler.ts
@@ -1,9 +1,10 @@
 import { sendAdminOAuthClientNotification } from "@calcom/emails/oauth-email-service";
-import { getTranslation } from "@calcom/i18n/server";
 import { OAuthClientRepository } from "@calcom/features/oauth/repositories/OAuthClientRepository";
 import { generateSecret } from "@calcom/features/oauth/utils/generateSecret";
+import { checkIfFreeEmailDomain } from "@calcom/features/watchlist/lib/freeEmailDomainCheck/checkIfFreeEmailDomain";
+import { getTranslation } from "@calcom/i18n/server";
 import type { PrismaClient } from "@calcom/prisma";
-
+import { TRPCError } from "@trpc/server";
 import type { TSubmitClientInputSchema } from "./submitClientForReview.schema";
 
 type SubmitClientOptions = {
@@ -21,6 +22,14 @@ type SubmitClientOptions = {
 export const submitClientForReviewHandler = async ({ ctx, input }: SubmitClientOptions) => {
   const { name, purpose, redirectUri, logo, websiteUrl, enablePkce } = input;
   const userId = ctx.user.id;
+
+  const isFreeEmail = await checkIfFreeEmailDomain({ email: ctx.user.email });
+  if (isFreeEmail) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Use a company email instead",
+    });
+  }
 
   const oAuthClientRepository = new OAuthClientRepository(ctx.prisma);
 


### PR DESCRIPTION
## What does this PR do?

Prevents users with free/personal email addresses (Gmail, Hotmail, Yahoo, etc.) from creating OAuth clients via the developer settings. When a user with a free email domain attempts to submit an OAuth client for review, a `BAD_REQUEST` error is thrown with the message **"Use a company email instead"**.

Uses the existing `checkIfFreeEmailDomain` helper from `@calcom/features/watchlist` which checks against both a hardcoded list of common free email providers and the dynamic watchlist service.

## Changes

- **`submitClientForReview.handler.ts`**: Added a free email domain check on `ctx.user.email` before proceeding with client creation. Throws `TRPCError` with code `BAD_REQUEST` if the email is from a free provider.
- **`submitClientForReview.handler.test.ts`**: Added test for the rejection path (free email → error thrown, no client created, no notification sent). Updated existing test to mock `checkIfFreeEmailDomain` returning `false`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Log in with a **free email** account (e.g. Gmail) and navigate to **Settings → Developer → OAuth Clients**
2. Attempt to create a new OAuth client
3. **Expected**: The submission should fail with the error message "Use a company email instead"
4. Log in with a **company email** account and repeat
5. **Expected**: OAuth client creation proceeds normally

## Important review notes

- [ ] **Scope**: This only guards the `submitClientForReview` handler (developer OAuth clients). The admin `createClient` endpoint and the Platform OAuth client creation (API v2) are not affected. Confirm this is the intended scope.
- [ ] **i18n**: The error message `"Use a company email instead"` is hardcoded in English per the request. Consider whether it should use a translation key.
- [ ] **Async check**: `checkIfFreeEmailDomain` is async and may hit the watchlist service/DB — verify this is acceptable overhead for the OAuth creation flow.

Link to Devin Session: https://app.devin.ai/sessions/06a8a85a4fc44b1790af4cfc8b2e6b4c
Requested by: @PeerRich