### PR TITLE
fix: isolate toggle mutations to prevent shared pending state

### DIFF
--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -59,7 +59,7 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
   const [isUpdateBtnLoading, setIsUpdateBtnLoading] = useState<boolean>(false);
   const [isTZScheduleOpen, setIsTZScheduleOpen] = useState<boolean>(false);
 
-  const mutation = trpc.viewer.me.updateProfile.useMutation({
+  const toggleMutationOptions = {
     onSuccess: async (res) => {
       await utils.viewer.me.invalidate();
       revalidateSettingsGeneral();
@@ -82,7 +82,12 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
       revalidateTravelSchedules();
       setIsUpdateBtnLoading(false);
     },
-  });
+  };
+  const mutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
+  const dynamicBookingMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
+  const seoIndexingMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
+  const monthlyDigestMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
+  const bookerEmailVerificationMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
 
   const timeFormatOptions = [
     { value: 12, label: t("12_hour") },
@@ -327,11 +332,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("dynamic_booking")}
           description={t("allow_dynamic_booking")}
-          disabled={mutation.isPending}
+          disabled={dynamicBookingMutation.isPending}
           checked={isAllowDynamicBookingChecked}
           onCheckedChange={(checked) => {
             setIsAllowDynamicBookingChecked(checked);
-            mutation.mutate({ allowDynamicBooking: checked });
+            dynamicBookingMutation.mutate({ allowDynamicBooking: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -341,11 +346,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("seo_indexing")}
           description={t("allow_seo_indexing")}
-          disabled={mutation.isPending || user.organizationSettings?.allowSEOIndexing === false}
+          disabled={seoIndexingMutation.isPending || user.organizationSettings?.allowSEOIndexing === false}
           checked={isAllowSEOIndexingChecked}
           onCheckedChange={(checked) => {
             setIsAllowSEOIndexingChecked(checked);
-            mutation.mutate({ allowSEOIndexing: checked });
+            seoIndexingMutation.mutate({ allowSEOIndexing: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -354,11 +359,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("monthly_digest_email")}
           description={t("monthly_digest_email_for_teams")}
-          disabled={mutation.isPending}
+          disabled={monthlyDigestMutation.isPending}
           checked={isReceiveMonthlyDigestEmailChecked}
           onCheckedChange={(checked) => {
             setIsReceiveMonthlyDigestEmailChecked(checked);
-            mutation.mutate({ receiveMonthlyDigestEmail: checked });
+            monthlyDigestMutation.mutate({ receiveMonthlyDigestEmail: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -367,11 +372,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("require_booker_email_verification")}
           description={t("require_booker_email_verification_description")}
-          disabled={mutation.isPending}
+          disabled={bookerEmailVerificationMutation.isPending}
           checked={isRequireBookerEmailVerificationChecked}
           onCheckedChange={(checked) => {
             setIsRequireBookerEmailVerificationChecked(checked);
-            mutation.mutate({ requiresBookerEmailVerification: checked });
+            bookerEmailVerificationMutation.mutate({ requiresBookerEmailVerification: checked });
           }}
           switchContainerClassName="mt-6"
         />


### PR DESCRIPTION
## What does this PR do?

In the General Settings page, all four toggle settings (Dynamic Booking, SEO Indexing, Monthly Digest Email, Require Booker Email Verification) were sharing a single useMutation instance. This meant that when any one toggle was clicked, all four toggles became disabled simultaneously until the server responded and data was refetched.

This fix gives each toggle its own dedicated mutation instance so only the toggle being changed is disabled during its pending state.

- Fixes #28330 (GitHub issue number)
- Fixes CAL-7298(Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)
### Before

https://github.com/user-attachments/assets/4b33949d-0306-4ef9-b6e2-956d8be83edb

### After

https://github.com/user-attachments/assets/4bf63076-a86f-4caa-8f3f-29e095871837







## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.(N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set? NO
- What are the minimal test data to have? N/A
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR? NO


