### PR TITLE
feat: add API endpoint to report bookings as spam

### DIFF
--- a/apps/api/v2/jest.config.ts
+++ b/apps/api/v2/jest.config.ts
@@ -5,6 +5,8 @@ const config: Config = {
   moduleFileExtensions: ["ts", "js", "json"],
   rootDir: ".",
   moduleNameMapper: {
+    "^@calcom/platform-libraries$": "<rootDir>/../../../packages/platform/libraries/index.ts",
+    "^@calcom/platform-libraries/(.*)$": "<rootDir>/../../../packages/platform/libraries/$1.ts",
     "@/(.*)": "<rootDir>/src/$1",
     "test/(.*)": "<rootDir>/test/$1",
   },

--- a/apps/api/v2/src/lib/repositories/prisma-booking-report.repository.ts
+++ b/apps/api/v2/src/lib/repositories/prisma-booking-report.repository.ts
@@ -1,0 +1,11 @@
+import { PrismaBookingReportRepository as PrismaBookingReportRepositoryLib } from "@calcom/platform-libraries/repositories";
+import type { PrismaClient } from "@calcom/prisma";
+import { Injectable } from "@nestjs/common";
+import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
+
+@Injectable()
+export class PrismaBookingReportRepository extends PrismaBookingReportRepositoryLib {
+  constructor(private readonly dbWrite: PrismaWriteService) {
+    super(dbWrite.prisma as unknown as PrismaClient);
+  }
+}

--- a/apps/api/v2/src/lib/repositories/prisma-watchlist.repository.ts
+++ b/apps/api/v2/src/lib/repositories/prisma-watchlist.repository.ts
@@ -1,0 +1,11 @@
+import { PrismaWatchlistRepository as PrismaWatchlistRepositoryLib } from "@calcom/platform-libraries/repositories";
+import type { PrismaClient } from "@calcom/prisma";
+import { Injectable } from "@nestjs/common";
+import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
+
+@Injectable()
+export class PrismaWatchlistRepository extends PrismaWatchlistRepositoryLib {
+  constructor(private readonly dbWrite: PrismaWriteService) {
+    super(dbWrite.prisma as unknown as PrismaClient);
+  }
+}

--- a/apps/api/v2/src/modules/organizations/bookings/inputs/report-booking-spam.input.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/inputs/report-booking-spam.input.ts
@@ -1,0 +1,13 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsOptional, IsString, MaxLength } from "class-validator";
+
+export class ReportBookingSpamInput {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  @ApiPropertyOptional({
+    description: "Optional description providing additional context about the spam report",
+    example: "This booker sent promotional content in the booking notes",
+  })
+  readonly description?: string;
+}

