### PR TITLE
fix: skip queuing booking webhook tasks when no subscribers match

### DIFF
--- a/packages/features/di/webhooks/modules/WebhookProducerService.module.ts
+++ b/packages/features/di/webhooks/modules/WebhookProducerService.module.ts
@@ -1,9 +1,9 @@
 import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
 import { moduleLoader as loggerServiceModule } from "@calcom/features/di/shared/services/logger.service";
 import { WebhookTaskerProducerService } from "@calcom/features/webhooks/lib/service/WebhookTaskerProducerService";
-
 import { moduleLoader as webhookTaskerModule } from "../tasker/WebhookTasker.module";
 import { WEBHOOK_TOKENS } from "../Webhooks.tokens";
+import { moduleLoader as webhookRepositoryModule } from "./WebhookRepository.module";
 
 /**
  * Producer Service Module
@@ -26,6 +26,7 @@ const loadModule = bindModuleToClassOnToken({
   classs: WebhookTaskerProducerService,
   depsMap: {
     webhookTasker: webhookTaskerModule,
+    webhookRepository: webhookRepositoryModule,
     logger: loggerServiceModule,
   },
 });

--- a/packages/features/di/webhooks/modules/WebhookRepository.module.ts
+++ b/packages/features/di/webhooks/modules/WebhookRepository.module.ts
@@ -1,0 +1,24 @@
+import type { ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as prismaModuleLoader } from "../../modules/Prisma";
+import { WEBHOOK_TOKENS } from "../Webhooks.tokens";
+import { webhookModule } from "./Webhook.module";
+
+const token = WEBHOOK_TOKENS.WEBHOOK_REPOSITORY;
+
+/**
+ * ModuleLoader for the WebhookRepository.
+ *
+ * Reuses the existing webhookModule which already binds WEBHOOK_REPOSITORY
+ * along with its dependencies (Prisma, EventTypeRepository, UsersRepository).
+ */
+export const moduleLoader = {
+  token,
+  loadModule(container) {
+    // Ensure Prisma is loaded (required by webhookModule bindings)
+    prismaModuleLoader.loadModule(container);
+    // Load webhook module which binds WEBHOOK_REPOSITORY and its cross-table dependencies
+    container.load(WEBHOOK_TOKENS.WEBHOOK_EVENT_TYPE_REPOSITORY, webhookModule);
+    container.load(WEBHOOK_TOKENS.WEBHOOK_USER_REPOSITORY, webhookModule);
+    container.load(WEBHOOK_TOKENS.WEBHOOK_REPOSITORY, webhookModule);
+  },
+} satisfies ModuleLoader;

--- a/packages/features/webhooks/lib/__tests__/producer/WebhookTaskerProducerService.test.ts
+++ b/packages/features/webhooks/lib/__tests__/producer/WebhookTaskerProducerService.test.ts
@@ -1,9 +1,9 @@
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
+import type { IWebhookRepository } from "../../interface/IWebhookRepository";
 import type { ILogger } from "../../interface/infrastructure";
-import type { WebhookTasker } from "../../tasker/WebhookTasker";
 import { WebhookTaskerProducerService } from "../../service/WebhookTaskerProducerService";
