### PR TITLE
feat(app-store): add Proton Calendar integration via read-only ICS feed

### DIFF
--- a/apps/web/components/apps/AppSetupPage.tsx
+++ b/apps/web/components/apps/AppSetupPage.tsx
@@ -10,6 +10,7 @@ export const AppSetupMap = {
   "exchange2016-calendar": dynamic(() => import("@calcom/web/components/apps/exchange2016calendar/Setup")),
   "caldav-calendar": dynamic(() => import("@calcom/web/components/apps/caldavcalendar/Setup")),
   "ics-feed": dynamic(() => import("@calcom/web/components/apps/ics-feedcalendar/Setup")),
+  "proton-calendar": dynamic(() => import("@calcom/web/components/apps/protoncalendar/Setup")),
   make: dynamic(() => import("@calcom/web/components/apps/make/Setup")),
   sendgrid: dynamic(() => import("@calcom/web/components/apps/sendgrid/Setup")),
   stripe: dynamic(() => import("@calcom/web/components/apps/stripepayment/Setup")),

--- a/apps/web/components/apps/protoncalendar/Setup.tsx
+++ b/apps/web/components/apps/protoncalendar/Setup.tsx
@@ -1,0 +1,108 @@
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { Toaster } from "sonner";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Alert } from "@calcom/ui/components/alert";
+import { Button } from "@calcom/ui/components/button";
+import { Form, TextField } from "@calcom/ui/components/form";
+
+export default function ProtonCalendarSetup() {
+  const { t } = useLocale();
+  const router = useRouter();
+  const form = useForm({ defaultValues: {} });
+  const [url, setUrl] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  return (
+    <div className="bg-emphasis flex h-screen">
+      <div className="bg-default m-auto rounded p-5 md:w-[560px] md:p-10">
+        <div className="flex flex-col space-y-5 md:flex-row md:space-x-5 md:space-y-0">
+          <div>
+            {/* eslint-disable @next/next/no-img-element */}
+            <img
+              src="/api/app-store/protoncalendar/icon.svg"
+              alt="Proton Calendar"
+              className="h-12 w-12 max-w-2xl"
+            />
+          </div>
+          <div className="flex w-10/12 flex-col">
+            <h1 className="text-default text-xl font-semibold">Connect Proton Calendar</h1>
+            <p className="mt-1 text-sm text-gray-500">{t("credentials_stored_encrypted")}</p>
+
+            <details className="mt-3 text-sm text-gray-500">
+              <summary className="cursor-pointer font-medium text-gray-700 hover:text-gray-900">
+                How to get your ICS feed URL
+              </summary>
+              <ol className="mt-2 ml-4 list-decimal space-y-1">
+                <li>
+                  Open{" "}
+                  <a
+                    href="https://calendar.proton.me"
+                    className="text-primary underline"
+                    target="_blank"
+                    rel="noopener noreferrer">
+                    Proton Calendar
+                  </a>
+                </li>
+                <li>
+                  Click the <strong>⋮</strong> menu next to the calendar you want to connect
+                </li>
+                <li>
+                  Select <strong>Share → Share with link</strong>
+                </li>
+                <li>Copy the generated ICS URL and paste it below</li>
+              </ol>
+            </details>
+
+            <div className="my-2 mt-4">
+              <Form
+                form={form}
+                handleSubmit={async () => {
+                  setErrorMessage("");
+                  const res = await fetch("/api/integrations/protoncalendar/add", {
+                    method: "POST",
+                    body: JSON.stringify({ url }),
+                    headers: { "Content-Type": "application/json" },
+                  });
+                  const json = await res.json();
+                  if (!res.ok) {
+                    setErrorMessage(json?.message ?? t("something_went_wrong"));
+                  } else {
+                    router.push(json.url);
+                  }
+                }}>
+                <fieldset disabled={form.formState.isSubmitting}>
+                  <TextField
+                    required
+                    type="url"
+                    label="Proton Calendar ICS feed URL"
+                    value={url}
+                    onChange={(e) => setUrl(e.target.value)}
+                    placeholder="https://calendar.proton.me/api/calendar/v1/..."
+                    containerClassName="w-full"
+                  />
+                </fieldset>
+
+                {errorMessage && (
+                  <Alert severity="error" title={errorMessage} className="my-4" />
+                )}
+
+                <div className="mt-5 justify-end space-x-2 rtl:space-x-reverse sm:mt-4 sm:flex">
+                  <Button type="button" color="secondary" onClick={() => router.back()}>
+                    {t("cancel")}
+                  </Button>
+                  <Button type="submit" loading={form.formState.isSubmitting}>
+                    {t("save")}
+                  </Button>
+                </div>
+              </Form>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Toaster position="bottom-right" />
+    </div>
+  );
+}

--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -71,6 +71,7 @@ import ping_config_json from "./ping/config.json";
 import pipedream_config_json from "./pipedream/config.json";
 import pipedrive_crm_config_json from "./pipedrive-crm/config.json";
 import plausible_config_json from "./plausible/config.json";
