### PR TITLE
feat: add Agent API Key option to API key creation dialog

### DIFF
--- a/apps/api/v2/src/lib/api-key/api-key.test.ts
+++ b/apps/api/v2/src/lib/api-key/api-key.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { isApiKey, sha256Hash, stripApiKey } from "./index";
+
+describe("api-key utilities", () => {
+  describe("sha256Hash", () => {
+    it("should produce a consistent hash for the same input", () => {
+      const hash1 = sha256Hash("test-key");
+      const hash2 = sha256Hash("test-key");
+      expect(hash1).toBe(hash2);
+    });
+
+    it("should produce different hashes for different inputs", () => {
+      expect(sha256Hash("key-a")).not.toBe(sha256Hash("key-b"));
+    });
+  });
+
+  describe("isApiKey", () => {
+    it("should return true for keys starting with the given prefix", () => {
+      expect(isApiKey("cal_abc123", "cal_")).toBe(true);
+    });
+
+    it("should return true for agent keys starting with prefix+agent_", () => {
+      expect(isApiKey("cal_agent_abc123", "cal_")).toBe(true);
+    });
+
+    it("should return false for keys not starting with the prefix", () => {
+      expect(isApiKey("Bearer some-token", "cal_")).toBe(false);
+    });
+  });
+
+  describe("stripApiKey", () => {
+    it("should strip the base prefix from a regular API key", () => {
+      expect(stripApiKey("cal_abc123", "cal_")).toBe("abc123");
+    });
+
+    it("should strip the agent prefix from an agent API key", () => {
+      expect(stripApiKey("cal_agent_abc123", "cal_")).toBe("abc123");
+    });
+
+    it("should use default prefix when none is provided", () => {
+      expect(stripApiKey("cal_abc123")).toBe("abc123");
+    });
+
+    it("should strip default agent prefix when no prefix is provided", () => {
+      expect(stripApiKey("cal_agent_abc123")).toBe("abc123");
+    });
+
+    it("should work with custom prefixes", () => {
+      expect(stripApiKey("custom_abc123", "custom_")).toBe("abc123");
+      expect(stripApiKey("custom_agent_abc123", "custom_")).toBe("abc123");
+    });
+
+    it("should produce the same raw key for regular and agent keys", () => {
+      const rawKey = "abc123def456";
+      const regularKey = `cal_${rawKey}`;
+      const agentKey = `cal_agent_${rawKey}`;
+
+      expect(stripApiKey(regularKey, "cal_")).toBe(rawKey);
+      expect(stripApiKey(agentKey, "cal_")).toBe(rawKey);
+    });
+
+    it("should produce matching hashes for regular and agent keys with the same raw key", () => {
+      const rawKey = "abc123def456";
+      const regularStripped = stripApiKey(`cal_${rawKey}`, "cal_");
+      const agentStripped = stripApiKey(`cal_agent_${rawKey}`, "cal_");
+
+      expect(sha256Hash(regularStripped)).toBe(sha256Hash(agentStripped));
+    });
+  });
+});

--- a/apps/api/v2/src/lib/api-key/index.ts
+++ b/apps/api/v2/src/lib/api-key/index.ts
@@ -2,7 +2,18 @@ import { createHash } from "node:crypto";
 
 export const sha256Hash = (token: string): string => createHash("sha256").update(token).digest("hex");
 
+const AGENT_KEY_INFIX = "agent_";
+
 export const isApiKey = (authString: string, prefix: string): boolean =>
   authString?.startsWith(prefix ?? "cal_");
 
-export const stripApiKey = (apiKey: string, prefix?: string): string => apiKey.replace(prefix ?? "cal_", "");
+export const stripApiKey = (apiKey: string, prefix?: string): string => {
+  const basePrefix = prefix ?? "cal_";
+  const agentPrefix = `${basePrefix}${AGENT_KEY_INFIX}`;
+
+  if (apiKey.startsWith(agentPrefix)) {
+    return apiKey.slice(agentPrefix.length);
+  }
+
+  return apiKey.slice(basePrefix.length);
+};

--- a/apps/web/modules/ee/api-keys/components/ApiKeyDialogForm.tsx
+++ b/apps/web/modules/ee/api-keys/components/ApiKeyDialogForm.tsx
@@ -1,23 +1,18 @@
-import Link from "next/link";
-import { useState } from "react";
-import { Controller, useForm } from "react-hook-form";
-
 import dayjs from "@calcom/dayjs";
