### PR TITLE
fix(emails): preserve 24h format in attendee confirmation emails

### DIFF
--- a/packages/emails/email-manager.test.ts
+++ b/packages/emails/email-manager.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import type { EventTypeMetadata } from "@calcom/prisma/zod-utils";
+import { TimeFormat } from "@calcom/lib/timeFormat";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { shouldSkipAttendeeEmailWithSettings, fetchOrganizationEmailSettings } from "./email-manager";
+import renderEmail from "./src/renderEmail";
 import AttendeeScheduledEmail from "./templates/attendee-scheduled-email";
 
 const mockGetEmailSettings = vi.fn();
@@ -404,5 +406,45 @@ describe("AttendeeScheduledEmail - Privacy fix for seated events", () => {
         "attendee2@example.com",
       ]);
     });
+  });
+});
+
+describe("AttendeeScheduledEmail - Time format fallback", () => {
+  const createMockPerson = (name: string, email: string): Person => ({
+    name,
+    email,
+    timeZone: "America/New_York",
+    language: {
+      translate: vi.fn((key: string) => key),
+      locale: "en",
+    },
+  });
+
+  it("uses organizer time format when attendee time format is missing", async () => {
+    const recipient = createMockPerson("Booker", "booker@example.com");
+
+    const calEvent = {
+      title: "Test Event",
+      type: "Test Event Type",
+      startTime: "2024-01-01T10:00:00Z",
+      endTime: "2024-01-01T11:00:00Z",
+      organizer: {
+        ...createMockPerson("Organizer", "organizer@example.com"),
+        timeFormat: TimeFormat.TWENTY_FOUR_HOUR,
+      },
+      attendees: [recipient],
+    } as CalendarEvent;
+
+    const email = new AttendeeScheduledEmail(calEvent, recipient);
+    await email.getHtml(calEvent, recipient);
+
+    expect(vi.mocked(renderEmail)).toHaveBeenCalledWith(
+      "AttendeeScheduledEmail",
+      expect.objectContaining({
+        attendee: expect.objectContaining({
+          timeFormat: TimeFormat.TWENTY_FOUR_HOUR,
+        }),
+      })
+    );
   });
 });

--- a/packages/emails/templates/attendee-scheduled-email.ts
+++ b/packages/emails/templates/attendee-scheduled-email.ts
@@ -58,9 +58,14 @@ export default class AttendeeScheduledEmail extends BaseEmail {
   }
 
   async getHtml(calEvent: CalendarEvent, attendee: Person) {
+    const attendeeWithTimeFormat = {
+      ...attendee,
+      timeFormat: attendee.timeFormat ?? calEvent.organizer.timeFormat,
+    };
+
     return await renderEmail("AttendeeScheduledEmail", {
       calEvent,
-      attendee,
+      attendee: attendeeWithTimeFormat,
     });
   }
 


### PR DESCRIPTION
## Summary
Fixes attendee (scheduler/booker) confirmation emails showing 12-hour time when the booking was made in 24-hour format.

## Root Cause
Attendee scheduled emails rely on `attendee.timeFormat`, but in this flow it can be missing. The template then falls back to 12-hour format by default.

## Fix
- In attendee scheduled email rendering, if `attendee.timeFormat` is missing, fallback to `calEvent.organizer.timeFormat`.
- This preserves the booking's chosen/host-applied time format for attendee confirmations.

## Tests
- Added regression test to assert attendee scheduled email render payload receives 24-hour `timeFormat` when attendee time format is absent and organizer uses 24-hour format.
- Ran:
  - `TZ=UTC yarn vitest run packages/emails/email-manager.test.ts`

## Scope
- Minimal change in email formatting path only.
- No API/schema changes.

Closes #28472
