### PR TITLE
feat: add option to skip CRM cancellation for blocklisted bookings

### DIFF
--- a/apps/web/modules/ee/organizations/components/BlocklistSkipCrmOnCancelSwitch.tsx
+++ b/apps/web/modules/ee/organizations/components/BlocklistSkipCrmOnCancelSwitch.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import type { RouterOutputs } from "@calcom/trpc/react";
+import { trpc } from "@calcom/trpc/react";
+import { SettingsToggle } from "@calcom/ui/components/form";
+import { showToast } from "@calcom/ui/components/toast";
+import { useState } from "react";
+
+interface BlocklistSkipCrmOnCancelSwitchProps {
+  currentOrg: RouterOutputs["viewer"]["organizations"]["listCurrent"];
+}
+
+export const BlocklistSkipCrmOnCancelSwitch = ({ currentOrg }: BlocklistSkipCrmOnCancelSwitchProps) => {
+  const { t } = useLocale();
+  const utils = trpc.useUtils();
+  const [skipCrmOnCancel, setSkipCrmOnCancel] = useState(
+    !!currentOrg?.organizationSettings?.blocklistSkipCrmOnCancel
+  );
+
+  const mutation = trpc.viewer.organizations.update.useMutation({
+    onSuccess: async () => {
+      showToast(t("settings_updated_successfully"), "success");
+    },
+    onError: () => {
+      showToast(t("error_updating_settings"), "error");
+    },
+    onSettled: () => {
+      utils.viewer.organizations.listCurrent.invalidate();
+    },
+  });
+
+  return (
+    <SettingsToggle
+      toggleSwitchAtTheEnd={true}
+      title={t("blocklist_skip_crm_on_cancel_title")}
+      disabled={mutation?.isPending}
+      description={t("blocklist_skip_crm_on_cancel_description")}
+      checked={skipCrmOnCancel}
+      onCheckedChange={(checked) => {
+        mutation.mutate({
+          blocklistSkipCrmOnCancel: checked,
+        });
+        setSkipCrmOnCancel(checked);
+      }}
+      switchContainerClassName="mt-4"
+    />
+  );
+};

