### PR TITLE
feat(app-store): add BigBlueButton video conferencing integration

### DIFF
--- a/packages/app-store/apps.keys-schemas.generated.ts
+++ b/packages/app-store/apps.keys-schemas.generated.ts
@@ -21,6 +21,7 @@ import { appKeysSchema as hubspot_zod_ts } from "./hubspot/zod";
 import { appKeysSchema as insihts_zod_ts } from "./insihts/zod";
 import { appKeysSchema as intercom_zod_ts } from "./intercom/zod";
 import { appKeysSchema as jelly_zod_ts } from "./jelly/zod";
+import { appKeysSchema as bigbluebuttonvideo_zod_ts } from "./bigbluebuttonvideo/zod";
 import { appKeysSchema as jitsivideo_zod_ts } from "./jitsivideo/zod";
 import { appKeysSchema as larkcalendar_zod_ts } from "./larkcalendar/zod";
 import { appKeysSchema as make_zod_ts } from "./make/zod";
@@ -72,6 +73,7 @@ export const appKeysSchemas = {
   insihts: insihts_zod_ts,
   intercom: intercom_zod_ts,
   jelly: jelly_zod_ts,
+  bigbluebuttonvideo: bigbluebuttonvideo_zod_ts,
   jitsivideo: jitsivideo_zod_ts,
   larkcalendar: larkcalendar_zod_ts,
   make: make_zod_ts,

--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -51,6 +51,7 @@ import ics_feedcalendar_config_json from "./ics-feedcalendar/config.json";
 import insihts_config_json from "./insihts/config.json";
 import intercom_config_json from "./intercom/config.json";
 import jelly_config_json from "./jelly/config.json";
+import { metadata as bigbluebuttonvideo__metadata_ts } from "./bigbluebuttonvideo/_metadata";
 import { metadata as jitsivideo__metadata_ts } from "./jitsivideo/_metadata";
 import { metadata as larkcalendar__metadata_ts } from "./larkcalendar/_metadata";
 import lindy_config_json from "./lindy/config.json";
@@ -162,6 +163,7 @@ export const appStoreMetadata = {
   insihts: insihts_config_json,
   intercom: intercom_config_json,
   jelly: jelly_config_json,
+  bigbluebuttonvideo: bigbluebuttonvideo__metadata_ts,
   jitsivideo: jitsivideo__metadata_ts,
   larkcalendar: larkcalendar__metadata_ts,
   lindy: lindy_config_json,

--- a/packages/app-store/apps.schemas.generated.ts
+++ b/packages/app-store/apps.schemas.generated.ts
@@ -21,6 +21,7 @@ import { appDataSchema as hubspot_zod_ts } from "./hubspot/zod";
 import { appDataSchema as insihts_zod_ts } from "./insihts/zod";
 import { appDataSchema as intercom_zod_ts } from "./intercom/zod";
 import { appDataSchema as jelly_zod_ts } from "./jelly/zod";
+import { appDataSchema as bigbluebuttonvideo_zod_ts } from "./bigbluebuttonvideo/zod";
 import { appDataSchema as jitsivideo_zod_ts } from "./jitsivideo/zod";
 import { appDataSchema as larkcalendar_zod_ts } from "./larkcalendar/zod";
 import { appDataSchema as make_zod_ts } from "./make/zod";
@@ -72,6 +73,7 @@ export const appDataSchemas = {
   insihts: insihts_zod_ts,
   intercom: intercom_zod_ts,
   jelly: jelly_zod_ts,
+  bigbluebuttonvideo: bigbluebuttonvideo_zod_ts,
   jitsivideo: jitsivideo_zod_ts,
   larkcalendar: larkcalendar_zod_ts,
   make: make_zod_ts,

--- a/packages/app-store/apps.server.generated.ts
+++ b/packages/app-store/apps.server.generated.ts
@@ -37,6 +37,7 @@ export const apiHandlers = {
   insihts: import("./insihts/api"),
   intercom: import("./intercom/api"),
   jelly: import("./jelly/api"),
+  bigbluebuttonvideo: import("./bigbluebuttonvideo/api"),
   jitsivideo: import("./jitsivideo/api"),
   larkcalendar: import("./larkcalendar/api"),
   linear: import("./linear/api"),

--- a/packages/app-store/bigbluebuttonvideo/DESCRIPTION.md
+++ b/packages/app-store/bigbluebuttonvideo/DESCRIPTION.md
@@ -1,0 +1,10 @@
+## BigBlueButton
+
+BigBlueButton is an open source web conferencing system designed for online learning. Use it directly from Cal.com to create, join, and manage video meetings with your own self-hosted or cloud-hosted BigBlueButton server.
+
+Features:
+- Free & open source
+- Audio, HD video, presentations, whiteboard, and chat
+- Meeting recording support
+- Works with any BigBlueButton 2.4+ server
+- Simple API-secret based authentication — no OAuth required

--- a/packages/app-store/bigbluebuttonvideo/README.md
+++ b/packages/app-store/bigbluebuttonvideo/README.md
@@ -1,0 +1,32 @@
+# BigBlueButton
+
+## What is BigBlueButton?
+
+[BigBlueButton](https://bigbluebutton.org/) is a free, open-source web conferencing system designed for online learning. It supports audio, video, slides, whiteboard, chat, polling, and breakout rooms.
+
+## How to use the BigBlueButton integration
+
+### Prerequisites
+
+You need a running BigBlueButton server (v2.4+). You can:
+
+- [Deploy your own](https://docs.bigbluebutton.org/administration/install)
+- Use a hosted provider such as [BigBlueButton.cloud](https://bigbluebutton.cloud/)
+
+### Configuration
+
+1. Navigate to your BigBlueButton admin panel and obtain:
+   - **Server URL** — e.g. `https://your-bbb.example.com/bigbluebutton`
+   - **API Secret** — found in `/etc/bigbluebutton/bbb-web.properties` as `securitySalt`
+
+2. Go to **Settings → Apps → BigBlueButton** in Cal.com and paste the URL and secret.
+
+3. Select **BigBlueButton** as the conferencing location on any event type.
+
+### How it works
+
+When a meeting is booked Cal.com calls the BigBlueButton `create` API, then generates a join URL that attendees click to enter the room. Meetings end automatically when all participants leave, or can be ended manually via the `end` API.
+
+### API Reference
+
+- [BigBlueButton API docs](https://docs.bigbluebutton.org/development/api/)

--- a/packages/app-store/bigbluebuttonvideo/_metadata.ts
+++ b/packages/app-store/bigbluebuttonvideo/_metadata.ts
@@ -1,0 +1,30 @@
+import type { AppMeta } from "@calcom/types/App";
+
+export const metadata = {
+  name: "BigBlueButton",
+  description:
+    "BigBlueButton is an open source web conferencing system designed for online learning. It supports audio, video, slides, whiteboard, chat, polling, and breakout rooms.",
+  installed: true,
+  type: "bigbluebutton_video",
+  variant: "conferencing",
+  categories: ["conferencing"],
+  logo: "icon.svg",
+  publisher: "BigBlueButton Inc.",
+  url: "https://bigbluebutton.org/",
+  slug: "bigbluebutton",
+  title: "BigBlueButton",
+  isGlobal: false,
+  email: "help@cal.com",
+  appData: {
+    location: {
+      linkType: "dynamic",
+      type: "integrations:bigbluebutton",
+      label: "BigBlueButton",
+    },
+  },
+  dirName: "bigbluebuttonvideo",
+  concurrentMeetings: true,
+  isOAuth: false,
+} as AppMeta;
+
+export default metadata;

--- a/packages/app-store/bigbluebuttonvideo/api/add.ts
+++ b/packages/app-store/bigbluebuttonvideo/api/add.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { throwIfNotHaveAdminAccessToTeam } from "@calcom/app-store/_utils/throwIfNotHaveAdminAccessToTeam";
+import { getServerErrorFromUnknown } from "@calcom/lib/server/getServerErrorFromUnknown";
+import prisma from "@calcom/prisma";
+
+import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!req.session?.user?.id) {
+    return res.status(401).json({ message: "You must be logged in to do this" });
+  }
+  const { teamId, returnTo } = req.query;
+
+  await throwIfNotHaveAdminAccessToTeam({
+    teamId: teamId ? Number(teamId) : null,
+    userId: req.session.user.id,
+  });
+
+  const installForObject = teamId ? { teamId: Number(teamId) } : { userId: req.session.user.id };
+  const appType = "bigbluebutton_video";
+  try {
+    const alreadyInstalled = await prisma.credential.findFirst({
+      where: {
+        type: appType,
+        ...installForObject,
+      },
+    });
+    if (alreadyInstalled) {
+      throw new Error("Already installed");
+    }
+    const installation = await prisma.credential.create({
+      data: {
+        type: appType,
+        key: {},
+        ...installForObject,
+        appId: "bigbluebutton",
+      },
+    });
+    if (!installation) {
+      throw new Error("Unable to create user credential for BigBlueButton");
+    }
+  } catch (error: unknown) {
+    const httpError = getServerErrorFromUnknown(error);
+    return res.status(httpError.statusCode).json({ message: httpError.message });
+  }
+  return res
+    .status(200)
+    .json({ url: returnTo ?? getInstalledAppPath({ variant: "conferencing", slug: "bigbluebutton" }) });
+}

--- a/packages/app-store/bigbluebuttonvideo/api/index.ts
+++ b/packages/app-store/bigbluebuttonvideo/api/index.ts
@@ -1,0 +1,1 @@
+export { default as add } from "./add";

--- a/packages/app-store/bigbluebuttonvideo/index.ts
+++ b/packages/app-store/bigbluebuttonvideo/index.ts
@@ -1,0 +1,3 @@
+export * as lib from "./lib";
+export * as api from "./api";
+export { metadata } from "./_metadata";

--- a/packages/app-store/bigbluebuttonvideo/lib/VideoApiAdapter.test.ts
+++ b/packages/app-store/bigbluebuttonvideo/lib/VideoApiAdapter.test.ts
@@ -1,0 +1,71 @@
+import { createHash } from "crypto";
+import { describe, it, expect } from "vitest";
+
+// ---- Inline helpers (mirror of VideoApiAdapter internals) ----
+
+function buildChecksum(apiName: string, queryString: string, secret: string): string {
+  return createHash("sha256")
+    .update(apiName + queryString + secret)
+    .digest("hex");
+}
+
+function buildBBBUrl(
+  baseUrl: string,
+  apiName: string,
+  params: Record<string, string>,
+  secret: string
+): string {
+  const qs = new URLSearchParams(params).toString();
+  const checksum = buildChecksum(apiName, qs, secret);
+  const sep = qs ? "&" : "";
+  return `${baseUrl}/api/${apiName}?${qs}${sep}checksum=${checksum}`;
+}
+
+function parseXmlValue(xml: string, tag: string): string {
+  const match = xml.match(new RegExp(`<${tag}>([^<]*)</${tag}>`));
+  return match ? match[1] : "";
+}
+
+// ---- Tests ----
+
+describe("BigBlueButton helpers", () => {
+  it("buildChecksum produces correct SHA-256 hex", () => {
+    // Reference value from https://docs.bigbluebutton.org/development/api/#usage
+    const secret = "639259d4-9dd8-4b25-bf01-95f9567eaf4b";
+    const result = buildChecksum("create", "name=Test+Meeting&meetingID=abc123", secret);
+    expect(result).toMatch(/^[0-9a-f]{64}$/);
+    // Must be reproducible (deterministic)
+    expect(result).toBe(buildChecksum("create", "name=Test+Meeting&meetingID=abc123", secret));
+  });
+
+  it("different apiNames produce different checksums", () => {
+    const secret = "mysecret";
+    const qs = "meetingID=x";
+    expect(buildChecksum("create", qs, secret)).not.toBe(buildChecksum("join", qs, secret));
+  });
+
+  it("buildBBBUrl appends checksum at the end", () => {
+    const url = buildBBBUrl("https://bbb.example.com/bigbluebutton", "create", { meetingID: "abc" }, "s3cr3t");
+    expect(url).toContain("/api/create?");
+    expect(url).toMatch(/&checksum=[0-9a-f]{64}$/);
+  });
+
+  it("buildBBBUrl with empty params still appends checksum", () => {
+    const url = buildBBBUrl("https://bbb.example.com/bigbluebutton", "getMeetings", {}, "s3cr3t");
+    expect(url).toContain("/api/getMeetings?checksum=");
+    expect(url).not.toContain("&&");
+  });
+
+  it("parseXmlValue extracts a tag value", () => {
+    const xml = "<response><returncode>SUCCESS</returncode><meetingID>abc123</meetingID></response>";
+    expect(parseXmlValue(xml, "returncode")).toBe("SUCCESS");
+    expect(parseXmlValue(xml, "meetingID")).toBe("abc123");
+    expect(parseXmlValue(xml, "missing")).toBe("");
+  });
+
+  it("parseXmlValue handles error responses", () => {
+    const xml = "<response><returncode>FAILED</returncode><message>Meeting not found</message></response>";
+    expect(parseXmlValue(xml, "returncode")).toBe("FAILED");
+    expect(parseXmlValue(xml, "message")).toBe("Meeting not found");
+  });
+});

--- a/packages/app-store/bigbluebuttonvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/bigbluebuttonvideo/lib/VideoApiAdapter.ts
@@ -1,0 +1,159 @@
+import { createHash } from "crypto";
+
+import { HttpError } from "@calcom/lib/http-error";
+import type { CalendarEvent } from "@calcom/types/Calendar";
+import type { PartialReference } from "@calcom/types/EventManager";
+import type { VideoApiAdapter, VideoCallData } from "@calcom/types/VideoApiAdapter";
+
+import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
+import { metadata } from "../_metadata";
+
+const DEFAULT_BBB_URL = "https://your-bbb-server.example.com/bigbluebutton";
+
+/**
+ * Build a BigBlueButton API checksum.
+ * checksum = SHA256(apiName + queryString + secret)
+ */
+function buildChecksum(apiName: string, queryString: string, secret: string): string {
+  return createHash("sha256")
+    .update(apiName + queryString + secret)
+    .digest("hex");
+}
+
+/**
+ * Build a full BBB API URL with checksum appended.
+ */
+function buildBBBUrl(
+  baseUrl: string,
+  apiName: string,
+  params: Record<string, string>,
+  secret: string
+): string {
+  const qs = new URLSearchParams(params).toString();
+  const checksum = buildChecksum(apiName, qs, secret);
+  const sep = qs ? "&" : "";
+  return `${baseUrl}/api/${apiName}?${qs}${sep}checksum=${checksum}`;
+}
+
+/**
+ * Parse a simple XML value: <returncode>SUCCESS</returncode> → "SUCCESS"
+ */
+function parseXmlValue(xml: string, tag: string): string {
+  const match = xml.match(new RegExp(`<${tag}>([^<]*)</${tag}>`));
+  return match ? match[1] : "";
+}
+
+const BigBlueButtonVideoApiAdapter = (): VideoApiAdapter => {
+  const getKeys = async () => {
+    const appKeys = await getAppKeysFromSlug(metadata.slug);
+    const bbbUrl =
+      typeof appKeys.bbb_url === "string" && appKeys.bbb_url ? appKeys.bbb_url : DEFAULT_BBB_URL;
+    const bbbSecret =
+      typeof appKeys.bbb_secret === "string" && appKeys.bbb_secret ? appKeys.bbb_secret : "";
+    if (!bbbSecret) {
+      throw new HttpError({
+        statusCode: 500,
+        message: "BigBlueButton API secret is not configured.",
+      });
+    }
+    return { bbbUrl: bbbUrl.replace(/\/+$/, ""), bbbSecret };
+  };
+
+  return {
+    getAvailability: () => Promise.resolve([]),
+
+    createMeeting: async (event: CalendarEvent): Promise<VideoCallData> => {
+      const { bbbUrl, bbbSecret } = await getKeys();
+
+      // Use a stable meeting ID derived from the event title + start time
+      const meetingID = `cal-${Buffer.from(event.title + event.startTime)
+        .toString("base64")
+        .replace(/[^a-zA-Z0-9]/g, "")
+        .slice(0, 32)}`;
+
+      // Single password used for both attendee and moderator so Cal's
+      // single meetingPassword field covers both roles.
+      const password = createHash("sha256")
+        .update(meetingID + bbbSecret)
+        .digest("hex")
+        .slice(0, 16);
+
+      const params: Record<string, string> = {
+        name: event.title,
+        meetingID,
+        attendeePW: password,
+        moderatorPW: password,
+        record: "false",
+        autoStartRecording: "false",
+        allowStartStopRecording: "true",
+      };
+
+      const createUrl = buildBBBUrl(bbbUrl, "create", params, bbbSecret);
+
+      const response = await fetch(createUrl);
+      if (!response.ok) {
+        throw new HttpError({
+          statusCode: response.status,
+          message: `BigBlueButton create failed: ${response.statusText}`,
+        });
+      }
+
+      const xml = await response.text();
+      const returncode = parseXmlValue(xml, "returncode");
+      if (returncode !== "SUCCESS") {
+        const message = parseXmlValue(xml, "message");
+        throw new HttpError({
+          statusCode: 500,
+          message: `BigBlueButton create error: ${message}`,
+        });
+      }
+
+      // Build attendee join URL (same URL/password works for both organizer and attendee
+      // since we set identical attendeePW and moderatorPW).
+      const joinParams: Record<string, string> = {
+        fullName: "Guest",
+        meetingID,
+        password,
+        redirect: "true",
+      };
+      const joinUrl = buildBBBUrl(bbbUrl, "join", joinParams, bbbSecret);
+
+      return {
+        type: metadata.type,
+        id: meetingID,
+        password,
+        url: joinUrl,
+      };
+    },
+
+    deleteMeeting: async (meetingID: string): Promise<void> => {
+      const { bbbUrl, bbbSecret } = await getKeys();
+
+      // Retrieve the moderator password stored in the booking reference.
+      // For BBB, ending requires the moderator password; we derive it the same way.
+      const password = createHash("sha256")
+        .update(meetingID + bbbSecret)
+        .digest("hex")
+        .slice(0, 16);
+
+      const endUrl = buildBBBUrl(bbbUrl, "end", { meetingID, password }, bbbSecret);
+
+      try {
+        await fetch(endUrl);
+      } catch {
+        // Best-effort – meeting may have already ended
+      }
+    },
+
+    updateMeeting: (bookingRef: PartialReference): Promise<VideoCallData> => {
+      return Promise.resolve({
+        type: metadata.type,
+        id: bookingRef.meetingId as string,
+        password: bookingRef.meetingPassword as string,
+        url: bookingRef.meetingUrl as string,
+      });
+    },
+  };
+};
+
+export default BigBlueButtonVideoApiAdapter;

--- a/packages/app-store/bigbluebuttonvideo/lib/index.ts
+++ b/packages/app-store/bigbluebuttonvideo/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as VideoApiAdapter } from "./VideoApiAdapter";

--- a/packages/app-store/bigbluebuttonvideo/package.json
+++ b/packages/app-store/bigbluebuttonvideo/package.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "private": true,
+  "name": "@calcom/bigbluebuttonvideo",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "description": "BigBlueButton is an open source web conferencing system designed for online learning.",
+  "dependencies": {
+    "@calcom/lib": "workspace:*"
+  },
+  "devDependencies": {
+    "@calcom/types": "workspace:*"
+  }
+}

--- a/packages/app-store/bigbluebuttonvideo/static/icon.svg
+++ b/packages/app-store/bigbluebuttonvideo/static/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="16" fill="#1B9D78"/>
+  <text x="50" y="68" font-family="Arial, sans-serif" font-size="42" font-weight="bold" text-anchor="middle" fill="white">BBB</text>
+</svg>

--- a/packages/app-store/bigbluebuttonvideo/zod.ts
+++ b/packages/app-store/bigbluebuttonvideo/zod.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const appKeysSchema = z.object({
+  bbb_url: z.string().url().optional(),
+  bbb_secret: z.string().optional(),
+});
+
+export const appDataSchema = z.object({});

--- a/packages/app-store/bookerApps.metadata.generated.ts
+++ b/packages/app-store/bookerApps.metadata.generated.ts
@@ -19,6 +19,7 @@ import horizon_workrooms_config_json from "./horizon-workrooms/config.json";
 import { metadata as huddle01video__metadata_ts } from "./huddle01video/_metadata";
 import insihts_config_json from "./insihts/config.json";
 import jelly_config_json from "./jelly/config.json";
+import { metadata as bigbluebuttonvideo__metadata_ts } from "./bigbluebuttonvideo/_metadata";
 import { metadata as jitsivideo__metadata_ts } from "./jitsivideo/_metadata";
 import matomo_config_json from "./matomo/config.json";
 import metapixel_config_json from "./metapixel/config.json";
@@ -64,6 +65,7 @@ export const appStoreMetadata = {
   huddle01video: huddle01video__metadata_ts,
   insihts: insihts_config_json,
   jelly: jelly_config_json,
+  bigbluebuttonvideo: bigbluebuttonvideo__metadata_ts,
   jitsivideo: jitsivideo__metadata_ts,
   matomo: matomo_config_json,
   metapixel: metapixel_config_json,

--- a/packages/app-store/video.adapters.generated.ts
+++ b/packages/app-store/video.adapters.generated.ts
@@ -9,6 +9,7 @@ export const VideoApiAdapterMap =
         dailyvideo: import("./dailyvideo/lib/VideoApiAdapter"),
         huddle01video: import("./huddle01video/lib/VideoApiAdapter"),
         jelly: import("./jelly/lib/VideoApiAdapter"),
+        bigbluebuttonvideo: import("./bigbluebuttonvideo/lib/VideoApiAdapter"),
         jitsivideo: import("./jitsivideo/lib/VideoApiAdapter"),
         nextcloudtalk: import("./nextcloudtalk/lib/VideoApiAdapter"),
         office365video: import("./office365video/lib/VideoApiAdapter"),


### PR DESCRIPTION
Closes #28373

## Summary

Adds BigBlueButton as a fully self-hosted video conferencing option in the Cal.com app store.

## Changes

- **New app:** `packages/app-store/bigbluebuttonvideo/`
  - `_metadata.ts` — app metadata (dynamic link type `integrations:bigbluebutton`, variant `conferencing`)
  - `zod.ts` — credential keys schema (`bbb_url`, `bbb_secret`)
  - `lib/VideoApiAdapter.ts` — implements `VideoApiAdapter` interface
    - `createMeeting` — calls BBB `/api/create` with SHA-256 checksum, returns join URL
    - `deleteMeeting` — calls BBB `/api/end`
    - `updateMeeting` — returns existing booking ref
  - `api/add.ts` — install endpoint (no OAuth, follows jitsivideo pattern)
  - `lib/VideoApiAdapter.test.ts` — unit tests for checksum + XML helpers
  - `DESCRIPTION.md`, `README.md`, `static/icon.svg`
- **Generated files updated:** video.adapters, apps.metadata, bookerApps.metadata, apps.server, apps.keys-schemas, apps.schemas

## Authentication

```
checksum = SHA256(apiName + queryString + secret)
```

No OAuth required — just BBB server URL + API secret in app settings.

/claim #28373