### PR TITLE
chore: remove duplicate translation key

### DIFF
--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4361,7 +4361,6 @@
   "domain_name": "Domain name",
   "blocked": "Blocked",
   "reported_by": "Reported by",
-  "no_pending_reports": "No pending reports",
   "most_recent": "Most recent",
   "most_reports": "Most reports",
   "spam": "Spam",


### PR DESCRIPTION
## What does this PR do?

This PR removes a redundant translation key value pair

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
