### PR TITLE
feat(admin): admins can create one-off custom appointments (#28463)

### DIFF
--- a/apps/web/modules/ee/users/components/UsersTable.tsx
+++ b/apps/web/modules/ee/users/components/UsersTable.tsx
@@ -164,6 +164,8 @@ function UsersTableBare() {
     fetchMoreOnBottomReached(tableContainerRef.current);
   }, [fetchMoreOnBottomReached]);
 
+  const [userToBookOneOff, setUserToBookOneOff] = useState<number | null>(null);
+
   const [userToDelete, setUserToDelete] = useState<number | null>(null);
 
   return (
@@ -274,6 +276,13 @@ function UsersTableBare() {
                           icon: "check",
                         },
                         {
+                          id: "one-off-appointment",
+                          label: "Create Custom Appointment",
+                          onClick: () => setUserToBookOneOff(user.id),
+                          icon: "calendar",
+                        },
+
+                        {
                           id: "impersonation",
                           label: "Impersonate",
                           onClick: () => {
@@ -311,6 +320,13 @@ function UsersTableBare() {
             if (!userToDelete) return;
             mutation.mutate({ userId: userToDelete });
           }}
+      {userToBookOneOff && (
+        <CreateCustomAppointmentDialog
+          user={userToBookOneOff}
+          onClose={() => setUserToBookOneOff(null)}
+        />
+      )}
+
         />
       </div>
       {showImpersonateModal && selectedUser && (
@@ -361,3 +377,110 @@ const DeleteUserDialog = ({
 };
 
 export const UsersTable = withLicenseRequired(UsersTableBare);
+
+const CreateCustomAppointmentDialog = ({
+  user,
+  onClose,
+}: {
+  user: number | null;
+  onClose: () => void;
+}) => {
+  const { t } = useLocale();
+  const utils = trpc.useUtils();
+
+  const mutation = trpc.viewer.admin.createCustomAppointment.useMutation({
+    onSuccess: () => {
+      showToast(t("appointment_created_successfully"), "success");
+      onClose();
+    },
+    onError: (error) => {
+      showToast(error.message, "error");
+    },
+  });
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
+  const [attendeeEmail, setAttendeeEmail] = useState("");
+  const [attendeeName, setAttendeeName] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (new Date(endTime) <= new Date(startTime)) {
+      showToast("End time must be after start time", "error");
+      return;
+    }
+
+    e.preventDefault();
+    if (!user || !title || !startTime || !endTime || !attendeeEmail || !attendeeName) return;
+
+    mutation.mutate({
+      targetUserId: user,
+      title,
+      description,
+      startTime: new Date(startTime).toISOString(),
+      endTime: new Date(endTime).toISOString(),
+      attendees: [{ email: attendeeEmail, name: attendeeName, timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone }],
+    });
+  };
+
+  return (
+    <Dialog open={!!user} onOpenChange={(open) => (open ? () => {} : onClose())}>
+      <DialogContent type="creation" title="Create Custom Appointment" description="Create a one-off appointment for this user without requiring an event type.">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <TextField
+            label="Title"
+            required
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Important Meeting"
+          />
+          <TextField
+            label="Description (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+          <TextField
+            type="datetime-local"
+            label="Start Time"
+            required
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
+          />
+          <TextField
+            type="datetime-local"
+            label="End Time"
+            required
+            value={endTime}
+            onChange={(e) => setEndTime(e.target.value)}
+          />
+          <div className="flex gap-4">
+            <TextField
+              label="Attendee Name"
+              required
+              value={attendeeName}
+              onChange={(e) => setAttendeeName(e.target.value)}
+              placeholder="John Doe"
+            />
+            <TextField
+              label="Attendee Email"
+              type="email"
+              required
+              value={attendeeEmail}
+              onChange={(e) => setAttendeeEmail(e.target.value)}
+              placeholder="john@example.com"
+            />
+          </div>
+
+          <DialogFooter showDivider className="mt-8">
+            <DialogClose color="secondary" onClick={onClose}>Cancel</DialogClose>
+            <Button color="primary" type="submit" loading={mutation.isLoading}>
+              Create Appointment
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/trpc/server/routers/viewer/admin/_router.ts
+++ b/packages/trpc/server/routers/viewer/admin/_router.ts
@@ -2,6 +2,7 @@ import { authedAdminProcedure } from "../../../procedures/authedProcedure";
 import { router } from "../../../trpc";
 import { ZAdminAssignFeatureToTeamSchema } from "./assignFeatureToTeam.schema";
 import { ZBillingPortalLinkSchema } from "./billingPortalLink.schema";
+import { ZCreateCustomAppointmentSchema } from "./createCustomAppointment.schema";
 import { ZCreateCouponSchema } from "./createCoupon.schema";
 import { ZCreateSelfHostedLicenseSchema } from "./createSelfHostedLicenseKey.schema";
 import { ZAdminGetTeamsForFeatureSchema } from "./getTeamsForFeature.schema";
@@ -60,6 +61,11 @@ export const adminRouter = router({
       const { default: handler } = await import("./createSelfHostedLicenseKey.handler");
       return handler(opts);
     }),
+  createCustomAppointment: authedAdminProcedure.input(ZCreateCustomAppointmentSchema).mutation(async (opts) => {
+    const { default: handler } = await import("./createCustomAppointment.handler");
+    return handler(opts);
+  }),
+
   createCoupon: authedAdminProcedure.input(ZCreateCouponSchema).mutation(async (opts) => {
     const { default: handler } = await import("./createCoupon.handler");
     return handler(opts);

--- a/packages/trpc/server/routers/viewer/admin/createCustomAppointment.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/createCustomAppointment.handler.ts
@@ -1,0 +1,72 @@
+import type { PrismaClient } from "@calcom/prisma";
+import type { TrpcSessionUser } from "@calcom/trpc/server/trpc";
+import { TRPCError } from "@trpc/server";
+
+import type { TCreateCustomAppointmentInputSchema } from "./createCustomAppointment.schema";
+
+type AdminCreateCustomAppointmentOptions = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+    prisma: PrismaClient;
+  };
+  input: TCreateCustomAppointmentInputSchema;
+};
+
+export const createCustomAppointmentHandler = async ({
+  ctx,
+  input,
+}: AdminCreateCustomAppointmentOptions) => {
+  const { user, prisma } = ctx;
+
+  // Double check admin role
+  if (user.role !== "ADMIN") {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Only system admins can create custom one-off appointments.",
+    });
+  }
+
+  // Verify target user exists
+  const targetUser = await prisma.user.findUnique({
+    where: { id: input.targetUserId },
+    select: { id: true, email: true, timeZone: true },
+  });
+
+  if (!targetUser) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Target user not found.",
+    });
+  }
+
+  // Create the booking directly (no event type needed)
+  const booking = await prisma.booking.create({
+    data: {
+      userId: targetUser.id,
+      title: input.title,
+      description: input.description,
+      startTime: new Date(input.startTime),
+      endTime: new Date(input.endTime),
+      status: "ACCEPTED",
+      location: input.location,
+      responses: {},
+      attendees: {
+        create: input.attendees.map((attendee) => ({
+          name: attendee.name,
+          email: attendee.email,
+          timeZone: targetUser.timeZone,
+        })),
+      },
+    },
+    include: {
+      attendees: true,
+    },
+  });
+
+  return {
+    success: true,
+    booking,
+  };
+};
+
+export default createCustomAppointmentHandler;

--- a/packages/trpc/server/routers/viewer/admin/createCustomAppointment.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/createCustomAppointment.handler.ts
@@ -39,6 +39,14 @@ export const createCustomAppointmentHandler = async ({
     });
   }
 
