### PR TITLE
fix(embed): prevent inline embed layout shift on narrow viewports

### DIFF
--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -953,6 +953,12 @@ class CalApi {
 
     iframe.style.height = "100%";
     iframe.style.width = "100%";
+    // Prevent transient scrollbar from causing layout shift on narrow viewports
+    // when iframe height is being adjusted to match content during day switches.
+    // Inline embeds manage height dynamically via __dimensionChanged, so internal
+    // scrolling is not needed.
+    iframe.setAttribute("scrolling", "no");
+    iframe.style.overflow = "hidden";
 
     containerEl.classList.add("cal-inline-container");
 


### PR DESCRIPTION
## Summary

Fixes the layout shift that occurs on narrow viewports when switching between days in the inline embed. The shift is caused by a transient scrollbar appearing inside the iframe while the content height changes and before the parent can adjust the iframe height via `__dimensionChanged`.

- Adds `scrolling="no"` attribute and `overflow: hidden` style to inline embed iframes
- Inline embeds already manage height dynamically via `__dimensionChanged` events, so internal iframe scrolling is not needed
- The parent `.cal-inline-container` already handles scrollbar hiding via CSS

Fixes #28475

## Visual Demo

The fix prevents the brief scrollbar flash visible in this [CodeSandbox](https://codesandbox.io/p/sandbox/vanillajs-week-view-inline-y9wgxc) linked from [cal.com embed help docs](https://cal.com/help/embedding/adding-embed) when switching days on a narrow viewport.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Open the [inline embed CodeSandbox](https://codesandbox.io/p/sandbox/vanillajs-week-view-inline-y9wgxc) or set up a local inline embed
2. Reduce the viewport width until the mobile layout is shown (time slots below the calendar)
3. Switch between different days
4. **Before:** The embed briefly shifts width as a scrollbar appears/disappears during height transitions
5. **After:** The layout remains stable regardless of which day is selected

Test in both Chrome and Firefox, as the issue manifests slightly differently (Chrome shows a brief scrollbar flash, Firefox shows persistent scrollbar on some days).

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have performed a self-QA

This contribution was developed with AI assistance (Claude Code).