### PR TITLE
fix: prevent layout flicker when clicking Back on reschedule form

### DIFF
--- a/apps/web/modules/bookings/components/Booker.tsx
+++ b/apps/web/modules/bookings/components/Booker.tsx
@@ -4,10 +4,7 @@ import { useIsPlatformBookerEmbed } from "@calcom/atoms/hooks/useIsPlatformBooke
 import dayjs from "@calcom/dayjs";
 import { useEmbedUiConfig } from "@calcom/embed-core/embed-iframe";
 import { updateEmbedBookerState } from "@calcom/embed-core/src/embed-iframe";
-import TurnstileCaptcha from "@calcom/web/modules/auth/components/Turnstile";
 import { useBookerStoreContext } from "@calcom/features/bookings/Booker/BookerStoreProvider";
-import { useIsQuickAvailabilityCheckFeatureEnabled } from "../hooks/useIsQuickAvailabilityCheckFeatureEnabled";
-import { useSkipConfirmStep } from "@calcom/web/modules/bookings/hooks/useSkipConfirmStep";
 import {
   fadeInLeft,
   getBookerSizeClassNames,
@@ -15,12 +12,12 @@ import {
 } from "@calcom/features/bookings/Booker/config";
 import framerFeatures from "@calcom/features/bookings/Booker/framer-features";
 import type { BookerProps } from "@calcom/features/bookings/Booker/types";
-import type { WrappedBookerProps } from "../types";
 import { isBookingDryRun } from "@calcom/features/bookings/Booker/utils/isBookingDryRun";
 import { isTimeSlotAvailable } from "@calcom/features/bookings/Booker/utils/isTimeslotAvailable";
 import { getQueryParam } from "@calcom/features/bookings/Booker/utils/query-param";
+import { Header } from "@calcom/features/bookings/components/Header";
+import { BookerSection } from "@calcom/features/bookings/components/Section";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import { useNonEmptyScheduleDays } from "@calcom/web/modules/schedules/hooks/useNonEmptyScheduleDays";
 import { scrollIntoViewSmooth } from "@calcom/lib/browser/browser.utils";
 import {
   CLOUDFLARE_SITE_ID,
@@ -32,12 +29,17 @@ import { BookerLayouts } from "@calcom/prisma/zod-utils";
 import classNames from "@calcom/ui/classNames";
 import { DialogContent } from "@calcom/ui/components/dialog";
 import { UnpublishedEntity } from "@calcom/ui/components/unpublished-entity";
+import TurnstileCaptcha from "@calcom/web/modules/auth/components/Turnstile";
+import { useSkipConfirmStep } from "@calcom/web/modules/bookings/hooks/useSkipConfirmStep";
 import PoweredBy from "@calcom/web/modules/ee/common/components/PoweredBy";
+import { useNonEmptyScheduleDays } from "@calcom/web/modules/schedules/hooks/useNonEmptyScheduleDays";
 import { AnimatePresence, LazyMotion, m } from "framer-motion";
 import { useEffect, useMemo, useRef } from "react";
 import StickyBox from "react-sticky-box";
 import { Toaster } from "sonner";
 import { shallow } from "zustand/shallow";
+import { useIsQuickAvailabilityCheckFeatureEnabled } from "../hooks/useIsQuickAvailabilityCheckFeatureEnabled";
+import type { WrappedBookerProps } from "../types";
 import { AvailableTimeSlots } from "./AvailableTimeSlots";
 import { BookEventForm } from "./BookEventForm";
 import { BookFormAsModal } from "./BookEventForm/BookFormAsModal";
@@ -45,12 +47,10 @@ import { DatePicker } from "./DatePicker";
 import { DryRunMessage } from "./DryRunMessage";
 import { EventMeta } from "./EventMeta";
 import { HavingTroubleFindingTime } from "./HavingTroubleFindingTime";
-import { Header } from "@calcom/features/bookings/components/Header";
 import { InstantBooking } from "./InstantBooking";
 import { LargeCalendar } from "./LargeCalendar";
 import { OverlayCalendar } from "./OverlayCalendar/OverlayCalendar";
 import { RedirectToInstantMeetingModal } from "./RedirectToInstantMeetingModal";
-import { BookerSection } from "@calcom/features/bookings/components/Section";
 import { SlotSelectionModalHeader } from "./SlotSelectionModalHeader";
 import { NotFound } from "./Unavailable";
 import { VerifyCodeDialog } from "./VerifyCodeDialog";
@@ -264,8 +264,13 @@ const BookerComponent = ({
   const slot = getQueryParam("slot");
 
   useEffect(() => {
-    setSelectedTimeslot(slot || null);
-  }, [slot, setSelectedTimeslot]);
+    const newSlot = slot || null;
+    // Only update if the value actually changed to avoid redundant re-renders
+    // that cause layout flicker when clicking "Back" from the booking form.
+    if (newSlot !== selectedTimeslot) {
+      setSelectedTimeslot(newSlot);
+    }
+  }, [slot, setSelectedTimeslot, selectedTimeslot]);
 
   const onSubmit = (timeSlot?: string) =>
     renderConfirmNotVerifyEmailButtonCond ? handleBookEvent(timeSlot) : handleVerifyEmail();


### PR DESCRIPTION
## What does this PR do?

Fixes the "disco" layout flicker that occurs when clicking "Back" from the booking/reschedule form in the Booker component.

**Root cause:** When clicking Back, `onCancel` calls `setSelectedTimeslot(null)`, which also clears the `slot` URL query param. A separate `useEffect` watching that query param then fires `setSelectedTimeslot(null)` *again* redundantly. This double state update triggers an extra re-render cycle where the CSS grid layout briefly flashes through an intermediate state (the grid collapses from booking → default → selecting_time layouts).

**Fix:** Guard the query-param-sync `useEffect` to only call `setSelectedTimeslot` when the value has actually changed, preventing the redundant update.

## Visual Demo

#### Video Demo:
Original issue (disco flicker on Back click):

![disco behaviour](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2N2VmNjZiMWZhYmEzZTllNTIxNTNkZjMiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi8xYTUzNTg2ZS1hNDhmLTQzMDctYjMxNy1iZDM0NzZkZTdmYTQiLCJpYXQiOjE3NzM3NDUxNTMsImV4cCI6MTc3NDM0OTk1M30.Qau7Cia-bjLsnRDLohs234j9aOHSISpwjl3xdE5snFo)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Open a booking page (month view layout)
2. Select a date and time slot to reach the booking form
3. Click "Back" to return to the time slot picker
4. **Before fix:** The layout briefly flickers/collapses ("disco" effect) as the grid transitions through an intermediate state
5. **After fix:** The layout transitions smoothly back to the time slot view without any flicker

Also verify:
- Selecting a time slot still works and navigates to the booking form
- The reschedule flow (arriving with a pre-selected slot via URL) still works correctly
- The `slot` query param is correctly synced when selecting/deselecting time slots

## Human Review Checklist

- [ ] Verify adding `selectedTimeslot` to the `useEffect` dependency array does not cause infinite loops or unintended re-render cycles (the guard `if (newSlot !== selectedTimeslot)` should prevent this)
- [ ] Confirm import reordering is cosmetic only (Biome auto-sort, no functional change)
- [ ] Consider whether any other code path could cause `slot` query param and `selectedTimeslot` to diverge in a way this guard would incorrectly suppress

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that my changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/692e8f6ade1b47ae85688fee6a988cc4
Requested by: @Ryukemeister