--- a/apps/web/modules/ee/organizations/components/BlocklistSkipCrmOnCancelSwitch.tsx
+++ b/apps/web/modules/ee/organizations/components/BlocklistSkipCrmOnCancelSwitch.tsx
@@ -23,6 +23,7 @@ export const BlocklistSkipCrmOnCancelSwitch = ({ currentOrg }: BlocklistSkipCrmO
       showToast(t("settings_updated_successfully"), "success");
     },
     onError: () => {
+      setSkipCrmOnCancel(!!currentOrg?.organizationSettings?.blocklistSkipCrmOnCancel);
       showToast(t("error_updating_settings"), "error");
     },
     onSettled: () => {
@@ -38,10 +39,10 @@ export const BlocklistSkipCrmOnCancelSwitch = ({ currentOrg }: BlocklistSkipCrmO
       description={t("blocklist_skip_crm_on_cancel_description")}
       checked={skipCrmOnCancel}
       onCheckedChange={(checked) => {
+        setSkipCrmOnCancel(checked);
         mutation.mutate({
           blocklistSkipCrmOnCancel: checked,
         });
-        setSkipCrmOnCancel(checked);
       }}
       switchContainerClassName="mt-4"
     />

--- a/apps/web/modules/ee/organizations/privacy.tsx
+++ b/apps/web/modules/ee/organizations/privacy.tsx
@@ -1,14 +1,13 @@
 "use client";
 
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { trpc } from "@calcom/trpc/react";
 import { usePathname } from "next/navigation";
-
 import { DataTableProvider } from "~/data-table/DataTableProvider";
 import { useSegments } from "~/data-table/hooks/useSegments";
 import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import { BlocklistSkipCrmOnCancelSwitch } from "~/ee/organizations/components/BlocklistSkipCrmOnCancelSwitch";
 import OrgAutoJoinSetting from "~/ee/organizations/components/OrgAutoJoinSetting";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { trpc } from "@calcom/trpc/react";
-
 import { BlocklistTable } from "~/ee/organizations/privacy/blocklist-table";
 import MakeTeamPrivateSwitch from "~/ee/teams/components/MakeTeamPrivateSwitch";
 
@@ -62,6 +61,7 @@ const PrivacyView = ({
                 <BlocklistTable permissions={watchlistPermissions} />
               </DataTableProvider>
             </div>
+            {permissions.canEdit && currentOrg && <BlocklistSkipCrmOnCancelSwitch currentOrg={currentOrg} />}
           </div>
         )}
       </div>

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -69,6 +69,7 @@ import {
   scheduleTrigger,
 } from "@calcom/features/webhooks/lib/scheduleTrigger";
 import type { EventPayloadType, EventTypeInfo } from "@calcom/features/webhooks/lib/sendPayload";
+import { getTranslation } from "@calcom/i18n/server";
 import { groupHostsByGroupId } from "@calcom/lib/bookings/hostGroupUtils";
 import { shouldIgnoreContactOwner } from "@calcom/lib/bookings/routing/utils";
 import { getVideoCallUrlFromCalEvent } from "@calcom/lib/CalEventParser";
@@ -83,7 +84,6 @@ import { criticalLogger } from "@calcom/lib/logger.server";
 import { getPiiFreeCalendarEvent, getPiiFreeEventType } from "@calcom/lib/piiFreeData";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { getServerErrorFromUnknown } from "@calcom/lib/server/getServerErrorFromUnknown";
-import { getTranslation } from "@calcom/i18n/server";
 import { getTimeFormatStringFromUserTimeFormat } from "@calcom/lib/timeFormat";
 import { distributedTracing } from "@calcom/lib/tracing/factory";
 import type { PrismaClient } from "@calcom/prisma";
@@ -671,7 +671,18 @@ async function handler(
     eventType,
   });
 
-  spamCheckService.startCheck({ email: bookerEmail, organizationId: eventOrganizationId });
+  const orgSettings = eventOrganizationId
+    ? await deps.prismaClient.organizationSettings.findUnique({
+        where: { organizationId: eventOrganizationId },
+        select: { blocklistSkipCrmOnCancel: true },
+      })
+    : null;
+
+  spamCheckService.startCheck({
+    email: bookerEmail,
+    organizationId: eventOrganizationId,
+    blocklistSkipCrmOnCancel: orgSettings?.blocklistSkipCrmOnCancel ?? false,
+  });
 
   if (!rawBookingData.rescheduleUid) {
     await checkActiveBookingsLimitForBooker({
@@ -2453,7 +2464,7 @@ async function handler(
     isBookingAuditEnabled,
   });
 
-  const webhookLocation= metadata?.videoCallUrl || evt.location;
+  const webhookLocation = metadata?.videoCallUrl || evt.location;
 
   const { assignmentReason: _emailAssignmentReason, ...evtWithoutAssignmentReason } = evt;
   const webhookData: EventPayloadType = {

--- a/packages/features/ee/organizations/repositories/OrganizationRepository.ts
+++ b/packages/features/ee/organizations/repositories/OrganizationRepository.ts
@@ -298,6 +298,7 @@ export class OrganizationRepository {
         disableAttendeeRescheduleRequestEmail: true,
         disableAttendeeLocationChangeEmail: true,
         disableAttendeeNewEventEmail: true,
+        blocklistSkipCrmOnCancel: true,
       },
     });
 
@@ -327,6 +328,7 @@ export class OrganizationRepository {
         disableAttendeeRescheduleRequestEmail: organizationSettings?.disableAttendeeRescheduleRequestEmail,
         disableAttendeeLocationChangeEmail: organizationSettings?.disableAttendeeLocationChangeEmail,
         disableAttendeeNewEventEmail: organizationSettings?.disableAttendeeNewEventEmail,
+        blocklistSkipCrmOnCancel: organizationSettings?.blocklistSkipCrmOnCancel,
       },
       user: {
         role: membership?.role,

--- a/packages/features/watchlist/lib/interface/IBlockingService.ts
+++ b/packages/features/watchlist/lib/interface/IBlockingService.ts
@@ -4,6 +4,7 @@ export interface BlockingResult {
   isBlocked: boolean;
   reason?: WatchlistType;
   watchlistEntry?: Record<string, unknown> | null;
+  skipCrmOnCancel?: boolean;
 }
 
 /**

--- a/packages/features/watchlist/lib/service/SpamCheckService.test.ts
+++ b/packages/features/watchlist/lib/service/SpamCheckService.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+import { WatchlistType } from "@calcom/prisma/enums";
+
+import type { BlockingResult } from "../interface/IBlockingService";
+import type { GlobalBlockingService } from "./GlobalBlockingService";
+import type { OrganizationBlockingService } from "./OrganizationBlockingService";
+import { SpamCheckService } from "./SpamCheckService";
+
+const mockGlobalBlockingService = {
+  isBlocked: vi.fn(),
+} as unknown as GlobalBlockingService;
+
+const mockOrgBlockingService = {
+  isBlocked: vi.fn(),
+} as unknown as OrganizationBlockingService;
+
+describe("SpamCheckService", () => {
+  let service: SpamCheckService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new SpamCheckService(mockGlobalBlockingService, mockOrgBlockingService);
+  });
+
+  describe("startCheck and waitForCheck", () => {
+    test("should throw if waitForCheck is called before startCheck", async () => {
+      await expect(service.waitForCheck()).rejects.toThrow(
+        "waitForCheck() called before startCheck(). You must call startCheck() first to initialize spam checking."
+      );
+    });
+
+    test("should return not blocked when no matches found", async () => {
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+      vi.mocked(mockOrgBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+
+      service.startCheck({ email: "clean@example.com", organizationId: 1 });
+      const result = await service.waitForCheck();
+
+      expect(result.isBlocked).toBe(false);
+    });
+
+    test("should return global block result when globally blocked", async () => {
+      const globalResult: BlockingResult = {
+        isBlocked: true,
+        reason: WatchlistType.EMAIL,
+        watchlistEntry: { id: "g1", value: "blocked@example.com" },
+      };
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockResolvedValue(globalResult);
+      vi.mocked(mockOrgBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+
+      service.startCheck({ email: "blocked@example.com", organizationId: 1 });
+      const result = await service.waitForCheck();
+
+      expect(result.isBlocked).toBe(true);
+      expect(result.reason).toBe(WatchlistType.EMAIL);
+      expect(result.skipCrmOnCancel).toBeUndefined();
+    });
+
+    test("should return org block result when org blocked", async () => {
+      const orgResult: BlockingResult = {
+        isBlocked: true,
+        reason: WatchlistType.DOMAIN,
+        watchlistEntry: { id: "o1", value: "competitor.com" },
+      };
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+      vi.mocked(mockOrgBlockingService.isBlocked).mockResolvedValue(orgResult);
+
+      service.startCheck({ email: "user@competitor.com", organizationId: 1 });
+      const result = await service.waitForCheck();
+
+      expect(result.isBlocked).toBe(true);
+      expect(result.reason).toBe(WatchlistType.DOMAIN);
+    });
+
+    test("should prioritize global block over org block", async () => {
+      const globalResult: BlockingResult = {
+        isBlocked: true,
+        reason: WatchlistType.EMAIL,
+        watchlistEntry: { id: "g1", value: "blocked@example.com" },
+      };
+      const orgResult: BlockingResult = {
+        isBlocked: true,
+        reason: WatchlistType.DOMAIN,
+        watchlistEntry: { id: "o1", value: "example.com" },
+      };
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockResolvedValue(globalResult);
+      vi.mocked(mockOrgBlockingService.isBlocked).mockResolvedValue(orgResult);
+
+      service.startCheck({ email: "blocked@example.com", organizationId: 1 });
+      const result = await service.waitForCheck();
+
+      expect(result).toEqual(globalResult);
+    });
+
+    test("should skip org check when organizationId is null", async () => {
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+
+      service.startCheck({ email: "user@example.com", organizationId: null });
+      const result = await service.waitForCheck();
+
+      expect(result.isBlocked).toBe(false);
+      expect(mockOrgBlockingService.isBlocked).not.toHaveBeenCalled();
+    });
+
+    test("should return not blocked on error", async () => {
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockRejectedValue(new Error("DB error"));
+
+      service.startCheck({ email: "user@example.com", organizationId: null });
+      const result = await service.waitForCheck();
+
+      expect(result.isBlocked).toBe(false);
+    });
+  });
+
+  describe("blocklistSkipCrmOnCancel flag", () => {
+    test("should include skipCrmOnCancel=true in result when org blocked and flag is true", async () => {
+      const orgResult: BlockingResult = {
+        isBlocked: true,
+        reason: WatchlistType.EMAIL,
+        watchlistEntry: { id: "o1", value: "blocked@example.com" },
+      };
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+      vi.mocked(mockOrgBlockingService.isBlocked).mockResolvedValue(orgResult);
+
+      service.startCheck({
+        email: "blocked@example.com",
+        organizationId: 1,
+        blocklistSkipCrmOnCancel: true,
+      });
+      const result = await service.waitForCheck();
+
+      expect(result.isBlocked).toBe(true);
+      expect(result.skipCrmOnCancel).toBe(true);
+    });
+
+    test("should include skipCrmOnCancel=false in result when org blocked and flag is false", async () => {
+      const orgResult: BlockingResult = {
+        isBlocked: true,
+        reason: WatchlistType.EMAIL,
+        watchlistEntry: { id: "o1", value: "blocked@example.com" },
+      };
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+      vi.mocked(mockOrgBlockingService.isBlocked).mockResolvedValue(orgResult);
+
+      service.startCheck({
+        email: "blocked@example.com",
+        organizationId: 1,
+        blocklistSkipCrmOnCancel: false,
+      });
+      const result = await service.waitForCheck();
+
+      expect(result.isBlocked).toBe(true);
+      expect(result.skipCrmOnCancel).toBe(false);
+    });
+
+    test("should not include skipCrmOnCancel when org blocked but flag is undefined", async () => {
+      const orgResult: BlockingResult = {
+        isBlocked: true,
+        reason: WatchlistType.EMAIL,
+        watchlistEntry: { id: "o1", value: "blocked@example.com" },
+      };
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+      vi.mocked(mockOrgBlockingService.isBlocked).mockResolvedValue(orgResult);
+
+      service.startCheck({
+        email: "blocked@example.com",
+        organizationId: 1,
+      });
+      const result = await service.waitForCheck();
+
+      expect(result.isBlocked).toBe(true);
+      expect(result.skipCrmOnCancel).toBeUndefined();
+    });
+
+    test("should not include skipCrmOnCancel when globally blocked even if flag is true", async () => {
+      const globalResult: BlockingResult = {
+        isBlocked: true,
+        reason: WatchlistType.EMAIL,
+        watchlistEntry: { id: "g1", value: "blocked@example.com" },
+      };
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockResolvedValue(globalResult);
+      vi.mocked(mockOrgBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+
+      service.startCheck({
+        email: "blocked@example.com",
+        organizationId: 1,
+        blocklistSkipCrmOnCancel: true,
+      });
+      const result = await service.waitForCheck();
+
+      expect(result.isBlocked).toBe(true);
+      expect(result.skipCrmOnCancel).toBeUndefined();
+    });
+
+    test("should not include skipCrmOnCancel when not blocked", async () => {
+      vi.mocked(mockGlobalBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+      vi.mocked(mockOrgBlockingService.isBlocked).mockResolvedValue({ isBlocked: false });
+
+      service.startCheck({
+        email: "clean@example.com",
+        organizationId: 1,
+        blocklistSkipCrmOnCancel: true,
+      });
+      const result = await service.waitForCheck();
+
+      expect(result.isBlocked).toBe(false);
+      expect(result.skipCrmOnCancel).toBeUndefined();
+    });
+  });
+});

--- a/packages/features/watchlist/lib/service/SpamCheckService.ts
+++ b/packages/features/watchlist/lib/service/SpamCheckService.ts
@@ -1,6 +1,5 @@
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
-
 import type { BlockingResult } from "../interface/IBlockingService";
 import type { GlobalBlockingService } from "./GlobalBlockingService";
 import type { OrganizationBlockingService } from "./OrganizationBlockingService";
@@ -19,8 +18,20 @@ export class SpamCheckService {
     private readonly organizationBlockingService: OrganizationBlockingService
   ) {}
 
-  startCheck({ email, organizationId }: { email: string; organizationId: number | null }): void {
-    this.spamCheckPromise = this.isBlocked(email, organizationId ?? undefined).catch((error) => {
+  startCheck({
+    email,
+    organizationId,
+    blocklistSkipCrmOnCancel,
+  }: {
+    email: string;
+    organizationId: number | null;
+    blocklistSkipCrmOnCancel?: boolean;
+  }): void {
+    this.spamCheckPromise = this.isBlocked(
+      email,
+      organizationId ?? undefined,
+      blocklistSkipCrmOnCancel
+    ).catch((error) => {
       logger.error("Error starting spam check", safeStringify(error));
       return { isBlocked: false };
     });
@@ -39,7 +50,11 @@ export class SpamCheckService {
    * Checks if an email is blocked by global or organization-specific watchlist rules
    * Runs both checks in parallel for better performance
    */
-  private async isBlocked(email: string, organizationId?: number): Promise<BlockingResult> {
+  private async isBlocked(
+    email: string,
+    organizationId?: number,
+    blocklistSkipCrmOnCancel?: boolean
+  ): Promise<BlockingResult> {
     const checks = [this.globalBlockingService.isBlocked(email)];
 
     if (organizationId) {
@@ -55,7 +70,7 @@ export class SpamCheckService {
 
     // Check organization blocking if it was performed
     if (orgResult?.isBlocked) {
-      return orgResult;
+      return { ...orgResult, skipCrmOnCancel: blocklistSkipCrmOnCancel };
     }
 
     return { isBlocked: false };

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4326,6 +4326,8 @@
   "no_description_provided": "No description provided",
   "organization_blocklist": "Organization blocklist",
   "manage_blocked_emails_and_domains": "Manage blocked emails and domains for your organization",
+  "blocklist_skip_crm_on_cancel_title": "Skip CRM cancellation for blocked bookings",
+  "blocklist_skip_crm_on_cancel_description": "When enabled, silently cancelled bookings from blocklisted emails or domains will not trigger the CRM cancellation flow",
   "guest_notifications": "Guest notifications",
   "guest_notifications_description": "Manage guest booking emails across all event types in your organization",
   "guest_booking_email_notifications": "Guest booking email notifications",

--- a/packages/prisma/migrations/20260319021438_add_blocklist_skip_crm_on_cancel/migration.sql
+++ b/packages/prisma/migrations/20260319021438_add_blocklist_skip_crm_on_cancel/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."OrganizationSettings" ADD COLUMN     "blocklistSkipCrmOnCancel" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -750,6 +750,7 @@ model OrganizationSettings {
   disableAttendeeRescheduleRequestEmail Boolean @default(false)
   disableAttendeeLocationChangeEmail    Boolean @default(false)
   disableAttendeeNewEventEmail          Boolean @default(false)
+  blocklistSkipCrmOnCancel              Boolean @default(false)
 }
 
 enum MembershipRole {

--- a/packages/trpc/server/routers/viewer/organizations/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/update.handler.ts
@@ -9,9 +9,7 @@ import { prisma } from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
 import { teamMetadataStrictSchema } from "@calcom/prisma/zod-utils";
-
 import { TRPCError } from "@trpc/server";
-
 import type { TrpcSessionUser } from "../../../types";
 import type { TUpdateInputSchema } from "./update.schema";
 
@@ -66,82 +64,87 @@ const updateOrganizationSettings = async ({
   const data: Prisma.OrganizationSettingsUpdateInput = {};
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("lockEventTypeCreation")) {
+  if (Object.hasOwn(input, "lockEventTypeCreation")) {
     data.lockEventTypeCreationForUsers = input.lockEventTypeCreation;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("adminGetsNoSlotsNotification")) {
+  if (Object.hasOwn(input, "adminGetsNoSlotsNotification")) {
     data.adminGetsNoSlotsNotification = input.adminGetsNoSlotsNotification;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("allowSEOIndexing")) {
+  if (Object.hasOwn(input, "allowSEOIndexing")) {
     data.allowSEOIndexing = input.allowSEOIndexing;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("orgProfileRedirectsToVerifiedDomain")) {
+  if (Object.hasOwn(input, "orgProfileRedirectsToVerifiedDomain")) {
     data.orgProfileRedirectsToVerifiedDomain = input.orgProfileRedirectsToVerifiedDomain;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("disablePhoneOnlySMSNotifications")) {
+  if (Object.hasOwn(input, "disablePhoneOnlySMSNotifications")) {
     data.disablePhoneOnlySMSNotifications = input.disablePhoneOnlySMSNotifications;
   }
 
-  if (input.hasOwnProperty("disableAutofillOnBookingPage")) {
+  if (Object.hasOwn(input, "disableAutofillOnBookingPage")) {
     data.disableAutofillOnBookingPage = input.disableAutofillOnBookingPage;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("orgAutoJoinOnSignup")) {
+  if (Object.hasOwn(input, "orgAutoJoinOnSignup")) {
     data.orgAutoJoinOnSignup = input.orgAutoJoinOnSignup;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("disableAttendeeConfirmationEmail")) {
+  if (Object.hasOwn(input, "disableAttendeeConfirmationEmail")) {
     data.disableAttendeeConfirmationEmail = input.disableAttendeeConfirmationEmail;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("disableAttendeeCancellationEmail")) {
+  if (Object.hasOwn(input, "disableAttendeeCancellationEmail")) {
     data.disableAttendeeCancellationEmail = input.disableAttendeeCancellationEmail;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("disableAttendeeRescheduledEmail")) {
+  if (Object.hasOwn(input, "disableAttendeeRescheduledEmail")) {
     data.disableAttendeeRescheduledEmail = input.disableAttendeeRescheduledEmail;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("disableAttendeeRequestEmail")) {
+  if (Object.hasOwn(input, "disableAttendeeRequestEmail")) {
     data.disableAttendeeRequestEmail = input.disableAttendeeRequestEmail;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("disableAttendeeReassignedEmail")) {
+  if (Object.hasOwn(input, "disableAttendeeReassignedEmail")) {
     data.disableAttendeeReassignedEmail = input.disableAttendeeReassignedEmail;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("disableAttendeeAwaitingPaymentEmail")) {
+  if (Object.hasOwn(input, "disableAttendeeAwaitingPaymentEmail")) {
     data.disableAttendeeAwaitingPaymentEmail = input.disableAttendeeAwaitingPaymentEmail;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("disableAttendeeRescheduleRequestEmail")) {
+  if (Object.hasOwn(input, "disableAttendeeRescheduleRequestEmail")) {
     data.disableAttendeeRescheduleRequestEmail = input.disableAttendeeRescheduleRequestEmail;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("disableAttendeeLocationChangeEmail")) {
+  if (Object.hasOwn(input, "disableAttendeeLocationChangeEmail")) {
     data.disableAttendeeLocationChangeEmail = input.disableAttendeeLocationChangeEmail;
   }
 
   // eslint-disable-next-line no-prototype-builtins
-  if (input.hasOwnProperty("disableAttendeeNewEventEmail")) {
+  if (Object.hasOwn(input, "disableAttendeeNewEventEmail")) {
     data.disableAttendeeNewEventEmail = input.disableAttendeeNewEventEmail;
+  }
+
+  // eslint-disable-next-line no-prototype-builtins
+  if (Object.hasOwn(input, "blocklistSkipCrmOnCancel")) {
+    data.blocklistSkipCrmOnCancel = input.blocklistSkipCrmOnCancel;
   }
 
   // If no settings values have changed lets skip this update

--- a/packages/trpc/server/routers/viewer/organizations/update.schema.ts
+++ b/packages/trpc/server/routers/viewer/organizations/update.schema.ts
@@ -1,8 +1,7 @@
-import { z } from "zod";
-
 import { timeZoneSchema } from "@calcom/lib/dayjs/timeZone.schema";
 import { validateUrlForSSRFSync } from "@calcom/lib/ssrfProtection";
 import { teamMetadataStrictSchema } from "@calcom/prisma/zod-utils";
+import { z } from "zod";
 
 /**
  * Optional nullable URL schema with SSRF protections
@@ -60,6 +59,7 @@ export type TUpdateInputSchemaInput = {
   disableAttendeeRescheduleRequestEmail?: boolean;
   disableAttendeeLocationChangeEmail?: boolean;
   disableAttendeeNewEventEmail?: boolean;
+  blocklistSkipCrmOnCancel?: boolean;
 };
 
 export type TUpdateInputSchema = {
@@ -96,6 +96,7 @@ export type TUpdateInputSchema = {
   disableAttendeeRescheduleRequestEmail?: boolean;
   disableAttendeeLocationChangeEmail?: boolean;
   disableAttendeeNewEventEmail?: boolean;
+  blocklistSkipCrmOnCancel?: boolean;
 };
 
 export const ZUpdateInputSchema: z.ZodType<TUpdateInputSchema, z.ZodTypeDef, TUpdateInputSchemaInput> =
@@ -138,4 +139,5 @@ export const ZUpdateInputSchema: z.ZodType<TUpdateInputSchema, z.ZodTypeDef, TUp
     disableAttendeeRescheduleRequestEmail: z.boolean().optional(),
     disableAttendeeLocationChangeEmail: z.boolean().optional(),
     disableAttendeeNewEventEmail: z.boolean().optional(),
+    blocklistSkipCrmOnCancel: z.boolean().optional(),
   });


### PR DESCRIPTION
## What does this PR do?

Adds an organization-level setting `blocklistSkipCrmOnCancel` that, when enabled, signals that silently cancelled bookings from blocklisted emails/domains should skip the CRM cancellation flow.

**Changes:**
- New `blocklistSkipCrmOnCancel` boolean field on `OrganizationSettings` (Prisma schema + migration)
- tRPC update schema/handler support for the new field
- `OrganizationRepository.findCurrentOrg` exposes the field
- New `BlocklistSkipCrmOnCancelSwitch` toggle component on the org privacy/blocklist page
- `SpamCheckService` accepts and threads the flag through to `BlockingResult.skipCrmOnCancel`
- `RegularBookingService` fetches the org setting and passes it to `startCheck`
- Unit tests for `SpamCheckService` covering the new `skipCrmOnCancel` flag behavior

## ⚠️ Important: Incomplete downstream consumption

**The `BlockingResult.skipCrmOnCancel` flag is plumbed through but no downstream code currently reads it to conditionally skip CRM operations.** A follow-up change is needed in the booking cancellation/decoy path (e.g., `EventManager` or `handleCancelBooking`) to actually honor this flag and skip CRM event deletion when it is `true`. This PR establishes the setting, UI, and data flow — the behavioral change is not yet wired end-to-end.

## Items for reviewer attention

1. **Extra DB query on all org bookings**: `RegularBookingService` now calls `organizationSettings.findUnique` for every org booking attempt, not just blocked ones. Consider whether this should be deferred until after `spamCheckResult.isBlocked` is confirmed, or batched with existing org data fetching.
2. **Cosmetic diff noise**: The diff includes `hasOwnProperty` → `Object.hasOwn` refactor across all settings in `update.handler.ts`, import reordering (biome auto-fix), and a whitespace fix. These are cosmetic but inflate the diff.
3. **`skipCrmOnCancel` only set for org-level blocks**: Global blocks won't carry this flag — intentional since the setting lives on `OrganizationSettings`.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no public API or doc changes.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to an organization's **Settings → Privacy** page
2. Scroll to the **Organization blocklist** section
3. A new toggle **"Skip CRM cancellation for blocked bookings"** should appear below the blocklist table (only visible to users with edit permissions)
4. Toggle it on → verify a success toast appears and the setting persists on page refresh
5. Toggle it off → same verification
6. Simulate a mutation error (e.g., network disconnect) → verify the toggle rolls back to its previous state
7. Verify the setting is stored in `OrganizationSettings.blocklistSkipCrmOnCancel` in the database

**Note:** End-to-end behavioral verification (CRM events actually being skipped on blocked booking) requires downstream consumption code which is not yet implemented.

## Checklist

- My code follows the style guidelines of this project
- I have checked if my changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/28be88bf0b1d435993609f0ce3f9841a
Requested by: @joeauyeung