### PR TITLE
feat: show upgrade banner for Booking History tab in BookingDetailsSheet

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/booking/[uid]/logs/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/booking/[uid]/logs/page.tsx
@@ -39,7 +39,7 @@ const Page = async ({ params }: PageProps) => {
 
   return (
     <ShellMainAppDir heading={t("booking_history")} subtitle={t("booking_history_description")}>
-      <BookingHistoryPage bookingUid={bookingUid} />
+      <BookingHistoryPage bookingUid={bookingUid} isOrgUser={session.user.organizationId != null} />
     </ShellMainAppDir>
   );
 };

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/booking/[uid]/logs/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/booking/[uid]/logs/page.tsx
@@ -39,7 +39,7 @@ const Page = async ({ params }: PageProps) => {
 
   return (
     <ShellMainAppDir heading={t("booking_history")} subtitle={t("booking_history_description")}>
-      <BookingHistoryPage bookingUid={bookingUid} isOrgUser={session.user.organizationId != null} />
+      <BookingHistoryPage bookingUid={bookingUid} isOrgUser={session.user.org?.id != null} />
     </ShellMainAppDir>
   );
 };

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/booking/[uid]/logs/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/booking/[uid]/logs/page.tsx
@@ -39,7 +39,7 @@ const Page = async ({ params }: PageProps) => {
 
   return (
     <ShellMainAppDir heading={t("booking_history")} subtitle={t("booking_history_description")}>
-      <BookingHistoryPage bookingUid={bookingUid} isOrgUser={session.user.org?.id != null} />
+      <BookingHistoryPage bookingUid={bookingUid} isOrgUser={session.user.profile?.organizationId != null} />
     </ShellMainAppDir>
   );
 };

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
@@ -79,7 +79,7 @@ const Page = async ({ params }: PageProps) => {
         permissions={{ canReadOthersBookings }}
         bookingsV3Enabled={bookingsV3Enabled}
         bookingAuditEnabled={bookingAuditEnabled}
-        isOrgUser={session.user.org?.id != null}
+        isOrgUser={session.user.profile?.organizationId != null}
       />
     </ShellMainAppDir>
   );

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
@@ -79,7 +79,7 @@ const Page = async ({ params }: PageProps) => {
         permissions={{ canReadOthersBookings }}
         bookingsV3Enabled={bookingsV3Enabled}
         bookingAuditEnabled={bookingAuditEnabled}
-        isOrgUser={session.user.organizationId != null}
+        isOrgUser={session.user.org?.id != null}
       />
     </ShellMainAppDir>
   );

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
@@ -79,6 +79,7 @@ const Page = async ({ params }: PageProps) => {
         permissions={{ canReadOthersBookings }}
         bookingsV3Enabled={bookingsV3Enabled}
         bookingAuditEnabled={bookingAuditEnabled}
+        isOrgUser={session.user.organizationId != null}
       />
     </ShellMainAppDir>
   );

--- a/apps/web/modules/billing/components/WideUpgradeBanner.tsx
+++ b/apps/web/modules/billing/components/WideUpgradeBanner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useClientOnly } from "@calcom/lib/hooks/useClientOnly";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { localStorage } from "@calcom/lib/webstorage";
 import { Icon } from "@calcom/ui/components/icon";
@@ -8,7 +9,6 @@ import { Button } from "@coss/ui/components/button";
 import Image from "next/image";
 import Link from "next/link";
 import posthog from "posthog-js";
-import { useClientOnly } from "@calcom/lib/hooks/useClientOnly";
 import { useState } from "react";
 import type { UpgradeTarget } from "./types";
 