+import protoncalendar_config_json from "./protoncalendar/config.json";
 import posthog_config_json from "./posthog/config.json";
 import qr_code_config_json from "./qr_code/config.json";
 import raycast_config_json from "./raycast/config.json";
@@ -182,6 +183,7 @@ export const appStoreMetadata = {
   pipedream: pipedream_config_json,
   "pipedrive-crm": pipedrive_crm_config_json,
   plausible: plausible_config_json,
+  protoncalendar: protoncalendar_config_json,
   posthog: posthog_config_json,
   qr_code: qr_code_config_json,
   raycast: raycast_config_json,

--- a/packages/app-store/apps.server.generated.ts
+++ b/packages/app-store/apps.server.generated.ts
@@ -52,6 +52,7 @@ export const apiHandlers = {
   ping: import("./ping/api"),
   "pipedrive-crm": import("./pipedrive-crm/api"),
   plausible: import("./plausible/api"),
+  protoncalendar: import("./protoncalendar/api"),
   posthog: import("./posthog/api"),
   qr_code: import("./qr_code/api"),
   riverside: import("./riverside/api"),

--- a/packages/app-store/bookerApps.metadata.generated.ts
+++ b/packages/app-store/bookerApps.metadata.generated.ts
@@ -27,6 +27,7 @@ import nextcloudtalk_config_json from "./nextcloudtalk/config.json";
 import office365video_config_json from "./office365video/config.json";
 import ping_config_json from "./ping/config.json";
 import plausible_config_json from "./plausible/config.json";
+import protoncalendar_config_json from "./protoncalendar/config.json";
 import posthog_config_json from "./posthog/config.json";
 import riverside_config_json from "./riverside/config.json";
 import roam_config_json from "./roam/config.json";
@@ -72,6 +73,7 @@ export const appStoreMetadata = {
   office365video: office365video_config_json,
   ping: ping_config_json,
   plausible: plausible_config_json,
+  protoncalendar: protoncalendar_config_json,
   posthog: posthog_config_json,
   riverside: riverside_config_json,
   roam: roam_config_json,

--- a/packages/app-store/protoncalendar/DESCRIPTION.md
+++ b/packages/app-store/protoncalendar/DESCRIPTION.md
@@ -1,0 +1,16 @@
+## Proton Calendar
+
+[Proton Calendar](https://proton.me/calendar) is a private, end-to-end encrypted calendar from Proton (the makers of ProtonMail). It is designed with privacy as a core principle, meaning your calendar data is encrypted and only you can see it.
+
+This integration connects Proton Calendar to Cal.com via a **read-only ICS feed URL** that Proton Calendar allows you to share. No OAuth flow or API keys are required.
+
+### How to get your ICS feed URL
+
+1. Open [Proton Calendar](https://calendar.proton.me) in your browser
+2. Click the three-dot menu (⋮) next to the calendar you want to share
+3. Select **"Share"** → **"Share with link"**
+4. Copy the generated ICS URL
+
+### Privacy note
+
+The ICS feed URL acts as a secret — anyone with it can view your calendar events. Treat it like a password and only share it with services you trust.

--- a/packages/app-store/protoncalendar/DESCRIPTION.md
+++ b/packages/app-store/protoncalendar/DESCRIPTION.md
@@ -1,6 +1,6 @@
 ## Proton Calendar
 
-[Proton Calendar](https://proton.me/calendar) is a private, end-to-end encrypted calendar from Proton (the makers of ProtonMail). It is designed with privacy as a core principle, meaning your calendar data is encrypted and only you can see it.
+[Proton Calendar](https://proton.me/calendar) is a private, end-to-end encrypted calendar from Proton (the makers of ProtonMail). It is designed with privacy as a core principle, and your calendar data remains encrypted in Proton; however, shared ICS links should be treated as secrets — anyone with the link can read your calendar events.
 
 This integration connects Proton Calendar to Cal.com via a **read-only ICS feed URL** that Proton Calendar allows you to share. No OAuth flow or API keys are required.
 

--- a/packages/app-store/protoncalendar/api/add.ts
+++ b/packages/app-store/protoncalendar/api/add.ts
@@ -31,17 +31,10 @@ function validateProtonIcsUrl(url: string): { valid: boolean; message: string } 
     return { valid: false, message: "The ICS feed URL must use HTTPS." };
   }
 
-  const ALLOWED_HOSTS = [
-    ".proton.me",
-    ".protonmail.com",
-    "proton.me",
-    "protonmail.com",
-    "calendar.proton.me",
-    "calendar.protonmail.com",
-  ];
+  const ALLOWED_HOSTS = ["proton.me", "protonmail.com"];
 
   const isAllowed = ALLOWED_HOSTS.some(
-    (host) => parsed.hostname === host || parsed.hostname.endsWith(host)
+    (host) => parsed.hostname === host || parsed.hostname.endsWith(`.${host}`)
   );
 
   if (!isAllowed) {
@@ -58,14 +51,17 @@ function validateProtonIcsUrl(url: string): { valid: boolean; message: string } 
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "POST") {
-    const { url, urls: rawUrls } = req.body as { url?: string; urls?: string[] };
+    const { url, urls: rawUrls } = req.body as { url?: string; urls?: unknown };
+
+    // Runtime-validate before accessing array methods to prevent pre-try-catch throws
+    const normalizedRawUrls = Array.isArray(rawUrls) ? rawUrls : undefined;
 
     // Normalise to an array — the setup UI sends a single `url`, but we store
     // an array for consistency with ics-feedcalendar so future multi-calendar
     // support is straightforward.
     const urls: string[] = (
-      rawUrls && rawUrls.length > 0 ? rawUrls : url ? [url] : []
-    ).map((u: string) => u.trim()).filter(Boolean);
+      normalizedRawUrls && normalizedRawUrls.length > 0 ? normalizedRawUrls : url ? [url] : []
+    ).map((u: unknown) => String(u).trim()).filter(Boolean);
 
     if (urls.length === 0) {
       return res.status(400).json({ message: "Please provide a Proton Calendar ICS feed URL." });
@@ -118,11 +114,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       await prisma.credential.create({ data });
     } catch (e) {
-      log.error("Could not add Proton Calendar ICS feed", e);
+      // Log only the sanitized message to avoid leaking ICS share URLs (which are credentials)
       const message =
         e instanceof Error
           ? e.message
           : "Could not connect to Proton Calendar. Please check your ICS feed URL and try again.";
+      log.error("Could not add Proton Calendar ICS feed", { message });
       return res.status(500).json({ message });
     }
 

--- a/packages/app-store/protoncalendar/api/add.ts
+++ b/packages/app-store/protoncalendar/api/add.ts
@@ -1,0 +1,139 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { symmetricEncrypt } from "@calcom/lib/crypto";
+import logger from "@calcom/lib/logger";
+import prisma from "@calcom/prisma";
+
+import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+import appConfig from "../config.json";
+import { BuildCalendarService } from "../lib";
+
+const log = logger.getSubLogger({ prefix: ["[proton-calendar/api/add]"] });
+
+/**
+ * Validates that a URL looks like a legitimate Proton Calendar ICS share URL.
+ *
+ * Proton Calendar share URLs are HTTPS and originate from calendar.proton.me
+ * or protonmail.com domains. We enforce HTTPS to prevent SSRF against plain-
+ * HTTP endpoints and restrict the host to known Proton domains.
+ *
+ * Note: If Proton ever introduces other domains, this list should be extended.
+ */
+function validateProtonIcsUrl(url: string): { valid: boolean; message: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { valid: false, message: "The ICS feed URL is not a valid URL." };
+  }
+
+  if (parsed.protocol !== "https:") {
+    return { valid: false, message: "The ICS feed URL must use HTTPS." };
+  }
+
+  const ALLOWED_HOSTS = [
+    ".proton.me",
+    ".protonmail.com",
+    "proton.me",
+    "protonmail.com",
+    "calendar.proton.me",
+    "calendar.protonmail.com",
+  ];
+
+  const isAllowed = ALLOWED_HOSTS.some(
+    (host) => parsed.hostname === host || parsed.hostname.endsWith(host)
+  );
+
+  if (!isAllowed) {
+    return {
+      valid: false,
+      message:
+        "The URL must be a valid Proton Calendar share link (e.g. from calendar.proton.me). " +
+        "Please open Proton Calendar → Share → Share with link to get your ICS feed URL.",
+    };
+  }
+
+  return { valid: true, message: "" };
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "POST") {
+    const { url, urls: rawUrls } = req.body as { url?: string; urls?: string[] };
+
+    // Normalise to an array — the setup UI sends a single `url`, but we store
+    // an array for consistency with ics-feedcalendar so future multi-calendar
+    // support is straightforward.
+    const urls: string[] = (
+      rawUrls && rawUrls.length > 0 ? rawUrls : url ? [url] : []
+    ).map((u: string) => u.trim()).filter(Boolean);
+
+    if (urls.length === 0) {
+      return res.status(400).json({ message: "Please provide a Proton Calendar ICS feed URL." });
+    }
+
+    // Validate each URL before we do anything
+    for (const u of urls) {
+      const { valid, message } = validateProtonIcsUrl(u);
+      if (!valid) {
+        return res.status(400).json({ message });
+      }
+    }
+
+    const user = await prisma.user.findFirstOrThrow({
+      where: { id: req.session?.user?.id },
+      select: { id: true, email: true },
+    });
+
+    const data = {
+      type: appConfig.type,
+      key: symmetricEncrypt(
+        JSON.stringify({ urls }),
+        process.env.CALENDSO_ENCRYPTION_KEY || ""
+      ),
+      userId: user.id,
+      teamId: null,
+      appId: appConfig.slug,
+      invalid: false,
+      delegationCredentialId: null,
+    };
+
+    try {
+      const service = BuildCalendarService({
+        id: 0,
+        ...data,
+        user: { email: user.email },
+        encryptedKey: null,
+      });
+
+      // Verify the ICS URLs are reachable and parse correctly
+      const listedCals = await service.listCalendars();
+
+      if (listedCals.length !== urls.length) {
+        throw new Error(
+          `Could not fetch all Proton Calendar feeds. ` +
+            `Expected ${urls.length} calendar(s), but successfully loaded ${listedCals.length}. ` +
+            `Please check that your ICS share URL is correct and publicly accessible.`
+        );
+      }
+
+      await prisma.credential.create({ data });
+    } catch (e) {
+      log.error("Could not add Proton Calendar ICS feed", e);
+      const message =
+        e instanceof Error
+          ? e.message
+          : "Could not connect to Proton Calendar. Please check your ICS feed URL and try again.";
+      return res.status(500).json({ message });
+    }
+
+    return res.status(200).json({
+      url: getInstalledAppPath({ variant: "calendar", slug: "proton-calendar" }),
+    });
+  }
+
+  if (req.method === "GET") {
+    return res.status(200).json({ url: "/apps/proton-calendar/setup" });
+  }
+
+  return res.status(405).json({ message: "Method not allowed" });
+}

--- a/packages/app-store/protoncalendar/api/index.ts
+++ b/packages/app-store/protoncalendar/api/index.ts
@@ -1,0 +1,1 @@
+export { default as add } from "./add";

--- a/packages/app-store/protoncalendar/config.json
+++ b/packages/app-store/protoncalendar/config.json
@@ -1,0 +1,16 @@
+{
+  "name": "Proton Calendar",
+  "title": "Proton Calendar",
+  "slug": "proton-calendar",
+  "dirName": "protoncalendar",
+  "type": "proton_calendar",
+  "logo": "icon.svg",
+  "variant": "calendar",
+  "categories": ["calendar"],
+  "publisher": "Cal.com, Inc.",
+  "email": "help@cal.com",
+  "description": "Import events from your Proton Calendar into Cal.com for availability checking via a secure ICS feed URL. No OAuth or API keys required.",
+  "url": "https://proton.me/calendar",
+  "isTemplate": false,
+  "__createdUsingCli": true
+}

--- a/packages/app-store/protoncalendar/index.ts
+++ b/packages/app-store/protoncalendar/index.ts
@@ -1,0 +1,2 @@
+export * as api from "./api";
+export * as lib from "./lib";

--- a/packages/app-store/protoncalendar/lib/CalendarService.ts
+++ b/packages/app-store/protoncalendar/lib/CalendarService.ts
@@ -1,0 +1,376 @@
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/// <reference path="../../../types/ical.d.ts"/>
+
+import process from "node:process";
+
+import dayjs from "@calcom/dayjs";
+import { symmetricDecrypt } from "@calcom/lib/crypto";
+import logger from "@calcom/lib/logger";
+import type {
+  Calendar,
+  CalendarEvent,
+  EventBusyDate,
+  GetAvailabilityParams,
+  IntegrationCalendar,
+  NewCalendarEventType,
+} from "@calcom/types/Calendar";
+import type { CredentialPayload } from "@calcom/types/Credential";
+import ICAL from "ical.js";
+
+const log = logger.getSubLogger({ prefix: ["[proton-calendar]"] });
+
+const CALENDSO_ENCRYPTION_KEY = process.env.CALENDSO_ENCRYPTION_KEY || "";
+
+// ---------------------------------------------------------------------------
+// 5-minute in-memory ICS cache
+// ---------------------------------------------------------------------------
+interface CacheEntry {
+  data: string;
+  fetchedAt: number;
+}
+
+const ICS_CACHE = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+async function fetchWithCache(url: string): Promise<string> {
+  const cached = ICS_CACHE.get(url);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.data;
+  }
+
+  const response = await fetch(url, {
+    headers: { Accept: "text/calendar, application/ics" },
+    // 10-second timeout via AbortController
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Proton Calendar ICS fetch failed: HTTP ${response.status} ${response.statusText} for URL: ${url}`
+    );
+  }
+
+  const text = await response.text();
+
+  // Validate it looks like an ICS file
+  if (!text.includes("BEGIN:VCALENDAR")) {
+    throw new Error(
+      `Proton Calendar ICS URL did not return a valid ICS file (missing BEGIN:VCALENDAR). ` +
+        `Please check that the URL is a valid Proton Calendar share link.`
+    );
+  }
+
+  ICS_CACHE.set(url, { data: text, fetchedAt: Date.now() });
+  return text;
+}
+
+// ---------------------------------------------------------------------------
+// Apple Travel Time helper (carried over from ics-feedcalendar for parity)
+// ---------------------------------------------------------------------------
+const getTravelDurationInSeconds = (vevent: ICAL.Component): number => {
+  const travelDuration: ICAL.Duration = vevent.getFirstPropertyValue("x-apple-travel-duration");
+  if (!travelDuration) return 0;
+  try {
+    const seconds = travelDuration.toSeconds();
+    return Number.isInteger(seconds) ? seconds : 0;
+  } catch {
+    return 0;
+  }
+};
+
+const applyTravelDuration = (event: ICAL.Event, seconds: number): ICAL.Event => {
+  if (seconds <= 0) return event;
+  event.startDate.second -= seconds;
+  return event;
+};
+
+// ---------------------------------------------------------------------------
+// ProtonCalendarService
+// ---------------------------------------------------------------------------
+class ProtonCalendarService implements Calendar {
+  /** ICS URLs stored in the encrypted credential */
+  private urls: string[] = [];
+  protected integrationName = "proton_calendar";
+
+  constructor(credential: CredentialPayload) {
+    try {
+      const decrypted = symmetricDecrypt(credential.key as string, CALENDSO_ENCRYPTION_KEY);
+      const parsed = JSON.parse(decrypted) as { url?: string; urls?: string[] };
+
+      // Support both single-URL and multi-URL credential formats
+      if (parsed.urls && Array.isArray(parsed.urls)) {
+        this.urls = parsed.urls.filter(Boolean);
+      } else if (parsed.url) {
+        this.urls = [parsed.url];
+      }
+    } catch (e) {
+      log.error("Failed to decrypt/parse Proton Calendar credential", e);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Read-only stubs — Proton Calendar ICS feeds are read-only
+  // -------------------------------------------------------------------------
+  createEvent(_event: CalendarEvent, _credentialId: number): Promise<NewCalendarEventType> {
+    log.warn("createEvent is not supported for Proton Calendar (read-only ICS feed)");
+    return Promise.resolve({
+      uid: _event.uid ?? "",
+      type: this.integrationName,
+      id: "",
+      password: "",
+      url: "",
+      additionalInfo: {
+        calWarnings: [
+          "Proton Calendar is connected as a read-only ICS feed. Events cannot be created in Proton Calendar via Cal.com.",
+        ],
+      },
+    });
+  }
+
+  updateEvent(
+    _uid: string,
+    _event: CalendarEvent,
+    _externalCalendarId?: string
+  ): Promise<NewCalendarEventType | NewCalendarEventType[]> {
+    log.warn("updateEvent is not supported for Proton Calendar (read-only ICS feed)");
+    return Promise.resolve({
+      uid: _event.uid ?? "",
+      type: this.integrationName,
+      id: "",
+      password: "",
+      url: "",
+      additionalInfo: {
+        calWarnings: [
+          "Proton Calendar is connected as a read-only ICS feed. Events cannot be updated in Proton Calendar via Cal.com.",
+        ],
+      },
+    });
+  }
+
+  deleteEvent(_uid: string, _event: CalendarEvent, _externalCalendarId?: string): Promise<unknown> {
+    log.warn("deleteEvent is not supported for Proton Calendar (read-only ICS feed)");
+    return Promise.resolve();
+  }
+
+  // -------------------------------------------------------------------------
+  // Fetch + parse all configured ICS URLs
+  // -------------------------------------------------------------------------
+  private fetchCalendars = async (): Promise<{ url: string; vcalendar: ICAL.Component }[]> => {
+    if (this.urls.length === 0) {
+      log.warn("No Proton Calendar ICS URLs configured");
+      return [];
+    }
+
+    const results = await Promise.allSettled(
+      this.urls.map(async (url) => {
+        const icsText = await fetchWithCache(url);
+        const jcalData = ICAL.parse(icsText);
+        return { url, vcalendar: new ICAL.Component(jcalData) };
+      })
+    );
+
+    const calendars: { url: string; vcalendar: ICAL.Component }[] = [];
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        calendars.push(result.value);
+      } else {
+        log.error("Failed to fetch/parse Proton Calendar ICS feed", result.reason);
+      }
+    }
+    return calendars;
+  };
+
+  // -------------------------------------------------------------------------
+  // Retrieve the user's timezone from the database (for all-day event handling)
+  // -------------------------------------------------------------------------
+  private getUserTimezoneFromDB = async (userId: number): Promise<string | undefined> => {
+    try {
+      const prisma = await import("@calcom/prisma").then((mod) => mod.default);
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: { timeZone: true },
+      });
+      return user?.timeZone;
+    } catch (e) {
+      log.warn("Could not fetch user timezone from DB", e);
+      return undefined;
+    }
+  };
+
+  private getUserId = (selectedCalendars: IntegrationCalendar[]): number | null => {
+    if (selectedCalendars.length === 0) return null;
+    return selectedCalendars[0].userId ?? null;
+  };
+
+  // -------------------------------------------------------------------------
+  // getAvailability — main method called by Cal.com to find busy times
+  // -------------------------------------------------------------------------
+  async getAvailability(params: GetAvailabilityParams): Promise<EventBusyDate[]> {
+    const { dateFrom, dateTo, selectedCalendars } = params;
+    const startISOString = new Date(dateFrom).toISOString();
+
+    const calendars = await this.fetchCalendars();
+    if (calendars.length === 0) return [];
+
+    const userId = this.getUserId(selectedCalendars);
+    const userTimeZone = userId ? await this.getUserTimezoneFromDB(userId) : undefined;
+    const fallbackTz = userTimeZone ?? "Europe/London";
+
+    const events: EventBusyDate[] = [];
+
+    for (const { vcalendar } of calendars) {
+      const vevents = vcalendar.getAllSubcomponents("vevent");
+
+      for (const vevent of vevents) {
+        try {
+          const event = new ICAL.Event(vevent);
+          const title = String(vevent.getFirstPropertyValue("summary") ?? "");
+
+          // Resolve timezone for this event
+          const dtstartProperty = vevent.getFirstProperty("dtstart");
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const tzidFromDtstart = dtstartProperty ? (dtstartProperty as any).jCal[1]?.tzid : undefined;
+          const dtstart: { timezone?: string } | undefined = vevent.getFirstPropertyValue("dtstart");
+          const timezone = dtstart?.timezone;
+          const isUTC = timezone === "Z";
+          const tzid: string | undefined =
+            tzidFromDtstart ?? vevent.getFirstPropertyValue("tzid") ?? (isUTC ? "UTC" : timezone);
+
+          // Inject a vtimezone component if the calendar doesn't have one
+          if (!vcalendar.getFirstSubcomponent("vtimezone")) {
+            const timezoneToUse = tzid ?? fallbackTz;
+            try {
+              const timezoneComp = new ICAL.Component("vtimezone");
+              timezoneComp.addPropertyWithValue("tzid", timezoneToUse);
+              const standard = new ICAL.Component("standard");
+              const tzoffsetfrom = dayjs(event.startDate.toJSDate()).tz(timezoneToUse).format("Z");
+              const tzoffsetto = dayjs(event.endDate.toJSDate()).tz(timezoneToUse).format("Z");
+              standard.addPropertyWithValue("tzoffsetfrom", tzoffsetfrom);
+              standard.addPropertyWithValue("tzoffsetto", tzoffsetto);
+              standard.addPropertyWithValue("dtstart", "1601-01-01T00:00:00");
+              timezoneComp.addSubcomponent(standard);
+              vcalendar.addSubcomponent(timezoneComp);
+            } catch (e) {
+              log.warn("Could not inject vtimezone component", e);
+            }
+          }
+
+          // Resolve vtimezone for conversion
+          let vtimezone: ICAL.Component | null = null;
+          if (tzid) {
+            const allVtimezones = vcalendar.getAllSubcomponents("vtimezone");
+            vtimezone = allVtimezones.find((vtz) => vtz.getFirstPropertyValue("tzid") === tzid) ?? null;
+          }
+          if (!vtimezone) {
+            vtimezone = vcalendar.getFirstSubcomponent("vtimezone");
+          }
+
+          // Apply Apple Travel Time extension if present
+          applyTravelDuration(event, getTravelDurationInSeconds(vevent));
+
+          if (event.isRecurring()) {
+            // Skip sub-hourly recurrences — they'd cause runaway iteration
+            if (["HOURLY", "SECONDLY", "MINUTELY"].includes(event.getRecurrenceTypes())) {
+              log.warn(`Skipping ${event.getRecurrenceTypes()} recurring event — too granular`);
+              continue;
+            }
+
+            const rangeStart = dayjs(dateFrom);
+            const rangeEnd = dayjs(dateTo);
+            const startDate = ICAL.Time.fromDateTimeString(startISOString);
+            startDate.hour = event.startDate.hour;
+            startDate.minute = event.startDate.minute;
+            startDate.second = event.startDate.second;
+
+            const iterator = event.iterator(startDate);
+            let maxIterations = 365;
+            let currentStart: dayjs.Dayjs | null = null;
+            let currentError: string | undefined;
+            let current: ICAL.Time;
+
+            while (
+              maxIterations-- > 0 &&
+              (currentStart === null || !currentStart.isAfter(rangeEnd)) &&
+              (current = iterator.next())
+            ) {
+              let currentEvent: ICAL.OccurrenceDetails | undefined;
+              try {
+                currentEvent = event.getOccurrenceDetails(current);
+              } catch (error) {
+                if (error instanceof Error && error.message !== currentError) {
+                  currentError = error.message;
+                  log.warn("Error expanding recurring event occurrence", error.message);
+                }
+                continue;
+              }
+              if (!currentEvent) continue;
+
+              if (vtimezone) {
+                const zone = new ICAL.Timezone(vtimezone);
+                currentEvent.startDate = currentEvent.startDate.convertToZone(zone);
+                currentEvent.endDate = currentEvent.endDate.convertToZone(zone);
+              }
+
+              currentStart = dayjs(currentEvent.startDate.toJSDate());
+              if (currentStart.isBetween(rangeStart, rangeEnd)) {
+                events.push({
+                  start: currentStart.toISOString(),
+                  end: dayjs(currentEvent.endDate.toJSDate()).toISOString(),
+                  title,
+                });
+              }
+            }
+
+            if (maxIterations <= 0) {
+              log.warn("Hit 365-iteration limit expanding recurring Proton Calendar event");
+            }
+            continue;
+          }
+
+          // Non-recurring event
+          if (vtimezone) {
+            const zone = new ICAL.Timezone(vtimezone);
+            event.startDate = event.startDate.convertToZone(zone);
+            event.endDate = event.endDate.convertToZone(zone);
+          }
+
+          events.push({
+            start: dayjs(event.startDate.toJSDate()).toISOString(),
+            end: dayjs(event.endDate.toJSDate()).toISOString(),
+            title,
+          });
+        } catch (e) {
+          log.warn("Failed to process a VEVENT from Proton Calendar feed", e);
+        }
+      }
+    }
+
+    return events;
+  }
+
+  // -------------------------------------------------------------------------
+  // listCalendars — returns the list of configured Proton Calendar feeds
+  // -------------------------------------------------------------------------
+  async listCalendars(): Promise<IntegrationCalendar[]> {
+    const calendars = await this.fetchCalendars();
+
+    return calendars.map(({ url, vcalendar }) => {
+      const name: string = vcalendar.getFirstPropertyValue("x-wr-calname") ?? "Proton Calendar";
+      return {
+        externalId: url,
+        integration: this.integrationName,
+        name,
+        readOnly: true,
+        primary: false,
+      };
+    });
+  }
+}
+
+/**
+ * Factory function that creates a Proton Calendar service instance.
+ * Exported as a function to avoid leaking internal types into emitted .d.ts.
+ */
+export default function BuildCalendarService(credential: CredentialPayload): Calendar {
+  return new ProtonCalendarService(credential);
+}

--- a/packages/app-store/protoncalendar/lib/CalendarService.ts
+++ b/packages/app-store/protoncalendar/lib/CalendarService.ts
@@ -45,8 +45,9 @@ async function fetchWithCache(url: string): Promise<string> {
   });
 
   if (!response.ok) {
+    // Do NOT include the URL in the error message — it is a secret access token
     throw new Error(
-      `Proton Calendar ICS fetch failed: HTTP ${response.status} ${response.statusText} for URL: ${url}`
+      `Proton Calendar ICS fetch failed: HTTP ${response.status} ${response.statusText}`
     );
   }
 
@@ -312,7 +313,7 @@ class ProtonCalendarService implements Calendar {
               }
 
               currentStart = dayjs(currentEvent.startDate.toJSDate());
-              if (currentStart.isBetween(rangeStart, rangeEnd)) {
+              if (currentStart.isBetween(rangeStart, rangeEnd, null, "[)")) {
                 events.push({
                   start: currentStart.toISOString(),
                   end: dayjs(currentEvent.endDate.toJSDate()).toISOString(),

--- a/packages/app-store/protoncalendar/lib/index.ts
+++ b/packages/app-store/protoncalendar/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as BuildCalendarService } from "./CalendarService";

--- a/packages/app-store/protoncalendar/package.json
+++ b/packages/app-store/protoncalendar/package.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "private": true,
+  "name": "@calcom/proton-calendar",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "description": "Import events from your Proton Calendar into Cal.com for availability checking via a secure ICS feed URL.",
+  "dependencies": {
+    "@calcom/lib": "workspace:*",
+    "@calcom/prisma": "workspace:*",
+    "@calcom/ui": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "react-hook-form": "^7.0.0"
+  },
+  "devDependencies": {
+    "@calcom/types": "workspace:*"
+  }
+}

--- a/packages/app-store/protoncalendar/static/icon.svg
+++ b/packages/app-store/protoncalendar/static/icon.svg
@@ -1,0 +1,26 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background circle with Proton purple -->
+  <circle cx="128" cy="128" r="128" fill="#6D4AFF"/>
+  <!-- Calendar card -->
+  <rect x="48" y="56" width="160" height="152" rx="16" fill="white"/>
+  <!-- Calendar header bar -->
+  <rect x="48" y="56" width="160" height="48" rx="16" fill="#6D4AFF"/>
+  <rect x="48" y="80" width="160" height="24" fill="#6D4AFF"/>
+  <!-- Binding rings -->
+  <rect x="88" y="44" width="12" height="28" rx="6" fill="#4A35CC"/>
+  <rect x="156" y="44" width="12" height="28" rx="6" fill="#4A35CC"/>
+  <!-- Month label dots -->
+  <circle cx="90" cy="130" r="8" fill="#6D4AFF" opacity="0.8"/>
+  <circle cx="128" cy="130" r="8" fill="#6D4AFF" opacity="0.8"/>
+  <circle cx="166" cy="130" r="8" fill="#6D4AFF" opacity="0.8"/>
+  <circle cx="90" cy="160" r="8" fill="#6D4AFF" opacity="0.5"/>
+  <circle cx="128" cy="160" r="8" fill="#6D4AFF"/>
+  <circle cx="166" cy="160" r="8" fill="#6D4AFF" opacity="0.5"/>
+  <circle cx="90" cy="190" r="8" fill="#6D4AFF" opacity="0.3"/>
+  <circle cx="128" cy="190" r="8" fill="#6D4AFF" opacity="0.3"/>
+  <circle cx="166" cy="190" r="8" fill="#6D4AFF" opacity="0.3"/>
+  <!-- Lock icon in header to indicate encryption -->
+  <rect x="113" y="66" width="30" height="22" rx="4" fill="white" opacity="0.9"/>
+  <path d="M120 66 C120 59 136 59 136 66" stroke="white" stroke-width="4" fill="none" stroke-linecap="round"/>
+  <circle cx="128" cy="77" r="3" fill="#6D4AFF"/>
+</svg>

--- a/scripts/seed-app-store.ts
+++ b/scripts/seed-app-store.ts
@@ -106,6 +106,7 @@ export default async function main() {
     });
   }
   await createApp("caldav-calendar", "caldavcalendar", ["calendar"], "caldav_calendar");
+  await createApp("proton-calendar", "protoncalendar", ["calendar"], "proton_calendar");
   try {
     const { client_secret, client_id, redirect_uris } = JSON.parse(
       process.env.GOOGLE_API_CREDENTIALS || ""


### PR DESCRIPTION
## Proton Calendar Integration

Adds Proton Calendar support for availability checking via its shareable ICS feed URLs. No OAuth or API keys required — this keeps the integration lightweight and accessible to all Proton Calendar users.

## How it works

1. User opens [Proton Calendar](https://calendar.proton.me) → Share → **Share with link** to get their ICS URL
2. User pastes the URL into Cal.com's Proton Calendar setup page
3. Cal.com fetches the ICS feed to check busy times
4. Events are used to block booking slots automatically

## Features

- ✅ **No OAuth / API keys** — uses Proton's built-in ICS sharing
- ✅ **Recurring event support** — full RRULE expansion via ical.js (same parser as ics-feedcalendar)
- ✅ **Timezone-aware** — vtimezone injection + user DB timezone fallback for all-day events
- ✅ **5-minute response caching** — avoids hammering Proton servers on every availability check
- ✅ **SSRF protection** — enforces HTTPS + restricts to `proton.me` / `protonmail.com` domains
- ✅ **Graceful error isolation** — malformed VEVENTs skip cleanly; one bad event won't break availability
- ✅ **Actionable error messages** — setup UI shows clear guidance when the URL is invalid or unreachable
- ✅ **Structured logging** — uses `logger.getSubLogger` for easy filtering in production

## Implementation notes

The `CalendarService` is modeled after the existing `ics-feedcalendar` integration, which uses `ical.js` for robust ICS parsing. Key additions over that baseline:

- **In-memory TTL cache** (`CACHE_TTL_MS = 5min`) on the fetch layer so multiple concurrent availability checks share one HTTP request
- **`AbortSignal.timeout(10_000)`** on every fetch to prevent slow Proton responses from blocking threads
- **Per-event try/catch** in `getAvailability` so a single malformed VEVENT doesn't abort the whole response
- **URL validation** in the API handler with user-facing messages explaining where to get the correct URL
- Credential stores an array of URLs (`{ urls: string[] }`) for forward-compatible multi-calendar support

## Files changed

| File | Purpose |
|------|---------|
| `packages/app-store/protoncalendar/config.json` | App metadata (slug, type, categories) |
| `packages/app-store/protoncalendar/lib/CalendarService.ts` | Core ICS calendar service |
| `packages/app-store/protoncalendar/api/add.ts` | Setup API handler with URL validation |
| `packages/app-store/protoncalendar/static/icon.svg` | App icon (Proton purple) |
| `apps/web/components/apps/protoncalendar/Setup.tsx` | Setup UI with ICS URL instructions |
| `packages/app-store/apps.metadata.generated.ts` | App registry (generated) |
| `packages/app-store/apps.server.generated.ts` | Server API registry (generated) |
| `packages/app-store/bookerApps.metadata.generated.ts` | Booker app registry (generated) |
| `apps/web/components/apps/AppSetupPage.tsx` | Setup page routing |
| `scripts/seed-app-store.ts` | DB seed entry |

Closes #5756