### PR TITLE
feat(routing-forms): support all event-type booking question types

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
@@ -208,7 +208,7 @@ function Field({
               }}
             />
           </div>
-          {["select", "multiselect"].includes(fieldType) ? (
+          {["select", "multiselect", "checkbox", "radio"].includes(fieldType) ? (
             <div className="bg-cal-muted w-full rounded-[10px] p-2">
               <Label className="text-subtle">{t("options")}</Label>
               <MultiOptionInput

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
@@ -15,6 +15,24 @@ function getWidgetsWithoutFactory(_configFor: ConfigFor) {
     email: {
       ...BasicConfig.widgets.text,
     },
+    address: {
+      ...BasicConfig.widgets.text,
+    },
+    multiemail: {
+      ...BasicConfig.widgets.text,
+    },
+    checkbox: {
+      ...BasicConfig.widgets.multiselect,
+    },
+    radio: {
+      ...BasicConfig.widgets.select,
+    },
+    boolean: {
+      ...BasicConfig.widgets.boolean,
+    },
+    url: {
+      ...BasicConfig.widgets.text,
+    },
   };
   return widgetsWithoutFactory;
 }
@@ -40,6 +58,58 @@ function getTypes(configFor: ConfigFor) {
       ...BasicConfig.types.text,
       widgets: {
         ...BasicConfig.types.text.widgets,
+      },
+    },
+    address: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+        address: {
+          ...BasicConfig.types.text.widgets.text,
+        },
+      },
+    },
+    multiemail: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+        multiemail: {
+          ...BasicConfig.types.text.widgets.text,
+        },
+      },
+    },
+    checkbox: {
+      ...BasicConfig.types.multiselect,
+      widgets: {
+        ...BasicConfig.types.multiselect.widgets,
+        checkbox: {
+          ...BasicConfig.types.multiselect.widgets.multiselect,
+          operators: [...(BasicConfig.types.multiselect.widgets.multiselect.operators || [])],
+        },
+      },
+    },
+    radio: {
+      ...BasicConfig.types.select,
+      widgets: {
+        ...BasicConfig.types.select.widgets,
+        radio: {
+          ...BasicConfig.types.select.widgets.select,
+        },
+      },
+    },
+    boolean: {
+      ...BasicConfig.types.boolean,
+      widgets: {
+        ...BasicConfig.types.boolean.widgets,
+      },
+    },
+    url: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+        url: {
+          ...BasicConfig.types.text.widgets.text,
+        },
       },
     },
     multiselect: {

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
@@ -76,7 +76,6 @@ const EmailFactory = (props: WidgetProps | undefined) => {
   );
 };
 
-// react-query-builder types have missing type property on Widget
 //TODO: Reuse FormBuilder Components - FormBuilder components are built considering Cal.com design system and coding guidelines. But when awesome-query-builder renders these components, it passes its own props which are different from what our Components expect.
 // So, a mapper should be written here that maps the props provided by awesome-query-builder to the props that our components expect.
 function withFactoryWidgets(widgets: WidgetsWithoutFactory) {
@@ -110,6 +109,33 @@ function withFactoryWidgets(widgets: WidgetsWithoutFactory) {
     email: {
       ...widgets.text,
       factory: EmailFactory,
+    },
+    address: {
+      ...widgets.text,
+      factory: TextFactory,
+      valuePlaceholder: "Enter Address",
+    },
+    multiemail: {
+      ...widgets.text,
+      factory: TextFactory,
+      valuePlaceholder: "Enter Email",
+    },
+    checkbox: {
+      ...(widgets.multiselect ?? widgets.text),
+      factory: MultiSelectFactory,
+    } as SelectWidgetType,
+    radio: {
+      ...(widgets.select ?? widgets.text),
+      factory: SelectFactory,
+    } as SelectWidgetType,
+    boolean: {
+      ...widgets.boolean,
+      factory: TextFactory,
+    },
+    url: {
+      ...widgets.text,
+      factory: TextFactory,
+      valuePlaceholder: "Enter URL",
     },
   };
   return widgetsWithFactory;

--- a/packages/app-store/routing-forms/lib/FieldTypes.ts
+++ b/packages/app-store/routing-forms/lib/FieldTypes.ts
@@ -6,6 +6,12 @@ export const enum RoutingFormFieldType {
   MULTI_SELECT = "multiselect",
   PHONE = "phone",
   EMAIL = "email",
+  ADDRESS = "address",
+  MULTI_EMAIL = "multiemail",
+  CHECKBOX = "checkbox",
+  RADIO = "radio",
+  BOOLEAN = "boolean",
+  URL = "url",
 }
 
 export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFieldType => {
@@ -17,6 +23,12 @@ export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFi
     RoutingFormFieldType.MULTI_SELECT,
     RoutingFormFieldType.PHONE,
     RoutingFormFieldType.EMAIL,
+    RoutingFormFieldType.ADDRESS,
+    RoutingFormFieldType.MULTI_EMAIL,
+    RoutingFormFieldType.CHECKBOX,
+    RoutingFormFieldType.RADIO,
+    RoutingFormFieldType.BOOLEAN,
+    RoutingFormFieldType.URL,
   ].includes(type as RoutingFormFieldType);
 };
 
