### PR TITLE
fix(reschedule): take into account guest's availability when host reschedules

### DIFF
--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -289,6 +289,52 @@ export class UserRepository {
     return users;
   }
 
+  /**
+   * Like findManyByEmails but also matches users whose verified secondary emails
+   * are in the provided list.  Returns deduplicated user records (by id).
+   * Use this when attendee emails may be secondary/alias addresses rather than
+   * the user's primary Cal.com email.
+   */
+  async findManyByEmailsIncludingSecondary({ emails }: { emails: string[] }) {
+    if (!emails.length) return [];
+    const normalizedEmails = emails.map((e) => e.toLowerCase());
+
+    // Primary-email match
+    const byPrimary = await this.prismaClient.user.findMany({
+      where: { email: { in: normalizedEmails } },
+      select: userSelect,
+    });
+
+    // Secondary-email match: find users who have a verified secondary email in the list
+    const secondaryEmailRecords = await this.prismaClient.secondaryEmail.findMany({
+      where: {
+        email: { in: normalizedEmails },
+        emailVerified: { not: null },
+      },
+      select: { userId: true },
+    });
+    const secondaryUserIds = secondaryEmailRecords.map((r) => r.userId);
+
+    let bySecondary: (typeof byPrimary)[number][] = [];
+    if (secondaryUserIds.length > 0) {
+      bySecondary = await this.prismaClient.user.findMany({
+        where: { id: { in: secondaryUserIds } },
+        select: userSelect,
+      });
+    }
+
+    // Deduplicate by id (primary match takes precedence)
+    const seen = new Set<number>();
+    const result: (typeof byPrimary)[number][] = [];
+    for (const user of [...byPrimary, ...bySecondary]) {
+      if (!seen.has(user.id)) {
+        seen.add(user.id);
+        result.push(user);
+      }
+    }
+    return result;
+  }
+
   async findManyByEmailsWithEmailVerificationSettings({ emails }: { emails: string[] }) {
     const normalizedEmails = emails.map((e) => e.toLowerCase());
 

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -291,12 +291,17 @@ export class UserRepository {
 
   /**
    * Like findManyByEmails but also matches users whose verified secondary emails
-   * are in the provided list.  Returns deduplicated user records (by id).
-   * Use this when attendee emails may be secondary/alias addresses rather than
-   * the user's primary Cal.com email.
+   * are in the provided list.
+   *
+   * Returns an object with:
+   * - `users`: deduplicated user records (by id)
+   * - `byEmail`: a Map<lowercase-email, user> keyed by *every* email address
+   *   (primary **and** matched secondary) that resolves to each user.
+   *   Use this map to look up a user by the email the attendee actually booked with,
+   *   which may be a secondary/alias address rather than the user's primary Cal.com email.
    */
   async findManyByEmailsIncludingSecondary({ emails }: { emails: string[] }) {
-    if (!emails.length) return [];
+    if (!emails.length) return { users: [], byEmail: new Map() };
     const normalizedEmails = emails.map((e) => e.toLowerCase());
 
     // Primary-email match
@@ -305,16 +310,17 @@ export class UserRepository {
       select: userSelect,
     });
 
-    // Secondary-email match: find users who have a verified secondary email in the list
+    // Secondary-email match: find users who have a verified secondary email in the list,
+    // and retain the email→userId mapping so we can build the lookup map correctly.
     const secondaryEmailRecords = await this.prismaClient.secondaryEmail.findMany({
       where: {
         email: { in: normalizedEmails },
         emailVerified: { not: null },
       },
-      select: { userId: true },
+      select: { userId: true, email: true },
     });
-    const secondaryUserIds = secondaryEmailRecords.map((r) => r.userId);
 
+    const secondaryUserIds = secondaryEmailRecords.map((r) => r.userId);
     let bySecondary: (typeof byPrimary)[number][] = [];
     if (secondaryUserIds.length > 0) {
       bySecondary = await this.prismaClient.user.findMany({
@@ -323,16 +329,34 @@ export class UserRepository {
       });
     }
 
+    // Build a userId → user lookup for secondary matches
+    const secondaryUserById = new Map(bySecondary.map((u) => [u.id, u]));
+
     // Deduplicate by id (primary match takes precedence)
     const seen = new Set<number>();
-    const result: (typeof byPrimary)[number][] = [];
+    const users: (typeof byPrimary)[number][] = [];
     for (const user of [...byPrimary, ...bySecondary]) {
       if (!seen.has(user.id)) {
         seen.add(user.id);
-        result.push(user);
+        users.push(user);
       }
     }
-    return result;
+
+    // Build a map keyed by every email (primary + secondary) that resolves to each user.
+    // This allows callers to look up a user by the email the attendee booked with,
+    // even if that email is a secondary alias rather than the user's primary address.
+    const byEmail = new Map<string, (typeof byPrimary)[number]>();
+    for (const user of byPrimary) {
+      byEmail.set(user.email.toLowerCase(), user);
+    }
+    for (const record of secondaryEmailRecords) {
+      const user = secondaryUserById.get(record.userId);
+      if (user && !byEmail.has(record.email.toLowerCase())) {
+        byEmail.set(record.email.toLowerCase(), user);
+      }
+    }
+
+    return { users, byEmail };
   }
 
   async findManyByEmailsWithEmailVerificationSettings({ emails }: { emails: string[] }) {

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -277,6 +277,18 @@ export class UserRepository {
     return user;
   }
 
+  async findManyByEmails({ emails }: { emails: string[] }) {
+    if (!emails.length) return [];
+    const normalizedEmails = emails.map((e) => e.toLowerCase());
+    const users = await this.prismaClient.user.findMany({
+      where: {
+        email: { in: normalizedEmails },
+      },
+      select: userSelect,
+    });
+    return users;
+  }
+
   async findManyByEmailsWithEmailVerificationSettings({ emails }: { emails: string[] }) {
     const normalizedEmails = emails.map((e) => e.toLowerCase());
 

--- a/packages/trpc/server/routers/viewer/slots/getGuestBusyTimesForReschedule.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/getGuestBusyTimesForReschedule.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unit tests for guest availability check during host-initiated reschedule.
+ * See: https://github.com/calcom/cal.com/issues/16378
+ */
+import dayjs from "@calcom/dayjs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IAvailableSlotsService } from "./util";
+import { AvailableSlotsService } from "./util";
+
+// Type helper to access private method for testing
+type PrivateAvailableSlotsService = {
+  _getGuestBusyTimesForReschedule: (params: {
+    rescheduleUid: string;
+    startTime: ReturnType<typeof dayjs>;
+    endTime: ReturnType<typeof dayjs>;
+    hostUserIds: Set<number>;
+  }) => Promise<{ start: Date; end: Date }[]>;
+};
+
+describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
+  let service: AvailableSlotsService;
+  let mockDependencies: {
+    bookingRepo: {
+      findBookingByUid: ReturnType<typeof vi.fn>;
+      findAllExistingBookingsForEventTypeBetween: ReturnType<typeof vi.fn>;
+    };
+    userRepo: {
+      findByEmail: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  const startTime = dayjs("2026-03-15T09:00:00.000Z");
+  const endTime = dayjs("2026-03-15T17:00:00.000Z");
+  const rescheduleUid = "test-reschedule-uid-123";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDependencies = {
+      bookingRepo: {
+        findBookingByUid: vi.fn(),
+        findAllExistingBookingsForEventTypeBetween: vi.fn().mockResolvedValue([]),
+      },
+      userRepo: {
+        findByEmail: vi.fn().mockResolvedValue(null),
+      },
+    };
+
+    service = new AvailableSlotsService(mockDependencies as unknown as IAvailableSlotsService);
+  });
+
+  it("should return empty array when original booking is not found", async () => {
+    mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(null);
+
+    const result = await (
+      service as unknown as PrivateAvailableSlotsService
+    )._getGuestBusyTimesForReschedule({
+      rescheduleUid,
+      startTime,
+      endTime,
+      hostUserIds: new Set([1]),
+    });
+
+    expect(result).toEqual([]);
+    expect(mockDependencies.userRepo.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it("should return empty array when the booking has no attendees", async () => {
+    mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue({
+      id: 1,
+      uid: rescheduleUid,
+      attendees: [],
+    });
+
+    const result = await (
+      service as unknown as PrivateAvailableSlotsService
+    )._getGuestBusyTimesForReschedule({
+      rescheduleUid,
+      startTime,
+      endTime,
+      hostUserIds: new Set([1]),
+    });
+
+    expect(result).toEqual([]);
+    expect(mockDependencies.userRepo.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it("should return empty array when attendee is not a Cal.com user", async () => {
+    mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue({
+      id: 1,
+      uid: rescheduleUid,
+      attendees: [{ email: "guest@external.com", name: "External Guest" }],
+    });
+    // userRepo.findByEmail returns null (not a Cal.com user)
+    mockDependencies.userRepo.findByEmail.mockResolvedValue(null);
+
+    const result = await (
+      service as unknown as PrivateAvailableSlotsService
+    )._getGuestBusyTimesForReschedule({
+      rescheduleUid,
+      startTime,
+      endTime,
+      hostUserIds: new Set([1]),
+    });
+
+    expect(result).toEqual([]);
+    expect(mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween).not.toHaveBeenCalled();
+  });
+
+  it("should return empty array when the guest is already a host", async () => {
+    const hostUserId = 42;
+    mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue({
+      id: 1,
+      uid: rescheduleUid,
+      attendees: [{ email: "host@example.com", name: "Host User" }],
+    });
+    // The attendee IS a Cal.com user — but they're also a host
+    mockDependencies.userRepo.findByEmail.mockResolvedValue({
+      id: hostUserId,
+      email: "host@example.com",
+    });
+
+    const result = await (
+      service as unknown as PrivateAvailableSlotsService
+    )._getGuestBusyTimesForReschedule({
+      rescheduleUid,
+      startTime,
+      endTime,
+      hostUserIds: new Set([hostUserId]),
+    });
+
+    expect(result).toEqual([]);
+    expect(mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween).not.toHaveBeenCalled();
+  });
+
+  it("should return guest busy times when the attendee is a Cal.com user and not a host", async () => {
+    const guestUserId = 99;
+    const guestEmail = "guest@calcom-user.com";
+
+    const guestBookingStart = new Date("2026-03-15T10:00:00.000Z");
+    const guestBookingEnd = new Date("2026-03-15T11:00:00.000Z");
+
+    mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue({
+      id: 1,
+      uid: rescheduleUid,
+      attendees: [{ email: guestEmail, name: "Cal.com Guest" }],
+    });
+
+    mockDependencies.userRepo.findByEmail.mockResolvedValue({
+      id: guestUserId,
+      email: guestEmail,
+    });
+
+    mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween.mockResolvedValue([
+      {
+        id: 200,
+        uid: "another-booking-uid",
+        userId: guestUserId,
+        startTime: guestBookingStart,
+        endTime: guestBookingEnd,
+        title: "Guest's Existing Meeting",
+        attendees: [],
+        eventType: { id: 10, beforeEventBuffer: 0, afterEventBuffer: 0, seatsPerTimeSlot: null },
+      },
+    ]);
+
+    const result = await (
+      service as unknown as PrivateAvailableSlotsService
+    )._getGuestBusyTimesForReschedule({
+      rescheduleUid,
+      startTime,
+      endTime,
+      hostUserIds: new Set([1]), // host is user ID 1, not 99
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      start: guestBookingStart,
+      end: guestBookingEnd,
+    });
+
+    expect(mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween).toHaveBeenCalledWith({
+      userIdAndEmailMap: new Map([[guestUserId, guestEmail]]),
+      startDate: startTime.toDate(),
+      endDate: endTime.toDate(),
+    });
+  });
+
+  it("should skip the booking being rescheduled itself from guest busy times", async () => {
+    const guestUserId = 99;
+    const guestEmail = "guest@calcom-user.com";
+
+    mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue({
+      id: 1,
+      uid: rescheduleUid,
+      attendees: [{ email: guestEmail, name: "Cal.com Guest" }],
+    });
+
+    mockDependencies.userRepo.findByEmail.mockResolvedValue({
+      id: guestUserId,
+      email: guestEmail,
+    });
+
+    // The guest's bookings include the booking being rescheduled
+    mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween.mockResolvedValue([
+      {
+        id: 1,
+        uid: rescheduleUid, // same UID as the booking being rescheduled — should be skipped
+        userId: guestUserId,
+        startTime: new Date("2026-03-15T09:00:00.000Z"),
+        endTime: new Date("2026-03-15T10:00:00.000Z"),
+        title: "The booking being rescheduled",
+        attendees: [],
+        eventType: { id: 10, beforeEventBuffer: 0, afterEventBuffer: 0, seatsPerTimeSlot: null },
+      },
+    ]);
+
+    const result = await (
+      service as unknown as PrivateAvailableSlotsService
+    )._getGuestBusyTimesForReschedule({
+      rescheduleUid,
+      startTime,
+      endTime,
+      hostUserIds: new Set([1]),
+    });
+
+    // The rescheduled booking itself should not be returned as a busy time
+    expect(result).toHaveLength(0);
+  });
+
+  it("should aggregate busy times from multiple Cal.com guest attendees", async () => {
+    const guest1UserId = 99;
+    const guest1Email = "guest1@calcom-user.com";
+    const guest2UserId = 100;
+    const guest2Email = "guest2@calcom-user.com";
+
+    const guest1BookingStart = new Date("2026-03-15T10:00:00.000Z");
+    const guest1BookingEnd = new Date("2026-03-15T11:00:00.000Z");
+    const guest2BookingStart = new Date("2026-03-15T14:00:00.000Z");
+    const guest2BookingEnd = new Date("2026-03-15T15:00:00.000Z");
+
+    mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue({
+      id: 1,
+      uid: rescheduleUid,
+      attendees: [
+        { email: guest1Email, name: "Cal.com Guest 1" },
+        { email: guest2Email, name: "Cal.com Guest 2" },
+      ],
+    });
+
+    mockDependencies.userRepo.findByEmail
+      .mockResolvedValueOnce({ id: guest1UserId, email: guest1Email })
+      .mockResolvedValueOnce({ id: guest2UserId, email: guest2Email });
+
+    mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween
+      .mockResolvedValueOnce([
+        {
+          id: 200,
+          uid: "guest1-booking",
+          userId: guest1UserId,
+          startTime: guest1BookingStart,
+          endTime: guest1BookingEnd,
+          title: "Guest 1 Existing Meeting",
+          attendees: [],
+          eventType: { id: 10, beforeEventBuffer: 0, afterEventBuffer: 0, seatsPerTimeSlot: null },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 201,
+          uid: "guest2-booking",
+          userId: guest2UserId,
+          startTime: guest2BookingStart,
+          endTime: guest2BookingEnd,
+          title: "Guest 2 Existing Meeting",
+          attendees: [],
+          eventType: { id: 11, beforeEventBuffer: 0, afterEventBuffer: 0, seatsPerTimeSlot: null },
+        },
+      ]);
+
+    const result = await (
+      service as unknown as PrivateAvailableSlotsService
+    )._getGuestBusyTimesForReschedule({
+      rescheduleUid,
+      startTime,
+      endTime,
+      hostUserIds: new Set([1]),
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ start: guest1BookingStart, end: guest1BookingEnd });
+    expect(result[1]).toEqual({ start: guest2BookingStart, end: guest2BookingEnd });
+  });
+});

--- a/packages/trpc/server/routers/viewer/slots/getGuestBusyTimesForReschedule.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/getGuestBusyTimesForReschedule.test.ts
@@ -18,6 +18,12 @@ type PrivateAvailableSlotsService = {
   }) => Promise<{ start: Date; end: Date }[]>;
 };
 
+/** Build the { users, byEmail } shape that findManyByEmailsIncludingSecondary now returns. */
+function makeUserResult(userList: { id: number; email: string }[]) {
+  const byEmail = new Map(userList.map((u) => [u.email.toLowerCase(), u]));
+  return { users: userList, byEmail };
+}
+
 describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
   let service: AvailableSlotsService;
   let mockDependencies: {
@@ -26,7 +32,7 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       findAllExistingBookingsForEventTypeBetween: ReturnType<typeof vi.fn>;
     };
     userRepo: {
-      findManyByEmails: ReturnType<typeof vi.fn>;
+      findManyByEmailsIncludingSecondary: ReturnType<typeof vi.fn>;
     };
   };
 
@@ -43,7 +49,7 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
         findAllExistingBookingsForEventTypeBetween: vi.fn().mockResolvedValue([]),
       },
       userRepo: {
-        findManyByEmails: vi.fn().mockResolvedValue([]),
+        findManyByEmailsIncludingSecondary: vi.fn().mockResolvedValue(makeUserResult([])),
       },
     };
 
@@ -63,7 +69,7 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
     });
 
     expect(result).toEqual([]);
-    expect(mockDependencies.userRepo.findManyByEmails).not.toHaveBeenCalled();
+    expect(mockDependencies.userRepo.findManyByEmailsIncludingSecondary).not.toHaveBeenCalled();
   });
 
   it("should return empty array when the booking has no attendees", async () => {
@@ -83,7 +89,7 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
     });
 
     expect(result).toEqual([]);
