### PR TITLE
fix: use independent mutations for settings toggles to prevent global loading state

### DIFF
--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -84,21 +84,40 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
     },
   });
 
-  const toggleMutationOptions = {
-    onSuccess: async () => {
-      await utils.viewer.me.invalidate();
-      revalidateSettingsGeneral();
-      showToast(t("settings_updated_successfully"), "success");
-    },
-    onError: () => {
-      showToast(t("error_updating_settings"), "error");
-    },
+  const toggleMutationOnSuccess = async () => {
+    await utils.viewer.me.invalidate();
+    revalidateSettingsGeneral();
+    showToast(t("settings_updated_successfully"), "success");
   };
 
-  const dynamicBookingMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
-  const seoIndexingMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
-  const monthlyDigestMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
-  const emailVerificationMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
+  const dynamicBookingMutation = trpc.viewer.me.updateProfile.useMutation({
+    onSuccess: toggleMutationOnSuccess,
+    onError: () => {
+      setIsAllowDynamicBookingChecked((prev) => !prev);
+      showToast(t("error_updating_settings"), "error");
+    },
+  });
+  const seoIndexingMutation = trpc.viewer.me.updateProfile.useMutation({
+    onSuccess: toggleMutationOnSuccess,
+    onError: () => {
+      setIsAllowSEOIndexingChecked((prev) => !prev);
+      showToast(t("error_updating_settings"), "error");
+    },
+  });
+  const monthlyDigestMutation = trpc.viewer.me.updateProfile.useMutation({
+    onSuccess: toggleMutationOnSuccess,
+    onError: () => {
+      setIsReceiveMonthlyDigestEmailChecked((prev) => !prev);
+      showToast(t("error_updating_settings"), "error");
+    },
+  });
+  const emailVerificationMutation = trpc.viewer.me.updateProfile.useMutation({
+    onSuccess: toggleMutationOnSuccess,
+    onError: () => {
+      setIsRequireBookerEmailVerificationChecked((prev) => !prev);
+      showToast(t("error_updating_settings"), "error");
+    },
+  });
 
   const timeFormatOptions = [
     { value: 12, label: t("12_hour") },

--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -84,6 +84,22 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
     },
   });
 
+  const toggleMutationOptions = {
+    onSuccess: async () => {
+      await utils.viewer.me.invalidate();
+      revalidateSettingsGeneral();
+      showToast(t("settings_updated_successfully"), "success");
+    },
+    onError: () => {
+      showToast(t("error_updating_settings"), "error");
+    },
+  };
+
+  const dynamicBookingMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
+  const seoIndexingMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
+  const monthlyDigestMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
+  const emailVerificationMutation = trpc.viewer.me.updateProfile.useMutation(toggleMutationOptions);
+
   const timeFormatOptions = [
     { value: 12, label: t("12_hour") },
     { value: 24, label: t("24_hour") },
@@ -327,11 +343,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("dynamic_booking")}
           description={t("allow_dynamic_booking")}
-          disabled={mutation.isPending}
+          disabled={dynamicBookingMutation.isPending}
           checked={isAllowDynamicBookingChecked}
           onCheckedChange={(checked) => {
             setIsAllowDynamicBookingChecked(checked);
-            mutation.mutate({ allowDynamicBooking: checked });
+            dynamicBookingMutation.mutate({ allowDynamicBooking: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -341,11 +357,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("seo_indexing")}
           description={t("allow_seo_indexing")}
-          disabled={mutation.isPending || user.organizationSettings?.allowSEOIndexing === false}
+          disabled={seoIndexingMutation.isPending || user.organizationSettings?.allowSEOIndexing === false}
           checked={isAllowSEOIndexingChecked}
           onCheckedChange={(checked) => {
             setIsAllowSEOIndexingChecked(checked);
-            mutation.mutate({ allowSEOIndexing: checked });
+            seoIndexingMutation.mutate({ allowSEOIndexing: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -354,11 +370,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("monthly_digest_email")}
           description={t("monthly_digest_email_for_teams")}
-          disabled={mutation.isPending}
+          disabled={monthlyDigestMutation.isPending}
           checked={isReceiveMonthlyDigestEmailChecked}
           onCheckedChange={(checked) => {
             setIsReceiveMonthlyDigestEmailChecked(checked);
-            mutation.mutate({ receiveMonthlyDigestEmail: checked });
+            monthlyDigestMutation.mutate({ receiveMonthlyDigestEmail: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -367,11 +383,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("require_booker_email_verification")}
           description={t("require_booker_email_verification_description")}
-          disabled={mutation.isPending}
+          disabled={emailVerificationMutation.isPending}
           checked={isRequireBookerEmailVerificationChecked}
           onCheckedChange={(checked) => {
             setIsRequireBookerEmailVerificationChecked(checked);
-            mutation.mutate({ requiresBookerEmailVerification: checked });
+            emailVerificationMutation.mutate({ requiresBookerEmailVerification: checked });
           }}
           switchContainerClassName="mt-6"
         />


### PR DESCRIPTION
## What does this PR do?

Previously all 4 `SettingsToggle` components on the General settings page shared a single `useMutation` hook, causing all toggles to be disabled when any one was mutating. This PR creates 4 independent mutation hooks so each toggle only disables itself during its own mutation.

- Fixes #28330

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to **Settings → My Account → General**
2. Toggle **Dynamic Booking** — only that toggle should show a loading/disabled state
3. The other 3 toggles (SEO Indexing, Monthly Digest, Email Verification) should remain interactive
4. Repeat for each toggle independently — each should only disable itself while mutating