--- a/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.ts
@@ -1,10 +1,24 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { GetBookingsOutput_2024_08_13, GetOrganizationsBookingsInput } from "@calcom/platform-types";
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { BookingsService_2024_08_13 } from "@/ee/bookings/2024-08-13/services/bookings.service";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import {
+  OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER,
   OPTIONAL_X_CAL_CLIENT_ID_HEADER,
   OPTIONAL_X_CAL_SECRET_KEY_HEADER,
-  OPTIONAL_API_KEY_HEADER,
-  OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER,
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
@@ -14,12 +28,10 @@ import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.g
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
+import { ReportBookingSpamInput } from "@/modules/organizations/bookings/inputs/report-booking-spam.input";
+import { ReportBookingSpamOutput } from "@/modules/organizations/bookings/outputs/report-booking-spam.output";
+import { OrganizationsBookingsSpamReportService } from "@/modules/organizations/bookings/services/organizations-bookings-spam-report.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import { Controller, UseGuards, Get, Param, ParseIntPipe, Query, HttpStatus, HttpCode } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { GetBookingsOutput_2024_08_13, GetOrganizationsBookingsInput } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId/bookings",
@@ -31,7 +43,10 @@ import { GetBookingsOutput_2024_08_13, GetOrganizationsBookingsInput } from "@ca
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
 @ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
 export class OrganizationsBookingsController {
-  constructor(private readonly bookingsService: BookingsService_2024_08_13) {}
+  constructor(
+    private readonly bookingsService: BookingsService_2024_08_13,
+    private readonly spamReportService: OrganizationsBookingsSpamReportService
+  ) {}
 
   @Get("/")
   @ApiOperation({ summary: "Get organization bookings" })
@@ -55,6 +70,31 @@ export class OrganizationsBookingsController {
       status: SUCCESS_STATUS,
       data: bookings,
       pagination,
+    };
+  }
+
+  @Post("/:bookingUid/report-spam")
+  @ApiOperation({ summary: "Report a booking as spam" })
+  @Roles("ORG_ADMIN")
+  @PlatformPlan("ESSENTIALS")
+  @HttpCode(HttpStatus.OK)
+  async reportBookingAsSpam(
+    @Param("orgId", ParseIntPipe) orgId: number,
+    @Param("bookingUid") bookingUid: string,
+    @Body() body: ReportBookingSpamInput,
+    @GetUser() user: UserWithProfile
+  ): Promise<ReportBookingSpamOutput> {
+    const result = await this.spamReportService.reportBookingAsSpam({
+      bookingUid,
+      orgId,
+      userId: user.id,
+      userEmail: user.email,
+      description: body.description,
+    });
+
+    return {
+      status: SUCCESS_STATUS,
+      data: result,
     };
   }
 }

--- a/apps/api/v2/src/modules/organizations/bookings/organizations.bookings.module.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/organizations.bookings.module.ts
@@ -1,14 +1,18 @@
+import { Module } from "@nestjs/common";
 import { BookingsModule_2024_08_13 } from "@/ee/bookings/2024-08-13/bookings.module";
+import { PrismaBookingRepository } from "@/lib/repositories/prisma-booking.repository";
+import { PrismaBookingReportRepository } from "@/lib/repositories/prisma-booking-report.repository";
+import { PrismaWatchlistRepository } from "@/lib/repositories/prisma-watchlist.repository";
 import { MembershipsModule } from "@/modules/memberships/memberships.module";
 import { OrganizationsUsersRepository } from "@/modules/organizations//users/index/organizations-users.repository";
 import { OrganizationsBookingsController } from "@/modules/organizations/bookings/organizations-bookings.controller";
+import { OrganizationsBookingsSpamReportService } from "@/modules/organizations/bookings/services/organizations-bookings-spam-report.service";
 import { OrganizationsRepository } from "@/modules/organizations/index/organizations.repository";
 import { OrganizationsTeamsRepository } from "@/modules/organizations/teams/index/organizations-teams.repository";
 import { OrganizationsUsersService } from "@/modules/organizations/users/index/services/organizations-users-service";
 import { PrismaModule } from "@/modules/prisma/prisma.module";
 import { RedisModule } from "@/modules/redis/redis.module";
 import { StripeModule } from "@/modules/stripe/stripe.module";
-import { Module } from "@nestjs/common";
 
 @Module({
   imports: [BookingsModule_2024_08_13, PrismaModule, StripeModule, RedisModule, MembershipsModule],
@@ -17,6 +21,10 @@ import { Module } from "@nestjs/common";
     OrganizationsTeamsRepository,
     OrganizationsUsersService,
     OrganizationsUsersRepository,
+    OrganizationsBookingsSpamReportService,
+    PrismaBookingRepository,
+    PrismaBookingReportRepository,
+    PrismaWatchlistRepository,
   ],
   controllers: [OrganizationsBookingsController],
 })