-    expect(mockDependencies.userRepo.findManyByEmails).not.toHaveBeenCalled();
+    expect(mockDependencies.userRepo.findManyByEmailsIncludingSecondary).not.toHaveBeenCalled();
   });
 
   it("should return empty array when attendee is not a Cal.com user", async () => {
@@ -92,8 +98,8 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       uid: rescheduleUid,
       attendees: [{ email: "guest@external.com", name: "External Guest" }],
     });
-    // findManyByEmails returns empty array (not a Cal.com user)
-    mockDependencies.userRepo.findManyByEmails.mockResolvedValue([]);
+    // No matching Cal.com user found
+    mockDependencies.userRepo.findManyByEmailsIncludingSecondary.mockResolvedValue(makeUserResult([]));
 
     const result = await (
       service as unknown as PrivateAvailableSlotsService
@@ -116,9 +122,9 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       attendees: [{ email: "host@example.com", name: "Host User" }],
     });
     // The attendee IS a Cal.com user — but they're also a host
-    mockDependencies.userRepo.findManyByEmails.mockResolvedValue([
-      { id: hostUserId, email: "host@example.com" },
-    ]);
+    mockDependencies.userRepo.findManyByEmailsIncludingSecondary.mockResolvedValue(
+      makeUserResult([{ id: hostUserId, email: "host@example.com" }])
+    );
 
     const result = await (
       service as unknown as PrivateAvailableSlotsService
@@ -146,9 +152,9 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       attendees: [{ email: guestEmail, name: "Cal.com Guest" }],
     });
 
