### PR TITLE
feat: add tooltip explaining hidden badges

### DIFF
--- a/apps/web/modules/event-types/components/EventTypeDescription.tsx
+++ b/apps/web/modules/event-types/components/EventTypeDescription.tsx
@@ -11,6 +11,7 @@ import type { baseEventTypeSelect } from "@calcom/prisma";
 import type { Prisma, EventType } from "@calcom/prisma/client";
 import { SchedulingType } from "@calcom/prisma/enums";
 import classNames from "@calcom/ui/classNames";
+import { Tooltip } from "@calcom/ui/components/tooltip";
 import { Badge } from "@calcom/ui/components/badge";
 
 export type EventTypeDescriptionProps = {
@@ -47,6 +48,14 @@ export const EventTypeDescription = ({
     ...eventType,
     metadata,
   });
+
+  const hiddenFeatures = [
+    eventType.requiresConfirmation &&
+      (metadata?.requiresConfirmationThreshold ? t("may_require_confirmation") : t("requires_confirmation")),
+    recurringEvent?.count && t("repeats_up_to", { count: recurringEvent.count }),
+  ]
+    .filter(Boolean)
+    .join(", ");
 
   return (
     <>
@@ -121,12 +130,13 @@ export const EventTypeDescription = ({
               </Badge>
             </li>
           )}
-          {/* TODO: Maybe add a tool tip to this? */}
-          {eventType.requiresConfirmation || (recurringEvent?.count) ? (
+          {eventType.requiresConfirmation || recurringEvent?.count ? (
             <li className="block xl:hidden">
-              <Badge variant="gray" startIcon="plus">
-                <p>{[eventType.requiresConfirmation, recurringEvent?.count].filter(Boolean).length}</p>
-              </Badge>
+              <Tooltip content={hiddenFeatures} side="bottom">
+                <Badge variant="gray" startIcon="plus">
+                  <p>{[eventType.requiresConfirmation, recurringEvent?.count].filter(Boolean).length}</p>
+                </Badge>
+              </Tooltip>
             </li>
           ) : (
             <></>


### PR DESCRIPTION
## What does this PR do?

This PR resolves an existing TODO in `EventTypeDescription` by adding a tooltip.

<img width="770" height="227" alt="image" src="https://github.com/user-attachments/assets/b8dd52ed-cb98-4aa8-bbc2-3df3349f5571" />


On smaller screens, some event metadata badges (such as requires confirmation and recurring event) are collapsed into a single `+N` indicator to save space. However, the indicator did not previously explain what those hidden badges represented.

#### Video Demo (if applicable):


[Screencast from 2026-03-12 00-31-46.webm](https://github.com/user-attachments/assets/044b01a8-d86f-4bec-a30b-1b434be6fa92)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