+  // Set up responses payload for downstream consumers
+  const booker = input.attendees[0];
+  const responses = {
+    email: booker.email,
+    name: booker.name,
+    location: input.location || "",
+  };
+
   // Create the booking directly (no event type needed)
   const booking = await prisma.booking.create({
     data: {
@@ -49,17 +57,29 @@ export const createCustomAppointmentHandler = async ({
       endTime: new Date(input.endTime),
       status: "ACCEPTED",
       location: input.location,
-      responses: {},
+      responses,
       attendees: {
         create: input.attendees.map((attendee) => ({
           name: attendee.name,
           email: attendee.email,
-          timeZone: targetUser.timeZone,
+          timeZone: attendee.timeZone,
         })),
       },
     },
-    include: {
-      attendees: true,
+    select: {
+      id: true,
+      uid: true,
+      title: true,
+      startTime: true,
+      endTime: true,
+      status: true,
+      attendees: {
+        select: {
+          name: true,
+          email: true,
+          timeZone: true,
+        },
+      },
     },
   });
 

--- a/packages/trpc/server/routers/viewer/admin/createCustomAppointment.schema.ts
+++ b/packages/trpc/server/routers/viewer/admin/createCustomAppointment.schema.ts
@@ -4,13 +4,17 @@ export const ZCreateCustomAppointmentSchema = z.object({
   targetUserId: z.number(),
   title: z.string(),
   description: z.string().optional(),
-  startTime: z.string().datetime(),
-  endTime: z.string().datetime(),
+  startTime: z.string(),
+  endTime: z.string(),
   location: z.string().optional(),
   attendees: z.array(z.object({
     email: z.string().email(),
     name: z.string(),
-  })),
+    timeZone: z.string(),
+  })).min(1),
+}).refine((data) => new Date(data.startTime) < new Date(data.endTime), {
+  message: "End time must be after start time",
+  path: ["endTime"],
 });
 
 export type TCreateCustomAppointmentInputSchema = z.infer<typeof ZCreateCustomAppointmentSchema>;

--- a/packages/trpc/server/routers/viewer/admin/createCustomAppointment.schema.ts
+++ b/packages/trpc/server/routers/viewer/admin/createCustomAppointment.schema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const ZCreateCustomAppointmentSchema = z.object({
+  targetUserId: z.number(),
+  title: z.string(),
+  description: z.string().optional(),
+  startTime: z.string().datetime(),
+  endTime: z.string().datetime(),
+  location: z.string().optional(),
+  attendees: z.array(z.object({
+    email: z.string().email(),
+    name: z.string(),
+  })),
+});
+
+export type TCreateCustomAppointmentInputSchema = z.infer<typeof ZCreateCustomAppointmentSchema>;


### PR DESCRIPTION
Fixes #28463. This adds the backend TRPC capability for system admins to create one-off custom appointments directly for users. It bypasses event types and provisions a one-off booking directly.