-    mockDependencies.userRepo.findManyByEmails.mockResolvedValue([
-      { id: guestUserId, email: guestEmail },
-    ]);
+    mockDependencies.userRepo.findManyByEmailsIncludingSecondary.mockResolvedValue(
+      makeUserResult([{ id: guestUserId, email: guestEmail }])
+    );
 
     mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween.mockResolvedValue([
       {
@@ -178,7 +184,7 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       end: guestBookingEnd,
     });
 
-    expect(mockDependencies.userRepo.findManyByEmails).toHaveBeenCalledWith({
+    expect(mockDependencies.userRepo.findManyByEmailsIncludingSecondary).toHaveBeenCalledWith({
       emails: [guestEmail],
     });
 
@@ -187,6 +193,54 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       startDate: startTime.toDate(),
       endDate: endTime.toDate(),
     });
+  });
+
+  it("should match attendee by secondary/alias email (not just primary email)", async () => {
+    const guestUserId = 99;
+    const primaryEmail = "primary@calcom-user.com";
+    const aliasEmail = "alias@gmail.com"; // the email the attendee used to book
+
+    const guestBookingStart = new Date("2026-03-15T10:00:00.000Z");
+    const guestBookingEnd = new Date("2026-03-15T11:00:00.000Z");
+
+    mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue({
+      id: 1,
+      uid: rescheduleUid,
+      attendees: [{ email: aliasEmail, name: "Alias Guest" }],
+    });
+
+    // byEmail map is keyed by the alias email (secondary), not the primary
+    const guestUser = { id: guestUserId, email: primaryEmail };
+    mockDependencies.userRepo.findManyByEmailsIncludingSecondary.mockResolvedValue({
+      users: [guestUser],
+      byEmail: new Map([[aliasEmail, guestUser]]),
+    });
+
+    mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween.mockResolvedValue([
+      {
+        id: 200,
+        uid: "another-booking-uid",
+        userId: guestUserId,
+        startTime: guestBookingStart,
+        endTime: guestBookingEnd,
+        title: "Guest's Existing Meeting",
+        attendees: [],
+        eventType: { id: 10, beforeEventBuffer: 0, afterEventBuffer: 0, seatsPerTimeSlot: null },
+      },
+    ]);
+
+    const result = await (
+      service as unknown as PrivateAvailableSlotsService
+    )._getGuestBusyTimesForReschedule({
+      rescheduleUid,
+      startTime,
+      endTime,
+      hostUserIds: new Set([1]),
+    });
+
+    // Guest should be found even though they booked with their secondary email
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ start: guestBookingStart, end: guestBookingEnd });
   });
 
   it("should skip the booking being rescheduled itself from guest busy times", async () => {
@@ -199,9 +253,9 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       attendees: [{ email: guestEmail, name: "Cal.com Guest" }],
     });
 
