### PR TITLE
fix(docs): correct ListSchedules prop name from getRedirectUrl to getScheduleUrl

### DIFF
--- a/docs/platform/atoms/list-schedules.mdx
+++ b/docs/platform/atoms/list-schedules.mdx
@@ -12,7 +12,7 @@ import { ListSchedules } from "@calcom/atoms";
 export default function ListSchedules() {
   return (
     <>
-      <ListSchedules getRedirectUrl={(scheduleId) => `/availability/${scheduleId}`} />
+      <ListSchedules getScheduleUrl={(scheduleId) => `/availability/${scheduleId}`} />
     </>
   );
 }
@@ -39,7 +39,7 @@ Below is a list of props that can be passed to the List schedules atom.
 
 | Name           | Required | Description                                                                                                       |
 | :------------- | :------- | :---------------------------------------------------------------------------------------------------------------- |
-| getRedirectUrl | No       | Callback function that determines where the user should be redirected when they click on a schedule from the atom |
+| getScheduleUrl | No       | Callback function that determines where the user should be redirected when they click on a schedule from the atom |
 
 ## Combining list schedules atom with availability settings atom
 
@@ -57,13 +57,13 @@ import { ListSchedules } from "@calcom/atoms";
 export default function ListSchedules() {
   return (
     <>
-      <ListSchedules getRedirectUrl={(scheduleId) => `/availability/${scheduleId}`} />
+      <ListSchedules getScheduleUrl={(scheduleId) => `/availability/${scheduleId}`} />
     </>
   );
 }
 ```
 
-`getRedirectUrl` prop is a callback function that determines where the user should be redirected when they click on a schedule from the atom. Say if you want to display your availability settings atom on the page `/availability/:scheduleId`, you need to make sure you return the exact same url when you call the `getRedirectUrl` function.
+`getScheduleUrl` prop is a callback function that determines where the user should be redirected when they click on a schedule from the atom. Say if you want to display your availability settings atom on the page `/availability/:scheduleId`, you need to make sure you return the exact same url when you call the `getScheduleUrl` function.
 
     </Step>
     <Step title="Setup availability settings atom">


### PR DESCRIPTION
closes #28417 

The documentation referenced `getRedirectUrl` but the actual component prop is `getScheduleUrl`, causing the callback to silently not fire.

## What does this PR do?

Fixes the `ListSchedules` atom documentation to use the correct prop name `getScheduleUrl` instead of `getRedirectUrl`. The implementation at [`packages/platform/atoms/list-schedules/wrappers/ListSchedulesPlatformWrapper.tsx` ](https://github.com/calcom/cal.com/blob/main/packages/platform/atoms/list-schedules/wrappers/ListSchedulesPlatformWrapper.tsx)and the example app both use `getScheduleUrl`, but the docs had `getRedirectUrl`, a prop that doesn't exist on the component. This causes the redirect callback to never fire, and schedule links fall back to `#`.

- Fixes #28417 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. This PR *is* the docs fix.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — docs-only change.

## How should this be tested?

1. Use the `ListSchedules` atom with `getScheduleUrl` prop as shown in the updated docs
2. Confirm the callback fires and schedule links navigate correctly
3. Compare prop name against the actual interface in [`ListSchedulesPlatformWrapper.tsx` (line [](18)](https://github.com/calcom/cal.com/blob/main/packages/platform/atoms/list-schedules/wrappers/ListSchedulesPlatformWrapper.tsx#L18))

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings