### PR TITLE
fix: handle pluralization for apps count in event type navigation

### DIFF
--- a/apps/web/playwright/fixtures/apps.ts
+++ b/apps/web/playwright/fixtures/apps.ts
@@ -130,7 +130,7 @@ export function createAppsFixture(page: Page) {
       await page.locator(`[data-testid='${app}-app-switch']`).click();
     },
     verifyAppsInfo: async (activeApps: number) => {
-      await expect(page.locator(`text=1 apps, ${activeApps} active`)).toBeVisible();
+      await expect(page.locator(`text=1 app, ${activeApps} active`)).toBeVisible();
     },
     verifyAppsInfoNew: async (app: string, eventTypeId: number) => {
       await page.goto(`event-types/${eventTypeId}?tabName=apps`);

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4774,5 +4774,7 @@
   "dashboard": "dashboard",
   "paypal_webhook_reminder": "Our integration creates a specific webhook on your PayPal account that we use to report back transactions to our system. If you delete this webhook, we will not be able to report back and you should uninstall and install the app again for this to work properly. Uninstalling the app won't delete your current event type price/currency configuration but you will not be able to receive bookings.",
   "discount_25": "-25%",
+  "apps_number_active_one": "{{installedCount}} app, {{count}} active",
+  "apps_number_active_other": "{{installedCount}} apps, {{count}} active",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4776,7 +4776,6 @@
   "discount_25": "-25%",
   "n_apps_one": "{{count}} app",
   "n_apps_other": "{{count}} apps",
-  "n_active_one": "{{count}} active",
-  "n_active_other": "{{count}} active",
+  "n_active": "{{count}} active",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4774,7 +4774,9 @@
   "dashboard": "dashboard",
   "paypal_webhook_reminder": "Our integration creates a specific webhook on your PayPal account that we use to report back transactions to our system. If you delete this webhook, we will not be able to report back and you should uninstall and install the app again for this to work properly. Uninstalling the app won't delete your current event type price/currency configuration but you will not be able to receive bookings.",
   "discount_25": "-25%",
-  "apps_number_active_one": "{{installedCount}} app, {{count}} active",
-  "apps_number_active_other": "{{installedCount}} apps, {{count}} active",
+  "n_apps_one": "{{count}} app",
+  "n_apps_other": "{{count}} apps",
+  "n_active_one": "{{count}} active",
+  "n_active_other": "{{count}} active",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/platform/atoms/event-types/hooks/useTabsNavigations.tsx
+++ b/packages/platform/atoms/event-types/hooks/useTabsNavigations.tsx
@@ -216,8 +216,7 @@ function getNavigation({
       name: t("apps"),
       href: `/event-types/${id}?tabName=apps`,
       icon: "grid-3x3",
-      //TODO: Handle proper translation with count handling
-      info: `${installedAppsNumber} apps, ${enabledAppsNumber} ${t("active")}`,
+      info: t("apps_number_active", { installedCount: installedAppsNumber, count: enabledAppsNumber }),
       "data-testid": "apps",
     },
   ];

--- a/packages/platform/atoms/event-types/hooks/useTabsNavigations.tsx
+++ b/packages/platform/atoms/event-types/hooks/useTabsNavigations.tsx
@@ -216,7 +216,7 @@ function getNavigation({
       name: t("apps"),
       href: `/event-types/${id}?tabName=apps`,
       icon: "grid-3x3",
-      info: t("apps_number_active", { installedCount: installedAppsNumber, count: enabledAppsNumber }),
+      info: `${t("n_apps", { count: installedAppsNumber })}, ${t("n_active", { count: enabledAppsNumber })}`,
       "data-testid": "apps",
     },
   ];


### PR DESCRIPTION
## What does this PR do?

The apps tab info string in the event type navigation was partially translated . active went through t() but apps was hardcoded in english with no plural handling.

This PR replaces the interpolated string with a proper i18next translation key

- Fixes #28407  (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
