### PR TITLE
feat: add createdAt and updatedAt to date overrides in schedule API

### DIFF
--- a/apps/api/v2/src/ee/schedules/schedules_2024_06_11/services/output-schedules.service.ts
+++ b/apps/api/v2/src/ee/schedules/schedules_2024_06_11/services/output-schedules.service.ts
@@ -1,8 +1,7 @@
-import { UsersRepository } from "@/modules/users/users.repository";
-import { Injectable } from "@nestjs/common";
-
 import type { WeekDay } from "@calcom/platform-types";
 import type { Availability, Schedule } from "@calcom/prisma/client";
+import { Injectable } from "@nestjs/common";
+import { UsersRepository } from "@/modules/users/users.repository";
 
 type DatabaseSchedule = Schedule & { availability: Availability[] };
 
@@ -66,6 +65,8 @@ export class OutputSchedulesService_2024_06_11 {
         endTime: this.padHoursMinutesWithZeros(
           override.endTime.getUTCHours() + ":" + override.endTime.getUTCMinutes()
         ),
+        createdAt: override.createdAt?.toISOString() ?? null,
+        updatedAt: override.updatedAt?.toISOString() ?? null,
       })),
     };
   }

--- a/packages/lib/schedules/transformers/getScheduleListItemData.ts
+++ b/packages/lib/schedules/transformers/getScheduleListItemData.ts
@@ -12,6 +12,8 @@ export type Schedule = {
     date: Date | null;
     days: number[];
     scheduleId: number | null;
+    createdAt: Date | null;
+    updatedAt: Date | null;
   }[];
 };
 

--- a/packages/platform/types/schedules/schedules-2024-06-11/outputs/schedule.output.ts
+++ b/packages/platform/types/schedules/schedules-2024-06-11/outputs/schedule.output.ts
@@ -1,11 +1,63 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsBoolean, IsString, ValidateNested, IsArray, IsTimeZone, IsNumber } from "class-validator";
-
 import {
-  ScheduleAvailabilityInput_2024_06_11,
-  ScheduleOverrideInput_2024_06_11,
-} from "../inputs/create-schedule.input";
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsISO8601,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsTimeZone,
+  Matches,
+  ValidateNested,
+} from "class-validator";
+import { TIME_FORMAT_HH_MM } from "../constants";
+import { ScheduleAvailabilityInput_2024_06_11 } from "../inputs/create-schedule.input";
+
+export class ScheduleOverrideOutput_2024_06_11 {
+  @IsISO8601({ strict: true })
+  @ApiProperty({
+    example: "2024-05-20",
+  })
+  date!: string;
+
+  @IsString()
+  @Matches(TIME_FORMAT_HH_MM, { message: "startTime must be a valid time format HH:MM" })
+  @ApiProperty({
+    example: "12:00",
+    description: "startTime must be a valid time in format HH:MM e.g. 12:00",
+  })
+  startTime!: string;
+
+  @IsString()
+  @Matches(TIME_FORMAT_HH_MM, { message: "endTime must be a valid time format HH:MM" })
+  @ApiProperty({
+    example: "13:00",
+    description: "endTime must be a valid time in format HH:MM e.g. 13:00",
+  })
+  endTime!: string;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiPropertyOptional({
+    type: String,
+    example: "2024-05-20T00:00:00.000Z",
+    description: "The date and time when the override was created.",
+    nullable: true,
+  })
+  createdAt?: string | null;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiPropertyOptional({
+    type: String,
+    example: "2024-05-20T00:00:00.000Z",
+    description: "The date and time when the override was last updated.",
+    nullable: true,
+  })
+  updatedAt?: string | null;
+}
 
 export class ScheduleOutput_2024_06_11 {
   @IsNumber()
@@ -50,16 +102,18 @@ export class ScheduleOutput_2024_06_11 {
 
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => ScheduleOverrideInput_2024_06_11)
+  @Type(() => ScheduleOverrideOutput_2024_06_11)
   @ApiProperty({
-    type: [ScheduleOverrideInput_2024_06_11],
+    type: [ScheduleOverrideOutput_2024_06_11],
     example: [
       {
         date: "2024-05-20",
         startTime: "18:00",
         endTime: "21:00",
+        createdAt: "2024-05-20T00:00:00.000Z",
+        updatedAt: "2024-05-20T00:00:00.000Z",
       },
     ],
   })
-  overrides!: ScheduleOverrideInput_2024_06_11[];
+  overrides!: ScheduleOverrideOutput_2024_06_11[];
 }

