### PR TITLE
fix: move i18n to a dev dependency in atoms package.json

### DIFF
--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -18,6 +18,7 @@
     "dev-off": "git checkout -- package.json vite.config.ts"
   },
   "devDependencies": {
+    "@calcom/i18n": "workspace:*",
     "@rollup/plugin-node-resolve": "15.0.1",
     "@tailwindcss/cli": "4.1.16",
     "@tailwindcss/postcss": "4.1.15",
@@ -78,7 +79,6 @@
   },
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@calcom/i18n": "workspace:*",
     "@radix-ui/react-dialog-atoms": "npm:@radix-ui/react-dialog@1.0.4",
     "@radix-ui/react-popover-atoms": "npm:@radix-ui/react-popover@1.0.6",
     "@radix-ui/react-slot": "1.1.2",


### PR DESCRIPTION
## What does this PR do?

when a user tries to install the latest version of atoms `2.3.6` they end up with the following error
```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND In : "@calcom/i18n@workspace:*" is in the dependencies but no package named "@calcom/i18n" is present in the workspace

This error happened while installing the dependencies of @calcom/atoms@2.3.6
```
the reason for this is because when this gets published to npm, the `workspace:*` protocol in dev dependency is supposed to be resolved by the package manager (Yarn/pnpm) to an actual version number. But since `@calcom/i18n` is an internal-only package — it's never published to npm. So there's no valid version to resolve it to, and it ends up in the published package.json as the raw `workspace:*` string. When an external customer installs `@calcom/atoms@2.3.6`, pnpm sees `@calcom/i18n@workspace:*` and tries to find it in their workspace — which doesn't exist

the fix here is to move `@calcom/i18n` from dependencies to devDependencies. It's only needed at build time to resolve the JSON imports and types — the actual translation data is already bundled into the output. It should never be a runtime dependency for external consumers.