### PR TITLE
fix: prevent nested <a> elements in NavigationItem tooltip

### DIFF
--- a/apps/web/modules/shell/navigation/NavigationItem.tsx
+++ b/apps/web/modules/shell/navigation/NavigationItem.tsx
@@ -204,49 +204,51 @@ export const NavigationItem: React.FC<{
         </Tooltip>
       ) : (
         <Tooltip side="right" content={t(item.name)} className="lg:hidden">
-          <Link
-            data-test-id={item.name}
-            onClick={() => trackNavigationClick(item.name)}
-            href={item.href}
-            aria-label={t(item.name)}
-            target={item.target}
-            className={classNames(
-              "todesktop:py-[7px] text-default group flex items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
-              item.child
-                ? `aria-[aria-current='page']:bg-transparent!`
-                : `[&[aria-current='page']]:bg-emphasis`,
-              isChild
-                ? `[&[aria-current='page']]:text-emphasis [&[aria-current='page']]:bg-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 ${
-                    props.index === 0 ? "mt-0" : "mt-1  hover:mt-1 [&[aria-current='page']]:mt-1"
-                  }`
-                : "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm md:justify-center lg:justify-start",
-              isLocaleReady
-                ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
-                : ""
-            )}
-            aria-current={current ? "page" : undefined}>
-            {item.icon && (
-              <Icon
-                name={item.isLoading ? "rotate-cw" : item.icon}
-                className={classNames(
-                  "todesktop:!text-blue-500 h-4 w-4 shrink-0 aria-[aria-current='page']:text-inherit lg:ltr:mr-2 lg:rtl:ml-2",
-                  item.isLoading && "animate-spin"
-                )}
-                aria-hidden="true"
-                aria-current={current ? "page" : undefined}
-              />
-            )}
-            {isLocaleReady ? (
-              <span
-                className="hidden w-full justify-between truncate text-ellipsis lg:flex"
-                data-testid={`${item.name}-test`}>
-                {t(item.name)}
-                {item.badge && item.badge}
-              </span>
-            ) : (
-              <SkeletonText className="h-[20px] w-full" />
-            )}
-          </Link>
+          <span>
+            <Link
+              data-test-id={item.name}
+              onClick={() => trackNavigationClick(item.name)}
+              href={item.href}
+              aria-label={t(item.name)}
+              target={item.target}
+              className={classNames(
+                "todesktop:py-[7px] text-default group flex items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
+                item.child
+                  ? `aria-[aria-current='page']:bg-transparent!`
+                  : `[&[aria-current='page']]:bg-emphasis`,
+                isChild
+                  ? `[&[aria-current='page']]:text-emphasis [&[aria-current='page']]:bg-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 ${
+                      props.index === 0 ? "mt-0" : "mt-1  hover:mt-1 [&[aria-current='page']]:mt-1"
+                    }`
+                  : "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm md:justify-center lg:justify-start",
+                isLocaleReady
+                  ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
+                  : ""
+              )}
+              aria-current={current ? "page" : undefined}>
+              {item.icon && (
+                <Icon
+                  name={item.isLoading ? "rotate-cw" : item.icon}
+                  className={classNames(
+                    "todesktop:!text-blue-500 h-4 w-4 shrink-0 aria-[aria-current='page']:text-inherit lg:ltr:mr-2 lg:rtl:ml-2",
+                    item.isLoading && "animate-spin"
+                  )}
+                  aria-hidden="true"
+                  aria-current={current ? "page" : undefined}
+                />
+              )}
+              {isLocaleReady ? (
+                <span
+                  className="hidden w-full justify-between truncate text-ellipsis lg:flex"
+                  data-testid={`${item.name}-test`}>
+                  {t(item.name)}
+                  {item.badge && item.badge}
+                </span>
+              ) : (
+                <SkeletonText className="h-[20px] w-full" />
+              )}
+            </Link>
+          </span>
         </Tooltip>
       )}
       {hasChildren && (


### PR DESCRIPTION
## What does this PR do?

Wraps the `<Link>` inside a bare `<span>` in the non-parent branch of `NavigationItem`, where it is a direct child of `<Tooltip>`.

`Tooltip` uses `TooltipPrimitive.Trigger` with `asChild`, which clones its direct child and merges trigger props onto it. When the direct child is a `<Link>` (which renders as `<a>`), this produces invalid HTML: `<a>` nested inside `<a>`. Wrapping in a bare `<span>` makes the span the cloned element instead, so `<Link>` renders normally inside it.

- Fixes #27984

## Visual Demo (For contributors especially)

N/A — structural HTML fix, no visual change.

## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A

## How should this be tested?

- No environment variables required
- Open the app, navigate to any page with the sidebar
- Inspect sidebar navigation items in DevTools
- Confirm no `<a>` inside `<a>` in the rendered HTML
- Confirm tooltip still appears on hover for collapsed sidebar items