--- a/packages/prisma/migrations/20260311195632_add_availability_timestamps/migration.sql
+++ b/packages/prisma/migrations/20260311195632_add_availability_timestamps/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."Availability" ADD COLUMN     "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -994,6 +994,8 @@ model Availability {
   date        DateTime?  @db.Date
   Schedule    Schedule?  @relation(fields: [scheduleId], references: [id])
   scheduleId  Int?
+  createdAt   DateTime?  @default(now())
+  updatedAt   DateTime?  @updatedAt
 
   @@index([userId])
   @@index([eventTypeId])


### PR DESCRIPTION
## What does this PR do?

Adds `createdAt` and `updatedAt` timestamp columns to the `Availability` Prisma model (which stores both regular availability and date overrides) and exposes them in the API V2 schedule endpoints, specifically in the overrides output.

This affects all endpoints that return schedule data with overrides, including:
- `GET /v2/organizations/{orgId}/users/{userId}/schedules`
- `GET /v2/organizations/{orgId}/users/{userId}/schedules/{scheduleId}`
- `GET /v2/schedules` and `GET /v2/schedules/{id}`
- `POST /v2/schedules` and `PATCH /v2/schedules/{id}`

### Changes:
1. **Prisma schema** (`packages/prisma/schema.prisma`) — Added nullable `createdAt` (`@default(now())`) and `updatedAt` (`@updatedAt`) to the `Availability` model. Nullable so existing rows get `null` rather than a backfilled timestamp.
2. **Migration** (`packages/prisma/migrations/20260311195632_add_availability_timestamps/`) — `ALTER TABLE` adding the two columns.
3. **Output DTO** (`packages/platform/types/.../schedule.output.ts`) — Created `ScheduleOverrideOutput_2024_06_11` (separate from the input DTO) with optional `createdAt`/`updatedAt` string fields. Updated `ScheduleOutput_2024_06_11` to use it.
4. **Output service** (`apps/api/v2/.../output-schedules.service.ts`) — Maps `override.createdAt` and `override.updatedAt` to ISO strings (or `null`) in the schedule response.
5. **Schedule type** (`packages/lib/schedules/transformers/getScheduleListItemData.ts`) — Added `createdAt` and `updatedAt` to the `Schedule` type so the availability page type-checks against the updated Prisma model.

### Non-breaking
The new fields are optional and nullable. Existing API consumers are unaffected — `createdAt`/`updatedAt` will simply appear as additional fields in the overrides array.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — OpenAPI docs auto-generate from NestJS decorators.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create or update a schedule with date overrides via the API V2 endpoints.
2. Fetch the schedule (e.g. `GET /v2/organizations/{orgId}/users/{userId}/schedules`) and verify each override object now includes `createdAt` and `updatedAt` fields.
3. For newly created overrides, both fields should be ISO date strings. For pre-existing overrides (created before this migration), both fields will be `null`.

## Important review notes

- **Delete-and-recreate pattern**: The repository's `updateSchedule` method deletes existing overrides and creates new ones rather than updating in-place. This means `updatedAt` will effectively always equal `createdAt` for overrides. Reviewers should confirm whether this is acceptable or if the update pattern should be changed.
- **No new tests added** for the output fields — worth considering whether an e2e or unit test should cover the new fields.
- **`getScheduleListItemData.ts` type update**: The `Schedule` type needed `createdAt`/`updatedAt` added because the Prisma model now includes them and the availability page passes data through this type. Reviewers should verify no callers of `getScheduleListItemData` are constructing `Schedule` objects without these fields.
- The import reordering in `output-schedules.service.ts` was applied by the pre-commit biome formatter, not a manual change.

Link to Devin session: https://app.devin.ai/sessions/6a6d61891e554d9bb75a91d1e4afc7d3
Requested by: @joeauyeung
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