--- a/apps/api/v2/src/modules/organizations/bookings/outputs/report-booking-spam.output.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/outputs/report-booking-spam.output.ts
@@ -1,0 +1,35 @@
+import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsBoolean, IsEnum, IsNumber, IsOptional, IsString } from "class-validator";
+
+class ReportBookingSpamData {
+  @ApiProperty({ description: "The UID of the reported booking" })
+  @IsString()
+  bookingUid!: string;
+
+  @ApiProperty({ description: "Number of booking reports created" })
+  @IsNumber()
+  reportedCount!: number;
+
+  @ApiProperty({ description: "Number of bookings cancelled" })
+  @IsNumber()
+  cancelledCount!: number;
+
+  @ApiProperty({ description: "Whether the booker email was added to the organization blocklist" })
+  @IsBoolean()
+  blocklisted!: boolean;
+
+  @ApiPropertyOptional({ description: "Additional details about the result" })
+  @IsOptional()
+  @IsString()
+  message?: string;
+}
+
+export class ReportBookingSpamOutput {
+  @ApiProperty({ example: SUCCESS_STATUS, enum: [SUCCESS_STATUS, ERROR_STATUS] })
+  @IsEnum([SUCCESS_STATUS, ERROR_STATUS])
+  status!: typeof SUCCESS_STATUS | typeof ERROR_STATUS;
+
+  @ApiProperty({ type: ReportBookingSpamData })
+  data!: ReportBookingSpamData;
+}

