### PR TITLE
docs: add README for sfdc-package

### DIFF
--- a/packages/app-store/salesforce/sfdc-package/README.md
+++ b/packages/app-store/salesforce/sfdc-package/README.md
@@ -1,0 +1,109 @@
+# Cal.com SFDC Package
+
+An unlocked Salesforce package that syncs Salesforce User record changes to Cal.com in real time.
+
+## What It Does
+
+When a Salesforce User record is updated (e.g. name, email, title, department), the package automatically detects the changed fields and sends them to Cal.com's `/api/integrations/salesforce/user-sync` endpoint via an asynchronous HTTP callout.
+
+### How It Works
+
+1. **`UserUpdateTrigger`** fires on `after update` of the `User` object.
+2. **`UserUpdateHandler`** compares old and new field values, building a payload of only the changed fields for each modified user.
+3. **`CalComCalloutQueueable`** sends each payload as a `POST` request to Cal.com using Salesforce Named Credentials. It automatically selects the correct credential based on the org type:
+   - **Sandbox / Scratch Org** -> `CalCom_Development`
+   - **Production** -> `CalCom_Production`
+
+### Payload Structure
+
+```json
+{
+  "salesforceUserId": "<Salesforce User ID>",
+  "email": "user@example.com",
+  "instanceUrl": "https://your-org.my.salesforce.com",
+  "orgId": "<Salesforce Org ID>",
+  "changedFields": {
+    "FirstName": "NewValue",
+    "Title": "NewTitle"
+  },
+  "timestamp": "2025-01-01T00:00:00.000Z"
+}
+```
+
+## Package Structure
+
+```
+sfdc-package/
+  force-app/main/default/
+    triggers/
+      UserUpdateTrigger.trigger        # Entry point - fires on User updates
+    classes/
+      UserUpdateHandler.cls            # Detects changed fields and builds payloads
+      CalComCalloutQueueable.cls       # Sends payloads to Cal.com asynchronously
+      CalComCalloutQueueableTest.cls   # Tests for the queueable callout
+      UserUpdateHandlerTest.cls        # Tests for the update handler
+      CalComHttpMock.cls               # HTTP mock for unit tests
+    namedCredentials/
+      CalCom_Development.namedCredential-meta.xml
+      CalCom_Production.namedCredential-meta.xml
+  sfdx-project.json                    # Package definition and version aliases
+```
+
+## Generating the Install Link
+
+### Prerequisites
+
+- [Salesforce CLI](https://developer.salesforce.com/tools/salesforcecli) installed
+- Access to the Dev Hub org (`team@cal.com`)
+
+### Steps
+
+All commands should be run from the `sfdc-package` directory:
+
+```bash
+cd packages/app-store/salesforce/sfdc-package
+```
+
+#### 1. Create a New Package Version
+
+```bash
+sf package version create \
+  --package "calcom-sfdc-package" \
+  --installation-key-bypass \
+  --wait 20 \
+  --target-dev-hub team@cal.com
+```
+
+Add `--code-coverage` when you are ready to promote to production (requires 75% Apex test coverage).
+
+#### 2. List Package Versions
+
+```bash
+sf package version list --target-dev-hub team@cal.com
+```
+
+Find the `Subscriber Package Version Id` (starts with `04t`) for the version you want to install.
+
+#### 3. Build the Install Link
+
+The install URL follows this format:
+
+```
+https://login.salesforce.com/packaging/installPackage.apexp?p0=<SUBSCRIBER_PACKAGE_VERSION_ID>
+```
+
+Replace `<SUBSCRIBER_PACKAGE_VERSION_ID>` with the `04t` ID from step 2. For example, using the latest version in `sfdx-project.json`:
+
+```
+https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKk0000000SwwIAE
+```
+
+> **Note:** Beta versions (not promoted) can only be installed in sandbox and scratch orgs. To allow installation in production, promote the version first:
+>
+> ```bash
+> sf package version promote \
+>   --package "calcom-sfdc-package@<VERSION>" \
+>   --target-dev-hub team@cal.com
+> ```
+>
+> Replace `<VERSION>` with the version number (e.g. `0.1.0-2`).


### PR DESCRIPTION
## What does this PR do?

Adds a README to the `packages/app-store/salesforce/sfdc-package/` directory documenting:

- **What the package does**: An unlocked Salesforce package that listens for User record updates and syncs changed fields to Cal.com's `/api/integrations/salesforce/user-sync` endpoint in real time.
- **How it works**: The trigger → handler → queueable callout flow, including Named Credential selection (dev vs prod).
- **Payload structure**: JSON shape sent to Cal.com.
- **Package file structure**: Overview of triggers, classes, tests, and named credentials.
- **How to generate an install link**: Step-by-step instructions for creating a package version, listing versions, and constructing the install URL.

> **Note for reviewer:** The parent `salesforce/README.md` already has a "Publishing the SFDC Package" section with similar commands. This new README lives inside `sfdc-package/` and adds higher-level context (what the package does, how it works, payload shape, file structure) that the parent README doesn't cover. Worth confirming this level of overlap is acceptable or if the parent README's publishing section should be consolidated here.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — this is internal developer documentation only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — documentation only, no code changes.

## How should this be tested?

No testing required — this PR only adds a Markdown README file with no code changes.

Review the README content for accuracy against the actual Apex source files in `sfdc-package/force-app/`.

## Human Review Checklist

- [ ] Verify the documented trigger → handler → queueable flow matches the actual Apex code
- [ ] Confirm the example install URL with package version ID `04tKk0000000SwwIAE` (from `sfdx-project.json`) is acceptable as an example
- [ ] Decide whether publishing instructions should live here, in the parent `salesforce/README.md`, or both

Link to Devin Session: https://app.devin.ai/sessions/78ef8c7310f146f0baf4fdb3aacaa796
Requested by: @joeauyeung
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
