### PR TITLE
fix: remove linkShallow from AppCategoryNavigation to prevent hydration mismatch

### DIFF
--- a/packages/app-store/_components/AppCategoryNavigation.tsx
+++ b/packages/app-store/_components/AppCategoryNavigation.tsx
@@ -44,14 +44,12 @@ const AppCategoryNavigation = ({
         <VerticalTabs
           tabs={appCategories}
           sticky
-          linkShallow
           itemClassname={classNames?.verticalTabsItem}
         />
       </div>
       <div className="block xl:hidden">
         <HorizontalTabs
           tabs={appCategories}
-          linkShallow
           scrollActiveTabIntoView
         />
       </div>


### PR DESCRIPTION
## What does this PR do?

Removes the `linkShallow` prop from both `<VerticalTabs>` and `<HorizontalTabs>` inside `AppCategoryNavigation`. The `shallow` routing option is a Pages Router feature and causes hydration mismatches when used in the App Router context.

- Fixes #28298

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to the **Apps** page (`/apps`)
2. Click between app categories (All, Calendar, Video, etc.)
3. Verify no hydration mismatch errors appear in the browser console
4. Verify navigation works correctly and the active tab is highlighted properly