### PR TITLE
feat: add insights chat box with groq integration

### DIFF
--- a/apps/web/app/api/insights/chat/route.ts
+++ b/apps/web/app/api/insights/chat/route.ts
@@ -241,7 +241,14 @@ async function callGroq(prompt: string): Promise<ChartConfig> {
     cleanedContent = cleanedContent.replace(/^```(?:json)?\s*/, "").replace(/\s*```$/, "");
   }
 
-  const parseResult = GroqParsedSchema.safeParse(JSON.parse(cleanedContent));
+  let rawParsed: unknown;
+  try {
+    rawParsed = JSON.parse(cleanedContent);
+  } catch {
+    throw new Error(`Failed to parse Groq response as JSON: ${cleanedContent.substring(0, 200)}`);
+  }
+
+  const parseResult = GroqParsedSchema.safeParse(rawParsed);
   if (!parseResult.success) {
     throw new Error(`Invalid response format from Groq: ${parseResult.error.message}`);
   }

--- a/apps/web/app/api/insights/chat/route.ts
+++ b/apps/web/app/api/insights/chat/route.ts
@@ -245,7 +245,7 @@ async function callGroq(prompt: string): Promise<ChartConfig> {
   try {
     rawParsed = JSON.parse(cleanedContent);
   } catch {
-    throw new Error(`Failed to parse Groq response as JSON: ${cleanedContent.substring(0, 200)}`);
+    throw new Error("Failed to parse Groq response as JSON");
   }
 
   const parseResult = GroqParsedSchema.safeParse(rawParsed);

--- a/apps/web/app/api/insights/chat/route.ts
+++ b/apps/web/app/api/insights/chat/route.ts
@@ -7,12 +7,15 @@ import {
   replaceDateRangeColumnFilter,
 } from "@calcom/features/insights/lib/bookingUtils";
 import { getDateRanges, getTimeView } from "@calcom/features/insights/server/insightsDateUtils";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import logger from "@calcom/lib/logger";
 import { readonlyPrisma } from "@calcom/prisma";
+import { MembershipRole } from "@calcom/prisma/enums";
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 import { cookies, headers } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { z } from "zod";
 
 const log = logger.getSubLogger({ prefix: [`/api/insights/chat`] });
 
@@ -176,12 +179,12 @@ interface GroqApiResult {
   choices: GroqChoice[];
 }
 
-interface GroqParsed {
-  endpoint: string;
-  chartType: string;
-  title: string;
-  description: string;
-}
+const GroqParsedSchema = z.object({
+  endpoint: z.string(),
+  chartType: z.string(),
+  title: z.string(),
+  description: z.string(),
+});
 
 interface ChartConfig {
   chartType: ChartType;
@@ -232,7 +235,18 @@ async function callGroq(prompt: string): Promise<ChartConfig> {
     throw new Error("No response content from Groq");
   }
 
-  const parsed: GroqParsed = JSON.parse(content.trim());
+  let cleanedContent = content.trim();
+  // Strip markdown code fences if the LLM wraps the JSON
+  if (cleanedContent.startsWith("```")) {
+    cleanedContent = cleanedContent.replace(/^```(?:json)?\s*/, "").replace(/\s*```$/, "");
+  }
+
+  const parseResult = GroqParsedSchema.safeParse(JSON.parse(cleanedContent));
+  if (!parseResult.success) {
+    throw new Error(`Invalid response format from Groq: ${parseResult.error.message}`);
+  }
+
+  const parsed = parseResult.data;
   const matchedEndpoint = AVAILABLE_ENDPOINTS.find((ep) => ep.name === parsed.endpoint);
   if (!matchedEndpoint) {
     throw new Error(`Unknown endpoint: ${parsed.endpoint}`);
@@ -444,7 +458,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   try {
     const body: RequestBody = await req.json();
-    const { query } = body;
+    const { query, scope, selectedTeamId } = body;
 
     if (!query || typeof query !== "string" || !query.trim()) {
       return NextResponse.json({ error: "Query is required" }, { status: 400 });
@@ -457,6 +471,48 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     if (!user) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Authorization: verify team membership and insights permission
+    if (scope === "team" && selectedTeamId) {
+      const membership = await readonlyPrisma.membership.findFirst({
+        where: { userId: user.id, teamId: selectedTeamId, accepted: true },
+        select: { id: true },
+      });
+
+      if (!membership && user.organizationId) {
+        // Check if the team is a child of the user's org
+        const isChildTeam = await readonlyPrisma.team.findFirst({
+          where: { id: selectedTeamId, parentId: user.organizationId },
+          select: { id: true },
+        });
+        if (!isChildTeam) {
+          return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+        }
+        const permissionCheck = new PermissionCheckService();
+        const hasAccess = await permissionCheck.checkPermission({
+          userId: user.id,
+          teamId: user.organizationId,
+          permission: "insights.read",
+          fallbackRoles: [MembershipRole.OWNER, MembershipRole.ADMIN],
+        });
+        if (!hasAccess) {
+          return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+        }
+      } else if (!membership) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+    } else if (scope === "org" && user.organizationId) {
+      const permissionCheck = new PermissionCheckService();
+      const hasAccess = await permissionCheck.checkPermission({
+        userId: user.id,
+        teamId: user.organizationId,
+        permission: "insights.read",
+        fallbackRoles: [MembershipRole.OWNER, MembershipRole.ADMIN],
+      });
+      if (!hasAccess) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
     }
 
     const prompt = buildGroqPrompt(query.trim());

--- a/apps/web/app/api/insights/chat/route.ts
+++ b/apps/web/app/api/insights/chat/route.ts
@@ -1,0 +1,477 @@
+import process from "node:process";
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import type { ColumnFilter } from "@calcom/features/data-table/lib/types";
+import { getInsightsBookingService } from "@calcom/features/di/containers/InsightsBooking";
+import {
+  extractDateRangeFromColumnFilters,
+  replaceDateRangeColumnFilter,
+} from "@calcom/features/insights/lib/bookingUtils";
+import { getDateRanges, getTimeView } from "@calcom/features/insights/server/insightsDateUtils";
+import logger from "@calcom/lib/logger";
+import { readonlyPrisma } from "@calcom/prisma";
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
+import { cookies, headers } from "next/headers";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+const log = logger.getSubLogger({ prefix: [`/api/insights/chat`] });
+
+type ChartType = "line" | "bar" | "pie" | "area";
+
+interface EndpointConfig {
+  name: string;
+  description: string;
+  dataKeys: string[];
+  xAxisKey: string;
+  suggestedChart: ChartType;
+}
+
+const AVAILABLE_ENDPOINTS: EndpointConfig[] = [
+  {
+    name: "eventTrends",
+    description:
+      "Booking event trends over time: created, completed, rescheduled, cancelled, no-show counts per period",
+    dataKeys: ["Created", "Completed", "Rescheduled", "Cancelled", "No-Show (Host)", "No-Show (Guest)"],
+    xAxisKey: "Month",
+    suggestedChart: "line",
+  },
+  {
+    name: "bookingKPIStats",
+    description:
+      "KPI stats: total created, completed, rescheduled, cancelled, no-show (host/guest), rating, CSAT with delta from previous period",
+    dataKeys: ["count"],
+    xAxisKey: "metric",
+    suggestedChart: "bar",
+  },
+  {
+    name: "popularEvents",
+    description: "Most popular event types ranked by booking count",
+    dataKeys: ["count"],
+    xAxisKey: "eventTypeName",
+    suggestedChart: "bar",
+  },
+  {
+    name: "membersWithMostBookings",
+    description: "Team members ranked by most total bookings",
+    dataKeys: ["count"],
+    xAxisKey: "name",
+    suggestedChart: "bar",
+  },
+  {
+    name: "membersWithLeastBookings",
+    description: "Team members ranked by least total bookings",
+    dataKeys: ["count"],
+    xAxisKey: "name",
+    suggestedChart: "bar",
+  },
+  {
+    name: "membersWithMostCancelledBookings",
+    description: "Team members ranked by most cancelled bookings",
+    dataKeys: ["count"],
+    xAxisKey: "name",
+    suggestedChart: "bar",
+  },
+  {
+    name: "membersWithMostNoShow",
+    description: "Team members ranked by most no-show bookings",
+    dataKeys: ["count"],
+    xAxisKey: "name",
+    suggestedChart: "bar",
+  },
+  {
+    name: "membersWithHighestRatings",
+    description: "Team members ranked by highest average ratings",
+    dataKeys: ["count"],
+    xAxisKey: "name",
+    suggestedChart: "bar",
+  },
+  {
+    name: "membersWithLowestRatings",
+    description: "Team members ranked by lowest average ratings",
+    dataKeys: ["count"],
+    xAxisKey: "name",
+    suggestedChart: "bar",
+  },
+  {
+    name: "bookingsByHourStats",
+    description: "Number of bookings grouped by hour of day (0-23)",
+    dataKeys: ["count"],
+    xAxisKey: "hour",
+    suggestedChart: "bar",
+  },
+  {
+    name: "csatOverTime",
+    description: "Customer satisfaction (CSAT) score percentage over time",
+    dataKeys: ["CSAT"],
+    xAxisKey: "Month",
+    suggestedChart: "line",
+  },
+  {
+    name: "noShowHostsOverTime",
+    description: "Number of host no-shows over time",
+    dataKeys: ["Count"],
+    xAxisKey: "Month",
+    suggestedChart: "line",
+  },
+  {
+    name: "membersWithMostCompletedBookings",
+    description: "Team members ranked by most completed bookings",
+    dataKeys: ["count"],
+    xAxisKey: "name",
+    suggestedChart: "bar",
+  },
+  {
+    name: "membersWithLeastCompletedBookings",
+    description: "Team members ranked by least completed bookings",
+    dataKeys: ["count"],
+    xAxisKey: "name",
+    suggestedChart: "bar",
+  },
+];
+
+const CHART_COLORS: string[] = [
+  "#a855f7",
+  "#22c55e",
+  "#3b82f6",
+  "#ef4444",
+  "#64748b",
+  "#f97316",
+  "#06b6d4",
+  "#ec4899",
+];
+
+function buildGroqPrompt(query: string): string {
+  const endpointDescriptions = AVAILABLE_ENDPOINTS.map(
+    (ep) => `- ${ep.name}: ${ep.description} (suggested chart: ${ep.suggestedChart})`
+  ).join("\n");
+
+  return `You are an AI assistant that helps users query their booking insights data. 
+Given a user's natural language question about their booking data, determine:
+1. Which data endpoint to query
+2. What chart type best visualizes the answer
+3. A short title for the chart
+4. A brief description of what the chart shows
+
+Available endpoints:
+${endpointDescriptions}
+
+Available chart types: line (for trends over time), bar (for comparisons/rankings), pie (for proportions/distributions), area (for cumulative/volume over time)
+
+User query: "${query}"
+
+Respond in JSON format only (no markdown, no code blocks):
+{
+  "endpoint": "<endpoint_name>",
+  "chartType": "<line|bar|pie|area>",
+  "title": "<short chart title>",
+  "description": "<brief description of the chart>"
+}`;
+}
+
+interface GroqChoice {
+  message: { content: string };
+}
+
+interface GroqApiResult {
+  choices: GroqChoice[];
+}
+
+interface GroqParsed {
+  endpoint: string;
+  chartType: string;
+  title: string;
+  description: string;
+}
+
+interface ChartConfig {
+  chartType: ChartType;
+  title: string;
+  description: string;
+  endpoint: string;
+  dataKeys: string[];
+  xAxisKey: string;
+  colors: string[];
+}
+
+async function callGroq(prompt: string): Promise<ChartConfig> {
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) {
+    throw new Error("GROQ_API_KEY environment variable is not configured");
+  }
+
+  const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "llama-3.3-70b-versatile",
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are a helpful assistant that maps natural language queries to data API endpoints. Always respond with valid JSON only, no markdown formatting.",
+        },
+        { role: "user", content: prompt },
+      ],
+      temperature: 0.1,
+      max_tokens: 300,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Groq API error: ${response.status} - ${errorText}`);
+  }
+
+  const result: GroqApiResult = await response.json();
+  const content = result.choices?.[0]?.message?.content;
+
+  if (!content) {
+    throw new Error("No response content from Groq");
+  }
+
+  const parsed: GroqParsed = JSON.parse(content.trim());
+  const matchedEndpoint = AVAILABLE_ENDPOINTS.find((ep) => ep.name === parsed.endpoint);
+  if (!matchedEndpoint) {
+    throw new Error(`Unknown endpoint: ${parsed.endpoint}`);
+  }
+
+  const validChartTypes: ChartType[] = ["line", "bar", "pie", "area"];
+  const chartType: ChartType = validChartTypes.includes(parsed.chartType as ChartType)
+    ? (parsed.chartType as ChartType)
+    : matchedEndpoint.suggestedChart;
+
+  return {
+    chartType,
+    title: parsed.title || "Insights Chart",
+    description: parsed.description || "",
+    endpoint: matchedEndpoint.name,
+    dataKeys: matchedEndpoint.dataKeys,
+    xAxisKey: matchedEndpoint.xAxisKey,
+    colors: CHART_COLORS.slice(0, matchedEndpoint.dataKeys.length),
+  };
+}
+
+interface RequestBody {
+  query: string;
+  scope: "user" | "team" | "org";
+  selectedTeamId?: number;
+  timeZone: string;
+  columnFilters?: ColumnFilter[];
+}
+
+function transformMembersToChart(
+  data: Array<{
+    userId: number;
+    user: { id: number; username: string | null; name: string | null; email: string; avatarUrl: string };
+    emailMd5: string;
+    count: number;
+  }>
+): Array<Record<string, unknown>> {
+  return data.map((item) => ({
+    name: item.user.name || `User ${item.userId}`,
+    count: item.count,
+  }));
+}
+
+async function fetchDataForEndpoint(
+  endpointName: string,
+  userId: number,
+  organizationId: number | null,
+  weekStart: string,
+  body: RequestBody
+): Promise<Array<Record<string, unknown>>> {
+  const { scope, selectedTeamId, timeZone, columnFilters } = body;
+
+  const service = getInsightsBookingService({
+    options: {
+      scope,
+      userId,
+      orgId: organizationId,
+      ...(selectedTeamId && { teamId: selectedTeamId }),
+    },
+    filters: {
+      ...(columnFilters && { columnFilters }),
+    },
+  });
+
+  switch (endpointName) {
+    case "eventTrends": {
+      const { startDate, endDate } = extractDateRangeFromColumnFilters(columnFilters);
+      const timeView = getTimeView(startDate, endDate);
+      const dateRanges = getDateRanges({ startDate, endDate, timeView, timeZone, weekStart });
+      const trendData = await service.getEventTrendsStats({ timeZone, dateRanges });
+      return trendData as Array<Record<string, unknown>>;
+    }
+
+    case "bookingKPIStats": {
+      const currentStats = await service.getBookingStats();
+      const previousPeriodDates = service.calculatePreviousPeriodDates();
+      const previousColumnFilters = replaceDateRangeColumnFilter({
+        columnFilters,
+        newStartDate: previousPeriodDates.startDate,
+        newEndDate: previousPeriodDates.endDate,
+      });
+      const previousService = getInsightsBookingService({
+        options: {
+          scope,
+          userId,
+          orgId: organizationId,
+          ...(selectedTeamId && { teamId: selectedTeamId }),
+        },
+        filters: { ...(previousColumnFilters && { columnFilters: previousColumnFilters }) },
+      });
+      const previousStats = await previousService.getBookingStats();
+      return [
+        { metric: "Created", count: currentStats.total_bookings, prev: previousStats.total_bookings },
+        {
+          metric: "Completed",
+          count: currentStats.completed_bookings,
+          prev: previousStats.completed_bookings,
+        },
+        {
+          metric: "Rescheduled",
+          count: currentStats.rescheduled_bookings,
+          prev: previousStats.rescheduled_bookings,
+        },
+        {
+          metric: "Cancelled",
+          count: currentStats.cancelled_bookings,
+          prev: previousStats.cancelled_bookings,
+        },
+        {
+          metric: "No-Show (Host)",
+          count: currentStats.no_show_host_bookings,
+          prev: previousStats.no_show_host_bookings,
+        },
+        { metric: "No-Show (Guest)", count: currentStats.no_show_guests, prev: previousStats.no_show_guests },
+      ];
+    }
+
+    case "popularEvents": {
+      const popData = await service.getPopularEventsStats();
+      return popData.map((item) => ({ eventTypeName: item.eventTypeName, count: item.count }));
+    }
+
+    case "membersWithMostBookings": {
+      const mbData = await service.getMembersStatsWithCount({ type: "all", sortOrder: "DESC" });
+      return transformMembersToChart(mbData);
+    }
+
+    case "membersWithLeastBookings": {
+      const lbData = await service.getMembersStatsWithCount({ type: "all", sortOrder: "ASC" });
+      return transformMembersToChart(lbData);
+    }
+
+    case "membersWithMostCancelledBookings": {
+      const mcData = await service.getMembersStatsWithCount({ type: "cancelled", sortOrder: "DESC" });
+      return transformMembersToChart(mcData);
+    }
+
+    case "membersWithMostNoShow": {
+      const nsData = await service.getMembersStatsWithCount({ type: "noShow", sortOrder: "DESC" });
+      return transformMembersToChart(nsData);
+    }
+
+    case "membersWithHighestRatings": {
+      const hrData = await service.getMembersRatingStats("DESC");
+      return transformMembersToChart(hrData);
+    }
+
+    case "membersWithLowestRatings": {
+      const lrData = await service.getMembersRatingStats("ASC");
+      return transformMembersToChart(lrData);
+    }
+
+    case "membersWithMostCompletedBookings": {
+      const mcompData = await service.getMembersStatsWithCount({
+        type: "accepted",
+        sortOrder: "DESC",
+        completed: true,
+      });
+      return transformMembersToChart(mcompData);
+    }
+
+    case "membersWithLeastCompletedBookings": {
+      const lcompData = await service.getMembersStatsWithCount({
+        type: "accepted",
+        sortOrder: "ASC",
+        completed: true,
+      });
+      return transformMembersToChart(lcompData);
+    }
+
+    case "bookingsByHourStats": {
+      const hourData = await service.getBookingsByHourStats({ timeZone });
+      return hourData.map((item) => ({
+        hour: `${item.hour.toString().padStart(2, "0")}:00`,
+        count: item.count,
+      }));
+    }
+
+    case "csatOverTime": {
+      const { startDate, endDate } = extractDateRangeFromColumnFilters(columnFilters);
+      const timeView = getTimeView(startDate, endDate);
+      const dateRanges = getDateRanges({ startDate, endDate, timeView, timeZone, weekStart });
+      const csatData = await service.getCSATOverTimeStats({ timeZone, dateRanges });
+      return csatData as Array<Record<string, unknown>>;
+    }
+
+    case "noShowHostsOverTime": {
+      const { startDate, endDate } = extractDateRangeFromColumnFilters(columnFilters);
+      const timeView = getTimeView(startDate, endDate);
+      const dateRanges = getDateRanges({ startDate, endDate, timeView, timeZone, weekStart });
+      const nsHostData = await service.getNoShowHostsOverTimeStats({ timeZone, dateRanges });
+      return nsHostData as Array<Record<string, unknown>>;
+    }
+
+    default:
+      return [];
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const headersList = await headers();
+  const cookiesList = await cookies();
+  const legacyReq = buildLegacyRequest(headersList, cookiesList);
+
+  const session = await getServerSession({ req: legacyReq });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body: RequestBody = await req.json();
+    const { query } = body;
+
+    if (!query || typeof query !== "string" || !query.trim()) {
+      return NextResponse.json({ error: "Query is required" }, { status: 400 });
+    }
+
+    const user = await readonlyPrisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { id: true, organizationId: true, weekStart: true },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const prompt = buildGroqPrompt(query.trim());
+    const chartConfig = await callGroq(prompt);
+    const data = await fetchDataForEndpoint(
+      chartConfig.endpoint,
+      user.id,
+      user.organizationId,
+      user.weekStart,
+      body
+    );
+
+    return NextResponse.json({ ...chartConfig, data });
+  } catch (err) {
+    log.error("Error processing insights chat query:", err instanceof Error ? err.message : String(err));
+    return NextResponse.json({ error: "Failed to process query. Please try again." }, { status: 500 });
+  }
+}

--- a/apps/web/modules/insights/components/chat/InsightsChatBox.tsx
+++ b/apps/web/modules/insights/components/chat/InsightsChatBox.tsx
@@ -20,7 +20,12 @@ interface ChatApiResponse {
   error?: string;
 }
 
-export function InsightsChatBox() {
+interface InsightsChatBoxProps {
+  scope: "user" | "team" | "org";
+  selectedTeamId?: number;
+}
+
+export function InsightsChatBox({ scope, selectedTeamId }: InsightsChatBoxProps) {
   const { t } = useLocale();
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -51,7 +56,8 @@ export function InsightsChatBox() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             query: query.trim(),
-            scope: "user",
+            scope,
+            ...(selectedTeamId && { selectedTeamId }),
             timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           }),
         });

--- a/apps/web/modules/insights/components/chat/InsightsChatBox.tsx
+++ b/apps/web/modules/insights/components/chat/InsightsChatBox.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button } from "@calcom/ui/components/button";
+import { Spinner } from "@calcom/ui/components/icon";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { InsightsChatChart } from "./InsightsChatChart";
+import { getSavedCharts, removeChart, SavedCharts, saveChart } from "./SavedCharts";
+import type { ChatChartResult } from "./types";
+
+interface ChatApiResponse {
+  chartType: ChatChartResult["chartType"];
+  title: string;
+  description: string;
+  endpoint: string;
+  dataKeys: string[];
+  xAxisKey: string;
+  colors: string[];
+  data: Record<string, unknown>[];
+  error?: string;
+}
+
+export function InsightsChatBox() {
+  const { t } = useLocale();
+  const [query, setQuery] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [chatResults, setChatResults] = useState<ChatChartResult[]>([]);
+  const [savedCharts, setSavedCharts] = useState<ChatChartResult[]>([]);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [showSaved, setShowSaved] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setSavedCharts(getSavedCharts());
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!query.trim() || isLoading) return;
+
+      setIsLoading(true);
+      setError(null);
+      setIsExpanded(true);
+
+      try {
+        const response = await fetch("/api/insights/chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            query: query.trim(),
+            scope: "user",
+            timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          }),
+        });
+
+        if (!response.ok) {
+          const errData: { error?: string } = await response.json();
+          throw new Error(errData.error || "Failed to process query");
+        }
+
+        const result: ChatApiResponse = await response.json();
+
+        if (result.error) {
+          throw new Error(result.error);
+        }
+
+        const chartResult: ChatChartResult = {
+          id: `chart-${Date.now()}`,
+          query: query.trim(),
+          chartType: result.chartType,
+          title: result.title,
+          description: result.description,
+          endpoint: result.endpoint,
+          dataKeys: result.dataKeys,
+          xAxisKey: result.xAxisKey,
+          colors: result.colors,
+          data: result.data,
+        };
+
+        setChatResults((prev) => [chartResult, ...prev]);
+        setQuery("");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An unexpected error occurred");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [query, isLoading]
+  );
+
+  const handleSaveChart = useCallback((chart: ChatChartResult) => {
+    const updated = saveChart(chart);
+    setSavedCharts(updated);
+  }, []);
+
+  const handleRemoveChart = useCallback((chartId: string) => {
+    const updated = removeChart(chartId);
+    setSavedCharts(updated);
+  }, []);
+
+  const savedChartIds = new Set(savedCharts.map((c) => c.id));
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 mx-auto max-w-4xl px-4 pb-4">
+      {isExpanded && (
+        <div
+          ref={resultsRef}
+          className="bg-default border-subtle mb-2 max-h-[60vh] overflow-y-auto rounded-xl border shadow-lg">
+          <div className="border-subtle bg-default sticky top-0 z-10 flex items-center justify-between border-b px-4 py-2">
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShowSaved(false)}
+                className={`text-sm font-medium px-2 py-1 rounded ${!showSaved ? "bg-emphasis text-emphasis" : "text-default"}`}>
+                Results ({chatResults.length})
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowSaved(true)}
+                className={`text-sm font-medium px-2 py-1 rounded ${showSaved ? "bg-emphasis text-emphasis" : "text-default"}`}>
+                {t("saved")} ({savedCharts.length})
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsExpanded(false)}
+              className="text-subtle hover:text-default text-sm">
+              Minimize
+            </button>
+          </div>
+
+          <div className="stack-y-3 p-4">
+            {showSaved ? (
+              <SavedCharts charts={savedCharts} onRemove={handleRemoveChart} />
+            ) : chatResults.length === 0 ? (
+              <p className="text-subtle py-8 text-center text-sm">{t("insights_chat_empty_state")}</p>
+            ) : (
+              chatResults.map((result) => (
+                <div key={result.id} className="stack-y-1">
+                  <p className="text-subtle text-xs">Query: {result.query}</p>
+                  <InsightsChatChart
+                    result={result}
+                    onSave={handleSaveChart}
+                    isSaved={savedChartIds.has(result.id)}
+                  />
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="relative">
+        <div className="bg-default border-subtle flex items-center gap-2 rounded-xl border p-2 shadow-lg">
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t("insights_chat_placeholder")}
+            className="text-default placeholder:text-muted min-w-0 flex-1 bg-transparent px-3 py-2 text-sm outline-none"
+            disabled={isLoading}
+          />
+          {isLoading ? (
+            <div className="flex h-9 w-9 items-center justify-center">
+              <Spinner className="h-5 w-5" />
+            </div>
+          ) : (
+            <Button type="submit" color="primary" size="sm" disabled={!query.trim()} StartIcon="send">
+              Send
+            </Button>
+          )}
+        </div>
+        {error && <p className="text-error mt-1 px-3 text-xs">{error}</p>}
+      </form>
+    </div>
+  );
+}

--- a/apps/web/modules/insights/components/chat/InsightsChatBox.tsx
+++ b/apps/web/modules/insights/components/chat/InsightsChatBox.tsx
@@ -94,7 +94,7 @@ export function InsightsChatBox({ scope, selectedTeamId }: InsightsChatBoxProps)
         setIsLoading(false);
       }
     },
-    [query, isLoading]
+    [query, isLoading, scope, selectedTeamId]
   );
 
   const handleSaveChart = useCallback((chart: ChatChartResult) => {

--- a/apps/web/modules/insights/components/chat/InsightsChatChart.tsx
+++ b/apps/web/modules/insights/components/chat/InsightsChatChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button } from "@calcom/ui/components/button";
 import { useState } from "react";
 import {
@@ -31,7 +32,7 @@ const CHART_COLORS: string[] = [
   "#ec4899",
 ];
 
-function RenderLineChart({ result }: { result: ChatChartResult }): React.JSX.Element {
+function RenderLineChart({ result }: { result: ChatChartResult }): JSX.Element {
   return (
     <ResponsiveContainer width="100%" height={300}>
       <LineChart data={result.data} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
@@ -61,7 +62,7 @@ function RenderLineChart({ result }: { result: ChatChartResult }): React.JSX.Ele
   );
 }
 
-function RenderBarChart({ result }: { result: ChatChartResult }): React.JSX.Element {
+function RenderBarChart({ result }: { result: ChatChartResult }): JSX.Element {
   return (
     <ResponsiveContainer width="100%" height={300}>
       <BarChart data={result.data} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
@@ -88,7 +89,7 @@ function RenderBarChart({ result }: { result: ChatChartResult }): React.JSX.Elem
   );
 }
 
-function RenderPieChart({ result }: { result: ChatChartResult }): React.JSX.Element {
+function RenderPieChart({ result }: { result: ChatChartResult }): JSX.Element {
   const dataKey = result.dataKeys[0] || "count";
   return (
     <ResponsiveContainer width="100%" height={300}>
@@ -100,9 +101,12 @@ function RenderPieChart({ result }: { result: ChatChartResult }): React.JSX.Elem
           cx="50%"
           cy="50%"
           outerRadius={100}
-          label={({ name, value }: { name: string; value: number }): string => `${name}: ${value}`}>
+          label={({ name, value }: { name: string; value?: number }): string => `${name}: ${value ?? 0}`}>
           {result.data.map((_entry: Record<string, unknown>, index: number) => (
-            <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+            <Cell
+              key={`cell-${index}`}
+              fill={result.colors[index] || CHART_COLORS[index % CHART_COLORS.length]}
+            />
           ))}
         </Pie>
         <Tooltip
@@ -117,7 +121,7 @@ function RenderPieChart({ result }: { result: ChatChartResult }): React.JSX.Elem
   );
 }
 
-function RenderAreaChart({ result }: { result: ChatChartResult }): React.JSX.Element {
+function RenderAreaChart({ result }: { result: ChatChartResult }): JSX.Element {
   return (
     <ResponsiveContainer width="100%" height={300}>
       <AreaChart data={result.data} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
@@ -155,6 +159,7 @@ export function InsightsChatChart({
   onSave: (result: ChatChartResult) => void;
   isSaved: boolean;
 }) {
+  const { t } = useLocale();
   const [saving, setSaving] = useState(false);
 
   const handleSave = () => {
@@ -185,7 +190,7 @@ export function InsightsChatChart({
           onClick={handleSave}
           disabled={isSaved || saving}
           StartIcon="download">
-          {isSaved ? "Saved" : "Save"}
+          {isSaved ? t("saved") : t("save")}
         </Button>
       </div>
       <ChartComponent result={result} />

--- a/apps/web/modules/insights/components/chat/InsightsChatChart.tsx
+++ b/apps/web/modules/insights/components/chat/InsightsChatChart.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { Button } from "@calcom/ui/components/button";
+import { useState } from "react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { ChatChartResult } from "./types";
+
+const CHART_COLORS: string[] = [
+  "#a855f7",
+  "#22c55e",
+  "#3b82f6",
+  "#ef4444",
+  "#64748b",
+  "#f97316",
+  "#06b6d4",
+  "#ec4899",
+];
+
+function RenderLineChart({ result }: { result: ChatChartResult }): React.JSX.Element {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={result.data} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+        <XAxis dataKey={result.xAxisKey} className="text-xs" axisLine={false} tickLine={false} />
+        <YAxis allowDecimals={false} className="text-xs opacity-50" axisLine={false} tickLine={false} />
+        <Tooltip
+          contentStyle={{
+            borderRadius: "8px",
+            border: "1px solid var(--cal-border-subtle)",
+            backgroundColor: "var(--cal-bg-default)",
+          }}
+        />
+        {result.dataKeys.map((key, i) => (
+          <Line
+            key={key}
+            type="monotone"
+            dataKey={key}
+            stroke={result.colors[i] || CHART_COLORS[i % CHART_COLORS.length]}
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+function RenderBarChart({ result }: { result: ChatChartResult }): React.JSX.Element {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={result.data} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+        <XAxis dataKey={result.xAxisKey} className="text-xs" axisLine={false} tickLine={false} />
+        <YAxis allowDecimals={false} className="text-xs opacity-50" axisLine={false} tickLine={false} />
+        <Tooltip
+          contentStyle={{
+            borderRadius: "8px",
+            border: "1px solid var(--cal-border-subtle)",
+            backgroundColor: "var(--cal-bg-default)",
+          }}
+        />
+        {result.dataKeys.map((key, i) => (
+          <Bar
+            key={key}
+            dataKey={key}
+            fill={result.colors[i] || CHART_COLORS[i % CHART_COLORS.length]}
+            radius={[4, 4, 0, 0]}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function RenderPieChart({ result }: { result: ChatChartResult }): React.JSX.Element {
+  const dataKey = result.dataKeys[0] || "count";
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <PieChart>
+        <Pie
+          data={result.data}
+          dataKey={dataKey}
+          nameKey={result.xAxisKey}
+          cx="50%"
+          cy="50%"
+          outerRadius={100}
+          label={({ name, value }: { name: string; value: number }): string => `${name}: ${value}`}>
+          {result.data.map((_entry: Record<string, unknown>, index: number) => (
+            <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={{
+            borderRadius: "8px",
+            border: "1px solid var(--cal-border-subtle)",
+            backgroundColor: "var(--cal-bg-default)",
+          }}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}
+
+function RenderAreaChart({ result }: { result: ChatChartResult }): React.JSX.Element {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <AreaChart data={result.data} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+        <XAxis dataKey={result.xAxisKey} className="text-xs" axisLine={false} tickLine={false} />
+        <YAxis allowDecimals={false} className="text-xs opacity-50" axisLine={false} tickLine={false} />
+        <Tooltip
+          contentStyle={{
+            borderRadius: "8px",
+            border: "1px solid var(--cal-border-subtle)",
+            backgroundColor: "var(--cal-bg-default)",
+          }}
+        />
+        {result.dataKeys.map((key, i) => (
+          <Area
+            key={key}
+            type="monotone"
+            dataKey={key}
+            stroke={result.colors[i] || CHART_COLORS[i % CHART_COLORS.length]}
+            fill={`${result.colors[i] || CHART_COLORS[i % CHART_COLORS.length]}33`}
+            strokeWidth={2}
+          />
+        ))}
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function InsightsChatChart({
+  result,
+  onSave,
+  isSaved,
+}: {
+  result: ChatChartResult;
+  onSave: (result: ChatChartResult) => void;
+  isSaved: boolean;
+}) {
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = () => {
+    setSaving(true);
+    onSave(result);
+    setTimeout(() => setSaving(false), 500);
+  };
+
+  const chartComponents = {
+    line: RenderLineChart,
+    bar: RenderBarChart,
+    pie: RenderPieChart,
+    area: RenderAreaChart,
+  };
+
+  const ChartComponent = chartComponents[result.chartType] || RenderBarChart;
+
+  return (
+    <div className="border-subtle bg-default rounded-lg border p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <div>
+          <h3 className="text-emphasis text-sm font-semibold">{result.title}</h3>
+          {result.description && <p className="text-subtle text-xs">{result.description}</p>}
+        </div>
+        <Button
+          color="secondary"
+          size="sm"
+          onClick={handleSave}
+          disabled={isSaved || saving}
+          StartIcon="download">
+          {isSaved ? "Saved" : "Save"}
+        </Button>
+      </div>
+      <ChartComponent result={result} />
+    </div>
+  );
+}

--- a/apps/web/modules/insights/components/chat/SavedCharts.tsx
+++ b/apps/web/modules/insights/components/chat/SavedCharts.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Button } from "@calcom/ui/components/button";
+import { InsightsChatChart } from "./InsightsChatChart";
+import type { ChatChartResult } from "./types";
+
+const STORAGE_KEY = "cal-insights-saved-charts";
+
+export function getSavedCharts(): ChatChartResult[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return [];
+    return JSON.parse(stored) as ChatChartResult[];
+  } catch {
+    return [];
+  }
+}
+
+export function saveChart(chart: ChatChartResult): ChatChartResult[] {
+  const existing = getSavedCharts();
+  const updated = [{ ...chart, savedAt: Date.now() }, ...existing];
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  return updated;
+}
+
+export function removeChart(chartId: string): ChatChartResult[] {
+  const existing = getSavedCharts();
+  const updated = existing.filter((c) => c.id !== chartId);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  return updated;
+}
+
+export function SavedCharts({
+  charts,
+  onRemove,
+}: {
+  charts: ChatChartResult[];
+  onRemove: (chartId: string) => void;
+}) {
+  if (charts.length === 0) return null;
+
+  return (
+    <div className="stack-y-3">
+      <h3 className="text-emphasis text-sm font-semibold">Saved Charts</h3>
+      {charts.map((chart) => (
+        <div key={chart.id} className="relative">
+          <InsightsChatChart result={chart} onSave={() => undefined} isSaved={true} />
+          <Button
+            color="destructive"
+            size="sm"
+            className="absolute right-2 top-2"
+            onClick={() => onRemove(chart.id)}
+            StartIcon="trash-2">
+            Remove
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/modules/insights/components/chat/SavedCharts.tsx
+++ b/apps/web/modules/insights/components/chat/SavedCharts.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button } from "@calcom/ui/components/button";
 import { InsightsChatChart } from "./InsightsChatChart";
 import type { ChatChartResult } from "./types";
@@ -38,11 +39,13 @@ export function SavedCharts({
   charts: ChatChartResult[];
   onRemove: (chartId: string) => void;
 }) {
+  const { t } = useLocale();
+
   if (charts.length === 0) return null;
 
   return (
     <div className="stack-y-3">
-      <h3 className="text-emphasis text-sm font-semibold">Saved Charts</h3>
+      <h3 className="text-emphasis text-sm font-semibold">{t("saved_charts")}</h3>
       {charts.map((chart) => (
         <div key={chart.id} className="relative">
           <InsightsChatChart result={chart} onSave={() => undefined} isSaved={true} />
@@ -52,7 +55,7 @@ export function SavedCharts({
             className="absolute right-2 top-2"
             onClick={() => onRemove(chart.id)}
             StartIcon="trash-2">
-            Remove
+            {t("remove")}
           </Button>
         </div>
       ))}

--- a/apps/web/modules/insights/components/chat/types.ts
+++ b/apps/web/modules/insights/components/chat/types.ts
@@ -1,0 +1,15 @@
+export type ChartType = "line" | "bar" | "pie" | "area";
+
+export interface ChatChartResult {
+  id: string;
+  query: string;
+  chartType: ChartType;
+  title: string;
+  description: string;
+  endpoint: string;
+  dataKeys: string[];
+  xAxisKey: string;
+  colors: string[];
+  data: Record<string, unknown>[];
+  savedAt?: number;
+}

--- a/apps/web/modules/insights/views/insights-view.tsx
+++ b/apps/web/modules/insights/views/insights-view.tsx
@@ -1,14 +1,9 @@
 "use client";
 
-import { usePathname } from "next/navigation";
-import { useState, useCallback } from "react";
-
 import { ColumnFilterType, type FilterableColumn } from "@calcom/features/data-table";
-import { DataTableProvider } from "~/data-table/DataTableProvider";
-import { DataTableFilters, DateRangeFilter } from "~/data-table/components";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { FilterType } from "@calcom/types/data-table";
-import { useDataTable } from "~/data-table/hooks/useDataTable";
-import { useSegments } from "~/data-table/hooks/useSegments";
+import { ButtonGroup } from "@calcom/ui/components/buttonGroup";
 import {
   AverageEventDurationChart,
   BookingKPICards,
@@ -18,25 +13,30 @@ import {
   HighestNoShowHostTable,
   HighestRatedMembersTable,
   LeastBookedTeamMembersTable,
+  LeastCompletedTeamMembersTable,
   LowestRatedMembersTable,
   MostBookedTeamMembersTable,
   MostCancelledBookingsTables,
   MostCompletedTeamMembersTable,
-  LeastCompletedTeamMembersTable,
   NoShowHostsOverTimeChart,
   PopularEventsTable,
-  RecentNoShowGuestsChart,
   RecentFeedbackTable,
+  RecentNoShowGuestsChart,
   TimezoneBadge,
 } from "@calcom/web/modules/insights/components/booking";
-import { InsightsOrgTeamsProvider } from "../components/context/InsightsOrgTeamsProvider";
-import { DateTargetSelector, type DateTarget } from "../components/filters/DateTargetSelector";
-import { Download } from "../components/filters/Download/Download";
-import { OrgTeamsFilter } from "../components/filters/OrgTeamsFilter";
 import { useInsightsBookings } from "@calcom/web/modules/insights/hooks/useInsightsBookings";
 import { useInsightsOrgTeams } from "@calcom/web/modules/insights/hooks/useInsightsOrgTeams";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { ButtonGroup } from "@calcom/ui/components/buttonGroup";
+import { usePathname } from "next/navigation";
+import { useCallback, useState } from "react";
+import { DataTableFilters, DateRangeFilter } from "~/data-table/components";
+import { DataTableProvider } from "~/data-table/DataTableProvider";
+import { useDataTable } from "~/data-table/hooks/useDataTable";
+import { useSegments } from "~/data-table/hooks/useSegments";
+import { InsightsChatBox } from "../components/chat/InsightsChatBox";
+import { InsightsOrgTeamsProvider } from "../components/context/InsightsOrgTeamsProvider";
+import { type DateTarget, DateTargetSelector } from "../components/filters/DateTargetSelector";
+import { Download } from "../components/filters/Download/Download";
+import { OrgTeamsFilter } from "../components/filters/OrgTeamsFilter";
 
 export default function InsightsPage({ timeZone }: { timeZone: string }) {
   const pathname = usePathname();
@@ -154,7 +154,12 @@ function InsightsPageContent() {
             {t("contact_support")}
           </a>
         </small>
+
+        {/* Spacer for the fixed chat box */}
+        <div className="h-20" />
       </div>
+
+      <InsightsChatBox />
     </>
   );
 }

--- a/apps/web/modules/insights/views/insights-view.tsx
+++ b/apps/web/modules/insights/views/insights-view.tsx
@@ -65,7 +65,7 @@ const startTimeColumn: Extract<FilterableColumn, { type: Extract<FilterType, "dr
 function InsightsPageContent() {
   const { t } = useLocale();
   const { table } = useInsightsBookings();
-  const { isAll, teamId, userId } = useInsightsOrgTeams();
+  const { isAll, teamId, userId, scope } = useInsightsOrgTeams();
   const { removeFilter } = useDataTable();
   const [dateTarget, _setDateTarget] = useState<"startTime" | "createdAt">("startTime");
 
@@ -159,7 +159,7 @@ function InsightsPageContent() {
         <div className="h-20" />
       </div>
 
-      <InsightsChatBox />
+      <InsightsChatBox scope={scope} selectedTeamId={teamId} />
     </>
   );
 }

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4751,5 +4751,7 @@
   "dashboard": "dashboard",
   "paypal_webhook_reminder": "Our integration creates a specific webhook on your PayPal account that we use to report back transactions to our system. If you delete this webhook, we will not be able to report back and you should uninstall and install the app again for this to work properly. Uninstalling the app won't delete your current event type price/currency configuration but you will not be able to receive bookings.",
   "discount_25": "-25%",
+  "insights_chat_placeholder": "Chat with your booking insights",
+  "insights_chat_empty_state": "Ask a question about your booking data to generate a chart",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4753,5 +4753,6 @@
   "discount_25": "-25%",
   "insights_chat_placeholder": "Chat with your booking insights",
   "insights_chat_empty_state": "Ask a question about your booking data to generate a chart",
+  "saved_charts": "Saved Charts",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }


### PR DESCRIPTION
## What does this PR do?

Adds a fixed-position chat box at the bottom of the `/insights` page that accepts natural language queries about booking data. Uses Groq (llama-3.3-70b-versatile) to interpret queries, maps them to existing insights data endpoints server-side, and dynamically renders the best chart type (line, bar, pie, area) using recharts. Users can save generated charts to localStorage.

**Architecture:**
- **API route** (`apps/web/app/api/insights/chat/route.ts`): Receives natural language query → calls Groq to determine endpoint + chart type → fetches data server-side via `InsightsBookingBaseService` → returns chart config + data
- **Client component** (`InsightsChatBox.tsx`): Pure presentation layer — sends query to API, renders results
- 14 insights endpoints are available for querying (event trends, KPIs, popular events, member rankings, CSAT, no-shows, bookings by hour, etc.)

## ⚠️ Key areas for reviewer attention

1. ~~No Zod validation on Groq LLM JSON output~~ — **Fixed**: Added `GroqParsedSchema` Zod schema with `.safeParse()`, plus try-catch around `JSON.parse` for malformed JSON
2. ~~Scope hardcoded to `"user"`~~ — **Fixed**: Chat box now receives `scope` and `selectedTeamId` from `useInsightsOrgTeams` hook via props
3. **`weekStart`** now reads from user preferences (`user.weekStart`) instead of being hardcoded
4. ~~No authorization beyond session check~~ — **Fixed**: Added `PermissionCheckService.checkPermission` for `insights.read` and team membership verification matching the tRPC pattern
5. **`GROQ_API_KEY` environment variable required** — runtime check only, no startup validation
6. **No tests** — this is a new feature with ~1000 lines of new code and zero test coverage
7. **`Record<string, unknown>[]`** is used throughout as the chart data type — loose typing

### Suggested human review checklist
- [ ] Verify the authorization logic in `route.ts:484-523` correctly mirrors the tRPC `userBelongsToTeamProcedure` pattern — custom auth in API routes is inherently riskier than reusing middleware
- [ ] Confirm `PermissionCheckService.checkPermission` API matches what's used in the codebase (params: `userId`, `teamId`, `permission`, `fallbackRoles`)
- [ ] Check if any edge cases exist where `scope` from `useInsightsOrgTeams` could be undefined or mismatched with `selectedTeamId`
- [ ] Verify localStorage `getSavedCharts()` handles corrupt/unexpected data gracefully (currently uses try-catch but no schema validation on the parsed array)

## Updates since last revision

Addressed Cubic AI review feedback (9 issues with confidence ≥ 9/10 across 3 review rounds):

- **Authorization bypass** (P0): Added `PermissionCheckService` checks for team membership and `insights.read` permission in the API route POST handler
- **Zod validation** (P2): Created `GroqParsedSchema` with `.safeParse()` and wrapped `JSON.parse` in try-catch for malformed LLM output
- **Scope wiring** (P1): `InsightsChatBox` now accepts `scope` and `selectedTeamId` props from `useInsightsOrgTeams`
- **Pie chart colors** (P2): Cell fill now uses `result.colors[index]` with CHART_COLORS fallback
- **i18n localization** (P3): Save/Saved buttons, "Saved Charts" heading, and Remove button all use `t()` with existing i18n keys (`save`, `saved`, `remove`, `saved_charts`)
- **useCallback deps** (P1): Added `scope` and `selectedTeamId` to `handleSubmit` dependency array
- **Error message hygiene** (P2): Removed raw Groq output from JSON parse error message to avoid leaking LLM responses into logs

Skipped: localStorage validation (confidence 8/10, below threshold).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Set `GROQ_API_KEY` environment variable with a valid Groq API key
2. Navigate to `/insights` page (logged in as a user with booking data)
3. The chat box should appear fixed at the bottom of the page
4. Try queries like:
   - "Show me booking trends over time" → should render a line chart
   - "Which team members have the most bookings?" → should render a bar chart
   - "What are my KPI stats?" → should render a bar chart with metrics
   - "Show popular event types" → should render a bar chart
5. Click "Save" on a chart → should persist in localStorage and appear in saved charts section
6. Click "Remove" on a saved chart → should remove it
7. Verify the chat box collapses/expands properly
8. **Switch between user/team/org scope** in the insights filters and verify the chat queries respect the selected scope

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My PR is too large (>500 lines or >10 files) and should be split into smaller PRs

---

Link to Devin Session: https://app.devin.ai/sessions/bf30df83b3c34a5eb14d101f3f92eab9
Requested by: @PeerRich