### PR TITLE
fix: add system-ui fallback to --font-sans for better non-Latin script rendering

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -116,7 +116,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <head nonce={nonce}>
         <style>{`
           :root {
-            --font-sans: ${interFont.style.fontFamily.replace(/\'/g, "")};
+            --font-sans: ${interFont.style.fontFamily.replace(/\'/g, "")}, system-ui;
             --font-cal: ${calFont.style.fontFamily.replace(/\'/g, "")};
           }
         `}</style>

--- a/apps/web/components/PageWrapper.tsx
+++ b/apps/web/components/PageWrapper.tsx
@@ -90,7 +90,7 @@ function PageWrapper(props: AppProps) {
 
       <style jsx global>{`
         :root {
-          --font-sans: ${interFont.style.fontFamily};
+          --font-sans: ${interFont.style.fontFamily}, system-ui;
           --font-cal: ${calFont.style.fontFamily};
         }
       `}</style>


### PR DESCRIPTION
## What does this PR do?

Adds `system-ui` as a fallback in the `--font-sans` CSS variable definition.

**Before:**
```
--font-sans: Inter, Inter Fallback;
```

**After:**
```
--font-sans: Inter, Inter Fallback, system-ui;
```

## Why?

When Inter doesn't cover a character (e.g. Arabic, Hebrew, Thai, CJK scripts), the browser falls all the way back to the browser's default serif or sans-serif, which varies wildly across operating systems and often looks inconsistent or broken.

`system-ui` is the OS's native UI font — on macOS it's San Francisco, on Windows it's Segoe UI, on Android it's Roboto. It's a well-supported, intentional fallback that keeps the visual style coherent when Inter's glyph coverage runs out.

## Changes

- `apps/web/app/layout.tsx` — inline `:root` style block (app router)
- `apps/web/components/PageWrapper.tsx` — inline `:root` style block (pages router)

## Testing

1. Set your browser or OS language to Arabic (or any non-Latin script)
2. Visit any booking page
3. Confirm text renders with the OS UI font instead of the browser default fallback

## Checklist

- [x] Self-review completed
- [x] No new dependencies added
- [x] Two-line change, no functional logic affected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
