### PR TITLE
feat: add booking question field types to routing forms (fixes #18987)

### DIFF
--- a/apps/web/components/apps/routing-forms/SingleForm.tsx
+++ b/apps/web/components/apps/routing-forms/SingleForm.tsx
@@ -2,6 +2,7 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
 import { useFormContext } from "react-hook-form";
 import type { UseFormReturn } from "react-hook-form";
 
@@ -159,6 +160,13 @@ function SingleForm({
   } as UptoDateForm;
 
   const handleSubmit = (data: RoutingFormWithResponseCount) => {
+    const fieldsWithIds = data.fields?.map((field) => {
+      if (!field.id) {
+        return { ...field, identifier: field.name, id: uuidv4() };
+      }
+      return field;
+    });
+    data.fields = fieldsWithIds;
     mutation.mutate({
       ...data,
     });

--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -91,8 +91,8 @@ export const FormBuilder = function FormBuilder({
   title: string;
   description: string;
   addFieldLabel: string;
-  disabled: boolean;
-  LockedIcon: false | JSX.Element;
+  disabled?: boolean;
+  LockedIcon?: false | JSX.Element;
   showPhoneAndEmailToggle?: boolean;
   /**
    * A readonly dataStore that is used to lookup the options for the fields. It works in conjunction with the field.getOptionAt property which acts as the key in options

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
@@ -15,6 +15,24 @@ function getWidgetsWithoutFactory(_configFor: ConfigFor) {
     email: {
       ...BasicConfig.widgets.text,
     },
+    url: {
+      ...BasicConfig.widgets.text,
+    },
+    address: {
+      ...BasicConfig.widgets.text,
+    },
+    multiemail: {
+      ...BasicConfig.widgets.text,
+    },
+    radio: {
+      ...BasicConfig.widgets.select,
+    },
+    checkbox: {
+      ...BasicConfig.widgets.multiselect,
+    },
+    boolean: {
+      ...BasicConfig.widgets.text,
+    },
   };
   return widgetsWithoutFactory;
 }
@@ -40,6 +58,61 @@ function getTypes(configFor: ConfigFor) {
       ...BasicConfig.types.text,
       widgets: {
         ...BasicConfig.types.text.widgets,
+      },
+    },
+    url: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+        url: {
+          ...BasicConfig.types.text.widgets.text,
+        },
+      },
+    },
+    address: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+        address: {
+          ...BasicConfig.types.text.widgets.text,
+        },
+      },
+    },
+    multiemail: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+        multiemail: {
+          ...BasicConfig.types.text.widgets.text,
+        },
+      },
+    },
+    radio: {
+      ...BasicConfig.types.select,
+      widgets: {
+        ...BasicConfig.types.select.widgets,
+        radio: {
+          ...BasicConfig.types.select.widgets.select,
+        },
+      },
+    },
+    checkbox: {
+      ...BasicConfig.types.multiselect,
+      widgets: {
+        ...BasicConfig.types.multiselect.widgets,
+        checkbox: {
+          ...BasicConfig.types.multiselect.widgets.multiselect,
+        },
+      },
+    },
+    boolean: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+        boolean: {
+          ...BasicConfig.types.text.widgets.text,
+          operators: ["select_equals", "select_not_equals"],
+        },
       },
     },
     multiselect: {

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
@@ -27,6 +27,12 @@ const {
   MultiSelectWidget,
   SelectWidget,
   NumberWidget,
+  UrlWidget,
+  AddressWidget,
+  MultiEmailWidget,
+  RadioWidget,
+  CheckboxWidget,
+  BooleanWidget,
   FieldSelect,
   Conjs,
   Button,
@@ -58,6 +64,28 @@ const PhoneFactory = (props: WidgetProps | undefined) => {
   }
   return <TextWidget type="tel" {...props} />;
 };
+
+const UrlFactory = (props: WidgetProps | undefined) => renderComponent(props, UrlWidget);
+const AddressFactory = (props: WidgetProps | undefined) => renderComponent(props, AddressWidget);
+const MultiEmailFactory = (props: WidgetProps | undefined) => renderComponent(props, MultiEmailWidget);
+
+const RadioFactory = (
+  props:
+    | (SelectWidgetProps & {
+        listValues: { title: string; value: string }[];
+      })
+    | undefined
+) => renderComponent(props, RadioWidget);
+
+const CheckboxFactory = (
+  props:
+    | (SelectWidgetProps & {
+        listValues: { title: string; value: string }[];
+      })
+    | undefined
+) => renderComponent(props, CheckboxWidget);
+
+const BooleanFactory = (props: WidgetProps | undefined) => renderComponent(props, BooleanWidget);
 
 const EmailFactory = (props: WidgetProps | undefined) => {
   if (!props) {
@@ -110,6 +138,30 @@ function withFactoryWidgets(widgets: WidgetsWithoutFactory) {
     email: {
       ...widgets.text,
       factory: EmailFactory,
+    },
+    url: {
+      ...widgets.text,
+      factory: UrlFactory,
+    },
+    address: {
+      ...widgets.text,
+      factory: AddressFactory,
+    },
+    multiemail: {
+      ...widgets.text,
+      factory: MultiEmailFactory,
+    },
+    radio: {
+      ...widgets.select,
+      factory: RadioFactory,
+    } as SelectWidgetType,
+    checkbox: {
+      ...widgets.multiselect,
+      factory: CheckboxFactory,
+    } as SelectWidgetType,
+    boolean: {
+      ...widgets.text,
+      factory: BooleanFactory,
     },
   };
   return widgetsWithFactory;

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/widgets.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/widgets.tsx
@@ -370,12 +370,113 @@ const FieldSelect = function FieldSelect(props: FieldProps) {
 
 const Provider = ({ children }: ProviderProps) => children;
 
+const UrlWidget = (props: TextLikeComponentPropsRAQB) => {
+  return <TextWidget type="url" {...props} />;
+};
+
+const AddressWidget = (props: TextLikeComponentPropsRAQB) => {
+  return <TextWidget type="text" placeholder={props.placeholder || "Enter address"} {...props} />;
+};
+
+const MultiEmailWidget = (props: TextLikeComponentPropsRAQB) => {
+  return <TextWidget type="email" placeholder={props.placeholder || "Enter email addresses"} {...props} />;
+};
+
+const RadioWidget = ({
+  listValues,
+  setValue,
+  value,
+  readOnly,
+}: SelectLikeComponentPropsRAQB) => {
+  if (!listValues) {
+    return null;
+  }
+  return (
+    <div className="mb-2 flex flex-col gap-1">
+      {listValues.map((item) => (
+        <label key={item.value} className="flex items-center gap-2 text-sm">
+          <input
+            type="radio"
+            value={item.value}
+            checked={value === item.value}
+            disabled={readOnly}
+            onChange={() => setValue(item.value)}
+            className="h-4 w-4"
+          />
+          {item.title}
+        </label>
+      ))}
+    </div>
+  );
+};
+
+const CheckboxWidget = ({
+  listValues,
+  setValue,
+  value,
+  readOnly,
+}: SelectLikeComponentPropsRAQB<string[]>) => {
+  if (!listValues) {
+    return null;
+  }
+  const currentValues: string[] = Array.isArray(value) ? value : value ? [value as unknown as string] : [];
+  return (
+    <div className="mb-2 flex flex-col gap-1">
+      {listValues.map((item) => (
+        <label key={item.value} className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            value={item.value}
+            checked={currentValues.includes(item.value)}
+            disabled={readOnly}
+            onChange={(e) => {
+              if (e.target.checked) {
+                setValue([...currentValues, item.value]);
+              } else {
+                setValue(currentValues.filter((v) => v !== item.value));
+              }
+            }}
+            className="h-4 w-4"
+          />
+          {item.title}
+        </label>
+      ))}
+    </div>
+  );
+};
+
+const BooleanWidget = ({
+  value,
+  setValue,
+  readOnly,
+  label,
+}: TextLikeComponentPropsRAQB<boolean>) => {
+  return (
+    <label className="mb-2 flex items-center gap-2 text-sm">
+      <input
+        type="checkbox"
+        checked={!!value}
+        disabled={readOnly}
+        onChange={(e) => setValue(e.target.checked)}
+        className="h-4 w-4"
+      />
+      {label}
+    </label>
+  );
+};
+
 const widgets = {
   TextWidget,
   TextAreaWidget,
   SelectWidget,
   NumberWidget,
   MultiSelectWidget,
+  UrlWidget,
+  AddressWidget,
+  MultiEmailWidget,
+  RadioWidget,
+  CheckboxWidget,
+  BooleanWidget,
   FieldSelect,
   Button,
   ButtonGroup,

--- a/packages/app-store/routing-forms/lib/FieldTypes.ts
+++ b/packages/app-store/routing-forms/lib/FieldTypes.ts
@@ -6,6 +6,12 @@ export const enum RoutingFormFieldType {
   MULTI_SELECT = "multiselect",
   PHONE = "phone",
   EMAIL = "email",
+  URL = "url",
+  ADDRESS = "address",
+  MULTI_EMAIL = "multiemail",
+  RADIO = "radio",
+  CHECKBOX = "checkbox",
+  BOOLEAN = "boolean",
 }
 
 export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFieldType => {
@@ -17,6 +23,12 @@ export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFi
     RoutingFormFieldType.MULTI_SELECT,
     RoutingFormFieldType.PHONE,
     RoutingFormFieldType.EMAIL,
+    RoutingFormFieldType.URL,
+    RoutingFormFieldType.ADDRESS,
+    RoutingFormFieldType.MULTI_EMAIL,
+    RoutingFormFieldType.RADIO,
+    RoutingFormFieldType.CHECKBOX,
+    RoutingFormFieldType.BOOLEAN,
   ].includes(type as RoutingFormFieldType);
 };
 
@@ -48,5 +60,29 @@ export const FieldTypes = [
   {
     label: "Email",
     value: RoutingFormFieldType.EMAIL,
+  },
+  {
+    label: "URL",
+    value: RoutingFormFieldType.URL,
+  },
+  {
+    label: "Address",
+    value: RoutingFormFieldType.ADDRESS,
+  },
+  {
+    label: "Multiple Email",
+    value: RoutingFormFieldType.MULTI_EMAIL,
+  },
+  {
+    label: "Radio Group",
+    value: RoutingFormFieldType.RADIO,
+  },
+  {
+    label: "Checkbox Group",
+    value: RoutingFormFieldType.CHECKBOX,
+  },
+  {
+    label: "Checkbox",
+    value: RoutingFormFieldType.BOOLEAN,
   },
 ] as const;

--- a/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
+++ b/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
@@ -27,7 +27,7 @@ function normalizeIdentifierForHandlebars(identifier: string): string {
   return identifier.replace(/\s+/g, "-");
 }
 
-type SelectFieldWebhookResponse = string | number | string[] | { label: string; id: string | null };
+type SelectFieldWebhookResponse = string | number | string[] | { label: string; id: string | null | undefined };
 export type FORM_SUBMITTED_WEBHOOK_RESPONSES = Record<
   string,
   {

--- a/packages/features/form-builder/schema.ts
+++ b/packages/features/form-builder/schema.ts
@@ -110,6 +110,7 @@ export const fieldTypeConfigSchema = z
   });
 
 export const fieldsSchema = z.array(fieldSchema);
+export type BookingField = z.infer<typeof fieldSchema>;
 
 function stringifyResponse(response: unknown): string {
   if (typeof response !== "string") {

--- a/packages/features/routing-forms/lib/zod.ts
+++ b/packages/features/routing-forms/lib/zod.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export type FieldOption = {
   label: string;
-  id: string | null;
+  id: string | null | undefined;
 };
 
 export type TNonRouterField = {
@@ -11,6 +11,7 @@ export type TNonRouterField = {
   identifier?: string;
   placeholder?: string;
   type: string;
+  name?: string;
   /** @deprecated in favour of `options` */
   selectText?: string;
   required?: boolean;
@@ -26,6 +27,7 @@ export const zodNonRouterField = z.object({
   identifier: z.string().optional(),
   placeholder: z.string().optional(),
   type: z.string(),
+  name: z.string().optional(),
   /**
    * @deprecated in favour of `options`
    */
@@ -39,7 +41,7 @@ export const zodNonRouterField = z.object({
         // To keep backwards compatibility with the options generated from legacy selectText, we allow saving null as id
         // It helps in differentiating whether the routing logic should consider the option.label as value or option.id as value.
         // This is important for legacy routes which has option.label saved in conditions and it must keep matching with the value of the option
-        id: z.string().or(z.null()),
+        id: z.string().or(z.null()).or(z.undefined()),
       })
     )
     .optional(),


### PR DESCRIPTION
## What does this PR do?
Fixes #18987

Adds booking question field types (URL, Address, Multiple Email, Radio Group, Checkbox Group, Boolean) to routing forms, allowing form creators to use the same rich field types available in event type booking questions.

### Changes
- Extended `RoutingFormFieldType` enum and `FieldTypes` array with 6 new field types
- Added RAQB widgets, config types, and UI factories for each new field type
- Extended zod schema to support `name` field and nullable option ids
- Added field normalization in SingleForm submit handler
- Made FormBuilder props optional for reuse outside event types
- Exported `BookingField` type from form-builder schema

### How to test
1. Go to Routing Forms → Edit form
2. Add a new field → verify new field types appear in the dropdown
3. Select each new type and configure options where applicable
4. Save the form and verify fields persist correctly
5. Test the form preview to ensure new field types render properly