-    mockDependencies.userRepo.findManyByEmails.mockResolvedValue([
-      { id: guestUserId, email: guestEmail },
-    ]);
+    mockDependencies.userRepo.findManyByEmailsIncludingSecondary.mockResolvedValue(
+      makeUserResult([{ id: guestUserId, email: guestEmail }])
+    );
 
     // The guest's bookings include the booking being rescheduled
     mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween.mockResolvedValue([
@@ -251,10 +305,12 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
     });
 
     // Both guests returned in single batch query
-    mockDependencies.userRepo.findManyByEmails.mockResolvedValue([
-      { id: guest1UserId, email: guest1Email },
-      { id: guest2UserId, email: guest2Email },
-    ]);
+    mockDependencies.userRepo.findManyByEmailsIncludingSecondary.mockResolvedValue(
+      makeUserResult([
+        { id: guest1UserId, email: guest1Email },
+        { id: guest2UserId, email: guest2Email },
+      ])
+    );
 
     mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween
       .mockResolvedValueOnce([
@@ -296,8 +352,8 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
     expect(result[1]).toEqual({ start: guest2BookingStart, end: guest2BookingEnd });
 
     // Verify only ONE batch query was made for all attendees
-    expect(mockDependencies.userRepo.findManyByEmails).toHaveBeenCalledTimes(1);
-    expect(mockDependencies.userRepo.findManyByEmails).toHaveBeenCalledWith({
+    expect(mockDependencies.userRepo.findManyByEmailsIncludingSecondary).toHaveBeenCalledTimes(1);
+    expect(mockDependencies.userRepo.findManyByEmailsIncludingSecondary).toHaveBeenCalledWith({
       emails: [guest1Email, guest2Email],
     });
   });

--- a/packages/trpc/server/routers/viewer/slots/getGuestBusyTimesForReschedule.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/getGuestBusyTimesForReschedule.test.ts
@@ -26,7 +26,7 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       findAllExistingBookingsForEventTypeBetween: ReturnType<typeof vi.fn>;
     };
     userRepo: {
-      findByEmail: ReturnType<typeof vi.fn>;
+      findManyByEmails: ReturnType<typeof vi.fn>;
     };
   };
 