+import type { WebhookTasker } from "../../tasker/WebhookTasker";
 
 /**
  * Unit Tests for WebhookTaskerProducerService
@@ -15,12 +15,34 @@ import { WebhookTaskerProducerService } from "../../service/WebhookTaskerProduce
 describe("WebhookTaskerProducerService", () => {
   let producer: WebhookTaskerProducerService;
   let mockWebhookTasker: WebhookTasker;
+  let mockWebhookRepository: IWebhookRepository;
   let mockLogger: ILogger;
+
+  const defaultSubscriber = {
+    id: "sub-1",
+    subscriberUrl: "https://example.com/webhook",
+    payloadTemplate: null,
+    appId: null,
+    secret: null,
+    time: null,
+    timeUnit: null,
+    eventTriggers: [WebhookTriggerEvents.BOOKING_CREATED],
+    version: "2021-10-20" as const,
+  };
 
   beforeEach(() => {
     mockWebhookTasker = {
       deliverWebhook: vi.fn().mockResolvedValue({ taskId: "mock-task-id" }),
     } as unknown as WebhookTasker;
+
+    mockWebhookRepository = {
+      getSubscribers: vi.fn().mockResolvedValue([defaultSubscriber]),
+      getWebhookById: vi.fn(),
+      findByWebhookId: vi.fn(),
+      findByOrgIdAndTrigger: vi.fn(),
+      getFilteredWebhooksForUser: vi.fn(),
+      listWebhooks: vi.fn(),
+    } as unknown as IWebhookRepository;
 
     mockLogger = {
       debug: vi.fn(),
@@ -32,6 +54,7 @@ describe("WebhookTaskerProducerService", () => {
 
     producer = new WebhookTaskerProducerService({
       webhookTasker: mockWebhookTasker,
+      webhookRepository: mockWebhookRepository,
       logger: mockLogger,
     });
   });
@@ -58,12 +81,40 @@ describe("WebhookTaskerProducerService", () => {
 
       await producer.queueBookingRequestedWebhook(params);
 
+      expect(mockWebhookRepository.getSubscribers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          triggerEvent: WebhookTriggerEvents.BOOKING_REQUESTED,
+          userId: 789,
+          eventTypeId: 456,
+        })
+      );
+
       expect(mockWebhookTasker.deliverWebhook).toHaveBeenCalledWith(
         expect.objectContaining({
           triggerEvent: WebhookTriggerEvents.BOOKING_REQUESTED,
           bookingUid: "booking-123",
           eventTypeId: 456,
           userId: 789,
+        })
+      );
+    });
+
+    it("should not queue task when no subscribers match", async () => {
+      vi.mocked(mockWebhookRepository.getSubscribers).mockResolvedValueOnce([]);
+
+      await producer.queueBookingRequestedWebhook({
+        bookingUid: "booking-123",
+        eventTypeId: 456,
+        userId: 789,
+      });
+
+      expect(mockWebhookRepository.getSubscribers).toHaveBeenCalled();
+      expect(mockWebhookTasker.deliverWebhook).not.toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "No webhook subscribers found, skipping task queue",
+        expect.objectContaining({
+          triggerEvent: WebhookTriggerEvents.BOOKING_REQUESTED,
+          bookingUid: "booking-123",
         })
       );
     });
@@ -148,6 +199,17 @@ describe("WebhookTaskerProducerService", () => {
           error: "Tasker error",
         })
       );
+    });
+
+    it("should propagate errors from webhookRepository.getSubscribers", async () => {
+      const error = new Error("DB connection failed");
+      vi.mocked(mockWebhookRepository.getSubscribers).mockRejectedValueOnce(error);
+
+      await expect(producer.queueBookingRequestedWebhook({ bookingUid: "booking-123" })).rejects.toThrow(
+        "DB connection failed"
+      );
+
+      expect(mockWebhookTasker.deliverWebhook).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/features/webhooks/lib/__tests__/webhookDelivery.integration-test.ts
+++ b/packages/features/webhooks/lib/__tests__/webhookDelivery.integration-test.ts
@@ -71,7 +71,7 @@ describe("Webhook Producer Integration", () => {
         id: `webhook-producer-test-${testId}`,
         userId: testUser.id,
         subscriberUrl: "https://example.com/webhook",
-        eventTriggers: [WebhookTriggerEvents.BOOKING_CREATED],
+        eventTriggers: [WebhookTriggerEvents.BOOKING_CREATED, WebhookTriggerEvents.BOOKING_REQUESTED],
         active: true,
       },
     });

--- a/packages/features/webhooks/lib/service/WebhookTaskerProducerService.ts
+++ b/packages/features/webhooks/lib/service/WebhookTaskerProducerService.ts
@@ -1,6 +1,7 @@
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 import { v4 as uuidv4 } from "uuid";
 import type { BookingTriggerEvents, PaymentTriggerEvents } from "../factory/versioned/PayloadBuilderFactory";
+import type { IWebhookRepository } from "../interface/IWebhookRepository";
 import type { ILogger } from "../interface/infrastructure";
 import type {
   IWebhookProducerService,
@@ -26,6 +27,7 @@ import type { WebhookTaskPayload } from "../types/webhookTask";
  */
 export interface IWebhookTaskerProducerServiceDeps {
   webhookTasker: WebhookTasker;
+  webhookRepository: IWebhookRepository;
   logger: ILogger;
 }
 