--- a/apps/api/v2/src/modules/organizations/bookings/services/organizations-bookings-spam-report.service.spec.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/services/organizations-bookings-spam-report.service.spec.ts
@@ -1,0 +1,304 @@
+import { BookingReportReason, BookingReportStatus, BookingStatus, WatchlistType } from "@calcom/prisma/enums";
+import { BadRequestException, ForbiddenException, Logger, NotFoundException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { PrismaBookingRepository } from "@/lib/repositories/prisma-booking.repository";
+import { PrismaBookingReportRepository } from "@/lib/repositories/prisma-booking-report.repository";
+import { PrismaWatchlistRepository } from "@/lib/repositories/prisma-watchlist.repository";
+import { OrganizationsBookingsSpamReportService } from "@/modules/organizations/bookings/services/organizations-bookings-spam-report.service";
+import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
+
+const mockCancelResult = {
+  success: true as const,
+  onlyRemovedAttendee: false as const,
+  bookingId: 1,
+  bookingUid: "test-uid",
+  message: "Booking cancelled",
+  isPlatformManagedUserBooking: false,
+};
+
+const mockHandleCancelBooking = jest.fn().mockResolvedValue(mockCancelResult);
+const mockDoesUserIdHaveAccessToBooking = jest.fn().mockResolvedValue(true);
+const mockNormalizeEmail = jest.fn().mockImplementation((email: string) => email.toLowerCase());
+
+jest.mock("@calcom/platform-libraries", () => ({
+  handleCancelBooking: (...args: unknown[]) => mockHandleCancelBooking(...args),
+  BookingAccessService: class {
+    doesUserIdHaveAccessToBooking(...args: unknown[]) {
+      return mockDoesUserIdHaveAccessToBooking(...args);
+    }
+  },
+  normalizeWatchlistEmail: (email: string) => mockNormalizeEmail(email),
+}));
+
+describe("OrganizationsBookingsSpamReportService", () => {
+  let service: OrganizationsBookingsSpamReportService;
+  let mockBookingRepo: {
+    findByUidIncludeReport: jest.Mock;
+    getActiveRecurringBookingsFromDate: jest.Mock;
+  };
+  let mockBookingReportRepo: {
+    createReport: jest.Mock;
+    findPendingReportsByEmail: jest.Mock;
+    bulkLinkWatchlistWithStatus: jest.Mock;
+  };
+  let mockWatchlistRepo: {
+    createEntryFromReport: jest.Mock;
+  };
+  let mockPrismaRead: {
+    prisma: {
+      booking: {
+        findMany: jest.Mock;
+      };
+    };
+  };
+
+  const orgId = 1;
+  const userId = 42;
+  const userEmail = "admin@org.com";
+  const bookingUid = "booking-uid-123";
+
+  beforeEach(async () => {
+    mockBookingRepo = {
+      findByUidIncludeReport: jest.fn(),
+      getActiveRecurringBookingsFromDate: jest.fn(),
+    };
+
+    mockBookingReportRepo = {
+      createReport: jest.fn().mockResolvedValue({ id: "report-1" }),
+      findPendingReportsByEmail: jest.fn().mockResolvedValue([]),
+      bulkLinkWatchlistWithStatus: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockWatchlistRepo = {
+      createEntryFromReport: jest.fn().mockResolvedValue({
+        watchlistEntry: { id: "watchlist-1" },
+        value: "spammer@test.com",
+      }),
+    };
+
+    mockPrismaRead = {
+      prisma: {
+        booking: {
+          findMany: jest.fn().mockResolvedValue([]),
+        },
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrganizationsBookingsSpamReportService,
+        { provide: PrismaReadService, useValue: mockPrismaRead },
+        { provide: PrismaBookingRepository, useValue: mockBookingRepo },
+        { provide: PrismaBookingReportRepository, useValue: mockBookingReportRepo },
+        { provide: PrismaWatchlistRepository, useValue: mockWatchlistRepo },
+      ],
+    }).compile();
+
+    service = module.get<OrganizationsBookingsSpamReportService>(OrganizationsBookingsSpamReportService);
+
+    jest.spyOn(Logger.prototype, "warn").mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  function createMockBooking(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 1,
+      uid: bookingUid,
+      startTime: new Date("2026-04-01"),
+      status: BookingStatus.ACCEPTED,
+      recurringEventId: null,
+      attendees: [{ email: "spammer@test.com" }],
+      report: null,
+      ...overrides,
+    };
+  }
+
+  describe("reportBookingAsSpam", () => {
+    it("reports a booking as spam, adds email to blocklist, and cancels upcoming bookings", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(createMockBooking());
+      mockPrismaRead.prisma.booking.findMany.mockResolvedValue([
+        { uid: "upcoming-1" },
+        { uid: "upcoming-2" },
+      ]);
+
+      const result = await service.reportBookingAsSpam({
+        bookingUid,
+        orgId,
+        userId,
+        userEmail,
+        description: "Spam booking",
+      });
+
+      expect(result.reportedCount).toBe(1);
+      expect(result.blocklisted).toBe(true);
+      expect(result.cancelledCount).toBe(2);
+      expect(result.bookingUid).toBe(bookingUid);
+
+      expect(mockBookingReportRepo.createReport).toHaveBeenCalledWith({
+        bookingUid,
+        bookerEmail: "spammer@test.com",
+        reportedById: userId,
+        reason: BookingReportReason.SPAM,
+        description: "Spam booking",
+        cancelled: false,
+        organizationId: orgId,
+      });
+
+      expect(mockWatchlistRepo.createEntryFromReport).toHaveBeenCalledWith({
+        type: WatchlistType.EMAIL,
+        value: "spammer@test.com",
+        organizationId: orgId,
+        isGlobal: false,
+        userId,
+        description: "Spam booking",
+      });
+
+      expect(mockHandleCancelBooking).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws ForbiddenException when user has no access to booking", async () => {
+      mockDoesUserIdHaveAccessToBooking.mockResolvedValueOnce(false);
+
+      await expect(service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail })).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it("throws NotFoundException when booking does not exist", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(null);
+
+      await expect(service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail })).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it("throws BadRequestException when booking is already reported", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(
+        createMockBooking({ report: { id: "existing-report" } })
+      );
+
+      await expect(service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail })).rejects.toThrow(
+        BadRequestException
+      );
+    });
+
+    it("throws BadRequestException when booking has no attendees", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(createMockBooking({ attendees: [] }));
+
+      await expect(service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail })).rejects.toThrow(
+        BadRequestException
+      );
+    });
+
+    it("reports all remaining recurring bookings when booking is recurring", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(
+        createMockBooking({ recurringEventId: "recurring-123" })
+      );
+      mockBookingRepo.getActiveRecurringBookingsFromDate.mockResolvedValue([
+        { id: 1, uid: "rec-1" },
+        { id: 2, uid: "rec-2" },
+        { id: 3, uid: "rec-3" },
+      ]);
+
+      const result = await service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail });
+
+      expect(result.reportedCount).toBe(3);
+      expect(mockBookingReportRepo.createReport).toHaveBeenCalledTimes(3);
+    });
+
+    it("links pending reports to watchlist entry when blocklisting succeeds", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(createMockBooking());
+      mockBookingReportRepo.findPendingReportsByEmail.mockResolvedValue([
+        { id: "report-1" },
+        { id: "report-2" },
+      ]);
+
+      await service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail });
+
+      expect(mockBookingReportRepo.bulkLinkWatchlistWithStatus).toHaveBeenCalledWith({
+        links: [
+          { reportId: "report-1", watchlistId: "watchlist-1" },
+          { reportId: "report-2", watchlistId: "watchlist-1" },
+        ],
+        status: BookingReportStatus.BLOCKED,
+      });
+    });
+
+    it("continues gracefully when blocklist creation fails", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(createMockBooking());
+      mockWatchlistRepo.createEntryFromReport.mockRejectedValue(new Error("DB error"));
+
+      const result = await service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail });
+
+      expect(result.blocklisted).toBe(false);
+      expect(result.reportedCount).toBe(1);
+    });
+
+    it("continues gracefully when cancelling a booking fails", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(createMockBooking());
+      mockPrismaRead.prisma.booking.findMany.mockResolvedValue([
+        { uid: "upcoming-1" },
+        { uid: "upcoming-2" },
+      ]);
+      mockHandleCancelBooking
+        .mockRejectedValueOnce(new Error("Cancel failed"))
+        .mockResolvedValueOnce(mockCancelResult);
+
+      const result = await service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail });
+
+      expect(result.cancelledCount).toBe(1);
+      expect(mockHandleCancelBooking).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses default description when none is provided", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(createMockBooking());
+
+      await service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail });
+
+      expect(mockWatchlistRepo.createEntryFromReport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: "Reported as spam via API",
+        })
+      );
+    });
+
+    it("passes correct cancellation params to handleCancelBooking", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(createMockBooking());
+      mockPrismaRead.prisma.booking.findMany.mockResolvedValue([{ uid: "upcoming-1" }]);
+
+      await service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail });
+
+      expect(mockHandleCancelBooking).toHaveBeenCalledWith({
+        bookingData: {
+          uid: "upcoming-1",
+          cancelledBy: userEmail,
+          skipCancellationReasonValidation: true,
+        },
+        userId,
+        impersonatedByUserUuid: null,
+        actionSource: "API_V2",
+      });
+    });
+
+    it("continues when report creation fails for individual bookings", async () => {
+      mockBookingRepo.findByUidIncludeReport.mockResolvedValue(
+        createMockBooking({ recurringEventId: "recurring-123" })
+      );
+      mockBookingRepo.getActiveRecurringBookingsFromDate.mockResolvedValue([
+        { id: 1, uid: "rec-1" },
+        { id: 2, uid: "rec-2" },
+      ]);
+      mockBookingReportRepo.createReport
+        .mockRejectedValueOnce(new Error("Report creation failed"))
+        .mockResolvedValueOnce({ id: "report-2" });
+
+      const result = await service.reportBookingAsSpam({ bookingUid, orgId, userId, userEmail });
+
+      expect(result.reportedCount).toBe(1);
+    });
+  });
+});