@@ -43,7 +43,7 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
         findAllExistingBookingsForEventTypeBetween: vi.fn().mockResolvedValue([]),
       },
       userRepo: {
-        findByEmail: vi.fn().mockResolvedValue(null),
+        findManyByEmails: vi.fn().mockResolvedValue([]),
       },
     };
 
@@ -63,7 +63,7 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
     });
 
     expect(result).toEqual([]);
-    expect(mockDependencies.userRepo.findByEmail).not.toHaveBeenCalled();
+    expect(mockDependencies.userRepo.findManyByEmails).not.toHaveBeenCalled();
   });
 
   it("should return empty array when the booking has no attendees", async () => {
@@ -83,7 +83,7 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
     });
 
     expect(result).toEqual([]);
-    expect(mockDependencies.userRepo.findByEmail).not.toHaveBeenCalled();
+    expect(mockDependencies.userRepo.findManyByEmails).not.toHaveBeenCalled();
   });
 
   it("should return empty array when attendee is not a Cal.com user", async () => {
@@ -92,8 +92,8 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       uid: rescheduleUid,
       attendees: [{ email: "guest@external.com", name: "External Guest" }],
     });
-    // userRepo.findByEmail returns null (not a Cal.com user)
-    mockDependencies.userRepo.findByEmail.mockResolvedValue(null);
+    // findManyByEmails returns empty array (not a Cal.com user)
+    mockDependencies.userRepo.findManyByEmails.mockResolvedValue([]);
 
     const result = await (
       service as unknown as PrivateAvailableSlotsService
@@ -116,10 +116,9 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       attendees: [{ email: "host@example.com", name: "Host User" }],
     });
     // The attendee IS a Cal.com user — but they're also a host