@@ -147,7 +149,8 @@ export class WebhookTaskerProducerService implements IWebhookProducerService {
   }
 
   /**
-   * Internal helper to queue booking-related webhooks
+   * Internal helper to queue booking-related webhooks.
+   * Checks for matching subscribers before queuing to avoid unnecessary task creation.
    */
   private async queueBookingWebhook(
     triggerEvent: Exclude<
@@ -157,6 +160,24 @@ export class WebhookTaskerProducerService implements IWebhookProducerService {
     params: QueueBookingWebhookParams
   ): Promise<void> {
     const operationId = params.operationId || uuidv4();
+
+    const subscribers = await this.deps.webhookRepository.getSubscribers({
+      triggerEvent,
+      userId: params.userId,
+      eventTypeId: params.eventTypeId,
+      teamId: params.teamId,
+      orgId: params.orgId,
+      oAuthClientId: params.oAuthClientId,
+    });
+
+    if (subscribers.length === 0) {
+      this.log.debug("No webhook subscribers found, skipping task queue", {
+        operationId,
+        triggerEvent,
+        bookingUid: params.bookingUid,
+      });
+      return;
+    }
 
     this.log.debug("Queueing booking webhook task", {
       operationId,

--- a/packages/features/webhooks/lib/service/__tests__/WebhookTaskerProducerService.test.ts
+++ b/packages/features/webhooks/lib/service/__tests__/WebhookTaskerProducerService.test.ts
@@ -1,6 +1,6 @@
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
+import type { IWebhookRepository } from "../../interface/IWebhookRepository";
 import type { ILogger } from "../../interface/infrastructure";
 import type { WebhookTasker } from "../../tasker/WebhookTasker";
 import { WebhookTaskerProducerService } from "../WebhookTaskerProducerService";
@@ -13,13 +13,36 @@ import { WebhookTaskerProducerService } from "../WebhookTaskerProducerService";
 describe("WebhookTaskerProducerService", () => {
   let producer: WebhookTaskerProducerService;
   let mockWebhookTasker: WebhookTasker;
+  let mockWebhookRepository: IWebhookRepository;
   let mockLogger: ILogger;
+
+  const defaultSubscriber = {
+    id: "sub-1",
+    subscriberUrl: "https://example.com/webhook",
+    payloadTemplate: null,
+    appId: null,
+    secret: null,
+    time: null,
+    timeUnit: null,
+    eventTriggers: [WebhookTriggerEvents.BOOKING_CREATED],
+    version: "2021-10-20" as const,
+  };
 
   beforeEach(() => {
     // Mock WebhookTasker
     mockWebhookTasker = {
       deliverWebhook: vi.fn().mockResolvedValue({ taskId: "task-id-123" }),
     } as unknown as WebhookTasker;
+
+    // Mock WebhookRepository - default to returning subscribers
+    mockWebhookRepository = {
+      getSubscribers: vi.fn().mockResolvedValue([defaultSubscriber]),
+      getWebhookById: vi.fn(),
+      findByWebhookId: vi.fn(),
+      findByOrgIdAndTrigger: vi.fn(),
+      getFilteredWebhooksForUser: vi.fn(),
+      listWebhooks: vi.fn(),
+    } as unknown as IWebhookRepository;
 
     // Mock Logger
     mockLogger = {
@@ -32,6 +55,7 @@ describe("WebhookTaskerProducerService", () => {
 
     producer = new WebhookTaskerProducerService({
       webhookTasker: mockWebhookTasker,
+      webhookRepository: mockWebhookRepository,
       logger: mockLogger,
     });
   });
@@ -57,6 +81,14 @@ describe("WebhookTaskerProducerService", () => {
         userId: 789,
       });
 
+      expect(mockWebhookRepository.getSubscribers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          triggerEvent: WebhookTriggerEvents.BOOKING_CREATED,
+          userId: 789,
+          eventTypeId: 456,
+        })
+      );
+
       expect(mockWebhookTasker.deliverWebhook).toHaveBeenCalledWith(
         expect.objectContaining({
           triggerEvent: WebhookTriggerEvents.BOOKING_CREATED,
@@ -65,6 +97,26 @@ describe("WebhookTaskerProducerService", () => {
           userId: 789,
           operationId: expect.any(String),
           timestamp: expect.any(String),
+        })
+      );
+    });
+
+    it("should not queue task when no subscribers match", async () => {
+      vi.mocked(mockWebhookRepository.getSubscribers).mockResolvedValueOnce([]);
+
+      await producer.queueBookingCreatedWebhook({
+        bookingUid: "booking-123",
+        eventTypeId: 456,
+        userId: 789,
+      });
+
+      expect(mockWebhookRepository.getSubscribers).toHaveBeenCalled();
+      expect(mockWebhookTasker.deliverWebhook).not.toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "No webhook subscribers found, skipping task queue",
+        expect.objectContaining({
+          triggerEvent: WebhookTriggerEvents.BOOKING_CREATED,
+          bookingUid: "booking-123",
         })
       );
     });
@@ -165,6 +217,19 @@ describe("WebhookTaskerProducerService", () => {
           error: "WebhookTasker failed",
         })
       );
+    });
+
+    it("should propagate errors from webhookRepository.getSubscribers", async () => {
+      const error = new Error("DB connection failed");
+      vi.mocked(mockWebhookRepository.getSubscribers).mockRejectedValueOnce(error);
+
+      await expect(
+        producer.queueBookingCreatedWebhook({
+          bookingUid: "booking-123",
+        })
+      ).rejects.toThrow("DB connection failed");
+
+      expect(mockWebhookTasker.deliverWebhook).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## What does this PR do?

Prevents `WebhookTaskerProducerService.queueBookingWebhook` from queuing unnecessary tasks when there are no webhook subscribers matching the payload. Before this change, every booking webhook event would queue a task to the tasker (Trigger.dev), even if no webhooks existed in the database for that trigger/user/team combination. The consumer would then query subscribers and immediately return — wasting task queue capacity.

Now, `queueBookingWebhook` calls `webhookRepository.getSubscribers()` first and returns early if the result is empty.

### Changes

- **`WebhookTaskerProducerService.ts`**: Added `webhookRepository` to the deps interface. In `queueBookingWebhook`, queries subscribers before queuing and skips if none match.
- **`WebhookRepository.module.ts`** (new): Exposes `WebhookRepository` as a `ModuleLoader` for the newer DI pattern, reusing the existing `webhookModule` bindings.
- **`WebhookProducerService.module.ts`**: Wires the new `webhookRepository` dependency into the producer's `depsMap`.
- **`webhookDelivery.integration-test.ts`**: Fixed pre-existing mismatch — the test webhook now subscribes to `BOOKING_REQUESTED` (matching the trigger the test exercises), not just `BOOKING_CREATED`.
- **Unit tests**: Updated both test suites with mock repository, added tests for the early-return path and error propagation (38 tests pass).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run unit tests:
   ```
   TZ=UTC yarn vitest run packages/features/webhooks/lib/service/__tests__/WebhookTaskerProducerService.test.ts packages/features/webhooks/lib/__tests__/producer/WebhookTaskerProducerService.test.ts
   ```
2. All 38 tests should pass, including the new "should not queue task when no subscribers match" and "should propagate errors from webhookRepository.getSubscribers" cases.

## Important review notes

- **Scope**: The subscriber check is only added to `queueBookingWebhook` (booking-related triggers). Payment, form, recording, and OOO webhook methods are unchanged — reviewer should confirm this is the desired scope.
- **Tradeoff**: The producer was previously designed to be lightweight with no DB access. This adds a `getSubscribers` DB query per booking webhook call. The query uses optimized raw SQL with UNION ALL, but this is a meaningful architectural change worth confirming.
- **DI wiring**: `WebhookRepository.module.ts` loads the full `webhookModule` into the container to get the repository and its transitive dependencies (Prisma, EventTypeRepository, UsersRepository). Verify no unnecessary overhead or circular dependencies arise.
- **Integration test fix**: The existing test had `eventTriggers: [BOOKING_CREATED]` but tested `queueBookingRequestedWebhook` (`BOOKING_REQUESTED`). This mismatch was hidden before because the producer never checked subscribers. Now corrected to include both triggers.

<!-- Link to Devin Session: https://app.devin.ai/sessions/b42b8ceed1804305a15ac18b7a5379cd -->
<!-- Requested by: @ThyMinimalDev -->