### PR TITLE
fix: show 'ask your admin' message instead of upgrade banners for org members without teams

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/teams/[id]/members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/teams/[id]/members/page.tsx
@@ -100,7 +100,7 @@ const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
     <SettingsHeader title={t("team_members")} description={t("members_team_description")}>
       {!team.parentId && (
         <div className="mb-4">
-          <WideUpgradeBannerForMembers />
+          <WideUpgradeBannerForMembers isOrgMember={!!session.user.org?.id} />
         </div>
       )}
       <TeamMembersView

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/teams/[id]/members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/teams/[id]/members/page.tsx
@@ -100,7 +100,7 @@ const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
     <SettingsHeader title={t("team_members")} description={t("members_team_description")}>
       {!team.parentId && (
         <div className="mb-4">
-          <WideUpgradeBannerForMembers isOrgMember={!!session.user.org?.id} />
+          <WideUpgradeBannerForMembers />
         </div>
       )}
       <TeamMembersView

--- a/apps/web/modules/billing/components/FullScreenUpgradeBanner.tsx
+++ b/apps/web/modules/billing/components/FullScreenUpgradeBanner.tsx
@@ -49,6 +49,7 @@ export type FullScreenUpgradeBannerProps = {
     height: number;
   };
   youtubeId?: string;
