### PR TITLE
fix: use independent mutations per toggle to prevent global loading state

### DIFF
--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -59,8 +59,8 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
   const [isUpdateBtnLoading, setIsUpdateBtnLoading] = useState<boolean>(false);
   const [isTZScheduleOpen, setIsTZScheduleOpen] = useState<boolean>(false);
 
-  const mutation = trpc.viewer.me.updateProfile.useMutation({
-    onSuccess: async (res) => {
+  const sharedMutationOptions = {
+    onSuccess: async (res: RouterOutputs["viewer"]["me"]["updateProfile"]) => {
       await utils.viewer.me.invalidate();
       revalidateSettingsGeneral();
       revalidateTravelSchedules();
@@ -82,7 +82,13 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
       revalidateTravelSchedules();
       setIsUpdateBtnLoading(false);
     },
-  });
+  };
+
+  const mutation = trpc.viewer.me.updateProfile.useMutation(sharedMutationOptions);
+  const dynamicBookingMutation = trpc.viewer.me.updateProfile.useMutation(sharedMutationOptions);
+  const seoIndexingMutation = trpc.viewer.me.updateProfile.useMutation(sharedMutationOptions);
+  const monthlyDigestMutation = trpc.viewer.me.updateProfile.useMutation(sharedMutationOptions);
+  const bookingVerificationMutation = trpc.viewer.me.updateProfile.useMutation(sharedMutationOptions);
 
   const timeFormatOptions = [
     { value: 12, label: t("12_hour") },
@@ -327,11 +333,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("dynamic_booking")}
           description={t("allow_dynamic_booking")}
-          disabled={mutation.isPending}
+          disabled={dynamicBookingMutation.isPending}
           checked={isAllowDynamicBookingChecked}
           onCheckedChange={(checked) => {
             setIsAllowDynamicBookingChecked(checked);
-            mutation.mutate({ allowDynamicBooking: checked });
+            dynamicBookingMutation.mutate({ allowDynamicBooking: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -341,11 +347,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("seo_indexing")}
           description={t("allow_seo_indexing")}
-          disabled={mutation.isPending || user.organizationSettings?.allowSEOIndexing === false}
+          disabled={seoIndexingMutation.isPending || user.organizationSettings?.allowSEOIndexing === false}
           checked={isAllowSEOIndexingChecked}
           onCheckedChange={(checked) => {
             setIsAllowSEOIndexingChecked(checked);
-            mutation.mutate({ allowSEOIndexing: checked });
+            seoIndexingMutation.mutate({ allowSEOIndexing: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -354,11 +360,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("monthly_digest_email")}
           description={t("monthly_digest_email_for_teams")}
-          disabled={mutation.isPending}
+          disabled={monthlyDigestMutation.isPending}
           checked={isReceiveMonthlyDigestEmailChecked}
           onCheckedChange={(checked) => {
             setIsReceiveMonthlyDigestEmailChecked(checked);
-            mutation.mutate({ receiveMonthlyDigestEmail: checked });
+            monthlyDigestMutation.mutate({ receiveMonthlyDigestEmail: checked });
           }}
           switchContainerClassName="mt-6"
         />
@@ -367,11 +373,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
           toggleSwitchAtTheEnd={true}
           title={t("require_booker_email_verification")}
           description={t("require_booker_email_verification_description")}
-          disabled={mutation.isPending}
+          disabled={bookingVerificationMutation.isPending}
           checked={isRequireBookerEmailVerificationChecked}
           onCheckedChange={(checked) => {
             setIsRequireBookerEmailVerificationChecked(checked);
-            mutation.mutate({ requiresBookerEmailVerification: checked });
+            bookingVerificationMutation.mutate({ requiresBookerEmailVerification: checked });
           }}
           switchContainerClassName="mt-6"
         />


### PR DESCRIPTION
## What does this PR do?

Fixes #28330

Previously all settings toggles shared a single `mutation` instance. 
This caused the form submit button's loading state to trigger when any 
toggle was clicked. Each toggle now has its own independent mutation so 
loading states are isolated per toggle.

## Visual Demo

https://github.com/user-attachments/assets/9b4193dd-9a32-4cf1-81bf-1b80c25aa2e6

## Mandatory Tasks
- [x] I have self-reviewed the code
- [x] I have updated developer docs if needed. N/A
- [x] I confirm automated tests are in place. N/A