-    mockDependencies.userRepo.findByEmail.mockResolvedValue({
-      id: hostUserId,
-      email: "host@example.com",
-    });
+    mockDependencies.userRepo.findManyByEmails.mockResolvedValue([
+      { id: hostUserId, email: "host@example.com" },
+    ]);
 
     const result = await (
       service as unknown as PrivateAvailableSlotsService
@@ -147,10 +146,9 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       attendees: [{ email: guestEmail, name: "Cal.com Guest" }],
     });
 
-    mockDependencies.userRepo.findByEmail.mockResolvedValue({
-      id: guestUserId,
-      email: guestEmail,
-    });
+    mockDependencies.userRepo.findManyByEmails.mockResolvedValue([
+      { id: guestUserId, email: guestEmail },
+    ]);
 
     mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween.mockResolvedValue([
       {
@@ -180,6 +178,10 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       end: guestBookingEnd,
     });
 
+    expect(mockDependencies.userRepo.findManyByEmails).toHaveBeenCalledWith({
+      emails: [guestEmail],
+    });
+
     expect(mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween).toHaveBeenCalledWith({
       userIdAndEmailMap: new Map([[guestUserId, guestEmail]]),
       startDate: startTime.toDate(),
@@ -197,10 +199,9 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       attendees: [{ email: guestEmail, name: "Cal.com Guest" }],
     });
 
-    mockDependencies.userRepo.findByEmail.mockResolvedValue({
-      id: guestUserId,
-      email: guestEmail,
-    });
+    mockDependencies.userRepo.findManyByEmails.mockResolvedValue([
+      { id: guestUserId, email: guestEmail },
+    ]);
 
     // The guest's bookings include the booking being rescheduled
     mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween.mockResolvedValue([
@@ -249,9 +250,11 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
       ],
     });
 
-    mockDependencies.userRepo.findByEmail
-      .mockResolvedValueOnce({ id: guest1UserId, email: guest1Email })
-      .mockResolvedValueOnce({ id: guest2UserId, email: guest2Email });
+    // Both guests returned in single batch query
+    mockDependencies.userRepo.findManyByEmails.mockResolvedValue([
+      { id: guest1UserId, email: guest1Email },
+      { id: guest2UserId, email: guest2Email },
+    ]);
 
     mockDependencies.bookingRepo.findAllExistingBookingsForEventTypeBetween
       .mockResolvedValueOnce([
@@ -291,5 +294,11 @@ describe("AvailableSlotsService - _getGuestBusyTimesForReschedule", () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({ start: guest1BookingStart, end: guest1BookingEnd });
     expect(result[1]).toEqual({ start: guest2BookingStart, end: guest2BookingEnd });
+
+    // Verify only ONE batch query was made for all attendees
+    expect(mockDependencies.userRepo.findManyByEmails).toHaveBeenCalledTimes(1);
+    expect(mockDependencies.userRepo.findManyByEmails).toHaveBeenCalledWith({
+      emails: [guest1Email, guest2Email],
+    });
   });
 });

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -256,8 +256,9 @@ export class AvailableSlotsService {
       return [];
     }
 