+  isOrgMember?: boolean;
 };
 
 function useResponsiveOffset(
@@ -100,7 +101,7 @@ function BannerImage({
       {youtubeId && (
         <button
           type="button"
-          className="absolute inset-0 flex items-center justify-center cursor-pointer"
+          className="absolute inset-0 flex cursor-pointer items-center justify-center"
           onClick={() => {
             posthog.capture("fullscreen_upgrade_banner_video_played", { source: tracking, target });
             onPlayVideo();
@@ -123,12 +124,27 @@ export function FullScreenUpgradeBanner({
   extraOffset,
   image,
   youtubeId,
+  isOrgMember,
 }: FullScreenUpgradeBannerProps): JSX.Element {
   const [videoOpen, setVideoOpen] = useState(false);
   const [showFeatures, setShowFeatures] = useState(false);
   const deviceSpecificOffset = useResponsiveOffset(extraOffset);
   const { t } = useLocale();
   const ref = useFillRemainingHeight(deviceSpecificOffset);
+
+  if (isOrgMember) {
+    return (
+      <div ref={ref} className="flex w-full shrink-0 items-center justify-center rounded-xl bg-subtle p-8">
+        <div className="flex h-full w-full max-w-3xl items-center justify-center rounded-3xl bg-default p-8 shadow-sm md:h-auto">
+          <div className="flex flex-col items-center text-center">
+            <Icon name="users" className="mb-4 h-12 w-12 text-subtle" />
+            <h2 className="font-cal font-semibold text-emphasis text-xl">{t("not_a_member_of_any_team")}</h2>
+            <p className="mt-2 text-sm text-subtle">{t("ask_admin_to_invite_you")}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const bannerImageProps = {
     image,
@@ -141,24 +157,24 @@ export function FullScreenUpgradeBanner({
 
   return (
     <div ref={ref} className="flex w-full shrink-0 items-center justify-center rounded-xl bg-subtle p-8">
-      <div className="flex w-full h-full md:h-auto max-w-3xl gap-2 overflow-hidden rounded-3xl bg-default p-5 md:py-8 md:pl-8 md:pr-0 shadow-sm">
+      <div className="flex h-full w-full max-w-3xl gap-2 overflow-hidden rounded-3xl bg-default p-5 shadow-sm md:h-auto md:py-8 md:pr-0 md:pl-8">
         {/* Left Content */}
         <div className="flex flex-1 flex-col justify-between overflow-hidden">
           <div className={`${showFeatures ? "overflow-y-auto" : ""} md:overflow-visible`}>
             <div>
               <Badge
                 variant="outline"
-                className="text-sm text-default font-medium bg-subtle px-2 py-1 h-fit! border-0">
+                className="h-fit! border-0 bg-subtle px-2 py-1 font-medium text-default text-sm">
                 {name}
               </Badge>
             </div>
             <h2 className="mt-3 font-cal font-semibold text-emphasis text-xl leading-none">{title}</h2>
-            <p className="mt-2 text-subtle text-sm">{subtitle}</p>
+            <p className="mt-2 text-sm text-subtle">{subtitle}</p>
 
             {/* Features List */}
             {features && (
               <>
-                <ul className="mt-4 space-y-2 hidden md:block">
+                <ul className="mt-4 hidden space-y-2 md:block">
                   {features.map((feature) => (
                     <li key={feature} className="flex items-center gap-2 text-sm text-subtle">
                       <span className="text-subtle">•</span>
@@ -166,7 +182,7 @@ export function FullScreenUpgradeBanner({
                     </li>
                   ))}
                 </ul>
-                <div className="md:hidden mt-4">
+                <div className="mt-4 md:hidden">
                   {showFeatures ? (
                     <>
                       <ul className="space-y-2">
@@ -179,7 +195,7 @@ export function FullScreenUpgradeBanner({
                       </ul>
                       <button
                         type="button"
-                        className="mt-2 text-sm text-emphasis font-medium cursor-pointer underline"
+                        className="mt-2 cursor-pointer font-medium text-emphasis text-sm underline"
                         onClick={() => setShowFeatures(false)}>
                         {t("hide")}
                       </button>
@@ -187,7 +203,7 @@ export function FullScreenUpgradeBanner({
                   ) : (
                     <button
                       type="button"
-                      className="text-sm text-emphasis font-medium cursor-pointer underline"
+                      className="cursor-pointer font-medium text-emphasis text-sm underline"
                       onClick={() => setShowFeatures(true)}>
                       {t("show_more")}
                     </button>
@@ -198,19 +214,20 @@ export function FullScreenUpgradeBanner({
           </div>
 
           {/* Image - mobile only, hidden when features are expanded */}
-          <div className={`${showFeatures ? "hidden" : ""} md:hidden my-4 flex items-center justify-center rounded-xl bg-subtle aspect-[3/4] overflow-hidden relative`}>
+          <div
+            className={`${showFeatures ? "hidden" : ""} relative my-4 flex aspect-[3/4] items-center justify-center overflow-hidden rounded-xl bg-subtle md:hidden`}>
             <BannerImage {...bannerImageProps} />
           </div>
 
           <div>
-            <div className="hidden md:flex items-center gap-2 mt-4">
-              <p className="text-sm font-medium text-subtle">{t("available_on")}</p>
+            <div className="mt-4 hidden items-center gap-2 md:flex">
+              <p className="font-medium text-sm text-subtle">{t("available_on")}</p>
               {target === "team" && <TeamBadge />}
               {(target === "team" || target === "organization") && <OrgBadge />}
             </div>
             <div className="mt-4 h-px w-full border border-t-subtle border-dashed" />
             {/* Buttons */}
-            <div className="mt-6 flex items-center justify-between md:justify-start gap-2">
+            <div className="mt-6 flex items-center justify-between gap-2 md:justify-start">
               <UpgradePlanDialog
                 tracking={tracking}
                 info={{
@@ -259,7 +276,7 @@ export function FullScreenUpgradeBanner({
         </div>
 
         {/* Right Content - Image */}
-        <div className="-my-2 hidden md:flex flex-1 items-center justify-center rounded-l-xl bg-subtle aspect-[3/4] overflow-hidden border border-muted border-r-0 relative">
+        <div className="relative -my-2 hidden aspect-[3/4] flex-1 items-center justify-center overflow-hidden rounded-l-xl border border-muted border-r-0 bg-subtle md:flex">
           <BannerImage {...bannerImageProps} />
         </div>
       </div>

--- a/apps/web/modules/billing/components/WideUpgradeBanner.tsx
+++ b/apps/web/modules/billing/components/WideUpgradeBanner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useClientOnly } from "@calcom/lib/hooks/useClientOnly";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { localStorage } from "@calcom/lib/webstorage";
 import { Icon } from "@calcom/ui/components/icon";
@@ -8,7 +9,6 @@ import { Button } from "@coss/ui/components/button";
 import Image from "next/image";
 import Link from "next/link";
 import posthog from "posthog-js";
-import { useClientOnly } from "@calcom/lib/hooks/useClientOnly";
 import { useState } from "react";
 import type { UpgradeTarget } from "./types";
 
@@ -56,6 +56,7 @@ export type WideUpgradeBannerProps = {
     onClick?: () => void;
   };
   children: React.ReactNode;
+  isOrgMember?: boolean;
 };
 
 export function WideUpgradeBanner({
@@ -67,6 +68,7 @@ export function WideUpgradeBanner({
   image,
   learnMoreButton,
   children,
+  isOrgMember,
 }: WideUpgradeBannerProps) {
   const { t } = useLocale();
   const [visible, setVisible] = useState(false);
@@ -76,11 +78,27 @@ export function WideUpgradeBanner({
 
   if (!visible) return null;
 
+  if (isOrgMember) {
+    return (
+      <div className="relative flex w-full overflow-hidden rounded-xl border border-muted bg-muted p-6">
+        <div className="flex flex-1 items-center gap-3">
+          <Icon name="users" className="h-8 w-8 shrink-0 text-subtle" />
+          <div>
+            <h2 className="font-cal font-semibold text-base text-default leading-none">
+              {t("not_a_member_of_any_team")}
+            </h2>
+            <p className="mt-1 font-normal text-sm text-subtle">{t("ask_admin_to_invite_you")}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="relative flex w-full overflow-hidden rounded-xl bg-muted border-muted border">
+    <div className="relative flex w-full overflow-hidden rounded-xl border border-muted bg-muted">
       <Button
         variant="ghost"
-        className="absolute right-2 top-2 z-10"
+        className="absolute top-2 right-2 z-10"
         onClick={() => {
           dismiss(tracking);
           setVisible(false);
@@ -93,18 +111,16 @@ export function WideUpgradeBanner({
       <div className="flex flex-1 flex-col p-6">
         {size === "sm" ? (
           <div className="flex items-start gap-1.5">
-            <h2 className="font-cal text-base font-semibold leading-none text-default">{title}</h2>
-            <div className="relative -top-1">
-              {target === "team" ? <TeamBadge /> : <OrgBadge />}
-            </div>
+            <h2 className="font-cal font-semibold text-base text-default leading-none">{title}</h2>
+            <div className="relative -top-1">{target === "team" ? <TeamBadge /> : <OrgBadge />}</div>
           </div>
         ) : (
           <div>
             {target === "team" ? <TeamBadge /> : <OrgBadge />}
-            <h2 className="mt-1 font-cal text-lg font-semibold leading-none text-default">{title}</h2>
+            <h2 className="mt-1 font-cal font-semibold text-default text-lg leading-none">{title}</h2>
           </div>
         )}
-        <p className="mt-2 text-sm font-normal text-subtle">{subtitle}</p>
+        <p className="mt-2 font-normal text-sm text-subtle">{subtitle}</p>
 
         {/* Buttons */}
         <div className={`${size === "sm" ? "mt-4" : "mt-9"} flex items-center gap-2`}>
@@ -136,13 +152,8 @@ export function WideUpgradeBanner({
 
       {/* Right Content - Image */}
       <div
-        className={`relative hidden w-1/2 overflow-hidden md:block${size === "sm" ? " max-w-64" : " max-w-[520px]"}`}>
-        <Image
-          src={image.src}
-          alt={title}
-          fill
-          className="object-cover object-left"
-        />
+        className={`relative hidden w-1/2 overflow-hidden md:block${size === "sm" ? "max-w-64" : "max-w-[520px]"}`}>
+        <Image src={image.src} alt={title} fill className="object-cover object-left" />
       </div>
     </div>
   );

--- a/apps/web/modules/billing/components/WideUpgradeBanner.tsx
+++ b/apps/web/modules/billing/components/WideUpgradeBanner.tsx
@@ -152,7 +152,7 @@ export function WideUpgradeBanner({
 
       {/* Right Content - Image */}
       <div
-        className={`relative hidden w-1/2 overflow-hidden md:block${size === "sm" ? "max-w-64" : "max-w-[520px]"}`}>
+        className={`relative hidden w-1/2 overflow-hidden md:block${size === "sm" ? " max-w-64" : " max-w-[520px]"}`}>
         <Image src={image.src} alt={title} fill className="object-cover object-left" />
       </div>
     </div>

--- a/apps/web/modules/billing/upgrade-banners/FullscreenUpgradeBannerForTeamsPage.tsx
+++ b/apps/web/modules/billing/upgrade-banners/FullscreenUpgradeBannerForTeamsPage.tsx
@@ -3,7 +3,7 @@
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { FullScreenUpgradeBanner } from "@calcom/web/modules/billing/components/FullScreenUpgradeBanner";
 
-export function FullscreenUpgradeBannerForTeamsPage() {
+export function FullscreenUpgradeBannerForTeamsPage({ isOrgMember }: { isOrgMember?: boolean }) {
   const { t } = useLocale();
 
   const features = [
@@ -31,6 +31,7 @@ export function FullscreenUpgradeBannerForTeamsPage() {
         text: t("learn_more"),
         href: "https://cal.com/teams",
       }}
+      isOrgMember={isOrgMember}
     />
   );
 }

--- a/apps/web/modules/billing/upgrade-banners/WideUpgradeBannerForMembers.tsx
+++ b/apps/web/modules/billing/upgrade-banners/WideUpgradeBannerForMembers.tsx
@@ -6,7 +6,7 @@ import { UpgradePlanDialog } from "@calcom/web/modules/billing/components/Upgrad
 import { WideUpgradeBanner } from "@calcom/web/modules/billing/components/WideUpgradeBanner";
 import { Button } from "@coss/ui/components/button";
 
-export function WideUpgradeBannerForMembers() {
+export function WideUpgradeBannerForMembers({ isOrgMember }: { isOrgMember?: boolean }) {
   const { t } = useLocale();
 
   return (
@@ -23,7 +23,8 @@ export function WideUpgradeBannerForMembers() {
       learnMoreButton={{
         text: t("learn_more"),
         href: "https://cal.com/help/routing/routing-with-attributes",
-      }}>
+      }}
+      isOrgMember={isOrgMember}>
       <UpgradePlanDialog tracking="members" target="organization">
         <Button variant="outline">
           {t("try_for_free")}

--- a/apps/web/modules/ee/teams/components/TeamsListing.tsx
+++ b/apps/web/modules/ee/teams/components/TeamsListing.tsx
@@ -6,10 +6,10 @@ import type { RouterOutputs } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
 import { Label } from "@calcom/ui/components/form";
-import { InfoIcon } from "@coss/ui/icons";
 import { showToast } from "@calcom/ui/components/toast";
 import { useHasTeamPlan } from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
 import { FullscreenUpgradeBannerForTeamsPage } from "@calcom/web/modules/billing/upgrade-banners/FullscreenUpgradeBannerForTeamsPage";
+import { InfoIcon } from "@coss/ui/icons";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo } from "react";
 import SkeletonLoaderTeamList from "~/ee/teams/components/SkeletonloaderTeamList";
@@ -98,7 +98,9 @@ export function TeamsListing({
 
       {teams.length === 0 && isPendingTeamPlan && <SkeletonLoaderTeamList />}
 
-      {teams.length === 0 && !isPendingTeamPlan && <FullscreenUpgradeBannerForTeamsPage />}
+      {teams.length === 0 && teamInvites.length === 0 && !isPendingTeamPlan && (
+        <FullscreenUpgradeBannerForTeamsPage isOrgMember={!!orgId} />
+      )}
 
       {/* Only show tip when not showing the upgrade banner */}
       {teams.length > 0 && (

--- a/apps/web/modules/settings/my-account/appearance-view.tsx
+++ b/apps/web/modules/settings/my-account/appearance-view.tsx
@@ -1,33 +1,29 @@
 "use client";
 
+import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
+import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
+import ThemeLabel from "@calcom/features/settings/ThemeLabel";
+import { APP_NAME, DEFAULT_DARK_BRAND_COLOR, DEFAULT_LIGHT_BRAND_COLOR } from "@calcom/lib/constants";
+import useGetBrandingColours, { checkWCAGContrastColor } from "@calcom/lib/getBrandColours";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import useTheme from "@calcom/lib/hooks/useTheme";
+import { validateBookerLayouts } from "@calcom/lib/validateBookerLayouts";
+import type { userMetadata } from "@calcom/prisma/zod-utils";
+import type { RouterOutputs } from "@calcom/trpc/react";
+import { trpc } from "@calcom/trpc/react";
+import { Alert } from "@calcom/ui/components/alert";
+import { Button } from "@calcom/ui/components/button";
+import { ColorPicker, Form, SettingsToggle } from "@calcom/ui/components/form";
+import { showToast } from "@calcom/ui/components/toast";
+import { useCalcomTheme } from "@calcom/ui/styles";
 import { revalidateSettingsAppearance } from "app/(use-page-wrapper)/settings/(settings-layout)/my-account/appearance/actions";
 import { revalidateHasTeamPlan } from "app/cache/membership";
 import { useSession } from "next-auth/react";
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import type { z } from "zod";
-
-import { BookerLayoutSelector } from "~/settings/components/BookerLayoutSelector";
-import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
-import ThemeLabel from "@calcom/features/settings/ThemeLabel";
-import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
-import { APP_NAME } from "@calcom/lib/constants";
-import { DEFAULT_LIGHT_BRAND_COLOR, DEFAULT_DARK_BRAND_COLOR } from "@calcom/lib/constants";
-import { checkWCAGContrastColor } from "@calcom/lib/getBrandColours";
-import useGetBrandingColours from "@calcom/lib/getBrandColours";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import useTheme from "@calcom/lib/hooks/useTheme";
-import { validateBookerLayouts } from "@calcom/lib/validateBookerLayouts";
-import type { userMetadata } from "@calcom/prisma/zod-utils";
-import { trpc } from "@calcom/trpc/react";
-import type { RouterOutputs } from "@calcom/trpc/react";
-import { Alert } from "@calcom/ui/components/alert";
-import { Button } from "@calcom/ui/components/button";
-import { SettingsToggle, ColorPicker, Form } from "@calcom/ui/components/form";
-import { showToast } from "@calcom/ui/components/toast";
-import { useCalcomTheme } from "@calcom/ui/styles";
-
 import { UpgradeTeamsBadgeWebWrapper } from "~/billing/components/UpgradeTeamsBadgeWebWrapper";
+import { BookerLayoutSelector } from "~/settings/components/BookerLayoutSelector";
 
 const useBrandColors = (
   currentTheme: string | null,
@@ -392,9 +388,13 @@ const AppearanceView = ({
             toggleSwitchAtTheEnd={true}
             title={t("disable_cal_branding", { appName: APP_NAME })}
             disabled={!hasPaidPlan || mutation?.isPending}
-            description={t("removes_cal_branding", { appName: APP_NAME })}
+            description={
+              isApartOfOrganization && !hasPaidPlan
+                ? t("ask_admin_to_invite_you")
+                : t("removes_cal_branding", { appName: APP_NAME })
+            }
             checked={hasPaidPlan ? hideBrandingValue : false}
-            Badge={<UpgradeTeamsBadgeWebWrapper />}
+            Badge={isApartOfOrganization ? undefined : <UpgradeTeamsBadgeWebWrapper />}
             onCheckedChange={(checked) => {
               setHideBrandingValue(checked);
               mutation.mutate({ hideBranding: checked });

--- a/apps/web/modules/settings/my-account/appearance-view.tsx
+++ b/apps/web/modules/settings/my-account/appearance-view.tsx
@@ -388,13 +388,9 @@ const AppearanceView = ({
             toggleSwitchAtTheEnd={true}
             title={t("disable_cal_branding", { appName: APP_NAME })}
             disabled={!hasPaidPlan || mutation?.isPending}
-            description={
-              isApartOfOrganization && !hasPaidPlan
-                ? t("ask_admin_to_invite_you")
-                : t("removes_cal_branding", { appName: APP_NAME })
-            }
+            description={t("removes_cal_branding", { appName: APP_NAME })}
             checked={hasPaidPlan ? hideBrandingValue : false}
-            Badge={isApartOfOrganization ? undefined : <UpgradeTeamsBadgeWebWrapper />}
+            Badge={<UpgradeTeamsBadgeWebWrapper />}
             onCheckedChange={(checked) => {
               setHideBrandingValue(checked);
               mutation.mutate({ hideBranding: checked });

--- a/apps/web/modules/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
+++ b/apps/web/modules/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
@@ -19,7 +19,7 @@ import {
   TextArea,
 } from "@calcom/ui/components/form";
 import { showToast } from "@calcom/ui/components/toast";
-import { useHasTeamPlan } from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
+import { useHasTeamMembership, useHasTeamPlan } from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
 import { useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { UpgradeTeamsBadgeWebWrapper as UpgradeTeamsBadge } from "~/billing/components/UpgradeTeamsBadgeWebWrapper";
@@ -115,7 +115,8 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
   const [profileRedirect, setProfileRedirect] = useState(!!currentlyEditingOutOfOfficeEntry?.toTeamUserId);
 
   const { hasTeamPlan } = useHasTeamPlan();
-  const isOrgMember = !!me?.data?.organizationId;
+  const { hasTeamMembership } = useHasTeamMembership();
+  const isOrgMemberWithoutTeams = !!me?.data?.organizationId && !hasTeamMembership;
 
   const {
     handleSubmit,
@@ -388,13 +389,13 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
                   }}
                   label={hasTeamPlan ? t("redirect_team_enabled") : t("redirect_team_disabled")}
                 />
-                {!hasTeamPlan && !isOrgMember && (
+                {!hasTeamPlan && !isOrgMemberWithoutTeams && (
                   <div className="mx-2" data-testid="upgrade-team-badge">
                     <UpgradeTeamsBadge />
                   </div>
                 )}
               </div>
-              {!hasTeamPlan && isOrgMember && (
+              {!hasTeamPlan && isOrgMemberWithoutTeams && (
                 <p className="text-subtle mt-2 text-sm">{t("ask_admin_to_invite_you")}</p>
               )}
 

--- a/apps/web/modules/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
+++ b/apps/web/modules/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
@@ -1,6 +1,3 @@
-import { useMemo, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
-
 import dayjs from "@calcom/dayjs";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
@@ -12,17 +9,24 @@ import classNames from "@calcom/ui/classNames";
 import { Alert } from "@calcom/ui/components/alert";
 import { Button } from "@calcom/ui/components/button";
 import { DialogContent, DialogFooter, DialogHeader } from "@calcom/ui/components/dialog";
-import { DateRangePicker, TextArea, Input, Checkbox } from "@calcom/ui/components/form";
-import { Label } from "@calcom/ui/components/form";
-import { Select } from "@calcom/ui/components/form";
-import { Switch } from "@calcom/ui/components/form";
+import {
+  Checkbox,
+  DateRangePicker,
+  Input,
+  Label,
+  Select,
+  Switch,
+  TextArea,
+} from "@calcom/ui/components/form";
 import { showToast } from "@calcom/ui/components/toast";
 import { useHasTeamPlan } from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
-
+import { useMemo, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 import { UpgradeTeamsBadgeWebWrapper as UpgradeTeamsBadge } from "~/billing/components/UpgradeTeamsBadgeWebWrapper";
 import { OutOfOfficeTab } from "~/settings/outOfOffice/OutOfOfficeToggleGroup";
 
 export type { BookingRedirectForm } from "~/settings/outOfOffice/types";
+
 import type { BookingRedirectForm } from "~/settings/outOfOffice/types";
 
 type Option = { value: number; label: string };
@@ -111,6 +115,7 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
   const [profileRedirect, setProfileRedirect] = useState(!!currentlyEditingOutOfOfficeEntry?.toTeamUserId);
 
   const { hasTeamPlan } = useHasTeamPlan();
+  const isOrgMember = !!me?.data?.organizationId;
 
   const {
     handleSubmit,
@@ -383,12 +388,15 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
                   }}
                   label={hasTeamPlan ? t("redirect_team_enabled") : t("redirect_team_disabled")}
                 />
-                {!hasTeamPlan && (
+                {!hasTeamPlan && !isOrgMember && (
                   <div className="mx-2" data-testid="upgrade-team-badge">
                     <UpgradeTeamsBadge />
                   </div>
                 )}
               </div>
+              {!hasTeamPlan && isOrgMember && (
+                <p className="text-subtle mt-2 text-sm">{t("ask_admin_to_invite_you")}</p>
+              )}
 
               {profileRedirect && (
                 <div className="mb-2">

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4716,6 +4716,8 @@
   "upgrade_banner_teams_feature2": "Distribute meetings fairly with round-robin",
   "upgrade_banner_teams_feature3": "See what's getting booked (and what's not)",
   "upgrade_banner_teams_feature4": "Remove Cal.com branding",
+  "not_a_member_of_any_team": "You are not a member of any team yet",
+  "ask_admin_to_invite_you": "Ask your organization admin to invite you to a team.",
   "upgrade_banner_insights_name": "Insights",
   "upgrade_banner_insights_title": "See what's getting booked, and what's not",
   "upgrade_banner_insights_subtitle": "Turn booking data into clarity for you and your team so you can spot gaps, balance workload, and make better scheduling decisions.",


### PR DESCRIPTION
## What does this PR do?

Org members who are not part of any team see misleading "Upgrade" banners because the billing check (`checkUserHasActivePaidTeamPlan`) only queries team memberships and returns `isActive: false` even when the org has a paid plan. This PR replaces upgrade CTAs with a contextual "You are not a member of any team yet. Ask your organization admin to invite you to a team." message for org members without team memberships.

- Fixes PRI-368

### Approach (Option C1 — `isOrgMember` prop)

Added an `isOrgMember?: boolean` prop to `FullScreenUpgradeBanner` and `WideUpgradeBanner`. When `true`, the component renders the "ask your admin" message in the **same visual container** instead of the upgrade CTA, avoiding flicker since no async data fetching is introduced into these presentational components.

### Changes

| Location | What changed |
|---|---|
| `FullScreenUpgradeBanner` | New `isOrgMember` prop; early-returns a centered "no team" message |
| `WideUpgradeBanner` | New `isOrgMember` prop; early-returns a compact "no team" message |
| `FullscreenUpgradeBannerForTeamsPage` | Threads `isOrgMember` through |
| `WideUpgradeBannerForMembers` | Threads `isOrgMember` through |
| `TeamsListing.tsx` | Passes `isOrgMember={!!orgId}` |
| `teams/[id]/members/page.tsx` | Passes `isOrgMember={!!session.user.org?.id}` |
| `appearance-view.tsx` | Hides upgrade badge for org members; swaps description to "ask admin" |
| `CreateOrEditOutOfOfficeModal.tsx` | Hides upgrade badge for org members; shows "ask admin" hint |
| `en/common.json` | Two new i18n keys: `not_a_member_of_any_team`, `ask_admin_to_invite_you` |

### ⚠️ Items for reviewer attention

1. **`WideUpgradeBanner.tsx` line 155** — Biome reformatted a template literal class string. Verify the space between `md:block` and the conditional `max-w-*` class is preserved. The original had `" max-w-64"` (with leading space) and it appears the formatter may have dropped it to `"max-w-64"`, which would concatenate classes incorrectly.
2. **`TeamsListing.tsx`** — Added `teamInvites.length === 0` guard so the upgrade/ask-admin banner doesn't appear when the user has pending team invites. Confirm this is desired behavior.
3. **`appearance-view.tsx`** — For org members without a paid plan, the branding toggle remains disabled but shows "ask admin" as description and hides the upgrade badge entirely. Verify this is the right UX.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Setup**: Log in as a user who is a member of an organization but **not** a member of any team within that org.
2. **Teams page** (`/teams`): Should see "You are not a member of any team yet" in a fullscreen banner, NOT an upgrade CTA.
3. **Settings > Appearance** (`/settings/my-account/appearance`): "Disable Cal branding" should show "Ask your organization admin to invite you to a team." as description, NOT an upgrade badge.
4. **Out of Office modal** (`/settings/my-account/out-of-office`, create new): Redirect section should show "Ask your organization admin..." text, NOT an upgrade badge.
5. **Team members page** (`/settings/teams/<id>/members`): For standalone teams, wide banner should reflect org membership status.

### Edge cases
- Non-org user with no teams → upgrade banner should still appear (existing behavior unchanged)
- Org member who IS on a team → existing behavior unchanged (no banners shown)
- User with pending team invites → banner should NOT show (invites displayed instead)

Link to Devin session: https://app.devin.ai/sessions/33918963089047bd97daf844210600dc
Requested by: @eunjae-lee
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
