### PR TITLE
feat: move fallback route webhook to trigger.dev architecture

### DIFF
--- a/packages/app-store/routing-forms/lib/formSubmissionUtils.test.ts
+++ b/packages/app-store/routing-forms/lib/formSubmissionUtils.test.ts
@@ -451,6 +451,10 @@ describe("_onFormSubmission with fallbackAction", () => {
     vi.mocked(getWebhooks).mockResolvedValue([]);
 
     await _onFormSubmission(mockForm, mockResponse, 123, undefined, mockFallbackAction);
+    // Flush microtasks so the fire-and-forget promise chain resolves
+    await vi.waitFor(() => {
+      expect(mockEmitRoutingFormFallbackHit).toHaveBeenCalled();
+    });
 
     expect(mockEmitRoutingFormFallbackHit).toHaveBeenCalledWith({
       form: { id: "form-1", name: "Test Form" },
@@ -470,6 +474,8 @@ describe("_onFormSubmission with fallbackAction", () => {
     vi.mocked(getWebhooks).mockResolvedValue([]);
 
     await _onFormSubmission(mockForm, mockResponse, 123);
+    // Give time for any potential async calls to resolve
+    await new Promise((r) => setTimeout(r, 0));
 
     expect(mockEmitRoutingFormFallbackHit).not.toHaveBeenCalled();
   });
@@ -484,6 +490,9 @@ describe("_onFormSubmission with fallbackAction", () => {
     };
 
     await _onFormSubmission(mockForm, mockResponse, 123, undefined, fallbackWithEventType);
+    await vi.waitFor(() => {
+      expect(mockEmitRoutingFormFallbackHit).toHaveBeenCalled();
+    });
 
     expect(mockEmitRoutingFormFallbackHit).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/app-store/routing-forms/lib/formSubmissionUtils.test.ts
+++ b/packages/app-store/routing-forms/lib/formSubmissionUtils.test.ts
@@ -44,6 +44,15 @@ vi.mock("@calcom/features/tasker", () => {
   return { default: Promise.resolve(tasker) };
 });
 
+const mockEmitRoutingFormFallbackHit = vi.fn(() => Promise.resolve());
+vi.mock("@calcom/features/di/webhooks/containers/webhook", () => ({
+  getWebhookFeature: () => ({
+    form: {
+      emitRoutingFormFallbackHit: mockEmitRoutingFormFallbackHit,
+    },
+  }),
+}));
+
 // Mock workflow dependencies
 vi.mock("@calcom/features/ee/workflows/lib/service/WorkflowService", () => ({
   WorkflowService: {
@@ -438,90 +447,35 @@ describe("_onFormSubmission with fallbackAction", () => {
     vi.restoreAllMocks();
   });
 
-  it("should fetch ROUTING_FORM_FALLBACK_HIT webhooks when fallbackAction is provided", async () => {
+  it("should call emitRoutingFormFallbackHit when fallbackAction is provided", async () => {
     vi.mocked(getWebhooks).mockResolvedValue([]);
 
     await _onFormSubmission(mockForm, mockResponse, 123, undefined, mockFallbackAction);
 
-    expect(getWebhooks).toHaveBeenCalledWith({
+    expect(mockEmitRoutingFormFallbackHit).toHaveBeenCalledWith({
+      form: { id: "form-1", name: "Test Form" },
+      responseId: 123,
+      fallbackAction: {
+        type: "externalRedirectUrl",
+        value: "https://example.com/fallback",
+      },
+      responses: mockResponse,
       userId: null,
       teamId: 1,
       orgId: 1,
-      triggerEvent: WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT,
     });
   });
 
-  it("should not fetch ROUTING_FORM_FALLBACK_HIT webhooks when fallbackAction is not provided", async () => {
+  it("should not call emitRoutingFormFallbackHit when fallbackAction is not provided", async () => {
     vi.mocked(getWebhooks).mockResolvedValue([]);
 
     await _onFormSubmission(mockForm, mockResponse, 123);
 
-    const calls = vi.mocked(getWebhooks).mock.calls;
-    const fallbackCalls = calls.filter(
-      (call) => call[0].triggerEvent === WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT
-    );
-    expect(fallbackCalls).toHaveLength(0);
+    expect(mockEmitRoutingFormFallbackHit).not.toHaveBeenCalled();
   });
 
-  it("should send ROUTING_FORM_FALLBACK_HIT webhook payload with correct data", async () => {
-    const mockWebhook: WebhookSubscriber = {
-      id: "wh-1",
-      secret: "secret",
-      subscriberUrl: "https://example.com/webhook",
-      payloadTemplate: null,
-      appId: null,
-      eventTriggers: [WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT],
-      time: null,
-      timeUnit: null,
-      version: WebhookVersionEnum.V_2021_10_20,
-    };
-    vi.mocked(getWebhooks).mockImplementation(async (opts) => {
-      if (opts.triggerEvent === WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT) {
-        return [mockWebhook];
-      }
-      return [];
-    });
-
-    await _onFormSubmission(mockForm, mockResponse, 123, undefined, mockFallbackAction);
-
-    expect(sendGenericWebhookPayload).toHaveBeenCalledWith(
-      expect.objectContaining({
-        secretKey: "secret",
-        triggerEvent: "ROUTING_FORM_FALLBACK_HIT",
-        webhook: mockWebhook,
-        data: {
-          formId: "form-1",
-          formName: "Test Form",
-          teamId: 1,
-          responseId: 123,
-          fallbackAction: {
-            type: "externalRedirectUrl",
-            value: "https://example.com/fallback",
-          },
-          responses: mockResponse,
-        },
-      })
-    );
-  });
-
-  it("should include eventTypeId in fallbackAction payload when present", async () => {
-    const mockWebhook: WebhookSubscriber = {
-      id: "wh-1",
-      secret: "secret",
-      subscriberUrl: "https://example.com/webhook",
-      payloadTemplate: null,
-      appId: null,
-      eventTriggers: [WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT],
-      time: null,
-      timeUnit: null,
-      version: WebhookVersionEnum.V_2021_10_20,
-    };
-    vi.mocked(getWebhooks).mockImplementation(async (opts) => {
-      if (opts.triggerEvent === WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT) {
-        return [mockWebhook];
-      }
-      return [];
-    });
+  it("should include eventTypeId in fallbackAction when present", async () => {
+    vi.mocked(getWebhooks).mockResolvedValue([]);
 
     const fallbackWithEventType = {
       type: "eventTypeRedirectUrl" as const,
@@ -531,81 +485,14 @@ describe("_onFormSubmission with fallbackAction", () => {
 
     await _onFormSubmission(mockForm, mockResponse, 123, undefined, fallbackWithEventType);
 
-    expect(sendGenericWebhookPayload).toHaveBeenCalledWith(
+    expect(mockEmitRoutingFormFallbackHit).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
-          fallbackAction: {
-            type: "eventTypeRedirectUrl",
-            value: "team/30min",
-            eventTypeId: 42,
-          },
-        }),
+        fallbackAction: {
+          type: "eventTypeRedirectUrl",
+          value: "team/30min",
+          eventTypeId: 42,
+        },
       })
     );
-  });
-
-  it("should send to multiple ROUTING_FORM_FALLBACK_HIT webhooks", async () => {
-    const mockWebhooks: WebhookSubscriber[] = [
-      {
-        id: "wh-1",
-        secret: "secret1",
-        subscriberUrl: "https://example.com/webhook1",
-        payloadTemplate: null,
-        appId: null,
-        eventTriggers: [WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT],
-        time: null,
-        timeUnit: null,
-        version: WebhookVersionEnum.V_2021_10_20,
-      },
-      {
-        id: "wh-2",
-        secret: "secret2",
-        subscriberUrl: "https://example.com/webhook2",
-        payloadTemplate: null,
-        appId: null,
-        eventTriggers: [WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT],
-        time: null,
-        timeUnit: null,
-        version: WebhookVersionEnum.V_2021_10_20,
-      },
-    ];
-    vi.mocked(getWebhooks).mockImplementation(async (opts) => {
-      if (opts.triggerEvent === WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT) {
-        return mockWebhooks;
-      }
-      return [];
-    });
-
-    await _onFormSubmission(mockForm, mockResponse, 123, undefined, mockFallbackAction);
-
-    const fallbackCalls = vi.mocked(sendGenericWebhookPayload).mock.calls.filter(
-      (call) => call[0].triggerEvent === "ROUTING_FORM_FALLBACK_HIT"
-    );
-    expect(fallbackCalls).toHaveLength(2);
-  });
-
-  it("should not throw when ROUTING_FORM_FALLBACK_HIT webhook payload fails", async () => {
-    const mockWebhook: WebhookSubscriber = {
-      id: "wh-1",
-      secret: "secret",
-      subscriberUrl: "https://example.com/webhook",
-      payloadTemplate: null,
-      appId: null,
-      eventTriggers: [WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT],
-      time: null,
-      timeUnit: null,
-      version: WebhookVersionEnum.V_2021_10_20,
-    };
-    vi.mocked(getWebhooks).mockImplementation(async (opts) => {
-      if (opts.triggerEvent === WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT) {
-        return [mockWebhook];
-      }
-      return [];
-    });
-    vi.mocked(sendGenericWebhookPayload).mockRejectedValueOnce(new Error("Network error"));
-
-    await expect(
-      _onFormSubmission(mockForm, mockResponse, 123, undefined, mockFallbackAction)
-    ).resolves.not.toThrow();
   });
 });

--- a/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
+++ b/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
@@ -179,21 +179,26 @@ export async function _onFormSubmission(
 
   // Emit fallback hit webhook via the new webhook architecture (trigger.dev)
   if (fallbackAction) {
-    const { getWebhookFeature } = await import("@calcom/features/di/webhooks/containers/webhook");
-    const webhooks = getWebhookFeature();
-    await webhooks.form.emitRoutingFormFallbackHit({
-      form: { id: form.id, name: form.name },
-      responseId,
-      fallbackAction: {
-        type: fallbackAction.type,
-        value: fallbackAction.value,
-        ...(fallbackAction.eventTypeId ? { eventTypeId: fallbackAction.eventTypeId } : {}),
-      },
-      responses: response,
-      userId,
-      teamId,
-      orgId,
-    });
+    import("@calcom/features/di/webhooks/containers/webhook")
+      .then(({ getWebhookFeature }) => {
+        const webhooks = getWebhookFeature();
+        return webhooks.form.emitRoutingFormFallbackHit({
+          form: { id: form.id, name: form.name },
+          responseId,
+          fallbackAction: {
+            type: fallbackAction.type,
+            value: fallbackAction.value,
+            ...(fallbackAction.eventTypeId ? { eventTypeId: fallbackAction.eventTypeId } : {}),
+          },
+          responses: response,
+          userId,
+          teamId,
+          orgId,
+        });
+      })
+      .catch((e) => {
+        moduleLogger.error("Error emitting ROUTING_FORM_FALLBACK_HIT webhook", e);
+      });
   }
 
   const [webhooksFormSubmitted, webhooksFormSubmittedNoEvent] = await Promise.all([

--- a/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
+++ b/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
@@ -197,7 +197,10 @@ export async function _onFormSubmission(
         });
       })
       .catch((e) => {
-        moduleLogger.error("Error emitting ROUTING_FORM_FALLBACK_HIT webhook", e);
+        moduleLogger.error("Error emitting ROUTING_FORM_FALLBACK_HIT webhook", {
+          errorMessage: e instanceof Error ? e.message : "Unknown error",
+          errorName: e instanceof Error ? e.name : "UnknownError",
+        });
       });
   }
 

--- a/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
+++ b/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
@@ -177,19 +177,28 @@ export async function _onFormSubmission(
     triggerEvent: WebhookTriggerEvents.FORM_SUBMITTED_NO_EVENT,
   };
 
-  const subscriberOptionsFallbackHit = fallbackAction
-    ? {
-        userId,
-        teamId,
-        orgId,
-        triggerEvent: WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT,
-      }
-    : null;
+  // Emit fallback hit webhook via the new webhook architecture (trigger.dev)
+  if (fallbackAction) {
+    const { getWebhookFeature } = await import("@calcom/features/di/webhooks/containers/webhook");
+    const webhooks = getWebhookFeature();
+    await webhooks.form.emitRoutingFormFallbackHit({
+      form: { id: form.id, name: form.name },
+      responseId,
+      fallbackAction: {
+        type: fallbackAction.type,
+        value: fallbackAction.value,
+        ...(fallbackAction.eventTypeId ? { eventTypeId: fallbackAction.eventTypeId } : {}),
+      },
+      responses: response,
+      userId,
+      teamId,
+      orgId,
+    });
+  }
 
-  const [webhooksFormSubmitted, webhooksFormSubmittedNoEvent, webhooksFallbackHit] = await Promise.all([
+  const [webhooksFormSubmitted, webhooksFormSubmittedNoEvent] = await Promise.all([
     getWebhooks(subscriberOptionsFormSubmitted),
     getWebhooks(subscriberOptionsFormSubmittedNoEvent),
-    subscriberOptionsFallbackHit ? getWebhooks(subscriberOptionsFallbackHit) : Promise.resolve([]),
   ]);
 
   const promisesFormSubmitted = webhooksFormSubmitted.map((webhook) => {
@@ -243,32 +252,7 @@ export async function _onFormSubmission(
         );
       });
 
-      const promisesFallbackHit = webhooksFallbackHit.map((webhook) =>
-        sendGenericWebhookPayload({
-          secretKey: webhook.secret,
-          triggerEvent: "ROUTING_FORM_FALLBACK_HIT",
-          createdAt: new Date().toISOString(),
-          webhook,
-          data: {
-            formId: form.id,
-            formName: form.name,
-            teamId: form.teamId,
-            responseId,
-            fallbackAction: fallbackAction
-              ? {
-                  type: fallbackAction.type,
-                  value: fallbackAction.value,
-                  ...(fallbackAction.eventTypeId ? { eventTypeId: fallbackAction.eventTypeId } : {}),
-                }
-              : undefined,
-            responses: response,
-          },
-        }).catch((e) => {
-          moduleLogger.error(`Error executing ROUTING_FORM_FALLBACK_HIT webhook`, e);
-        })
-      );
-
-      const promises = [...promisesFormSubmitted, ...promisesFormSubmittedNoEvent, ...promisesFallbackHit];
+      const promises = [...promisesFormSubmitted, ...promisesFormSubmittedNoEvent];
 
       await Promise.all(promises);
 
@@ -322,7 +306,7 @@ export async function _onFormSubmission(
 }
 export const onFormSubmission = withReporting(_onFormSubmission, "onFormSubmission");
 
-export type TargetRoutingFormForResponse= SerializableForm<
+export type TargetRoutingFormForResponse = SerializableForm<
   App_RoutingForms_Form & {
     user: {
       id: number;

--- a/packages/features/webhooks/lib/dto/types.ts
+++ b/packages/features/webhooks/lib/dto/types.ts
@@ -216,6 +216,21 @@ export interface FormSubmittedNoEventDTO extends BaseEventDTO {
   };
 }
 
+export interface RoutingFormFallbackHitDTO extends BaseEventDTO {
+  triggerEvent: typeof WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT;
+  form: {
+    id: string;
+    name: string;
+  };
+  responseId: number;
+  fallbackAction?: {
+    type: string;
+    value: string;
+    eventTypeId?: number;
+  };
+  responses: Record<string, unknown>;
+}
+
 export interface MeetingStartedDTO extends BaseEventDTO {
   triggerEvent: typeof WebhookTriggerEvents.MEETING_STARTED;
   booking: {
@@ -353,6 +368,7 @@ export type WebhookEventDTO =
   | OOOCreatedDTO
   | FormSubmittedDTO
   | FormSubmittedNoEventDTO
+  | RoutingFormFallbackHitDTO
   | RecordingReadyDTO
   | TranscriptionGeneratedDTO
   | MeetingStartedDTO

--- a/packages/features/webhooks/lib/factory/base/BaseFormPayloadBuilder.ts
+++ b/packages/features/webhooks/lib/factory/base/BaseFormPayloadBuilder.ts
@@ -1,4 +1,4 @@
-import type { FormSubmittedDTO, FormSubmittedNoEventDTO } from "../../dto/types";
+import type { FormSubmittedDTO, FormSubmittedNoEventDTO, RoutingFormFallbackHitDTO } from "../../dto/types";
 import type { WebhookPayload } from "../types";
 import type { IFormPayloadBuilder } from "../versioned/PayloadBuilderFactory";
 
@@ -16,5 +16,5 @@ export abstract class BaseFormPayloadBuilder implements IFormPayloadBuilder {
    * Build the form webhook payload.
    * Each version must implement this method with its specific payload structure.
    */
-  abstract build(dto: FormSubmittedDTO | FormSubmittedNoEventDTO): WebhookPayload;
+  abstract build(dto: FormSubmittedDTO | FormSubmittedNoEventDTO | RoutingFormFallbackHitDTO): WebhookPayload;
 }

--- a/packages/features/webhooks/lib/factory/types.ts
+++ b/packages/features/webhooks/lib/factory/types.ts
@@ -13,6 +13,19 @@ export interface FormSubmittedPayload {
   responses: Record<string, unknown>;
 }
 
+export interface RoutingFormFallbackHitPayload {
+  formId: string;
+  formName: string;
+  teamId?: number | null;
+  responseId: number;
+  fallbackAction?: {
+    type: string;
+    value: string;
+    eventTypeId?: number;
+  };
+  responses: Record<string, unknown>;
+}
+
 export interface RecordingPayload {
   downloadLink?: string;
   downloadLinks?: {
@@ -92,6 +105,7 @@ export interface WebhookPayload {
     | OOOEntryPayloadType
     | BookingNoShowUpdatedPayload
     | FormSubmittedPayload
+    | RoutingFormFallbackHitPayload
     | RecordingPayload
     | MeetingPayload
     | InstantMeetingPayload

--- a/packages/features/webhooks/lib/factory/versioned/PayloadBuilderFactory.ts
+++ b/packages/features/webhooks/lib/factory/versioned/PayloadBuilderFactory.ts
@@ -12,6 +12,7 @@ import type {
   MeetingStartedDTO,
   OOOCreatedDTO,
   RecordingReadyDTO,
+  RoutingFormFallbackHitDTO,
   TranscriptionGeneratedDTO,
   WebhookEventDTO,
 } from "../../dto/types";
@@ -31,8 +32,9 @@ export interface IBookingPayloadBuilder extends IPayloadBuilder<BookingWebhookEv
   build(dto: BookingWebhookEventDTO): WebhookPayload;
 }
 
-export interface IFormPayloadBuilder extends IPayloadBuilder<FormSubmittedDTO | FormSubmittedNoEventDTO> {
-  build(dto: FormSubmittedDTO | FormSubmittedNoEventDTO): WebhookPayload;
+export interface IFormPayloadBuilder
+  extends IPayloadBuilder<FormSubmittedDTO | FormSubmittedNoEventDTO | RoutingFormFallbackHitDTO> {
+  build(dto: FormSubmittedDTO | FormSubmittedNoEventDTO | RoutingFormFallbackHitDTO): WebhookPayload;
 }
 
 export interface IOOOPayloadBuilder extends IPayloadBuilder<OOOCreatedDTO> {

--- a/packages/features/webhooks/lib/factory/versioned/v2021-10-20/FormPayloadBuilder.ts
+++ b/packages/features/webhooks/lib/factory/versioned/v2021-10-20/FormPayloadBuilder.ts
@@ -1,8 +1,12 @@
 import type { FORM_SUBMITTED_WEBHOOK_RESPONSES } from "@calcom/app-store/routing-forms/lib/formSubmissionUtils";
-
-import type { FormSubmittedDTO, FormSubmittedNoEventDTO } from "../../../dto/types";
-import type { WebhookPayload } from "../../types";
+import { WebhookTriggerEvents } from "@calcom/prisma/enums";
+import type {
+  FormSubmittedDTO,
+  FormSubmittedNoEventDTO,
+  RoutingFormFallbackHitDTO,
+} from "../../../dto/types";
 import { BaseFormPayloadBuilder } from "../../base/BaseFormPayloadBuilder";
+import type { WebhookPayload } from "../../types";
 
 /**
  * Form payload builder for webhook version 2021-10-20.
@@ -13,10 +17,15 @@ import { BaseFormPayloadBuilder } from "../../base/BaseFormPayloadBuilder";
  * - Backwards compatibility: response values also at root level
  */
 export class FormPayloadBuilder extends BaseFormPayloadBuilder {
-  /**
-   * Build the form webhook payload for v2021-10-20.
-   */
-  build(dto: FormSubmittedDTO | FormSubmittedNoEventDTO): WebhookPayload {
+  build(dto: FormSubmittedDTO | FormSubmittedNoEventDTO | RoutingFormFallbackHitDTO): WebhookPayload {
+    if (dto.triggerEvent === WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT) {
+      return this.buildFallbackHitPayload(dto);
+    }
+
+    return this.buildFormSubmittedPayload(dto);
+  }
+
+  private buildFormSubmittedPayload(dto: FormSubmittedDTO | FormSubmittedNoEventDTO): WebhookPayload {
     const responses = dto.response.data;
 
     const payload: {
@@ -32,13 +41,27 @@ export class FormPayloadBuilder extends BaseFormPayloadBuilder {
       responses,
     };
 
-    // Add unwrapped response fields at root level for backwards compatibility
     this.addBackwardsCompatibilityFields(payload, responses);
 
     return {
       triggerEvent: dto.triggerEvent,
       createdAt: dto.createdAt,
       payload,
+    };
+  }
+
+  private buildFallbackHitPayload(dto: RoutingFormFallbackHitDTO): WebhookPayload {
+    return {
+      triggerEvent: dto.triggerEvent,
+      createdAt: dto.createdAt,
+      payload: {
+        formId: dto.form.id,
+        formName: dto.form.name,
+        teamId: dto.teamId ?? null,
+        responseId: dto.responseId,
+        fallbackAction: dto.fallbackAction,
+        responses: dto.responses,
+      },
     };
   }
 

--- a/packages/features/webhooks/lib/interface/services.ts
+++ b/packages/features/webhooks/lib/interface/services.ts
@@ -110,6 +110,21 @@ export interface IFormEventEmitter {
     platformClientId?: string;
     isDryRun?: boolean;
   }): Promise<void>;
+
+  emitRoutingFormFallbackHit(params: {
+    form: { id: string; name: string };
+    responseId: number;
+    fallbackAction?: {
+      type: string;
+      value: string;
+      eventTypeId?: number;
+    };
+    responses: Record<string, unknown>;
+    userId?: number | null;
+    teamId?: number | null;
+    orgId?: number | null;
+    isDryRun?: boolean;
+  }): Promise<void>;
 }
 
 // Form Scheduling Interface - Form webhook scheduling operations

--- a/packages/features/webhooks/lib/interface/services.ts
+++ b/packages/features/webhooks/lib/interface/services.ts
@@ -123,6 +123,7 @@ export interface IFormEventEmitter {
     userId?: number | null;
     teamId?: number | null;
     orgId?: number | null;
+    platformClientId?: string;
     isDryRun?: boolean;
   }): Promise<void>;
 }

--- a/packages/features/webhooks/lib/service/FormWebhookService.ts
+++ b/packages/features/webhooks/lib/service/FormWebhookService.ts
@@ -72,6 +72,7 @@ export class FormWebhookService implements IFormWebhookService {
     userId?: number | null;
     teamId?: number | null;
     orgId?: number | null;
+    platformClientId?: string;
     isDryRun?: boolean;
   }): Promise<void> {
     const dto: RoutingFormFallbackHitDTO = {
@@ -80,6 +81,7 @@ export class FormWebhookService implements IFormWebhookService {
       userId: params.userId,
       teamId: params.teamId,
       orgId: params.orgId,
+      platformClientId: params.platformClientId,
       form: params.form,
       responseId: params.responseId,
       fallbackAction: params.fallbackAction,

--- a/packages/features/webhooks/lib/service/FormWebhookService.ts
+++ b/packages/features/webhooks/lib/service/FormWebhookService.ts
@@ -1,10 +1,9 @@
 import type { FORM_SUBMITTED_WEBHOOK_RESPONSES } from "@calcom/app-store/routing-forms/lib/formSubmissionUtils";
 import dayjs from "@calcom/dayjs";
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
-
-import type { FormSubmittedDTO, FormSubmittedNoEventDTO } from "../dto/types";
+import type { FormSubmittedDTO, FormSubmittedNoEventDTO, RoutingFormFallbackHitDTO } from "../dto/types";
 import type { FormSubmittedPayload } from "../factory/types";
-import type { IWebhookService, IFormWebhookService } from "../interface/services";
+import type { IFormWebhookService, IWebhookService } from "../interface/services";
 import type { IWebhookNotifier } from "../interface/webhook";
 
 export class FormWebhookService implements IFormWebhookService {
@@ -56,6 +55,35 @@ export class FormWebhookService implements IFormWebhookService {
       platformClientId: params.platformClientId,
       form: params.form,
       response: params.response,
+    };
+
+    await this.webhookNotifier.emitWebhook(dto, params.isDryRun);
+  }
+
+  async emitRoutingFormFallbackHit(params: {
+    form: { id: string; name: string };
+    responseId: number;
+    fallbackAction?: {
+      type: string;
+      value: string;
+      eventTypeId?: number;
+    };
+    responses: Record<string, unknown>;
+    userId?: number | null;
+    teamId?: number | null;
+    orgId?: number | null;
+    isDryRun?: boolean;
+  }): Promise<void> {
+    const dto: RoutingFormFallbackHitDTO = {
+      triggerEvent: WebhookTriggerEvents.ROUTING_FORM_FALLBACK_HIT,
+      createdAt: new Date().toISOString(),
+      userId: params.userId,
+      teamId: params.teamId,
+      orgId: params.orgId,
+      form: params.form,
+      responseId: params.responseId,
+      fallbackAction: params.fallbackAction,
+      responses: params.responses,
     };
 
     await this.webhookNotifier.emitWebhook(dto, params.isDryRun);


### PR DESCRIPTION
## What does this PR do?

Migrates the `ROUTING_FORM_FALLBACK_HIT` webhook event from the legacy direct `sendGenericWebhookPayload` pattern to the new webhook architecture (`FormWebhookService` → `WebhookNotifier` → `PayloadBuilderFactory`), enabling trigger.dev async execution.

### Changes

- Adds `RoutingFormFallbackHitDTO` to the webhook DTO types and `WebhookEventDTO` union
- Adds `RoutingFormFallbackHitPayload` to the factory payload types
- Extends `IFormPayloadBuilder` / `BaseFormPayloadBuilder` to accept the new DTO
- Adds `buildFallbackHitPayload()` to `FormPayloadBuilder` (v2021-10-20)
- Adds `emitRoutingFormFallbackHit` to `IFormEventEmitter` interface and `FormWebhookService` (includes `platformClientId` support)
- Replaces the direct `sendGenericWebhookPayload` call in `formSubmissionUtils.ts` with a **fire-and-forget** call to `webhooks.form.emitRoutingFormFallbackHit()` via dynamic import
- Removes the now-unnecessary `subscriberOptionsFallbackHit` / `webhooksFallbackHit` / `promisesFallbackHit` code
- Updates unit tests to mock the DI container and verify `emitRoutingFormFallbackHit` is called with the correct params
- Error logging in the `.catch()` handler is sanitized — only `errorMessage` and `errorName` are logged, avoiding potential leakage of sensitive form response data

Note: `PayloadBuilderFactory` already mapped `ROUTING_FORM_FALLBACK_HIT` → `"form"` builder, so no change was needed there.

### ⚠️ Items for reviewer attention

1. **Fire-and-forget emission**: The fallback webhook is emitted via `.then().catch()` (not `await`ed), so it does not block the rest of form submission side effects (`FORM_SUBMITTED` webhooks, workflows, emails). Errors are logged (sanitized) but swallowed. Verify this is acceptable.
2. **`platformClientId` not wired at call site**: The `emitRoutingFormFallbackHit` interface accepts `platformClientId`, but the call in `formSubmissionUtils.ts` does not pass it. If platform/OAuth-scoped subscribers need this event, the caller would need to be updated to thread through the `platformClientId`.
3. **Test coverage shift**: Detailed tests for multi-subscriber delivery and error propagation were removed from the unit tests, since those concerns are now handled by the `WebhookNotifier` / trigger.dev layer. The remaining tests verify correct params are passed to `emitRoutingFormFallbackHit`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Configure a routing form with a fallback action
2. Create a webhook subscriber for `ROUTING_FORM_FALLBACK_HIT`
3. Submit a form response that triggers the fallback route
4. Verify the webhook is received with the correct payload shape: `{ formId, formName, teamId, responseId, fallbackAction, responses }`
5. If trigger.dev is enabled (`ENABLE_ASYNC_TASKER=true`), verify the webhook is processed asynchronously via trigger.dev
6. Verify that a failure in the fallback webhook emission does **not** block `FORM_SUBMITTED` webhooks from firing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

---

Link to Devin session: https://app.devin.ai/sessions/8db59be3ba4a479184b018c14fd8e65c
Requested by: @joeauyeung
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
