### PR TITLE
fix: throw errors in sendWebhookDirectly instead of returning error objects

### DIFF
--- a/packages/features/webhooks/lib/service/WebhookService.test.ts
+++ b/packages/features/webhooks/lib/service/WebhookService.test.ts
@@ -1,12 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
+import process from "node:process";
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
-
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WebhookSubscriber } from "../dto/types";
-import { IWebhookRepository, WebhookVersion } from "../interface/IWebhookRepository";
+import type { WebhookPayload } from "../factory/types";
+import { type IWebhookRepository, WebhookVersion } from "../interface/IWebhookRepository";
+import type { ILogger, ITasker } from "../interface/infrastructure";
 import { WebhookService } from "./WebhookService";
-import { ILogger, ITasker } from "../interface/infrastructure";
-import { WebhookPayload } from "../factory/types";
 
 describe("WebhookService", () => {
   let mockFetch: ReturnType<typeof vi.fn>;
@@ -70,6 +69,96 @@ describe("WebhookService", () => {
     vi.unstubAllGlobals();
   });
 
+  describe("error handling in sendWebhookDirectly", () => {
+    const subscriber: WebhookSubscriber = {
+      id: "webhook-1",
+      subscriberUrl: "https://example.com/webhook",
+      payloadTemplate: null,
+      appId: null,
+      secret: "test-secret",
+      eventTriggers: [WebhookTriggerEvents.BOOKING_CREATED],
+      version: WebhookVersion.V_2021_10_20,
+    };
+
+    const payload = {
+      createdAt: new Date().toISOString(),
+      payload: { test: "data", triggerEvent: WebhookTriggerEvents.BOOKING_CREATED },
+    } as unknown as WebhookPayload;
+
+    it("should throw on network errors when sending directly", async () => {
+      mockFetch.mockRejectedValue(new TypeError("fetch failed"));
+
+      const service = new WebhookService(
+        mockRepository as unknown as IWebhookRepository,
+        mockTasker as unknown as ITasker,
+        mockLogger as unknown as ILogger
+      );
+
+      await expect(
+        service.processWebhooks(WebhookTriggerEvents.BOOKING_CREATED, payload, [subscriber])
+      ).resolves.not.toThrow();
+
+      // The error is caught by processWebhooks via Promise.allSettled, but it should have been thrown by sendWebhook
+      const subLogger = mockLogger.getSubLogger.mock.results[0].value;
+      expect(subLogger.error).toHaveBeenCalledWith(
+        "Error sending webhook",
+        expect.objectContaining({
+          error: expect.stringContaining("Failed to send webhook to https://example.com/webhook"),
+        })
+      );
+    });
+
+    it("should throw on non-OK HTTP responses when sending directly", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: vi.fn().mockResolvedValue("Internal Server Error"),
+      });
+
+      const service = new WebhookService(
+        mockRepository as unknown as IWebhookRepository,
+        mockTasker as unknown as ITasker,
+        mockLogger as unknown as ILogger
+      );
+
+      await service.processWebhooks(WebhookTriggerEvents.BOOKING_CREATED, payload, [subscriber]);
+
+      const subLogger = mockLogger.getSubLogger.mock.results[0].value;
+      expect(subLogger.error).toHaveBeenCalledWith(
+        "Error sending webhook",
+        expect.objectContaining({
+          error: expect.stringContaining(
+            "Webhook POST to https://example.com/webhook failed with status 500"
+          ),
+        })
+      );
+    });
+
+    it("should return error object instead of throwing when TASKER_ENABLE_WEBHOOKS is '1'", async () => {
+      process.env.TASKER_ENABLE_WEBHOOKS = "1";
+      mockTasker.create.mockRejectedValue(new Error("Tasker failed"));
+
+      const service = new WebhookService(
+        mockRepository as unknown as IWebhookRepository,
+        mockTasker as unknown as ITasker,
+        mockLogger as unknown as ILogger
+      );
+
+      await service.processWebhooks(WebhookTriggerEvents.BOOKING_CREATED, payload, [subscriber]);
+
+      // When TASKER_ENABLE_WEBHOOKS is '1', errors are caught and returned as result objects
+      // so processWebhooks logs via the 'Webhook failed' path, not 'Error sending webhook'
+      const subLogger = mockLogger.getSubLogger.mock.results[0].value;
+      expect(subLogger.error).toHaveBeenCalledWith(
+        "Webhook failed",
+        expect.objectContaining({
+          error: "Tasker failed",
+          statusCode: 0,
+        })
+      );
+    });
+  });
+
   describe("X-Cal-Webhook-Version header", () => {
     it("should include X-Cal-Webhook-Version header when sending webhook directly", async () => {
       const service = new WebhookService(
@@ -88,7 +177,7 @@ describe("WebhookService", () => {
         version: WebhookVersion.V_2021_10_20,
       };
 
-      const payload = {
+      const payload: WebhookPayload = {
         createdAt: new Date().toISOString(),
         payload: { test: "data", triggerEvent: WebhookTriggerEvents.BOOKING_CREATED },
       } as unknown as WebhookPayload;

--- a/packages/features/webhooks/lib/service/WebhookService.ts
+++ b/packages/features/webhooks/lib/service/WebhookService.ts
@@ -1,10 +1,9 @@
 import { createHmac } from "node:crypto";
-
+import process from "node:process";
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
-
-import type { WebhookSubscriber, WebhookDeliveryResult } from "../dto/types";
+import type { WebhookDeliveryResult, WebhookSubscriber } from "../dto/types";
 import type { WebhookPayload } from "../factory/types";
-import type { ITasker, ILogger } from "../interface/infrastructure";
+import type { ILogger, ITasker } from "../interface/infrastructure";
 import type { IWebhookRepository, IWebhookService } from "../interface/services";
 
 export class WebhookService implements IWebhookService {
@@ -23,23 +22,24 @@ export class WebhookService implements IWebhookService {
     payload: WebhookPayload,
     subscriber: WebhookSubscriber
   ): Promise<WebhookDeliveryResult> {
-    try {
-      // TODO: Ideally we should inject this flag as well. Would be awesome when we would be able to unit test without mocking env variables too. Also with trigger.dev, this would be further worked on, so we can leave this as is for now
-      if (process.env.TASKER_ENABLE_WEBHOOKS === "1") {
+    // TODO: Ideally we should inject this flag as well. Would be awesome when we would be able to unit test without mocking env variables too. Also with trigger.dev, this would be further worked on, so we can leave this as is for now
+    if (process.env.TASKER_ENABLE_WEBHOOKS === "1") {
+      try {
         return await this.scheduleWebhook(trigger, payload, subscriber);
-      } else {
-        return await this.sendWebhookDirectly(trigger, payload, subscriber);
+      } catch (error) {
+        return {
+          ok: false,
+          status: 0,
+          message: error instanceof Error ? error.message : String(error),
+          duration: 0,
+          subscriberUrl: subscriber.subscriberUrl,
+          webhookId: subscriber.id,
+        };
       }
-    } catch (error) {
-      return {
-        ok: false,
-        status: 0,
-        message: error instanceof Error ? error.message : String(error),
-        duration: 0,
-        subscriberUrl: subscriber.subscriberUrl,
-        webhookId: subscriber.id,
-      };
     }
+
+    // When sending directly, propagate errors so callers can handle them
+    return await this.sendWebhookDirectly(trigger, payload, subscriber);
   }
 
   private async scheduleWebhook(
@@ -95,21 +95,34 @@ export class WebhookService implements IWebhookService {
       ? createHmac("sha256", subscriber.secret).update(body).digest("hex")
       : "no-secret-provided";
 
-    const response = await fetch(subscriberUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": contentType,
-        "X-Cal-Signature-256": signature,
-        "X-Cal-Webhook-Version": subscriber.version,
-      },
-      redirect: "manual",
-      body,
-    });
+    let response: Response;
+    try {
+      response = await fetch(subscriberUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": contentType,
+          "X-Cal-Signature-256": signature,
+          "X-Cal-Webhook-Version": subscriber.version,
+        },
+        redirect: "manual",
+        body,
+      });
+    } catch (error) {
+      throw new Error(
+        `Failed to send webhook to ${subscriberUrl}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
 
     const responseText = await response.text();
 
+    if (!response.ok) {
+      throw new Error(
+        `Webhook POST to ${subscriberUrl} failed with status ${response.status}: ${responseText}`
+      );
+    }
+
     return {
-      ok: response.ok,
+      ok: true,
       status: response.status,
       message: responseText || undefined,
       duration: 0,


### PR DESCRIPTION
## What does this PR do?

Changes error handling in `WebhookService.sendWebhook` so that when `process.env.TASKER_ENABLE_WEBHOOKS !== "1"` (i.e., `sendWebhookDirectly` is used), fetch errors are **thrown** with descriptive messages instead of being silently returned as `{ ok: false, ... }` result objects.

Two categories of errors are now thrown from `sendWebhookDirectly`:
- **Network errors** (fetch rejects): `"Failed to send webhook to <url>: <reason>"`
- **Non-OK HTTP responses** (4xx/5xx): `"Webhook POST to <url> failed with status <code>: <body>"`

When `TASKER_ENABLE_WEBHOOKS === "1"` (scheduled via tasker), the existing catch-and-return-error-object behavior is **preserved unchanged**.

## Important review notes

- `sendWebhook` is `protected` — verify no subclass relies on the previous catch-all behavior for the direct path.
- In `processWebhooks`, errors from the direct path now flow through the `catch (err)` block (logged as `"Error sending webhook"`) instead of the `if (!result.ok)` branch (logged as `"Webhook failed"`). This is intentional but changes the logging path.
- `response.text()` is called before the `!response.ok` check; if `.text()` itself throws, that error will propagate unmodified.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the unit tests: `TZ=UTC yarn test packages/features/webhooks/lib/service/WebhookService.test.ts`
2. All 6 tests should pass (3 new + 3 existing).
3. New tests verify:
   - Network fetch failures throw with descriptive message (direct mode)
   - Non-OK HTTP responses throw with status and body (direct mode)
   - Tasker mode (`TASKER_ENABLE_WEBHOOKS=1`) still returns error objects without throwing

No special env vars needed beyond the defaults (tests stub `TASKER_ENABLE_WEBHOOKS` internally).

## Checklist

- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked that my changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/f30ee1000838408f9f934ef35a1402e9
Requested by: @ThyMinimalDev