-import type { TApiKeys } from "~/ee/api-keys/components/ApiKeyListItem";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
-import { API_NAME_LENGTH_MAX_LIMIT } from "@calcom/lib/constants";
-import { IS_CALCOM } from "@calcom/lib/constants";
+import { API_NAME_LENGTH_MAX_LIMIT, IS_CALCOM } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
 import { DialogFooter } from "@calcom/ui/components/dialog";
-import { Form } from "@calcom/ui/components/form";
-import { TextField } from "@calcom/ui/components/form";
-import { SelectField } from "@calcom/ui/components/form";
-import { Switch } from "@calcom/ui/components/form";
+import { Form, SelectField, Switch, TextField } from "@calcom/ui/components/form";
 import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import { revalidateApiKeysList } from "@calcom/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/actions";
+import Link from "next/link";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import type { TApiKeys } from "~/ee/api-keys/components/ApiKeyListItem";
+import LicenseRequired from "~/ee/common/components/LicenseRequired";
 
 export default function ApiKeyDialogForm({
   defaultValues,
@@ -51,6 +46,8 @@ export default function ApiKeyDialogForm({
     note: "" as string | null,
     neverExpires: false,
   });
+
+  const [keyType, setKeyType] = useState<"api_key" | "agent">("api_key");
 
   const form = useForm({
     defaultValues: {
@@ -143,7 +140,7 @@ export default function ApiKeyDialogForm({
             if (defaultValues) {
               await updateApiKeyMutation.mutate({ id: defaultValues.id, note: event.note });
             } else {
-              const apiKey = await utils.client.viewer.apiKeys.create.mutate(event);
+              const apiKey = await utils.client.viewer.apiKeys.create.mutate({ ...event, keyType });
               setApiKey(apiKey);
               setApiKeyDetails({ ...event });
               await utils.viewer.apiKeys.list.invalidate();
@@ -158,9 +155,22 @@ export default function ApiKeyDialogForm({
             </h2>
             {IS_CALCOM ? (
               <div className="mt-4 flex flex-col gap-2 sm:flex-row">
-                <div className="border-emphasis relative flex w-full items-start rounded-[10px] border p-4 text-sm">
+                <button
+                  type="button"
+                  onClick={() => setKeyType("api_key")}
+                  className={`relative flex w-full cursor-pointer items-start rounded-[10px] border p-4 text-left text-sm ${
+                    keyType === "api_key" ? "border-emphasis ring-emphasis ring-1" : "border-subtle"
+                  }`}>
                   {t("api_key_modal_subtitle")}
-                </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setKeyType("agent")}
+                  className={`relative flex w-full cursor-pointer items-start rounded-[10px] border p-4 text-left text-sm ${
+                    keyType === "agent" ? "border-emphasis ring-emphasis ring-1" : "border-subtle"
+                  }`}>
+                  {t("agent_api_key_modal_subtitle")}
+                </button>
                 <Link
                   target="_blank"
                   rel="noopener noreferrer"

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -1487,7 +1487,7 @@
   "test_failed": "Test failed",
   "provide_api_key": "Provide API key",
   "api_key_modal_subtitle": "API keys allow you to make API calls for your own account.",
-  "agent_api_key_modal_subtitle": "Agent API Key allows your agent to make API calls on behalf of you.",
+  "agent_api_key_modal_subtitle": "An Agent API Key allows your agent to make API calls on your behalf.",
   "api_key_modal_subtitle_platform": "Create an OAuth app and allow user to schedule.",
   "api_keys_subtitle": "Generate API keys to use for accessing your own account.",
   "create_api_key": "Create an API key",

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -1487,6 +1487,7 @@
   "test_failed": "Test failed",
   "provide_api_key": "Provide API key",
   "api_key_modal_subtitle": "API keys allow you to make API calls for your own account.",
+  "agent_api_key_modal_subtitle": "Agent API Key allows your agent to make API calls on behalf of you.",
   "api_key_modal_subtitle_platform": "Create an OAuth app and allow user to schedule.",
   "api_keys_subtitle": "Generate API keys to use for accessing your own account.",
   "create_api_key": "Create an API key",

--- a/packages/trpc/server/routers/viewer/apiKeys/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/apiKeys/create.handler.ts
@@ -1,9 +1,8 @@
-import { v4 } from "uuid";
-
+import process from "node:process";
 import { generateUniqueAPIKey } from "@calcom/ee/api-keys/lib/apiKeys";
 import prisma from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
-
+import { v4 } from "uuid";
 import type { TrpcSessionUser } from "../../../types";
 import { checkPermissions } from "./_auth-middleware";
 import type { TCreateInputSchema } from "./create.schema";
@@ -19,7 +18,7 @@ export const createHandler = async ({ ctx, input }: CreateHandlerOptions) => {
   const [hashedApiKey, apiKey] = generateUniqueAPIKey();
 
   // Here we snap never expires before deleting it so it's not passed to prisma create call.
-  const { neverExpires, teamId, ...rest } = input;
+  const { neverExpires, teamId, keyType, ...rest } = input;
   const userId = ctx.user.id;
 
   /** Only admin or owner can create apiKeys of team (if teamId is passed) */
@@ -37,7 +36,8 @@ export const createHandler = async ({ ctx, input }: CreateHandlerOptions) => {
     },
   });
 
-  const apiKeyPrefix = process.env.API_KEY_PREFIX ?? "cal_";
+  const baseApiKeyPrefix = process.env.API_KEY_PREFIX ?? "cal_";
+  const apiKeyPrefix = keyType === "agent" ? `${baseApiKeyPrefix}agent_` : baseApiKeyPrefix;
 
   const prefixedApiKey = `${apiKeyPrefix}${apiKey}`;
 

--- a/packages/trpc/server/routers/viewer/apiKeys/create.schema.ts
+++ b/packages/trpc/server/routers/viewer/apiKeys/create.schema.ts
@@ -6,6 +6,7 @@ export type TCreateInputSchema = {
   neverExpires?: boolean;
   appId?: string | null;
   teamId?: number;
+  keyType?: "api_key" | "agent";
 };
 
 export const ZCreateInputSchema: z.ZodType<TCreateInputSchema> = z.object({
@@ -14,4 +15,5 @@ export const ZCreateInputSchema: z.ZodType<TCreateInputSchema> = z.object({
   neverExpires: z.boolean().optional(),
   appId: z.string().optional().nullable(),
   teamId: z.number().optional(),
+  keyType: z.enum(["api_key", "agent"]).optional(),
 });


### PR DESCRIPTION
## What does this PR do?

Adds a third "Agent API Key" option to the API key creation dialog, positioned between the existing "API Key" and "OAuth" options (on cal.com only).

When a user selects "Agent API Key", the generated key is prefixed with `cal_agent_` instead of the default `cal_` prefix. The API v2 key verification (`stripApiKey`) is updated to correctly strip both `cal_agent_` and `cal_` prefixes so that agent keys authenticate successfully.

**Changes:**
- **UI** (`ApiKeyDialogForm.tsx`): The existing static info card is now a selectable button; a new "Agent API Key" button is added with a ring/border style to indicate selection state.
- **Schema** (`create.schema.ts`): Adds optional `keyType: "api_key" | "agent"` field (non-breaking, defaults to undefined → regular key).
- **Handler** (`create.handler.ts`): Uses `keyType` to build the appropriate prefix (`cal_agent_` for agent, `cal_` otherwise).
- **API v2 verification** (`api-key/index.ts`): `stripApiKey` now checks for the longer `cal_agent_` prefix first, falling back to the base prefix.
- **i18n**: Adds `agent_api_key_modal_subtitle` translation string.
- **Tests**: 12 unit tests covering `stripApiKey` with agent prefix, hash consistency, and custom prefixes.

> **Note:** API v1 verification was intentionally left unchanged per team guidance — only v2 was updated.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to **Settings → Developer → API Keys** and click **Add**.
2. On cal.com (not self-hosted), the dialog should show three selectable cards: **API Key** (selected by default), **Agent API Key**, and **OAuth** (external link).
3. Select "Agent API Key", fill in a name, and create.
4. The generated key should start with `cal_agent_` (e.g. `cal_agent_abc123...`).
5. Selecting "API Key" and creating should produce a key starting with `cal_` as before.
6. Agent keys should authenticate successfully against API v2 endpoints.

## Human Review Checklist

- [ ] **UI styling**: Verify the three selectable cards render correctly side-by-side, with proper active/inactive states (ring on selected, subtle border on others).
- [ ] **V1 scope**: Confirm it's acceptable that API v1 does _not_ handle the `cal_agent_` prefix (agent keys will only work with v2).
- [ ] **No DB persistence of key type**: The agent vs. regular distinction lives only in the prefix — there is no column to query/filter by key type later. Verify this is intentional.
- [ ] **`stripApiKey` behavior change**: The function now uses `slice()` instead of `replace()` for both regular and agent keys. Functionally equivalent for well-formed keys, but a subtle change worth confirming.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is not too large

---

Link to Devin session: https://app.devin.ai/sessions/58bb12087b5446d98563a096dfbfc881
Requested by: @PeerRich