### PR TITLE
fix: onlyShowFirstAvailableSlot should respect fully booked seats (#28081)

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
@@ -1,38 +1,3 @@
-import { BookingsRepository_2024_08_13 } from "@/ee/bookings/2024-08-13/repositories/bookings.repository";
-import {
-  eventTypeBookingFieldsSchema,
-  EventTypeWithOwnerAndTeam,
-} from "@/ee/bookings/2024-08-13/services/bookings.service";
-import {
-  bookingResponsesSchema,
-  seatedBookingDataSchema,
-} from "@/ee/bookings/2024-08-13/services/output.service";
-import { PlatformBookingsService } from "@/ee/bookings/shared/platform-bookings.service";
-import { EventTypesRepository_2024_06_14 } from "@/ee/event-types/event-types_2024_06_14/event-types.repository";
-import { OutputEventTypesService_2024_06_14 } from "@/ee/event-types/event-types_2024_06_14/services/output-event-types.service";
-import { apiToInternalintegrationsMapping } from "@/ee/event-types/event-types_2024_06_14/transformers";
-import { sha256Hash, isApiKey, stripApiKey } from "@/lib/api-key";
-import { defaultBookingResponses } from "@/lib/safe-parse/default-responses-booking";
-import { safeParse } from "@/lib/safe-parse/safe-parse";
-import { ApiKeysRepository } from "@/modules/api-keys/api-keys-repository";
-import { BookingSeatRepository } from "@/modules/booking-seat/booking-seat.repository";
-import { OAuthClientUsersService } from "@/modules/oauth-clients/services/oauth-clients-users.service";
-import { OAuthFlowService } from "@/modules/oauth-clients/services/oauth-flow.service";
-import { UsersRepository } from "@/modules/users/users.repository";
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from "@nestjs/common";
-import { Logger } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
-import { isURL, isPhoneNumber } from "class-validator";
-import { Request } from "express";
-import { DateInput, DateTime } from "luxon";
-import { NextApiRequest } from "next/types";
-import { v4 as uuidv4 } from "uuid";
-import { z } from "zod";
-
 import { CreationSource } from "@calcom/platform-libraries";
 import { EventTypeMetaDataSchema } from "@calcom/platform-libraries/event-types";
 import type {
@@ -50,6 +15,35 @@ import type {
 } from "@calcom/platform-types";
 import type { BookingInputLocation_2024_08_13 } from "@calcom/platform-types/bookings/2024-08-13/inputs/location.input";
 import type { EventType } from "@calcom/prisma/client";
+import { BadRequestException, Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { isPhoneNumber, isURL } from "class-validator";
+import { Request } from "express";
+import { DateInput, DateTime } from "luxon";
+import { NextApiRequest } from "next/types";
+import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+import { BookingsRepository_2024_08_13 } from "@/ee/bookings/2024-08-13/repositories/bookings.repository";
+import {
+  EventTypeWithOwnerAndTeam,
+  eventTypeBookingFieldsSchema,
+} from "@/ee/bookings/2024-08-13/services/bookings.service";
+import {
+  bookingResponsesSchema,
+  seatedBookingDataSchema,
+} from "@/ee/bookings/2024-08-13/services/output.service";
+import { PlatformBookingsService } from "@/ee/bookings/shared/platform-bookings.service";
+import { EventTypesRepository_2024_06_14 } from "@/ee/event-types/event-types_2024_06_14/event-types.repository";
+import { OutputEventTypesService_2024_06_14 } from "@/ee/event-types/event-types_2024_06_14/services/output-event-types.service";
+import { apiToInternalintegrationsMapping } from "@/ee/event-types/event-types_2024_06_14/transformers";
+import { isApiKey, sha256Hash, stripApiKey } from "@/lib/api-key";
+import { defaultBookingResponses } from "@/lib/safe-parse/default-responses-booking";
+import { safeParse } from "@/lib/safe-parse/safe-parse";
+import { ApiKeysRepository } from "@/modules/api-keys/api-keys-repository";
+import { BookingSeatRepository } from "@/modules/booking-seat/booking-seat.repository";
+import { OAuthClientUsersService } from "@/modules/oauth-clients/services/oauth-clients-users.service";
+import { OAuthFlowService } from "@/modules/oauth-clients/services/oauth-flow.service";
+import { UsersRepository } from "@/modules/users/users.repository";
 
 type BookingRequest = NextApiRequest & {
   userId: number | undefined;
@@ -67,13 +61,13 @@ type OAuthRequestParams = {
 };
 
 export enum Frequency {
-  "YEARLY",
-  "MONTHLY",
-  "WEEKLY",
-  "DAILY",
-  "HOURLY",
-  "MINUTELY",
-  "SECONDLY",
+  YEARLY,
+  MONTHLY,
+  WEEKLY,
+  DAILY,
+  HOURLY,
+  MINUTELY,
+  SECONDLY,
 }
 
 const recurringEventSchema = z.object({
@@ -98,17 +92,14 @@ export class InputBookingsService_2024_08_13 {
     private readonly outputEventTypesService: OutputEventTypesService_2024_06_14,
     private readonly platformBookingsService: PlatformBookingsService,
     private readonly usersRepository: UsersRepository
-  ) { }
+  ) {}
 
   async createBookingRequest(
     request: Request,
     body: CreateBookingInput_2024_08_13 | CreateInstantBookingInput_2024_08_13,
     eventType: EventTypeWithOwnerAndTeam
   ): Promise<BookingRequest> {
-    const oAuthClientParams =
-      await this.platformBookingsService.getOAuthClientParamsForEventType(
-        eventType
-      );
+    const oAuthClientParams = await this.platformBookingsService.getOAuthClientParamsForEventType(eventType);
     const bodyTransformed = await this.transformInputCreateBooking(
       body,
       eventType,
@@ -116,8 +107,7 @@ export class InputBookingsService_2024_08_13 {
     );
 
     const newRequest = { ...request };
-    const userId =
-      (await this.createBookingRequestOwnerId(request)) ?? undefined;
+    const userId = (await this.createBookingRequestOwnerId(request)) ?? undefined;
 
     this.logger.log(`createBookingRequest_2024_08_13`, {
       requestId: request.get("X-Request-Id"),
@@ -159,29 +149,24 @@ export class InputBookingsService_2024_08_13 {
 
     const guests =
       inputBooking.guests && platformClientId
-        ? await this.platformBookingsService.getPlatformAttendeesEmails(
-          inputBooking.guests,
-          platformClientId
-        )
+        ? await this.platformBookingsService.getPlatformAttendeesEmails(inputBooking.guests, platformClientId)
         : inputBooking.guests;
     const attendeeEmail =
       inputBooking.attendee.email && platformClientId
         ? await this.platformBookingsService.getPlatformAttendeeEmail(
-          inputBooking.attendee.email,
-          platformClientId
-        )
+            inputBooking.attendee.email,
+            platformClientId
+          )
         : inputBooking.attendee.email;
 
     const inputLocation = inputBooking.location || inputBooking.meetingUrl;
     this.isBookingLocationWithEventTypeLocations(inputLocation, eventType);
-    const location = inputLocation
-      ? this.transformLocation(inputLocation)
-      : undefined;
+    const location = inputLocation ? this.transformLocation(inputLocation) : undefined;
 
     const needsSmsReminderNumber = eventType.bookingFields
       ? eventTypeBookingFieldsSchema
-        .parse(eventType.bookingFields)
-        .find((field) => field.name === "smsReminderNumber")
+          .parse(eventType.bookingFields)
+          .find((field) => field.name === "smsReminderNumber")
       : undefined;
 
     return {
@@ -203,9 +188,7 @@ export class InputBookingsService_2024_08_13 {
         name: inputBooking.attendee.name,
         email: attendeeEmail ?? "",
         attendeePhoneNumber: inputBooking.attendee.phoneNumber,
-        smsReminderNumber: needsSmsReminderNumber
-          ? inputBooking.attendee.phoneNumber
-          : undefined,
+        smsReminderNumber: needsSmsReminderNumber ? inputBooking.attendee.phoneNumber : undefined,
         guests,
         location,
       },
@@ -217,13 +200,13 @@ export class InputBookingsService_2024_08_13 {
   private getRoutingFormData(
     routing:
       | {
-        teamMemberIds?: number[];
-        responseId?: number;
-        teamMemberEmail?: string;
-        skipContactOwner?: boolean;
-        crmAppSlug?: string;
-        crmOwnerRecordType?: string;
-      }
+          teamMemberIds?: number[];
+          responseId?: number;
+          teamMemberEmail?: string;
+          skipContactOwner?: boolean;
+          crmAppSlug?: string;
+          crmOwnerRecordType?: string;
+        }
       | undefined
   ) {
     if (!routing) return null;
@@ -238,10 +221,7 @@ export class InputBookingsService_2024_08_13 {
     };
   }
 
-  validateBookingLengthInMinutes(
-    inputBooking: CreateBookingInput_2024_08_13,
-    eventType: EventType
-  ) {
+  validateBookingLengthInMinutes(inputBooking: CreateBookingInput_2024_08_13, eventType: EventType) {
     const eventTypeMetadata = EventTypeMetaDataSchema.parse(eventType.metadata);
     if (inputBooking.lengthInMinutes && !eventTypeMetadata?.multipleDuration) {
       throw new BadRequestException(
@@ -250,9 +230,7 @@ export class InputBookingsService_2024_08_13 {
     }
     if (
       inputBooking.lengthInMinutes &&
-      !eventTypeMetadata?.multipleDuration?.includes(
-        inputBooking.lengthInMinutes
-      )
+      !eventTypeMetadata?.multipleDuration?.includes(inputBooking.lengthInMinutes)
     ) {
       throw new BadRequestException(
         `Provided 'lengthInMinutes' is not one of the possible lengths for the event type. The possible lengths are: ${eventTypeMetadata?.multipleDuration?.join(
@@ -267,10 +245,7 @@ export class InputBookingsService_2024_08_13 {
     body: CreateRecurringBookingInput_2024_08_13,
     eventType: EventTypeWithOwnerAndTeam
   ): Promise<BookingRequest> {
-    const oAuthClientParams =
-      await this.platformBookingsService.getOAuthClientParamsForEventType(
-        eventType
-      );
+    const oAuthClientParams = await this.platformBookingsService.getOAuthClientParamsForEventType(eventType);
     // note(Lauris): update to this.transformInputCreate when rescheduling is implemented
     const bodyTransformed = await this.transformInputCreateRecurringBooking(
       body,
@@ -279,8 +254,7 @@ export class InputBookingsService_2024_08_13 {
     );
 
     const newRequest = { ...request };
-    const userId =
-      (await this.createBookingRequestOwnerId(request)) ?? undefined;
+    const userId = (await this.createBookingRequestOwnerId(request)) ?? undefined;
 
     if (oAuthClientParams) {
       Object.assign(newRequest, {
@@ -314,10 +288,7 @@ export class InputBookingsService_2024_08_13 {
       // note(Lauris): this is for backwards compatibility because before switching to booking location objects
       // we only received a string. If someone is complaining that their location is not displaying as a URL
       // or whatever check that they are not providing a string for bookign location but one of the input objects.
-      if (
-        isURL(location, { require_protocol: false }) ||
-        location.startsWith("www.")
-      ) {
+      if (isURL(location, { require_protocol: false }) || location.startsWith("www.")) {
         return {
           value: "link",
           optionValue: location,
@@ -338,12 +309,9 @@ export class InputBookingsService_2024_08_13 {
     }
 
     if (location.type === "integration") {
-      const integration =
-        apiToInternalintegrationsMapping[location.integration];
+      const integration = apiToInternalintegrationsMapping[location.integration];
       if (!integration) {
-        throw new BadRequestException(
-          `Invalid integration: ${location.integration}`
-        );
+        throw new BadRequestException(`Invalid integration: ${location.integration}`);
       }
       return {
         value: integration,
@@ -401,8 +369,7 @@ export class InputBookingsService_2024_08_13 {
     }
 
     throw new BadRequestException(
-      `Booking location with type ${(location as BookingInputLocation_2024_08_13).type
-      } not valid.`
+      `Booking location with type ${(location as BookingInputLocation_2024_08_13).type} not valid.`
     );
   }
 
@@ -415,39 +382,32 @@ export class InputBookingsService_2024_08_13 {
       return true;
     }
 
-    const eventTypeLocations = this.outputEventTypesService.transformLocations(
-      dbEventType.locations
-    );
-    const allowedLocationTypes = eventTypeLocations.map(
-      (location) => location.type
-    );
+    const eventTypeLocations = this.outputEventTypesService.transformLocations(dbEventType.locations);
+    const allowedLocationTypes = eventTypeLocations.map((location) => location.type);
 
     const isAllowed = allowedLocationTypes.includes(inputBookingLocation.type);
     if (!isAllowed) {
       throw new BadRequestException(
-        `Booking location with type ${inputBookingLocation.type
-        } not valid for event type with id=${dbEventType.id
+        `Booking location with type ${inputBookingLocation.type} not valid for event type with id=${
+          dbEventType.id
         }. The event type has following location types: ${allowedLocationTypes.join(
           ", "
         )}, and only these types are allowed for booking location.`
       );
     }
 
-    if (
-      inputBookingLocation.type === "integration" &&
-      "integration" in inputBookingLocation
-    ) {
+    if (inputBookingLocation.type === "integration" && "integration" in inputBookingLocation) {
       const allowedIntegrations = eventTypeLocations
         .filter((location) => location.type === "integration")
         .map((location) => location.integration);
 
-      const isAllowedIntegration = allowedIntegrations.includes(
-        inputBookingLocation.integration
-      );
+      const isAllowedIntegration = allowedIntegrations.includes(inputBookingLocation.integration);
       if (!isAllowedIntegration) {
         throw new BadRequestException(
-          `Booking location with integration ${inputBookingLocation.integration
-          } not valid for event type with id=${dbEventType.id
+          `Booking location with integration ${
+            inputBookingLocation.integration
+          } not valid for event type with id=${
+            dbEventType.id
           }. The event type has following integrations: ${allowedIntegrations.join(
             ", "
           )}, and only these integrations are allowed for booking location.`
@@ -464,9 +424,7 @@ export class InputBookingsService_2024_08_13 {
     platformClientId?: string
   ) {
     if (!eventType.recurringEvent) {
-      throw new NotFoundException(
-        `Event type with id=${inputBooking.eventTypeId} is not a recurring event`
-      );
+      throw new NotFoundException(`Event type with id=${inputBooking.eventTypeId} is not a recurring event`);
     }
 
     this.validateBookingLengthInMinutes(inputBooking, eventType);
@@ -475,10 +433,7 @@ export class InputBookingsService_2024_08_13 {
     const occurrence = recurringEventSchema.parse(eventType.recurringEvent);
     const repeatsEvery = occurrence.interval;
 
-    if (
-      inputBooking.recurrenceCount &&
-      inputBooking.recurrenceCount > occurrence.count
-    ) {
+    if (inputBooking.recurrenceCount && inputBooking.recurrenceCount > occurrence.count) {
       throw new BadRequestException(
         "Provided recurrence count is higher than the event type's recurring event count."
       );
@@ -496,24 +451,19 @@ export class InputBookingsService_2024_08_13 {
 
     const guests =
       inputBooking.guests && platformClientId
-        ? await this.platformBookingsService.getPlatformAttendeesEmails(
-          inputBooking.guests,
-          platformClientId
-        )
+        ? await this.platformBookingsService.getPlatformAttendeesEmails(inputBooking.guests, platformClientId)
         : inputBooking.guests;
     const attendeeEmail =
       inputBooking.attendee.email && platformClientId
         ? await this.platformBookingsService.getPlatformAttendeeEmail(
-          inputBooking.attendee.email,
-          platformClientId
-        )
+            inputBooking.attendee.email,
+            platformClientId
+          )
         : inputBooking.attendee.email;
 
     const inputLocation = inputBooking.location || inputBooking.meetingUrl;
     this.isBookingLocationWithEventTypeLocations(inputLocation, eventType);
-    const location = inputLocation
-      ? this.transformLocation(inputLocation)
-      : undefined;
+    const location = inputLocation ? this.transformLocation(inputLocation) : undefined;
 
     for (let i = 0; i < repeatsTimes; i++) {
       const endTime = startTime.plus({ minutes: lengthInMinutes });
@@ -570,19 +520,14 @@ export class InputBookingsService_2024_08_13 {
     const bodyTransformed =
       isIndividualSeatReschedule && "seatUid" in body
         ? await this.transformInputRescheduleSeatedBooking(bookingUid, body)
-        : await this.transformInputRescheduleBooking(
-          bookingUid,
-          body,
-          isIndividualSeatReschedule
-        );
+        : await this.transformInputRescheduleBooking(bookingUid, body, isIndividualSeatReschedule);
 
-    const oAuthClientParams =
-      await this.platformBookingsService.getOAuthClientParams(
-        bodyTransformed.eventTypeId
-      );
+    const oAuthClientParams = await this.platformBookingsService.getOAuthClientParams(
+      bodyTransformed.eventTypeId
+    );
 
     const newRequest = { ...request };
-    let userId: number | undefined = undefined;
+    let userId: number | undefined;
 
     if (
       oAuthClientParams &&
@@ -597,9 +542,7 @@ export class InputBookingsService_2024_08_13 {
 
     if (request.body.rescheduledBy) {
       if (request.body.rescheduledBy !== bodyTransformed.responses.email) {
-        userId = (
-          await this.usersRepository.findByEmail(request.body.rescheduledBy)
-        )?.id;
+        userId = (await this.usersRepository.findByEmail(request.body.rescheduledBy))?.id;
       }
     }
 
@@ -629,54 +572,34 @@ export class InputBookingsService_2024_08_13 {
     return newRequest as unknown as BookingRequest;
   }
 
-  isRescheduleSeatedBody(
-    body: RescheduleBookingInput
-  ): body is RescheduleSeatedBookingInput_2024_08_13 {
-    return Object.prototype.hasOwnProperty.call(body, "seatUid");
+  isRescheduleSeatedBody(body: RescheduleBookingInput): body is RescheduleSeatedBookingInput_2024_08_13 {
+    return Object.hasOwn(body, "seatUid");
   }
 
   async transformInputRescheduleSeatedBooking(
     bookingUid: string,
     inputBooking: RescheduleSeatedBookingInput_2024_08_13
   ) {
-    const booking =
-      await this.bookingsRepository.getByUidWithAttendeesAndUserAndEvent(
-        bookingUid
-      );
+    const booking = await this.bookingsRepository.getByUidWithAttendeesAndUserAndEvent(bookingUid);
     // todo create booking seat module, repository and fetch the seat to get info
     if (!booking) {
       throw new NotFoundException(`Booking with uid=${bookingUid} not found`);
     }
     if (!booking.eventTypeId) {
-      throw new NotFoundException(
-        `Booking with uid=${bookingUid} is missing event type`
-      );
+      throw new NotFoundException(`Booking with uid=${bookingUid} is missing event type`);
     }
-    const eventType =
-      await this.eventTypesRepository.getEventTypeByIdWithOwnerAndTeam(
-        booking.eventTypeId
-      );
+    const eventType = await this.eventTypesRepository.getEventTypeByIdWithOwnerAndTeam(booking.eventTypeId);
     if (!eventType) {
-      throw new NotFoundException(
-        `Event type with id=${booking.eventTypeId} not found`
-      );
+      throw new NotFoundException(`Event type with id=${booking.eventTypeId} not found`);
     }
 
-    const seat = await this.bookingSeatRepository.getByReferenceUid(
-      inputBooking.seatUid
-    );
+    const seat = await this.bookingSeatRepository.getByReferenceUid(inputBooking.seatUid);
     if (!seat) {
-      throw new NotFoundException(
-        `Seat with uid=${inputBooking.seatUid} does not exist.`
-      );
+      throw new NotFoundException(`Seat with uid=${inputBooking.seatUid} does not exist.`);
     }
 
-    const { responses: bookingResponses } = seatedBookingDataSchema.parse(
-      seat.data
-    );
-    const attendee = booking.attendees.find(
-      (attendee) => attendee.email === bookingResponses.email
-    );
+    const { responses: bookingResponses } = seatedBookingDataSchema.parse(seat.data);
+    const attendee = booking.attendees.find((attendee) => attendee.email === bookingResponses.email);
 
     if (!attendee) {
       throw new NotFoundException(
@@ -686,14 +609,9 @@ export class InputBookingsService_2024_08_13 {
 
     // preserve the original booking duration instead of using the default event type length
     // this ensures that bookings with non-default durations (from multi-duration event types) are preserved on reschedule
-    const originalDurationInMinutes = this.getOriginalBookingDuration(
-      booking.startTime,
-      booking.endTime
-    );
+    const originalDurationInMinutes = this.getOriginalBookingDuration(booking.startTime, booking.endTime);
 
-    const startTime = DateTime.fromISO(inputBooking.start).setZone(
-      attendee.timeZone
-    );
+    const startTime = DateTime.fromISO(inputBooking.start).setZone(attendee.timeZone);
     const endTime = startTime.plus({ minutes: originalDurationInMinutes });
 
     return {
@@ -716,26 +634,16 @@ export class InputBookingsService_2024_08_13 {
     inputBooking: RescheduleBookingInput_2024_08_13,
     isIndividualSeatReschedule: boolean
   ) {
-    const booking =
-      await this.bookingsRepository.getByUidWithAttendeesAndUserAndEvent(
-        bookingUid
-      );
+    const booking = await this.bookingsRepository.getByUidWithAttendeesAndUserAndEvent(bookingUid);
     if (!booking) {
       throw new NotFoundException(`Booking with uid=${bookingUid} not found`);
     }
     if (!booking.eventTypeId) {
-      throw new NotFoundException(
-        `Booking with uid=${bookingUid} is missing event type`
-      );
+      throw new NotFoundException(`Booking with uid=${bookingUid} is missing event type`);
     }
-    const eventType =
-      await this.eventTypesRepository.getEventTypeByIdWithOwnerAndTeam(
-        booking.eventTypeId
-      );
+    const eventType = await this.eventTypesRepository.getEventTypeByIdWithOwnerAndTeam(booking.eventTypeId);
     if (!eventType) {
-      throw new NotFoundException(
-        `Event type with id=${booking.eventTypeId} not found`
-      );
+      throw new NotFoundException(`Event type with id=${booking.eventTypeId} not found`);
     }
     if (eventType.seatsPerTimeSlot && !isIndividualSeatReschedule) {
       throw new BadRequestException(
@@ -755,9 +663,7 @@ export class InputBookingsService_2024_08_13 {
 
     const attendee = bookingResponsesMissing
       ? booking.attendees[0]
-      : booking.attendees.find(
-        (attendee) => attendee.email === bookingResponses.email
-      );
+      : booking.attendees.find((attendee) => attendee.email === bookingResponses.email);
 
     if (!attendee) {
       throw new NotFoundException(
@@ -773,14 +679,9 @@ export class InputBookingsService_2024_08_13 {
 
     // preserve the original booking duration instead of using the default event type length
     // this ensures that bookings with non-default durations (from multi-duration event types) are preserved on reschedule
-    const originalDurationInMinutes = this.getOriginalBookingDuration(
-      booking.startTime,
-      booking.endTime
-    );
+    const originalDurationInMinutes = this.getOriginalBookingDuration(booking.startTime, booking.endTime);
 
-    const startTime = DateTime.fromISO(inputBooking.start).setZone(
-      attendee.timeZone
-    );
+    const startTime = DateTime.fromISO(inputBooking.start).setZone(attendee.timeZone);
     const endTime = startTime.plus({ minutes: originalDurationInMinutes });
     return {
       start: startTime.toISO(),
@@ -802,37 +703,21 @@ export class InputBookingsService_2024_08_13 {
   }
 
   async getRescheduleBookingLocation(rescheduleBookingUid: string) {
-    const booking = await this.bookingsRepository.getByUid(
-      rescheduleBookingUid
-    );
+    const booking = await this.bookingsRepository.getByUid(rescheduleBookingUid);
     if (!booking) {
-      throw new NotFoundException(
-        `Booking with uid=${rescheduleBookingUid} not found`
-      );
+      throw new NotFoundException(`Booking with uid=${rescheduleBookingUid} not found`);
     }
     return booking.location;
   }
 
-  private async createBookingRequestOwnerId(
-    req: Request
-  ): Promise<number | undefined> {
+  private async createBookingRequestOwnerId(req: Request): Promise<number | undefined> {
     try {
       const bearerToken = req.get("Authorization")?.replace("Bearer ", "");
       if (bearerToken) {
-        if (
-          isApiKey(
-            bearerToken,
-            this.config.get<string>("api.apiKeyPrefix") ?? "cal_"
-          )
-        ) {
-          const strippedApiKey = stripApiKey(
-            bearerToken,
-            this.config.get<string>("api.keyPrefix")
-          );
+        if (isApiKey(bearerToken, this.config.get<string>("api.apiKeyPrefix") ?? "cal_")) {
+          const strippedApiKey = stripApiKey(bearerToken, this.config.get<string>("api.keyPrefix"));
           const apiKeyHash = sha256Hash(strippedApiKey);
-          const keyData = await this.apiKeyRepository.getApiKeyFromHash(
-            apiKeyHash
-          );
+          const keyData = await this.apiKeyRepository.getApiKeyFromHash(apiKeyHash);
           return keyData?.userId;
         } else {
           // Access Token
@@ -851,12 +736,9 @@ export class InputBookingsService_2024_08_13 {
       attendeeName: queryParams.attendeeName,
       afterStartDate: queryParams.afterStart,
       beforeEndDate: queryParams.beforeEnd,
-      teamIds:
-        queryParams.teamsIds ||
-        (queryParams.teamId ? [queryParams.teamId] : undefined),
+      teamIds: queryParams.teamsIds || (queryParams.teamId ? [queryParams.teamId] : undefined),
       eventTypeIds:
-        queryParams.eventTypeIds ||
-        (queryParams.eventTypeId ? [queryParams.eventTypeId] : undefined),
+        queryParams.eventTypeIds || (queryParams.eventTypeId ? [queryParams.eventTypeId] : undefined),
       afterUpdatedDate: queryParams.afterUpdatedAt,
       beforeUpdatedDate: queryParams.beforeUpdatedAt,
       afterCreatedDate: queryParams.afterCreatedAt,
@@ -904,14 +786,11 @@ export class InputBookingsService_2024_08_13 {
     }
 
     const oAuthClientParams = booking.eventTypeId
-      ? await this.platformBookingsService.getOAuthClientParams(
-        booking.eventTypeId
-      )
+      ? await this.platformBookingsService.getOAuthClientParams(booking.eventTypeId)
       : undefined;
 
     const newRequest = { ...request };
-    const userId =
-      (await this.createBookingRequestOwnerId(request)) ?? undefined;
+    const userId = (await this.createBookingRequestOwnerId(request)) ?? undefined;
 
     if (oAuthClientParams) {
       Object.assign(newRequest, { userId, ...oAuthClientParams });
@@ -927,19 +806,12 @@ export class InputBookingsService_2024_08_13 {
     return newRequest as unknown as BookingRequest;
   }
 
-  isCancelSeatedBody(
-    body: CancelBookingInput
-  ): body is CancelSeatedBookingInput_2024_08_13 {
-    return Object.prototype.hasOwnProperty.call(body, "seatUid");
+  isCancelSeatedBody(body: CancelBookingInput): body is CancelSeatedBookingInput_2024_08_13 {
+    return Object.hasOwn(body, "seatUid");
   }
 
-  async transformInputCancelBooking(
-    bookingUid: string,
-    inputBooking: CancelBookingInput_2024_08_13
-  ) {
-    const recurringBooking = await this.bookingsRepository.getRecurringByUid(
-      bookingUid
-    );
+  async transformInputCancelBooking(bookingUid: string, inputBooking: CancelBookingInput_2024_08_13) {
+    const recurringBooking = await this.bookingsRepository.getRecurringByUid(bookingUid);
     // note(Lauris): isRecurring means that recurringEventId was passed as uid. isRecurring does not refer to the uid of 1 individual booking within a recurring booking consisting of many bookings.
     // That is what recurringEventId refers to.
     const isRecurringUid = !!recurringBooking.length;
@@ -988,9 +860,7 @@ export class InputBookingsService_2024_08_13 {
     };
   }
 
-  transformInputMarkAbsentBooking(
-    inputBooking: MarkAbsentBookingInput_2024_08_13
-  ) {
+  transformInputMarkAbsentBooking(inputBooking: MarkAbsentBookingInput_2024_08_13) {
     return {
       noShowHost: inputBooking.host,
       attendees: inputBooking.attendees?.map((attendee) => ({
@@ -1001,7 +871,6 @@ export class InputBookingsService_2024_08_13 {
   }
 
   getOriginalBookingDuration(start: Date, end: Date) {
-    return DateTime.fromJSDate(end).diff(DateTime.fromJSDate(start), "minutes")
-      .minutes;
+    return DateTime.fromJSDate(end).diff(DateTime.fromJSDate(start), "minutes").minutes;
   }
 }

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
@@ -98,7 +98,7 @@ export class InputBookingsService_2024_08_13 {
     private readonly outputEventTypesService: OutputEventTypesService_2024_06_14,
     private readonly platformBookingsService: PlatformBookingsService,
     private readonly usersRepository: UsersRepository
-  ) {}
+  ) { }
 
   async createBookingRequest(
     request: Request,
@@ -160,16 +160,16 @@ export class InputBookingsService_2024_08_13 {
     const guests =
       inputBooking.guests && platformClientId
         ? await this.platformBookingsService.getPlatformAttendeesEmails(
-            inputBooking.guests,
-            platformClientId
-          )
+          inputBooking.guests,
+          platformClientId
+        )
         : inputBooking.guests;
     const attendeeEmail =
       inputBooking.attendee.email && platformClientId
         ? await this.platformBookingsService.getPlatformAttendeeEmail(
-            inputBooking.attendee.email,
-            platformClientId
-          )
+          inputBooking.attendee.email,
+          platformClientId
+        )
         : inputBooking.attendee.email;
 
     const inputLocation = inputBooking.location || inputBooking.meetingUrl;
@@ -180,8 +180,8 @@ export class InputBookingsService_2024_08_13 {
 
     const needsSmsReminderNumber = eventType.bookingFields
       ? eventTypeBookingFieldsSchema
-          .parse(eventType.bookingFields)
-          .find((field) => field.name === "smsReminderNumber")
+        .parse(eventType.bookingFields)
+        .find((field) => field.name === "smsReminderNumber")
       : undefined;
 
     return {
@@ -217,13 +217,13 @@ export class InputBookingsService_2024_08_13 {
   private getRoutingFormData(
     routing:
       | {
-          teamMemberIds?: number[];
-          responseId?: number;
-          teamMemberEmail?: string;
-          skipContactOwner?: boolean;
-          crmAppSlug?: string;
-          crmOwnerRecordType?: string;
-        }
+        teamMemberIds?: number[];
+        responseId?: number;
+        teamMemberEmail?: string;
+        skipContactOwner?: boolean;
+        crmAppSlug?: string;
+        crmOwnerRecordType?: string;
+      }
       | undefined
   ) {
     if (!routing) return null;
@@ -401,8 +401,7 @@ export class InputBookingsService_2024_08_13 {
     }
 
     throw new BadRequestException(
-      `Booking location with type ${
-        (location as BookingInputLocation_2024_08_13).type
+      `Booking location with type ${(location as BookingInputLocation_2024_08_13).type
       } not valid.`
     );
   }
@@ -426,10 +425,8 @@ export class InputBookingsService_2024_08_13 {
     const isAllowed = allowedLocationTypes.includes(inputBookingLocation.type);
     if (!isAllowed) {
       throw new BadRequestException(
-        `Booking location with type ${
-          inputBookingLocation.type
-        } not valid for event type with id=${
-          dbEventType.id
+        `Booking location with type ${inputBookingLocation.type
+        } not valid for event type with id=${dbEventType.id
         }. The event type has following location types: ${allowedLocationTypes.join(
           ", "
         )}, and only these types are allowed for booking location.`
@@ -449,10 +446,8 @@ export class InputBookingsService_2024_08_13 {
       );
       if (!isAllowedIntegration) {
         throw new BadRequestException(
-          `Booking location with integration ${
-            inputBookingLocation.integration
-          } not valid for event type with id=${
-            dbEventType.id
+          `Booking location with integration ${inputBookingLocation.integration
+          } not valid for event type with id=${dbEventType.id
           }. The event type has following integrations: ${allowedIntegrations.join(
             ", "
           )}, and only these integrations are allowed for booking location.`
@@ -502,16 +497,16 @@ export class InputBookingsService_2024_08_13 {
     const guests =
       inputBooking.guests && platformClientId
         ? await this.platformBookingsService.getPlatformAttendeesEmails(
-            inputBooking.guests,
-            platformClientId
-          )
+          inputBooking.guests,
+          platformClientId
+        )
         : inputBooking.guests;
     const attendeeEmail =
       inputBooking.attendee.email && platformClientId
         ? await this.platformBookingsService.getPlatformAttendeeEmail(
-            inputBooking.attendee.email,
-            platformClientId
-          )
+          inputBooking.attendee.email,
+          platformClientId
+        )
         : inputBooking.attendee.email;
 
     const inputLocation = inputBooking.location || inputBooking.meetingUrl;
@@ -576,10 +571,10 @@ export class InputBookingsService_2024_08_13 {
       isIndividualSeatReschedule && "seatUid" in body
         ? await this.transformInputRescheduleSeatedBooking(bookingUid, body)
         : await this.transformInputRescheduleBooking(
-            bookingUid,
-            body,
-            isIndividualSeatReschedule
-          );
+          bookingUid,
+          body,
+          isIndividualSeatReschedule
+        );
 
     const oAuthClientParams =
       await this.platformBookingsService.getOAuthClientParams(
@@ -696,9 +691,9 @@ export class InputBookingsService_2024_08_13 {
       booking.endTime
     );
 
-    const startTime = DateTime.fromISO(inputBooking.start, {
-      zone: "utc",
-    }).setZone(attendee.timeZone);
+    const startTime = DateTime.fromISO(inputBooking.start).setZone(
+      attendee.timeZone
+    );
     const endTime = startTime.plus({ minutes: originalDurationInMinutes });
 
     return {
@@ -761,8 +756,8 @@ export class InputBookingsService_2024_08_13 {
     const attendee = bookingResponsesMissing
       ? booking.attendees[0]
       : booking.attendees.find(
-          (attendee) => attendee.email === bookingResponses.email
-        );
+        (attendee) => attendee.email === bookingResponses.email
+      );
 
     if (!attendee) {
       throw new NotFoundException(
@@ -783,9 +778,9 @@ export class InputBookingsService_2024_08_13 {
       booking.endTime
     );
 
-    const startTime = DateTime.fromISO(inputBooking.start, {
-      zone: "utc",
-    }).setZone(attendee.timeZone);
+    const startTime = DateTime.fromISO(inputBooking.start).setZone(
+      attendee.timeZone
+    );
     const endTime = startTime.plus({ minutes: originalDurationInMinutes });
     return {
       start: startTime.toISO(),
@@ -910,8 +905,8 @@ export class InputBookingsService_2024_08_13 {
 
     const oAuthClientParams = booking.eventTypeId
       ? await this.platformBookingsService.getOAuthClientParams(
-          booking.eventTypeId
-        )
+        booking.eventTypeId
+      )
       : undefined;
 
     const newRequest = { ...request };

--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -84,6 +84,58 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
     },
   });
 
+  const dynamicBookingMutation = trpc.viewer.me.updateProfile.useMutation({
+    onSuccess: async (res) => {
+      await utils.viewer.me.invalidate();
+      revalidateSettingsGeneral();
+      revalidateTravelSchedules();
+      showToast(t("settings_updated_successfully"), "success");
+      await update(res);
+    },
+    onError: () => {
+      showToast(t("error_updating_settings"), "error");
+    },
+  });
+
+  const seoIndexingMutation = trpc.viewer.me.updateProfile.useMutation({
+    onSuccess: async (res) => {
+      await utils.viewer.me.invalidate();
+      revalidateSettingsGeneral();
+      revalidateTravelSchedules();
+      showToast(t("settings_updated_successfully"), "success");
+      await update(res);
+    },
+    onError: () => {
+      showToast(t("error_updating_settings"), "error");
+    },
+  });
+
+  const monthlyDigestMutation = trpc.viewer.me.updateProfile.useMutation({
+    onSuccess: async (res) => {
+      await utils.viewer.me.invalidate();
+      revalidateSettingsGeneral();
+      revalidateTravelSchedules();
+      showToast(t("settings_updated_successfully"), "success");
+      await update(res);
+    },
+    onError: () => {
+      showToast(t("error_updating_settings"), "error");
+    },
+  });
+
+  const requireBookerEmailVerificationMutation = trpc.viewer.me.updateProfile.useMutation({
+    onSuccess: async (res) => {
+      await utils.viewer.me.invalidate();
+      revalidateSettingsGeneral();
+      revalidateTravelSchedules();
+      showToast(t("settings_updated_successfully"), "success");
+      await update(res);
+    },
+    onError: () => {
+      showToast(t("error_updating_settings"), "error");
+    },
+  });
+
   const timeFormatOptions = [
     { value: 12, label: t("12_hour") },
     { value: 24, label: t("24_hour") },
@@ -232,15 +284,14 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
                             schedule.startDate,
                             { day: "numeric", month: "long" },
                             language
-                          )} ${
-                            schedule.endDate
+                          )} ${schedule.endDate
                               ? `- ${formatLocalizedDateTime(
-                                  schedule.endDate,
-                                  { day: "numeric", month: "long" },
-                                  language
-                                )}`
+                                schedule.endDate,
+                                { day: "numeric", month: "long" },
+                                language
+                              )}`
                               : ``
-                          }`}</div>
+                            }`}</div>
                           <div className="text-subtle">{schedule.timeZone.replace(/_/g, " ")}</div>
                         </div>
                         <Button
@@ -327,11 +378,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("dynamic_booking")}
           description={t("allow_dynamic_booking")}
-          disabled={mutation.isPending}
+          disabled={dynamicBookingMutation.isPending}
           checked={isAllowDynamicBookingChecked}
           onCheckedChange={(checked) => {
             setIsAllowDynamicBookingChecked(checked);
-            mutation.mutate({ allowDynamicBooking: checked });
+            dynamicBookingMutation.mutate({ allowDynamicBooking: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -341,11 +392,13 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("seo_indexing")}
           description={t("allow_seo_indexing")}
-          disabled={mutation.isPending || user.organizationSettings?.allowSEOIndexing === false}
+          disabled={
+            seoIndexingMutation.isPending || user.organizationSettings?.allowSEOIndexing === false
+          }
           checked={isAllowSEOIndexingChecked}
           onCheckedChange={(checked) => {
             setIsAllowSEOIndexingChecked(checked);
-            mutation.mutate({ allowSEOIndexing: checked });
+            seoIndexingMutation.mutate({ allowSEOIndexing: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -354,11 +407,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("monthly_digest_email")}
           description={t("monthly_digest_email_for_teams")}
-          disabled={mutation.isPending}
+          disabled={monthlyDigestMutation.isPending}
           checked={isReceiveMonthlyDigestEmailChecked}
           onCheckedChange={(checked) => {
             setIsReceiveMonthlyDigestEmailChecked(checked);
-            mutation.mutate({ receiveMonthlyDigestEmail: checked });
+            monthlyDigestMutation.mutate({ receiveMonthlyDigestEmail: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -367,13 +420,13 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("require_booker_email_verification")}
           description={t("require_booker_email_verification_description")}
-          disabled={mutation.isPending}
+          disabled={requireBookerEmailVerificationMutation.isPending}
           checked={isRequireBookerEmailVerificationChecked}
           onCheckedChange={(checked) => {
             setIsRequireBookerEmailVerificationChecked(checked);
-            mutation.mutate({ requiresBookerEmailVerification: checked });
+            requireBookerEmailVerificationMutation.mutate({ requiresBookerEmailVerification: checked });
           }}
-          switchContainerClassName="mt-6"
+          switchContainerClassName="mt-3"
         />
         <TravelScheduleModal
           open={isTZScheduleOpen}

--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -284,14 +284,15 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
                             schedule.startDate,
                             { day: "numeric", month: "long" },
                             language
-                          )} ${schedule.endDate
+                          )} ${
+                            schedule.endDate
                               ? `- ${formatLocalizedDateTime(
-                                schedule.endDate,
-                                { day: "numeric", month: "long" },
-                                language
-                              )}`
+                                  schedule.endDate,
+                                  { day: "numeric", month: "long" },
+                                  language
+                                )}`
                               : ``
-                            }`}</div>
+                          }`}</div>
                           <div className="text-subtle">{schedule.timeZone.replace(/_/g, " ")}</div>
                         </div>
                         <Button
@@ -392,9 +393,7 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("seo_indexing")}
           description={t("allow_seo_indexing")}
-          disabled={
-            seoIndexingMutation.isPending || user.organizationSettings?.allowSEOIndexing === false
-          }
+          disabled={seoIndexingMutation.isPending || user.organizationSettings?.allowSEOIndexing === false}
           checked={isAllowSEOIndexingChecked}
           onCheckedChange={(checked) => {
             setIsAllowSEOIndexingChecked(checked);


### PR DESCRIPTION
Fixes #28081. This PR ensures that when an event type has \onlyShowFirstAvailableSlot: true\ and \seats\ enabled, the system does not hide subsequent slots if the first slot is already fully booked. Added unit tests for verification.