@@ -45,7 +45,8 @@ export type WideUpgradeBannerProps = {
   subtitle: string;
   target: UpgradeTarget;
   size?: "md" | "sm";
-  image: {
+  dismissible?: boolean;
+  image?: {
     src: string;
     width: number;
     height: number;
@@ -64,39 +65,42 @@ export function WideUpgradeBanner({
   subtitle,
   target,
   size = "md",
+  dismissible = true,
   image,
   learnMoreButton,
   children,
 }: WideUpgradeBannerProps) {
   const { t } = useLocale();
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = useState(!dismissible);
   useClientOnly(() => {
-    setVisible(!isDismissed(tracking));
+    if (dismissible) {
+      setVisible(!isDismissed(tracking));
+    }
   });
 
   if (!visible) return null;
 
   return (
     <div className="relative flex w-full overflow-hidden rounded-xl bg-muted border-muted border">
-      <Button
-        variant="ghost"
-        className="absolute right-2 top-2 z-10"
-        onClick={() => {
-          dismiss(tracking);
-          setVisible(false);
-          posthog.capture("large_upgrade_banner_dismissed", { source: tracking, target });
-        }}>
-        {/* This button goes on top of the image, so it's better to force this color */}
-        <Icon name="x" className="h-4 w-4 text-gray-700" />
-      </Button>
+      {dismissible && (
+        <Button
+          variant="ghost"
+          className="absolute right-2 top-2 z-10"
+          onClick={() => {
+            dismiss(tracking);
+            setVisible(false);
+            posthog.capture("large_upgrade_banner_dismissed", { source: tracking, target });
+          }}>
+          {/* This button goes on top of the image, so it's better to force this color */}
+          <Icon name="x" className="h-4 w-4 text-gray-700" />
+        </Button>
+      )}
       {/* Left Content */}
       <div className="flex flex-1 flex-col p-6">
         {size === "sm" ? (
           <div className="flex items-start gap-1.5">
             <h2 className="font-cal text-base font-semibold leading-none text-default">{title}</h2>
-            <div className="relative -top-1">
-              {target === "team" ? <TeamBadge /> : <OrgBadge />}
-            </div>
+            <div className="relative -top-1">{target === "team" ? <TeamBadge /> : <OrgBadge />}</div>
           </div>
         ) : (
           <div>
@@ -135,15 +139,12 @@ export function WideUpgradeBanner({
       </div>
 
       {/* Right Content - Image */}
-      <div
-        className={`relative hidden w-1/2 overflow-hidden md:block${size === "sm" ? " max-w-64" : " max-w-[520px]"}`}>
-        <Image
-          src={image.src}
-          alt={title}
-          fill
-          className="object-cover object-left"
-        />
-      </div>
+      {image && (
+        <div
+          className={`relative hidden w-1/2 overflow-hidden md:block${size === "sm" ? " max-w-64" : " max-w-[520px]"}`}>
+          <Image src={image.src} alt={title} fill className="object-cover object-left" />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/modules/billing/upgrade-banners/WideUpgradeBannerForBookingAudit.tsx
+++ b/apps/web/modules/billing/upgrade-banners/WideUpgradeBannerForBookingAudit.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Icon } from "@calcom/ui/components/icon";
+import { UpgradePlanDialog } from "@calcom/web/modules/billing/components/UpgradePlanDialog";
+import { WideUpgradeBanner } from "@calcom/web/modules/billing/components/WideUpgradeBanner";
+import { Button } from "@coss/ui/components/button";
+
+export function WideUpgradeBannerForBookingAudit() {
+  const { t } = useLocale();
+
+  return (
+    <WideUpgradeBanner
+      tracking="bookings.booking-history-audit-logs"
+      title={t("booking_history_requires_organization")}
+      subtitle={t("booking_history_upgrade_description")}
+      target="organization"
+      size="sm"
+      dismissible={false}>
+      <UpgradePlanDialog tracking="booking-history-audit-logs" target="organization">
+        <Button variant="outline">
+          {t("try_for_free")}
+          <Icon name="arrow-right" />
+        </Button>
+      </UpgradePlanDialog>
+    </WideUpgradeBanner>
+  );
+}

--- a/apps/web/modules/booking-audit/components/BookingHistory.tsx
+++ b/apps/web/modules/booking-audit/components/BookingHistory.tsx
@@ -10,12 +10,14 @@ import { FilterSearchField, Select } from "@calcom/ui/components/form";
 import { Icon, type IconName } from "@calcom/ui/components/icon";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { Tooltip } from "@calcom/ui/components/tooltip";
+import { WideUpgradeBannerForBookingAudit } from "@calcom/web/modules/billing/upgrade-banners/WideUpgradeBannerForBookingAudit";
 import { format, formatDistanceToNow } from "date-fns";
 import Link from "next/link";
 import { useState } from "react";
 
 interface BookingHistoryProps {
   bookingUid: string;
+  isOrgUser?: boolean;
 }
 
 type TranslationComponent = {
@@ -30,14 +32,14 @@ type TranslationWithParams = {
 };
 
 type DisplayFieldValue =
-    | { type: "translationKey"; valueKey: string }
-    | { type: "rawValue"; value: string }
-    | { type: "rawValues"; values: string[] }
-    | { type: "translationsWithParams"; valuesWithParams: TranslationWithParams[] };
+  | { type: "translationKey"; valueKey: string }
+  | { type: "rawValue"; value: string }
+  | { type: "rawValues"; values: string[] }
+  | { type: "translationsWithParams"; valuesWithParams: TranslationWithParams[] };
 
 type DisplayField = {
-    labelKey: string;
-    fieldValue: DisplayFieldValue;
+  labelKey: string;
+  fieldValue: DisplayFieldValue;
 };
 
 type AuditLog = {
@@ -333,15 +335,15 @@ function BookingLogsTimeline({ logs }: BookingLogsTimelineProps) {
                       {/* Render displayFields if available, otherwise show type */}
                       {log.displayFields && log.displayFields.length > 0
                         ? log.displayFields.map((field, idx) => (
-                          <div
-                            key={idx}
-                            className="flex items-start gap-2 py-2 border-b px-3 border-subtle">
-                            <span className="font-medium text-emphasis w-[140px]">{t(field.labelKey)}</span>
-                            <span className="font-medium">
-                              <DisplayFieldValueComponent fieldValue={field.fieldValue} />
-                            </span>
-                          </div>
-                        ))
+                            <div
+                              key={idx}
+                              className="flex items-start gap-2 py-2 border-b px-3 border-subtle">
+                              <span className="font-medium text-emphasis w-[140px]">{t(field.labelKey)}</span>
+                              <span className="font-medium">
+                                <DisplayFieldValueComponent fieldValue={field.fieldValue} />
+                              </span>
+                            </div>
+                          ))
                         : null}
                       <div className="flex items-start gap-2 py-2 border-b px-3 border-subtle">
                         <span className="font-medium text-emphasis w-[140px]">{t("actor")}</span>
@@ -461,7 +463,15 @@ function useBookingLogsFilters(auditLogs: AuditLog[], searchTerm: string, actorF
   return { filteredLogs, actorOptions };
 }
 
-export function BookingHistory({ bookingUid }: BookingHistoryProps) {
+export function BookingHistory({ bookingUid, isOrgUser = false }: BookingHistoryProps) {
+  if (!isOrgUser) {
+    return <WideUpgradeBannerForBookingAudit />;
+  }
+
+  return <BookingHistoryContent bookingUid={bookingUid} />;
+}
+
+function BookingHistoryContent({ bookingUid }: { bookingUid: string }) {
   const [searchTerm, setSearchTerm] = useState("");
   const [actorFilter, setActorFilter] = useState<string | null>(null);
   const { t } = useLocale();

--- a/apps/web/modules/booking-audit/components/BookingHistoryPage.tsx
+++ b/apps/web/modules/booking-audit/components/BookingHistoryPage.tsx
@@ -4,12 +4,13 @@ import { BookingHistory } from "./BookingHistory";
 
 interface BookingHistoryPageProps {
   bookingUid: string;
+  isOrgUser?: boolean;
 }
 
 /**
  * BookingHistoryPage - Wrapper component for standalone page context
  * Adds page-specific styling and layout for the booking history view
  */
-export function BookingHistoryPage({ bookingUid }: BookingHistoryPageProps) {
-  return <BookingHistory bookingUid={bookingUid} />;
+export function BookingHistoryPage({ bookingUid, isOrgUser = false }: BookingHistoryPageProps) {
+  return <BookingHistory bookingUid={bookingUid} isOrgUser={isOrgUser} />;
 }

--- a/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
+++ b/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
@@ -31,8 +31,8 @@ import {
   SheetTitle,
 } from "@calcom/ui/components/sheet";
 import { Tooltip } from "@calcom/ui/components/tooltip";
-import { ExternalLinkIcon, RepeatIcon } from "@coss/ui/icons";
 import { BookingHistory } from "@calcom/web/modules/booking-audit/components/BookingHistory";
+import { ExternalLinkIcon, RepeatIcon } from "@coss/ui/icons";
 import assignmentReasonBadgeTitleMap from "@lib/booking/assignmentReasonBadgeTitleMap";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef } from "react";
@@ -43,12 +43,9 @@ import { BookingActionsStoreProvider } from "../../../components/booking/actions
 import { RejectBookingButton } from "../../../components/booking/RejectBookingButton";
 import type { BookingListingStatus } from "../../../components/booking/types";
 import { usePaymentStatus } from "../hooks/usePaymentStatus";
+import { checkSheetActive, createBookingSheetKeydownHandler } from "../lib/bookingSheetKeyboardHandler";
 import { useBookingDetailsSheetStore } from "../store/bookingDetailsSheetStore";
 import type { BookingOutput } from "../types";
-import {
-  checkSheetActive,
-  createBookingSheetKeydownHandler,
-} from "../lib/bookingSheetKeyboardHandler";
 import { JoinMeetingButton } from "./JoinMeetingButton";
 
 type BookingMetaData = z.infer<typeof bookingMetadataSchema>;
@@ -59,6 +56,7 @@ interface BookingDetailsSheetProps {
   userId?: number;
   userEmail?: string;
   bookingAuditEnabled?: boolean;
+  isOrgUser?: boolean;
 }
 
 export function BookingDetailsSheet({
@@ -67,6 +65,7 @@ export function BookingDetailsSheet({
   userId,
   userEmail,
   bookingAuditEnabled = false,
+  isOrgUser = false,
 }: BookingDetailsSheetProps) {
   const booking = useBookingDetailsSheetStore((state) => state.getSelectedBooking());
   const selectedBookingUid = useBookingDetailsSheetStore((state) => state.selectedBookingUid);
@@ -93,6 +92,7 @@ export function BookingDetailsSheet({
         userId={userId}
         userEmail={userEmail}
         bookingAuditEnabled={bookingAuditEnabled}
+        isOrgUser={isOrgUser}
       />
     </BookingActionsStoreProvider>
   );
@@ -105,12 +105,14 @@ interface BookingDetailsSheetInnerProps {
   userId?: number;
   userEmail?: string;
   bookingAuditEnabled?: boolean;
+  isOrgUser?: boolean;
 }
 
 function useActiveSegment(bookingAuditEnabled: boolean) {
-  const [activeSegment, setActiveSegmentInStore] = useBookingDetailsSheetStore(
-    (state) => [state.activeSegment, state.setActiveSegment]
-  );
+  const [activeSegment, setActiveSegmentInStore] = useBookingDetailsSheetStore((state) => [
+    state.activeSegment,
+    state.setActiveSegment,
+  ]);
 
   const getDerivedActiveSegment = ({
     activeSegment,
@@ -131,9 +133,7 @@ function useActiveSegment(bookingAuditEnabled: boolean) {
   });
 
   const setDerivedActiveSegment = (segment: "info" | "history") => {
-    setActiveSegmentInStore(
-      getDerivedActiveSegment({ activeSegment: segment, bookingAuditEnabled })
-    );
+    setActiveSegmentInStore(getDerivedActiveSegment({ activeSegment: segment, bookingAuditEnabled }));
   };
 
   return [derivedActiveSegment, setDerivedActiveSegment] as const;
@@ -146,20 +146,19 @@ function BookingDetailsSheetInner({
   userId,
   userEmail,
   bookingAuditEnabled = false,
+  isOrgUser = false,
 }: BookingDetailsSheetInnerProps) {
   const { t } = useLocale();
-  const [activeSegment, setActiveSegment] =
-    useActiveSegment(bookingAuditEnabled);
+  const [activeSegment, setActiveSegment] = useActiveSegment(bookingAuditEnabled);
 
   // Fetch additional booking details for reschedule information
-  const { data: bookingDetails } =
-    trpc.viewer.bookings.getBookingDetails.useQuery(
-      { uid: booking.uid },
-      {
-        // Keep data fresh but don't refetch too aggressively
-        staleTime: 5 * 60 * 1000, // 5 minutes
-      }
-    );
+  const { data: bookingDetails } = trpc.viewer.bookings.getBookingDetails.useQuery(
+    { uid: booking.uid },
+    {
+      // Keep data fresh but don't refetch too aggressively
+      staleTime: 5 * 60 * 1000, // 5 minutes
+    }
+  );
 
   // Get navigation state from the store in a single selector
   const navigation = useBookingDetailsSheetStore((state) => {
@@ -174,12 +173,8 @@ function BookingDetailsSheetInner({
       isTransitioning: state.isTransitioning,
       setSelectedBookingUid: state.setSelectedBookingUid,
       setActiveSegment: state.setActiveSegment,
-      canGoNext:
-        hasNextInArray ||
-        (isLastInArray && state.capabilities?.canNavigateToNextPeriod()),
-      canGoPrev:
-        hasPreviousInArray ||
-        (isFirstInArray && state.capabilities?.canNavigateToPreviousPeriod()),
+      canGoNext: hasNextInArray || (isLastInArray && state.capabilities?.canNavigateToNextPeriod()),
+      canGoPrev: hasPreviousInArray || (isFirstInArray && state.capabilities?.canNavigateToPreviousPeriod()),
     };
   });
 
@@ -253,9 +248,7 @@ function BookingDetailsSheetInner({
 
   const isPending = booking.status === BookingStatus.PENDING;
 
-  const parsedMetadata = bookingMetadataSchema.safeParse(
-    booking.metadata ?? null
-  );
+  const parsedMetadata = bookingMetadataSchema.safeParse(booking.metadata ?? null);
   const bookingMetadata = parsedMetadata.success ? parsedMetadata.data : null;
 
   const recurringInfo =
@@ -303,8 +296,7 @@ function BookingDetailsSheetInner({
                   <div className="flex items-center gap-1.5">
                     <span>{t("previous_shortcut")}</span>
                   </div>
-                }
-              >
+                }>
                 <Button
                   variant="icon"
                   size="sm"
@@ -323,8 +315,7 @@ function BookingDetailsSheetInner({
                   <div className="flex items-center gap-1.5">
                     <span>{t("next_shortcut")}</span>
                   </div>
-                }
-              >
+                }>
                 <Button
                   variant="icon"
                   size="sm"
@@ -343,8 +334,7 @@ function BookingDetailsSheetInner({
                   <div className="flex items-center gap-1.5">
                     <span>{t("close_shortcut")}</span>
                   </div>
-                }
-              >
+                }>
                 <Button
                   variant="icon"
                   size="sm"
@@ -408,12 +398,7 @@ function BookingDetailsSheetInner({
 
                 <AssignmentReasonSection booking={booking} />
 
-                {booking.payment?.[0] && (
-                  <PaymentSection
-                    booking={booking}
-                    payment={booking.payment[0]}
-                  />
-                )}
+                {booking.payment?.[0] && <PaymentSection booking={booking} payment={booking.payment[0]} />}
 
                 <SlotsSection booking={booking} />
 
@@ -429,7 +414,7 @@ function BookingDetailsSheetInner({
             )}
 
             {bookingAuditEnabled && activeSegment === "history" && (
-              <BookingHistory bookingUid={booking.uid} />
+              <BookingHistory bookingUid={booking.uid} isOrgUser={isOrgUser} />
             )}
           </div>
         </SheetBody>
@@ -458,8 +443,7 @@ function BookingDetailsSheetInner({
                     <div className="flex items-center gap-1.5">
                       <span>{t("join_shortcut")}</span>
                     </div>
-                  }
-                >
+                  }>
                   <div ref={joinButtonWrapperRef}>
                     <JoinMeetingButton
                       location={booking.location}
@@ -474,8 +458,7 @@ function BookingDetailsSheetInner({
             <BookingActionsDropdown
               booking={{
                 ...booking,
-                listingStatus:
-                  booking.status.toLowerCase() as BookingListingStatus,
+                listingStatus: booking.status.toLowerCase() as BookingListingStatus,
                 recurringInfo: undefined,
                 loggedInUser: {
                   userId,
@@ -525,13 +508,8 @@ function WhenSection({
         className={classNames(
           "flex flex-col font-medium text-emphasis text-sm",
           rescheduled && "line-through"
-        )}
-      >
-        <DisplayTimestamp
-          startTime={startTime}
-          endTime={endTime}
-          timeZone={timeZone}
-        />
+        )}>
+        <DisplayTimestamp startTime={startTime} endTime={endTime} timeZone={timeZone} />
       </div>
     </Section>
   );
@@ -577,10 +555,7 @@ function WhoSection({ booking }: { booking: BookingOutput }) {
               imageSrc={
                 booking.user.avatarUrl
                   ? getUserAvatarUrl(booking.user)
-                  : getPlaceholderAvatar(
-                      null,
-                      booking.user.name || booking.user.email
-                    )
+                  : getPlaceholderAvatar(null, booking.user.name || booking.user.email)
               }
               alt={booking.user.name || booking.user.email || ""}
             />
@@ -596,20 +571,14 @@ function WhoSection({ booking }: { booking: BookingOutput }) {
                 </Badge>
               </div>
               {!booking.eventType?.hideOrganizerEmail && (
-                <p className="truncate text-default text-sm leading-[1.2]">
-                  {booking.user.email}
-                </p>
+                <p className="truncate text-default text-sm leading-[1.2]">{booking.user.email}</p>
               )}
             </div>
           </div>
         )}
 
         {booking.attendees.map((attendee, idx) => {
-          const name =
-            attendee.user?.name ||
-            attendee.name ||
-            attendee.user?.email ||
-            attendee.email;
+          const name = attendee.user?.name || attendee.name || attendee.user?.email || attendee.email;
           return (
             <div key={idx} className="flex items-center gap-4">
               <Avatar
@@ -636,13 +605,7 @@ function WhoSection({ booking }: { booking: BookingOutput }) {
   );
 }
 
-function WhereSection({
-  booking,
-  meta,
-}: {
-  booking: BookingOutput;
-  meta: BookingMetaData | null;
-}) {
+function WhereSection({ booking, meta }: { booking: BookingOutput; meta: BookingMetaData | null }) {
   const { t } = useLocale();
 
   const { locationToDisplay, provider, isLocationURL } = useBookingLocation({
@@ -680,15 +643,12 @@ function WhereSection({
           />
         )}
         <div className="flex min-w-0 items-baseline gap-1">
-          <span className="shrink-0 font-medium text-emphasis">
-            {provider?.label}:
-          </span>
+          <span className="shrink-0 font-medium text-emphasis">{provider?.label}:</span>
           <a
             href={locationToDisplay}
             target="_blank"
             rel="noopener noreferrer"
-            className="truncate text-blue-600 hover:underline"
-          >
+            className="truncate text-blue-600 hover:underline">
             {locationToDisplay}
           </a>
         </div>
@@ -724,26 +684,19 @@ function RecurringInfoSection({
 function AssignmentReasonSection({ booking }: { booking: BookingOutput }) {
   const { t } = useLocale();
 
-  if (
-    !booking.assignmentReasonSortedByCreatedAt ||
-    booking.assignmentReasonSortedByCreatedAt.length === 0
-  ) {
+  if (!booking.assignmentReasonSortedByCreatedAt || booking.assignmentReasonSortedByCreatedAt.length === 0) {
     return null;
   }
 
   const reason =
-    booking.assignmentReasonSortedByCreatedAt[
-      booking.assignmentReasonSortedByCreatedAt.length - 1
-    ];
+    booking.assignmentReasonSortedByCreatedAt[booking.assignmentReasonSortedByCreatedAt.length - 1];
   if (!reason.reasonString) {
     return null;
   }
 
   return (
     <Section title={t("assignment_reason")}>
-      <div className="font-medium text-emphasis text-sm">
-        {reason.reasonString}
-      </div>
+      <div className="font-medium text-emphasis text-sm">{reason.reasonString}</div>
     </Section>
   );
 }
@@ -761,9 +714,7 @@ function PaymentSection({
   const parsedEventTypeMetadata = booking.eventType?.metadata
     ? EventTypeMetaDataSchema.safeParse(booking.eventType.metadata)
     : null;
-  const eventTypeMetadata = parsedEventTypeMetadata?.success
-    ? parsedEventTypeMetadata.data
-    : null;
+  const eventTypeMetadata = parsedEventTypeMetadata?.success ? parsedEventTypeMetadata.data : null;
 
   const refundPolicy = eventTypeMetadata?.apps?.stripe?.refundPolicy;
   const refundDaysCount = eventTypeMetadata?.apps?.stripe?.refundDaysCount;
@@ -783,9 +734,7 @@ function PaymentSection({
   return (
     <Section title={t("payment")}>
       <p className="font-medium text-emphasis text-sm">{formattedPrice}</p>
-      {paymentStatusMessage && (
-        <p className="text-subtle text-xs">{paymentStatusMessage}</p>
-      )}
+      {paymentStatusMessage && <p className="text-subtle text-xs">{paymentStatusMessage}</p>}
     </Section>
   );
 }
@@ -806,9 +755,7 @@ function SlotsSection({ booking }: { booking: BookingOutput }) {
 
   return (
     <Section title={t("slots")}>
-      <p className="font-medium text-emphasis text-sm">
-        {t("slots_taken", { takenSeats, totalSeats })}
-      </p>
+      <p className="font-medium text-emphasis text-sm">{t("slots_taken", { takenSeats, totalSeats })}</p>
     </Section>
   );
 }
@@ -871,8 +818,7 @@ function OldRescheduledBookingInfo({
     return null;
   }
 
-  const cancellationReason =
-    booking.cancellationReason || booking.rejectionReason;
+  const cancellationReason = booking.cancellationReason || booking.rejectionReason;
   const rescheduledBy = booking.rescheduledBy;
   const cancelledBy = booking.cancelledBy;
 
@@ -895,9 +841,7 @@ function OldRescheduledBookingInfo({
       )}
       {cancellationReason && (
         <Section title={t("reason")}>
-          <p className="whitespace-pre-wrap font-medium text-emphasis text-sm">
-            {cancellationReason}
-          </p>
+          <p className="whitespace-pre-wrap font-medium text-emphasis text-sm">{cancellationReason}</p>
         </Section>
       )}
       {cancelledBy && (
@@ -918,16 +862,13 @@ function NewRescheduledBookingInfo({ booking }: { booking: BookingOutput }) {
     return null;
   }
 
-  const cancellationReason =
-    booking.cancellationReason || booking.rejectionReason;
+  const cancellationReason = booking.cancellationReason || booking.rejectionReason;
   const rescheduledBy = booking.rescheduler;
 
   return (
     <>
       <Section title={t("rescheduled_by")}>
-        {rescheduledBy && (
-          <p className="font-medium text-emphasis text-sm">{rescheduledBy}</p>
-        )}
+        {rescheduledBy && <p className="font-medium text-emphasis text-sm">{rescheduledBy}</p>}
         <Link href={`/booking/${booking.fromReschedule}`}>
           <div className="flex items-center gap-1 text-default text-sm underline">
             {t("original_booking")}
@@ -937,9 +878,7 @@ function NewRescheduledBookingInfo({ booking }: { booking: BookingOutput }) {
       </Section>
       {cancellationReason && (
         <Section title={t("reschedule_reason")}>
-          <p className="whitespace-pre-wrap font-medium text-emphasis text-sm">
-            {cancellationReason}
-          </p>
+          <p className="whitespace-pre-wrap font-medium text-emphasis text-sm">{cancellationReason}</p>
         </Section>
       )}
     </>
@@ -951,17 +890,14 @@ function CancelledBookingInfo({ booking }: { booking: BookingOutput }) {
   const { t } = useLocale();
 
   // Only show for cancelled/rejected bookings that were NOT rescheduled
-  const isCancelled =
-    booking.status === BookingStatus.CANCELLED ||
-    booking.status === BookingStatus.REJECTED;
+  const isCancelled = booking.status === BookingStatus.CANCELLED || booking.status === BookingStatus.REJECTED;
   const wasRescheduled = booking.rescheduled === true;
 
   if (!isCancelled || wasRescheduled) {
     return null;
   }
 
-  const cancellationReason =
-    booking.cancellationReason || booking.rejectionReason;
+  const cancellationReason = booking.cancellationReason || booking.rejectionReason;
   const cancelledBy = booking.cancelledBy;
 
   if (!cancellationReason && !cancelledBy) {
@@ -977,9 +913,7 @@ function CancelledBookingInfo({ booking }: { booking: BookingOutput }) {
       )}
       {cancellationReason && (
         <Section title={t("reason")}>
-          <p className="whitespace-pre-wrap font-medium text-emphasis text-sm">
-            {cancellationReason}
-          </p>
+          <p className="whitespace-pre-wrap font-medium text-emphasis text-sm">{cancellationReason}</p>
         </Section>
       )}
     </>
@@ -995,9 +929,7 @@ function AdditionalNotesSection({ booking }: { booking: BookingOutput }) {
 
   return (
     <Section title={t("additional_notes")}>
-      <p className="whitespace-pre-wrap font-medium text-emphasis text-sm">
-        {booking.description}
-      </p>
+      <p className="whitespace-pre-wrap font-medium text-emphasis text-sm">{booking.description}</p>
     </Section>
   );
 }
@@ -1026,9 +958,7 @@ function BookingHeaderBadges({
           {reasonTitle}
         </Badge>
       )}
-      {booking.eventType.team && (
-        <Badge variant="gray">{booking.eventType.team.name}</Badge>
-      )}
+      {booking.eventType.team && <Badge variant="gray">{booking.eventType.team.name}</Badge>}
       {booking.paid && !payment ? (
         <Badge variant="orange">{t("error_collecting_card")}</Badge>
       ) : booking.paid ? (
@@ -1063,9 +993,7 @@ function TrackingSection({
     return null;
   }
 
-  const utmEntries = Object.entries(tracking).filter(([_, value]) =>
-    Boolean(value)
-  );
+  const utmEntries = Object.entries(tracking).filter(([_, value]) => Boolean(value));
 
   if (utmEntries.length === 0) {
     return null;
@@ -1077,9 +1005,7 @@ function TrackingSection({
         {utmEntries.map(([key, value]) => (
           <div key={key} className="mb-1 last:mb-0">
             <span className="font-medium">{key}</span>:{" "}
-            <code className="rounded bg-subtle px-1 py-0.5 font-mono text-default text-xs">
-              {value}
-            </code>
+            <code className="rounded bg-subtle px-1 py-0.5 font-mono text-default text-xs">{value}</code>
           </div>
         ))}
       </div>

--- a/apps/web/modules/bookings/components/BookingListContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingListContainer.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import dayjs from "@calcom/dayjs";
-import { useDataTable } from "~/data-table/hooks/useDataTable";
-import { useDisplayedFilterCount } from "~/data-table/hooks/useDisplayedFilterCount";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
@@ -22,6 +20,8 @@ import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues"
 import { useListAutoSelector } from "~/bookings/hooks/useListAutoSelector";
 import { useSwitchToCorrectStatusTab } from "~/bookings/hooks/useSwitchToCorrectStatusTab";
 import { DataTableFilters, DataTableSegment } from "~/data-table/components";
+import { useDataTable } from "~/data-table/hooks/useDataTable";
+import { useDisplayedFilterCount } from "~/data-table/hooks/useDisplayedFilterCount";
 import {
   BookingDetailsSheetStoreProvider,
   useBookingDetailsSheetStore,
@@ -66,6 +66,7 @@ interface BookingListContainerProps {
   };
   bookingsV3Enabled: boolean;
   bookingAuditEnabled: boolean;
+  isOrgUser: boolean;
 }
 
 interface BookingListInnerProps extends BookingListContainerProps {
@@ -83,6 +84,7 @@ function BookingListInner({
   bookings,
   bookingsV3Enabled,
   bookingAuditEnabled,
+  isOrgUser,
   data,
   isPending,
   hasError,
@@ -225,6 +227,7 @@ function BookingListInner({
           userId={user?.id}
           userEmail={user?.email}
           bookingAuditEnabled={bookingAuditEnabled}
+          isOrgUser={isOrgUser}
         />
       )}
     </>

--- a/apps/web/modules/bookings/views/bookings-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-view.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { ColumnFilterType, type SystemFilterSegment } from "@calcom/features/data-table";
-import { DataTableProvider } from "~/data-table/DataTableProvider";
-import { useSegments } from "~/data-table/hooks/useSegments";
-import FeatureOptInBannerWrapper from "~/feature-opt-in/components/FeatureOptInBannerWrapper";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
 import dynamic from "next/dynamic";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useMemo } from "react";
+import { DataTableProvider } from "~/data-table/DataTableProvider";
+import { useSegments } from "~/data-table/hooks/useSegments";
+import FeatureOptInBannerWrapper from "~/feature-opt-in/components/FeatureOptInBannerWrapper";
 import { useFeatureOptInBanner } from "../../feature-opt-in/hooks/useFeatureOptInBanner";
 import { BookingListContainer } from "../components/BookingListContainer";
 import { useActiveFiltersValidator } from "../hooks/useActiveFiltersValidator";
@@ -29,6 +29,7 @@ type BookingsProps = {
   };
   bookingsV3Enabled: boolean;
   bookingAuditEnabled: boolean;
+  isOrgUser: boolean;
 };
 
 function useSystemSegments(userId?: number) {
@@ -77,7 +78,13 @@ export default function Bookings(props: BookingsProps) {
   );
 }
 
-function BookingsContent({ status, permissions, bookingsV3Enabled, bookingAuditEnabled }: BookingsProps) {
+function BookingsContent({
+  status,
+  permissions,
+  bookingsV3Enabled,
+  bookingAuditEnabled,
+  isOrgUser,
+}: BookingsProps) {
   const [view] = useBookingsView({ bookingsV3Enabled });
   const router = useRouter();
   const handleOptInSuccess = useCallback(() => {
@@ -93,6 +100,7 @@ function BookingsContent({ status, permissions, bookingsV3Enabled, bookingAuditE
           permissions={permissions}
           bookingsV3Enabled={bookingsV3Enabled}
           bookingAuditEnabled={bookingAuditEnabled}
+          isOrgUser={isOrgUser}
         />
       )}
       {bookingsV3Enabled && view === "calendar" && (

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4547,6 +4547,8 @@
   "saved": "Saved",
   "booking_history": "Booking history",
   "booking_history_description": "View the history of actions performed on this booking",
+  "booking_history_requires_organization": "Booking history requires an organization",
+  "booking_history_upgrade_description": "Upgrade to an organization plan to access detailed booking audit logs and track changes made to your bookings.",
   "enable_custom_host_locations": "Enable custom host locations",
   "enable_custom_host_locations_description": "Allow each host to have their own meeting location",
   "locations_disabled_per_host_enabled": "Locations are controlled per-host when custom host locations option is enabled",


### PR DESCRIPTION
## What does this PR do?

When a non-org user opens the "History" tab in the BookingDetailsSheet, they previously saw a generic red error message after a failed API call (`ORGANIZATION_ID_REQUIRED`). This PR checks org membership upfront and shows a `WideUpgradeBanner` immediately, skipping the unnecessary API call entirely.

- Fixes CAL-PRI-372

### Changes

1. **`WideUpgradeBanner`**: Made `image` prop optional and added `dismissible` prop. When `dismissible={false}`, the dismiss button is hidden and localStorage state is ignored.
2. **New `WideUpgradeBannerForBookingAudit`** component following existing banner patterns (`size="sm"`, no image, `target="organization"`, non-dismissible).
3. **Threaded `isOrgUser`** from server pages (`session.user.profile?.organizationId != null`) through the component chain: `page.tsx` → `BookingsList` → `BookingListContainer` → `BookingDetailsSheet` → `BookingHistory`.
4. **Split `BookingHistory`** into a wrapper (checks `isOrgUser`, renders banner or delegates) and `BookingHistoryContent` (contains the tRPC query), so the API call is never made for non-org users.
5. **Added i18n keys**: `booking_history_requires_organization` and `booking_history_upgrade_description`.
6. **Standalone `/booking/[uid]/logs` page**: Also threads `isOrgUser` from the server session through `BookingHistoryPage` → `BookingHistory`, so the standalone route correctly shows audit logs for org users and the upgrade banner for non-org users.

### Updates since last revision

- Changed org membership check from `session.user.org?.id` to `session.user.profile?.organizationId` in both `/booking/[uid]/logs/page.tsx` and `/bookings/[status]/page.tsx`. The `org` property only reflects the *current* org context (which may be null if the user isn't switched into an org), whereas `profile?.organizationId` reflects actual org membership — matching the established pattern used elsewhere in the codebase (e.g. `app/page.tsx`, `members/page.tsx`).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Log in as a **non-org user** (e.g. `pro:pro` at `http://localhost:3000`) → Bookings → open a booking → click "History" tab → verify upgrade banner appears immediately (no spinner, no error)
2. Log in as an **org user** → same flow → verify audit logs load normally (no banner)
3. Verify the upgrade button opens the upgrade dialog
4. Visit `/booking/[uid]/logs` directly as a non-org user → verify upgrade banner appears
5. Visit `/booking/[uid]/logs` directly as an org user → verify audit logs load normally

## Human Review Checklist

- [ ] Verify the `WideUpgradeBanner` changes don't break the existing `WideUpgradeBannerForMembers` (which passes `image` explicitly and relies on default `dismissible=true`)
- [ ] Confirm `session.user.profile?.organizationId != null` is the correct stable check for org membership (vs. `session.user.org?.id` which only reflects current org context)
- [ ] Review the `dismissible` + `visible` state logic: when `dismissible={false}`, banner initializes as visible (`useState(!dismissible)`) and skips the localStorage `isDismissed` check
- [ ] `isOrgUser` defaults to `false` in component props — verify all callers pass it correctly so the banner doesn't appear for actual org users
- [ ] Note: diff includes auto-formatting changes in `BookingDetailsSheet.tsx` from biome — functional changes are only the `isOrgUser` prop additions

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/de9986b8cf9849cfbd959a40291ab62f
Requested by: @eunjae-lee