### PR TITLE
fix: remove linkShallow from AppCategoryNavigation to prevent hydration mismatch

### DIFF
--- a/packages/app-store/_components/AppCategoryNavigation.tsx
+++ b/packages/app-store/_components/AppCategoryNavigation.tsx
@@ -44,14 +44,12 @@ const AppCategoryNavigation = ({
         <VerticalTabs
           tabs={appCategories}
           sticky
-          linkShallow
           itemClassname={classNames?.verticalTabsItem}
         />
       </div>
       <div className="block xl:hidden">
         <HorizontalTabs
           tabs={appCategories}
-          linkShallow
           scrollActiveTabIntoView
         />
       </div>


### PR DESCRIPTION
## What?
Removes the `linkShallow` prop from both `<VerticalTabs>` and `<HorizontalTabs>` 
in `AppCategoryNavigation`.

## Why?
The `shallow` prop is a Pages Router feature and is not supported in the App Router. 
It is silently ignored and can cause hydration mismatches, breaking sub-nav clicks 
on self-hosted instances.

## How to verify?
1. Navigate to Apps > Installed Apps
2. Click sub-navigation links (All, Calendar, Video, etc.)
3. Confirm they respond on first click without requiring a page refresh

Fixes #28298