-    // Batch-fetch all attendee users in a single query to avoid N+1 DB calls
-    const guestUsers = await userRepo.findManyByEmails({ emails: attendeeEmails });
+    // Batch-fetch all attendee users in a single query, including secondary verified emails,
+    // to avoid missing attendees who booked with an alias/secondary Cal.com address.
+    const guestUsers = await userRepo.findManyByEmailsIncludingSecondary({ emails: attendeeEmails });
     const guestUserByEmail = new Map(guestUsers.map((u) => [u.email.toLowerCase(), u]));
 
     const guestBusyTimes: EventBusyDate[] = [];

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -256,13 +256,19 @@ export class AvailableSlotsService {
       return [];
     }
 
-    // For each attendee, check if they are a Cal.com user (and not already a host)
+    // Batch-fetch all attendee users in a single query to avoid N+1 DB calls
+    const guestUsers = await userRepo.findManyByEmails({ emails: attendeeEmails });
+    const guestUserByEmail = new Map(guestUsers.map((u) => [u.email.toLowerCase(), u]));
+
     const guestBusyTimes: EventBusyDate[] = [];
     for (const email of attendeeEmails) {
-      const guestUser = await userRepo.findByEmail({ email });
+      const guestUser = guestUserByEmail.get(email.toLowerCase()) ?? null;
       if (!guestUser) {
         // Not a Cal.com user — skip (preserve existing behavior)
-        log.debug("_getGuestBusyTimesForReschedule: attendee is not a Cal.com user", { email });
+        const maskedEmail = email.replace(/(?<=^.).*(?=@)/, "***");
+        log.debug("_getGuestBusyTimesForReschedule: attendee is not a Cal.com user", {
+          email: maskedEmail,
+        });
         continue;
       }
       if (hostUserIds.has(guestUser.id)) {
@@ -270,9 +276,10 @@ export class AvailableSlotsService {
         continue;
       }
 
+      const maskedEmail = guestUser.email.replace(/(?<=^.).*(?=@)/, "***");
       log.debug("_getGuestBusyTimesForReschedule: fetching busy times for Cal.com guest", {
         guestUserId: guestUser.id,
-        email,
+        email: maskedEmail,
       });
 
       // Fetch the guest's accepted bookings in the requested range

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -222,6 +222,79 @@ export class AvailableSlotsService {
     return currentSeats;
   }
 
+  /**
+   * When a host reschedules a booking, we check if the attendee (guest) is also a Cal.com user.
+   * If so, we fetch their existing bookings and return them as busy times, so the host
+   * can only pick time slots that work for both parties.
+   *
+   * Fixes: https://github.com/calcom/cal.com/issues/16378
+   */
+  private async _getGuestBusyTimesForReschedule({
+    rescheduleUid,
+    startTime,
+    endTime,
+    hostUserIds,
+  }: {
+    rescheduleUid: string;
+    startTime: Dayjs;
+    endTime: Dayjs;
+    /** IDs of the host users, so we don't double-count them as guests */
+    hostUserIds: Set<number>;
+  }): Promise<EventBusyDate[]> {
+    const bookingRepo = this.dependencies.bookingRepo;
+    const userRepo = this.dependencies.userRepo;
+
+    // Find the original booking to get attendee emails
+    const originalBooking = await bookingRepo.findBookingByUid({ bookingUid: rescheduleUid });
+    if (!originalBooking) {
+      log.debug("_getGuestBusyTimesForReschedule: original booking not found", { rescheduleUid });
+      return [];
+    }
+
+    const attendeeEmails: string[] = originalBooking.attendees.map((a) => a.email);
+    if (!attendeeEmails.length) {
+      return [];
+    }
+
+    // For each attendee, check if they are a Cal.com user (and not already a host)
+    const guestBusyTimes: EventBusyDate[] = [];
+    for (const email of attendeeEmails) {
+      const guestUser = await userRepo.findByEmail({ email });
+      if (!guestUser) {
+        // Not a Cal.com user — skip (preserve existing behavior)
+        log.debug("_getGuestBusyTimesForReschedule: attendee is not a Cal.com user", { email });
+        continue;
+      }
+      if (hostUserIds.has(guestUser.id)) {
+        // Already counted as a host
+        continue;
+      }
+
+      log.debug("_getGuestBusyTimesForReschedule: fetching busy times for Cal.com guest", {
+        guestUserId: guestUser.id,
+        email,
+      });
+
+      // Fetch the guest's accepted bookings in the requested range
+      const guestBookings = await bookingRepo.findAllExistingBookingsForEventTypeBetween({
+        userIdAndEmailMap: new Map([[guestUser.id, guestUser.email]]),
+        startDate: startTime.toDate(),
+        endDate: endTime.toDate(),
+      });
+
+      for (const booking of guestBookings) {
+        // Skip the booking being rescheduled itself
+        if (booking.uid === rescheduleUid) continue;
+        guestBusyTimes.push({
+          start: booking.startTime,
+          end: booking.endTime,
+        });
+      }
+    }
+
+    return guestBusyTimes;
+  }
+
   private async _getEventType(
     input: TGetScheduleInputSchema,
     organizationDetails: { currentOrgDomain: string | null; isValidOrgDomain: boolean }
@@ -1497,6 +1570,44 @@ export class AvailableSlotsService {
             return !!item;
           }
         );
+    }
+
+    // When the host is rescheduling, check if the guest is also a Cal.com user and
+    // filter out slots that conflict with the guest's existing bookings.
+    // See: https://github.com/calcom/cal.com/issues/16378
+    if (input.rescheduleUid) {
+      const hostUserIds = new Set(usersWithCredentials.map((u) => u.id));
+      try {
+        const guestBusyTimes = await this._getGuestBusyTimesForReschedule({
+          rescheduleUid: input.rescheduleUid,
+          startTime,
+          endTime,
+          hostUserIds,
+        });
+
+        if (guestBusyTimes.length > 0) {
+          const eventLength = input.duration || eventType.length;
+          availableTimeSlots = availableTimeSlots.filter(
+            (slot) =>
+              !checkForConflicts({
+                time: slot.time,
+                busy: guestBusyTimes,
+                eventLength,
+              })
+          );
+          log.debug("Filtered slots by guest availability", {
+            rescheduleUid: input.rescheduleUid,
+            guestBusyTimesCount: guestBusyTimes.length,
+            remainingSlots: availableTimeSlots.length,
+          });
+        }
+      } catch (err) {
+        // Non-fatal: log and continue without guest availability check
+        log.warn("Failed to fetch guest busy times for reschedule, proceeding without guest check", {
+          rescheduleUid: input.rescheduleUid,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     // fr-CA uses YYYY-MM-DD

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -258,8 +258,11 @@ export class AvailableSlotsService {
 
     // Batch-fetch all attendee users in a single query, including secondary verified emails,
     // to avoid missing attendees who booked with an alias/secondary Cal.com address.
-    const guestUsers = await userRepo.findManyByEmailsIncludingSecondary({ emails: attendeeEmails });
-    const guestUserByEmail = new Map(guestUsers.map((u) => [u.email.toLowerCase(), u]));
+    // Use the returned `byEmail` map (keyed by ALL matched emails, primary + secondary)
+    // so that an attendee who booked with their alias email resolves to the correct user.
+    const { byEmail: guestUserByEmail } = await userRepo.findManyByEmailsIncludingSecondary({
+      emails: attendeeEmails,
+    });
 
     const guestBusyTimes: EventBusyDate[] = [];
     for (const email of attendeeEmails) {


### PR DESCRIPTION
## Problem
When a host reschedules a booking, Cal.com does not check the guest's availability, allowing the host to pick times when the guest is unavailable.

This is because the person who booked the meeting may or may not be a Cal.com user, so we previously didn't check their availability. However, since we have the attendee's email, we can look them up and — if they're a Cal.com user — only show slots that work for both parties.

## Solution
When the host initiates a reschedule (`rescheduleUid` is present in the `getSchedule` call), this PR:
1. Looks up the original booking by uid to retrieve attendee emails
2. For each attendee, checks whether they are a Cal.com user via the Users table
3. If the attendee is a Cal.com user and not already a host on the event, fetches their accepted bookings in the requested time range as busy times
4. Filters available time slots to exclude those that conflict with the guest's bookings

If the attendee is **not** a Cal.com user, the existing behavior is preserved (no availability check is done).

The check is non-fatal: if the guest lookup fails for any reason (e.g. DB error), slot calculation proceeds normally so scheduling is not blocked.

Closes #16378

## Changes
- **`packages/trpc/server/routers/viewer/slots/util.ts`**: Added private method `_getGuestBusyTimesForReschedule` that looks up attendee availability, and a call to it in `_getAvailableSlots` when `rescheduleUid` is present
- **`packages/trpc/server/routers/viewer/slots/getGuestBusyTimesForReschedule.test.ts`**: Unit tests covering all key scenarios

## Test scenarios
- Original booking not found → returns empty (no change to existing behavior)
- Booking has no attendees → returns empty
- Attendee is not a Cal.com user → returns empty (external guest, no check)
- Attendee is already a host on the event → skipped (not double-counted)
- Attendee **is** a Cal.com user → their bookings are returned as busy times and slots are filtered
- The booking being rescheduled itself is excluded from guest busy times (so the current slot stays available)
- Multiple Cal.com guests → all are checked and their busy times are aggregated