--- a/apps/api/v2/src/modules/organizations/bookings/services/organizations-bookings-spam-report.service.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/services/organizations-bookings-spam-report.service.ts
@@ -1,0 +1,192 @@
+import {
+  BookingAccessService,
+  handleCancelBooking,
+  normalizeWatchlistEmail,
+} from "@calcom/platform-libraries";
+import { BookingReportReason, BookingReportStatus, BookingStatus, WatchlistType } from "@calcom/prisma/enums";
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from "@nestjs/common";
+import { PrismaBookingRepository } from "@/lib/repositories/prisma-booking.repository";
+import { PrismaBookingReportRepository } from "@/lib/repositories/prisma-booking-report.repository";
+import { PrismaWatchlistRepository } from "@/lib/repositories/prisma-watchlist.repository";
+import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
+
+export interface ReportBookingSpamResult {
+  bookingUid: string;
+  reportedCount: number;
+  cancelledCount: number;
+  blocklisted: boolean;
+  message: string;
+}
+
+@Injectable()
+export class OrganizationsBookingsSpamReportService {
+  private readonly logger = new Logger("OrganizationsBookingsSpamReportService");
+
+  constructor(
+    private readonly dbRead: PrismaReadService,
+    private readonly bookingRepo: PrismaBookingRepository,
+    private readonly bookingReportRepo: PrismaBookingReportRepository,
+    private readonly watchlistRepo: PrismaWatchlistRepository
+  ) {}
+
+  async reportBookingAsSpam(params: {
+    bookingUid: string;
+    orgId: number;
+    userId: number;
+    userEmail: string;
+    description?: string;
+  }): Promise<ReportBookingSpamResult> {
+    const { bookingUid, orgId, userId, userEmail, description } = params;
+
+    const bookingAccessService = new BookingAccessService(this.dbRead.prisma);
+    const hasAccess = await bookingAccessService.doesUserIdHaveAccessToBooking({
+      userId,
+      bookingUid,
+    });
+
+    if (!hasAccess) {
+      throw new ForbiddenException("You don't have access to this booking");
+    }
+
+    const booking = await this.bookingRepo.findByUidIncludeReport({ bookingUid });
+
+    if (!booking) {
+      throw new NotFoundException("Booking not found");
+    }
+
+    if (booking.report) {
+      throw new BadRequestException("This booking has already been reported");
+    }
+
+    const bookerEmail = booking.attendees[0]?.email;
+    if (!bookerEmail) {
+      throw new BadRequestException("Booking has no attendees");
+    }
+
+    let reportedBookingUids: string[] = [bookingUid];
+    if (booking.recurringEventId) {
+      const remainingBookings = await this.bookingRepo.getActiveRecurringBookingsFromDate({
+        recurringEventId: booking.recurringEventId,
+        fromDate: booking.startTime,
+      });
+      reportedBookingUids = remainingBookings.map((b: { uid: string }) => b.uid);
+    }
+
+    let createdCount = 0;
+    for (const uid of reportedBookingUids) {
+      try {
+        await this.bookingReportRepo.createReport({
+          bookingUid: uid,
+          bookerEmail,
+          reportedById: userId,
+          reason: BookingReportReason.SPAM,
+          description,
+          cancelled: false,
+          organizationId: orgId,
+        });
+        createdCount++;
+      } catch (error) {
+        this.logger.warn(`Failed to create report for booking ${uid}: ${error}`);
+      }
+    }
+
+    const normalizedEmail = normalizeWatchlistEmail(bookerEmail);
+    let blocklisted = false;
+    let watchlistEntryId: string | null = null;
+    try {
+      const { watchlistEntry } = await this.watchlistRepo.createEntryFromReport({
+        type: WatchlistType.EMAIL,
+        value: normalizedEmail,
+        organizationId: orgId,
+        isGlobal: false,
+        userId,
+        description: description ?? "Reported as spam via API",
+      });
+      watchlistEntryId = watchlistEntry.id;
+      blocklisted = true;
+    } catch (error) {
+      this.logger.warn(`Failed to add ${normalizedEmail} to blocklist: ${error}`);
+    }
+
+    if (watchlistEntryId) {
+      const pendingReports = await this.bookingReportRepo.findPendingReportsByEmail({
+        email: normalizedEmail,
+        organizationId: orgId,
+      });
+      if (pendingReports.length > 0) {
+        await this.bookingReportRepo.bulkLinkWatchlistWithStatus({
+          links: pendingReports.map((r) => ({ reportId: r.id, watchlistId: watchlistEntryId })),
+          status: BookingReportStatus.BLOCKED,
+        });
+      }
+    }
+
+    let cancelledCount = 0;
+    const upcomingBookings = await this.findUpcomingBookingsByEmailInOrg({
+      bookerEmail: normalizedEmail,
+      orgId,
+    });
+
+    for (const upcomingBooking of upcomingBookings) {
+      try {
+        await handleCancelBooking({
+          bookingData: {
+            uid: upcomingBooking.uid,
+            cancelledBy: userEmail,
+            skipCancellationReasonValidation: true,
+          },
+          userId,
+          impersonatedByUserUuid: null,
+          actionSource: "API_V2",
+        });
+        cancelledCount++;
+      } catch (error) {
+        this.logger.warn(`Failed to cancel booking ${upcomingBooking.uid}: ${error}`);
+      }
+    }
+
+    const isRecurring = Boolean(booking.recurringEventId) && createdCount > 1;
+    const baseMessage = isRecurring ? `${createdCount} recurring bookings reported` : "Booking reported";
+
+    return {
+      bookingUid: reportedBookingUids[0],
+      reportedCount: createdCount,
+      cancelledCount,
+      blocklisted,
+      message: `${baseMessage} as spam, ${cancelledCount} booking(s) cancelled, email ${blocklisted ? "added to" : "not added to"} blocklist`,
+    };
+  }
+
+  private async findUpcomingBookingsByEmailInOrg(params: {
+    bookerEmail: string;
+    orgId: number;
+  }): Promise<Array<{ uid: string }>> {
+    const { bookerEmail, orgId } = params;
+
+    return this.dbRead.prisma.booking.findMany({
+      where: {
+        attendees: {
+          some: {
+            email: { equals: bookerEmail, mode: "insensitive" },
+          },
+        },
+        startTime: { gt: new Date() },
+        status: {
+          in: [BookingStatus.ACCEPTED, BookingStatus.PENDING, BookingStatus.AWAITING_HOST],
+        },
+        eventType: {
+          team: {
+            OR: [{ id: orgId }, { parentId: orgId }],
+          },
+        },
+      },
+      select: { uid: true },
+    });
+  }
+}