@@ -48,5 +60,29 @@ export const FieldTypes = [
   {
     label: "Email",
     value: RoutingFormFieldType.EMAIL,
+  },
+  {
+    label: "Address",
+    value: RoutingFormFieldType.ADDRESS,
+  },
+  {
+    label: "Multiple emails",
+    value: RoutingFormFieldType.MULTI_EMAIL,
+  },
+  {
+    label: "Checkbox group",
+    value: RoutingFormFieldType.CHECKBOX,
+  },
+  {
+    label: "Radio group",
+    value: RoutingFormFieldType.RADIO,
+  },
+  {
+    label: "Checkbox",
+    value: RoutingFormFieldType.BOOLEAN,
+  },
+  {
+    label: "URL",
+    value: RoutingFormFieldType.URL,
   },
 ] as const;

--- a/packages/app-store/routing-forms/lib/getQueryBuilderConfig.ts
+++ b/packages/app-store/routing-forms/lib/getQueryBuilderConfig.ts
@@ -64,7 +64,13 @@ export function getQueryBuilderConfigForFormFields(form: Pick<RoutingForm, "fiel
         valueSources: ["value"],
         fieldSettings: {
           // IMPORTANT: listValues must be undefined for non-select/multiselect fields otherwise RAQB doesn't like it. It ends up considering all the text values as per the listValues too which could be empty as well making all values invalid
-          listValues: fieldType === "select" || fieldType === "multiselect" ? options : undefined,
+          listValues:
+            fieldType === "select" ||
+            fieldType === "multiselect" ||
+            fieldType === "checkbox" ||
+            fieldType === "radio"
+              ? options
+              : undefined,
         },
       };
     } else {

--- a/packages/app-store/routing-forms/lib/transformResponse.ts
+++ b/packages/app-store/routing-forms/lib/transformResponse.ts
@@ -69,7 +69,7 @@ export function getFieldResponseForJsonLogic({
     }
     return value;
   }
-  if (field.type === "multiselect") {
+  if (field.type === "multiselect" || field.type === "checkbox") {
     // Could be option id(i.e. a UUIDv4) or option label for ease of prefilling
     let valueOrLabelArray = value instanceof Array ? value : value.toString().split(",");
 
@@ -80,7 +80,7 @@ export function getFieldResponseForJsonLogic({
     return valueOrLabelArray;
   }
 
-  if (field.type === "select") {
+  if (field.type === "select" || field.type === "radio") {
     const valueAsStringOrStringArray = typeof value === "number" ? String(value) : value;
     const valueAsString =
       valueAsStringOrStringArray instanceof Array


### PR DESCRIPTION
## Summary

Extends routing forms to support the full set of question types available in the event-type FormBuilder.

### New field types added
| Type | Description |
|------|-------------|
| `address` | Address field (text input) |
| `multiemail` | Multiple email addresses |
| `checkbox` | Checkbox group (multiple choice, like multiselect) |
| `radio` | Radio group (single choice, like select) |
| `boolean` | Single checkbox (yes/no) |
| `url` | URL field (text input with URL placeholder) |

### Implementation
- **`FieldTypes.ts`**: Added 6 new `RoutingFormFieldType` enum values and corresponding `FieldTypes` entries shown in the form builder UI
- **`config.ts`** (RAQB config): Added widget/type definitions for new types, mapping them to appropriate RAQB base types (text, select, multiselect, boolean)
- **`uiConfig.tsx`**: Wired factory components — text-like types use `TextFactory`, checkbox → `MultiSelectFactory`, radio → `SelectFactory`
- **`getQueryBuilderConfig.ts`**: Extended `listValues` hydration to include `checkbox` and `radio` types
- **`transformResponse.ts`**: Handle `checkbox` like `multiselect` and `radio` like `select` for option ID resolution
- **`FormEdit.tsx`**: Show options editor UI for `checkbox` and `radio` field types

### Related
- Closes #18987
- Addresses user request to have routing form question types match event booking question types