--- a/packages/platform/libraries/index.ts
+++ b/packages/platform/libraries/index.ts
@@ -133,3 +133,4 @@ export { verifyCodeChallenge } from "@calcom/lib/pkce";
 export { validateUrlForSSRFSync } from "@calcom/lib/ssrfProtection";
 export { checkEmailVerificationRequired } from "@calcom/trpc/server/routers/publicViewer/checkIfUserEmailVerificationRequired.handler";
 export { verifyCode as verifyCodeAuthenticated } from "@calcom/trpc/server/routers/viewer/organizations/verifyCode.handler";
+export { normalizeEmail as normalizeWatchlistEmail } from "@calcom/features/watchlist/lib/utils/normalization";

--- a/packages/platform/libraries/repositories.ts
+++ b/packages/platform/libraries/repositories.ts
@@ -16,3 +16,5 @@ export { PrismaBookingAttendeeRepository } from "@calcom/features/bookings/repos
 export { ProfileRepository as PrismaProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 export { AccessCodeRepository as PrismaAccessCodeRepository } from "@calcom/features/oauth/repositories/AccessCodeRepository";
 export { OAuthClientRepository as PrismaOAuthClientRepository } from "@calcom/features/oauth/repositories/OAuthClientRepository";
+export { PrismaBookingReportRepository } from "@calcom/features/bookingReport/repositories/PrismaBookingReportRepository";
+export { WatchlistRepository as PrismaWatchlistRepository } from "@calcom/features/watchlist/lib/repository/WatchlistRepository";


### PR DESCRIPTION
## What does this PR do?

Adds a new API V2 endpoint `POST /v2/organizations/:orgId/bookings/:bookingUid/report-spam` that allows org admins to report bookings as spam. When a booking is reported:

1. A `BookingReport` record is created with reason `SPAM` (handles recurring bookings by reporting all remaining instances)
2. The booker's email is normalized and added to the organization's blocklist (watchlist)
3. All upcoming bookings from that email within the org are silently cancelled via `handleCancelBooking`
4. Pending reports for the same email are linked to the new watchlist entry

The endpoint degrades gracefully — if blocklisting or individual cancellations fail, the operation continues and reports partial results.

**Endpoint:** `POST /v2/organizations/:orgId/bookings/:bookingUid/report-spam`
**Auth:** Requires `ORG_ADMIN` role, `ESSENTIALS` platform plan
**Body:** `{ description?: string }` (optional context for the spam report)

### New files
- **Service:** `OrganizationsBookingsSpamReportService` — core business logic
- **Input/Output DTOs** — request validation and response shape
- **Repository wrappers:** `PrismaBookingReportRepository`, `PrismaWatchlistRepository` — NestJS-injectable wrappers extending platform-libraries base classes
- **Unit tests:** 12 test cases covering happy path, error paths, recurring bookings, graceful degradation

### Supporting changes
- Exported `PrismaBookingReportRepository` and `WatchlistRepository` from `platform-libraries/repositories.ts`
- Exported `normalizeWatchlistEmail` from `platform-libraries/index.ts`
- Added `@calcom/platform-libraries` module name mappings to `apps/api/v2/jest.config.ts` (fixes pre-existing broken tests that mock this module)

## Important review items

1. **`BookingAccessService` is directly instantiated** (service.ts:43) rather than injected via DI — this was done because it requires the Prisma client in its constructor and is a stateless utility. Reviewer should confirm this is acceptable.
2. **`findUpcomingBookingsByEmailInOrg` accesses `this.dbRead.prisma` directly** (service.ts:168-189) instead of going through a repository — this is a one-off query scoped to this feature. Worth deciding if it should be extracted to a repository method.
3. **`booking.attendees[0]?.email`** is used to determine the booker's email — reviewer should verify the first attendee is always the booker in this context.
4. **`as unknown as PrismaClient`** cast in both repository wrappers follows existing patterns in the codebase but bypasses type safety.
5. **Jest config change is broad** — adds module resolution for all `@calcom/platform-libraries/*` imports, which could theoretically affect other tests.

## How should this be tested?

**Manual testing via API:**
1. Set environment variables: API key with `ORG_ADMIN` role, `orgId` of an organization with `ESSENTIALS` plan
2. Create a test booking with a recognizable email (e.g., `spam-test@example.com`)
3. Call `POST /v2/organizations/:orgId/bookings/:bookingUid/report-spam` with optional description
4. Verify response shows:
   - `reportedCount: 1` (or more for recurring bookings)
   - `blocklisted: true`
   - `cancelledCount: N` for upcoming bookings from that email
5. Verify in database:
   - `BookingReport` record created with `SPAM` reason
   - `Watchlist` entry exists for the email
   - Upcoming bookings are cancelled

**Recurring bookings:**
1. Create a recurring booking with multiple instances
2. Report the first instance as spam
3. Verify all remaining instances are reported (check `reportedCount` in response)

**Error cases (automated via unit tests):**
- User without access → `ForbiddenException`
- Booking already reported → `BadRequestException`
- Booking with no attendees → `BadRequestException`
- Graceful degradation when blocklisting fails
- Graceful degradation when individual cancellations fail

## Checklist

- [x] I have self-reviewed the code
- [x] I have updated the developer docs — N/A, endpoint is self-documenting via OpenAPI
- [x] I confirm automated tests are in place (12 unit tests, 100% code coverage for new service)
- [ ] My PR is not too large (11 files changed, 628 insertions) — most changes are new files; modified files have minimal changes

---

**Devin Session:** https://app.devin.ai/sessions/9f3760ffe9fc47638b075969f8d32222  
**Requested by:** @joeauyeung
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
