### PR TITLE
feat(routing-forms): unify booking questions UI with event-types

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
@@ -2,250 +2,217 @@
 
 import { FieldTypes } from "@calcom/app-store/routing-forms/lib/FieldTypes";
 import type { RoutingFormWithResponseCount } from "@calcom/app-store/routing-forms/types/types";
-import { LearnMoreLink } from "@calcom/features/eventtypes/components/LearnMoreLink";
+import { Dialog } from "@calcom/features/components/controlled-dialog";
+import { fieldTypesConfigMap } from "@calcom/features/form-builder/fieldTypes";
 import { getFieldIdentifier } from "@calcom/features/form-builder/utils/getFieldIdentifier";
+import type { TNonRouterField } from "@calcom/features/routing-forms/lib/zod";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import classNames from "@calcom/ui/classNames";
+import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
-import { FormCard, FormCardBody } from "@calcom/ui/components/card";
-import {
-  BooleanToggleGroupField,
-  Label,
-  MultiOptionInput,
-  SelectField,
-  TextField,
-} from "@calcom/ui/components/form";
-import { Tooltip } from "@calcom/ui/components/tooltip";
+import { DialogClose, DialogContent, DialogFooter, DialogHeader } from "@calcom/ui/components/dialog";
+import { CheckboxField, Form, InputField, SelectField } from "@calcom/ui/components/form";
 import type { getServerSidePropsForSingleFormView as getServerSideProps } from "@calcom/web/lib/apps/routing-forms/[...pages]/getServerSidePropsSingleForm";
 import SingleForm from "@components/apps/routing-forms/SingleForm";
-import { ChevronDownIcon, MenuIcon } from "@coss/ui/icons";
+import { ArrowDownIcon, ArrowUpIcon, MenuIcon } from "@coss/ui/icons";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
-import type { UseFormReturn } from "react-hook-form";
-import { Controller, useFieldArray, useWatch } from "react-hook-form";
+import { useState } from "react";
+import type { SubmitHandler, UseFormReturn } from "react-hook-form";
+import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { Toaster } from "sonner";
 import { v4 as uuidv4 } from "uuid";
 
 type HookForm = UseFormReturn<RoutingFormWithResponseCount>;
+type RoutingFormField = TNonRouterField & {
+  router?: { id: string; name: string; description: string };
+  routerField?: TNonRouterField;
+};
 
-function Field({
-  fieldIndex,
-  hookForm,
-  hookFieldNamespace,
-  deleteField,
-  moveUp,
-  moveDown,
-  appUrl,
+type FieldDialog = {
+  isOpen: boolean;
+  fieldIndex: number;
+  data: RoutingFormField | null;
+};
+
+function Options({
+  value,
+  onChange,
+}: {
+  value: { id: string | null; label: string }[];
+  onChange: (value: { id: string | null; label: string }[]) => void;
+}) {
+  const { t } = useLocale();
+  return (
+    <div className="mt-6">
+      <div className="bg-cal-muted rounded-md p-4">
+        <div className="flex flex-col gap-3">
+          {value?.map((option, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <div className="relative grow">
+                <input
+                  required
+                  value={option.label}
+                  onChange={(e) => {
+                    const newOptions = [...value];
+                    newOptions[index] = { id: option.id, label: e.target.value };
+                    onChange(newOptions);
+                  }}
+                  placeholder={`Option ${index + 1}`}
+                  className="border-default bg-default text-default placeholder:text-muted focus-visible:ring-brand-default focus:border-emphasis w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus-visible:ring-2"
+                />
+              </div>
+              {value.length > 1 && (
+                <Button
+                  type="button"
+                  color="minimal"
+                  variant="icon"
+                  StartIcon="x"
+                  onClick={() => {
+                    const newOptions = [...value];
+                    newOptions.splice(index, 1);
+                    onChange(newOptions);
+                  }}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+        <Button
+          type="button"
+          color="minimal"
+          className="mt-3"
+          StartIcon="plus"
+          onClick={() => {
+            onChange([...(value || []), { id: uuidv4(), label: "" }]);
+          }}>
+          {t("add_an_option")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function FieldEditDialog({
+  dialog,
+  onOpenChange,
+  handleSubmit,
   disableTypeChange,
 }: {
-  fieldIndex: number;
-  hookForm: HookForm;
-  hookFieldNamespace: `fields.${number}`;
-  deleteField: {
-    check: () => boolean;
-    fn: () => void;
-  };
-  moveUp: {
-    check: () => boolean;
-    fn: () => void;
-  };
-  moveDown: {
-    check: () => boolean;
-    fn: () => void;
-  };
-  appUrl: string;
+  dialog: FieldDialog;
+  onOpenChange: (isOpen: boolean) => void;
+  handleSubmit: SubmitHandler<RoutingFormField>;
   disableTypeChange: boolean;
 }) {
   const { t } = useLocale();
 
-  const router = hookForm.getValues(`${hookFieldNamespace}.router`);
-  const routerField = hookForm.getValues(`${hookFieldNamespace}.routerField`);
-
-  const label = useWatch({
-    control: hookForm.control,
-    name: `${hookFieldNamespace}.label`,
+  const fieldForm = useForm<RoutingFormField>({
+    defaultValues: dialog.data || {
+      id: uuidv4(),
+      type: "text",
+      label: "",
+      identifier: "",
+      required: false,
+    },
   });
 
-  const identifier = useWatch({
-    control: hookForm.control,
-    name: `${hookFieldNamespace}.identifier`,
-  });
-
-  const fieldType = useWatch({
-    control: hookForm.control,
-    name: `${hookFieldNamespace}.type`,
-  });
-
-  const preCountFieldLabel = label || routerField?.label || "Field";
-  const fieldLabel = `${fieldIndex + 1}. ${preCountFieldLabel}`;
+  const fieldType = fieldForm.watch("type");
+  const fieldTypeConfig = fieldTypesConfigMap[fieldType as keyof typeof fieldTypesConfigMap];
+  const needsOptions = fieldTypeConfig?.needsOptions;
+  const isTextType = fieldTypeConfig?.isTextType;
 
   return (
-    <div data-testid="field">
-      <FormCard
-        label={fieldLabel}
-        moveUp={moveUp}
-        moveDown={moveDown}
-        badge={
-          router
-            ? {
-                text: router.name,
-                variant: "gray",
-                href: `${appUrl}/form-edit/${router.id}`,
-              }
-            : null
-        }
-        deleteField={router ? null : deleteField}>
-        <FormCardBody>
-          <div className="mb-3 w-full">
-            <TextField
-              data-testid={`${hookFieldNamespace}.label`}
-              disabled={!!router}
-              label="Label"
-              className="grow"
-              placeholder={t("this_is_what_your_users_would_see")}
-              defaultValue={label || routerField?.label || "Field"}
+    <Dialog open={dialog.isOpen} onOpenChange={onOpenChange} modal={false}>
+      <DialogContent className="max-h-none" data-testid="edit-field-dialog" forceOverlayWhenNoModal={true}>
+        <Form id="routing-form-field-builder" form={fieldForm} handleSubmit={handleSubmit}>
+          <div className="h-auto max-h-[85vh] overflow-y-auto">
+            <DialogHeader title={t("add_a_booking_question")} />
+
+            {/* Identifier FIRST — not prefilled */}
+            <InputField
               required
-              {...hookForm.register(`${hookFieldNamespace}.label`)}
+              {...fieldForm.register("identifier")}
+              containerClassName="mt-6"
               onChange={(e) => {
-                const newLabel = e.target.value;
-                // Use label from useWatch which is guaranteed to be the previous value
-                // since useWatch updates reactively (after re-render), not synchronously
-                const previousLabel = label || "";
-                hookForm.setValue(`${hookFieldNamespace}.label`, newLabel, {
-                  shouldDirty: true,
-                });
-                const currentIdentifier = hookForm.getValues(`${hookFieldNamespace}.identifier`);
-                // Only auto-update identifier if it was auto-generated from the previous label
-                // This preserves manual identifier changes
-                const isIdentifierGeneratedFromPreviousLabel =
-                  currentIdentifier === getFieldIdentifier(previousLabel).toLowerCase();
-                if (!currentIdentifier || isIdentifierGeneratedFromPreviousLabel) {
-                  hookForm.setValue(
-                    `${hookFieldNamespace}.identifier`,
-                    getFieldIdentifier(newLabel).toLowerCase(),
-                    { shouldDirty: true }
-                  );
-                }
-              }}
-            />
-          </div>
-          <div className="mb-3 w-full">
-            <TextField
-              disabled={!!router}
-              label={t("identifier_url_parameter")}
-              hint={
-                <LearnMoreLink
-                  t={t}
-                  i18nKey="identifier_url_parameter_hint"
-                  href="https://cal.com/help/routing/connect-routing-form-to-booking-questions"
-                />
-              }
-              name={`${hookFieldNamespace}.identifier`}
-              required
-              placeholder={t("identifies_name_field")}
-              value={identifier || routerField?.identifier || label || routerField?.label || ""}
-              onChange={(e) => {
-                hookForm.setValue(`${hookFieldNamespace}.identifier`, e.target.value.toLowerCase(), {
+                fieldForm.setValue("identifier", getFieldIdentifier(e.target.value || "").toLowerCase(), {
                   shouldDirty: true,
                 });
               }}
+              label={t("identifier")}
+              placeholder=""
             />
-          </div>
-          <div className="mb-3 w-full">
-            <Controller
-              name={`${hookFieldNamespace}.type`}
-              control={hookForm.control}
-              defaultValue={routerField?.type}
-              render={({ field: { value, onChange } }) => {
-                const defaultValue = FieldTypes.find((fieldType) => fieldType.value === value);
-                if (disableTypeChange) {
+
+            <InputField
+              required
+              {...fieldForm.register("label")}
+              containerClassName="mt-6"
+              label={t("label")}
+            />
+
+            <SelectField
+              containerClassName="mt-6"
+              label={t("input_type")}
+              isDisabled={disableTypeChange}
+              options={FieldTypes}
+              value={FieldTypes.find((ft) => ft.value === fieldType)}
+              onChange={(option) => {
+                if (!option) return;
+                fieldForm.setValue("type", option.value, { shouldDirty: true });
+              }}
+            />
+
+            {isTextType && (
+              <InputField
+                {...fieldForm.register("placeholder")}
+                containerClassName="mt-6"
+                label={t("placeholder")}
+              />
+            )}
+
+            {needsOptions && (
+              <Controller
+                name="options"
+                control={fieldForm.control}
+                defaultValue={[
+                  { id: uuidv4(), label: "" },
+                  { id: uuidv4(), label: "" },
+                ]}
+                render={({ field: { value, onChange } }) => {
+                  const opts = (value || []) as { id: string | null; label: string }[];
                   return (
-                    <div className="data-testid-field-type">
-                      <Label htmlFor="field-type-button">{t("type")}</Label>
-                      <Tooltip content={t("field_type_change_suggestion")}>
-                        <Button
-                          type="button"
-                          disabled
-                          color="secondary"
-                          className={classNames(
-                            "h-8 w-full justify-between text-left text-sm",
-                            !!router && "bg-subtle cursor-not-allowed"
-                          )}>
-                          <span className="text-default">{defaultValue?.label || t("select_field_type")}</span>
-                          <ChevronDownIcon className="text-default h-4 w-4" />
-                        </Button>
-                      </Tooltip>
+                    <div className="mt-6">
+                      <label className="text-default mb-2 block text-sm font-medium">{t("options")}</label>
+                      <Options value={opts} onChange={onChange} />
                     </div>
                   );
-                } else {
-                  return (
-                    <SelectField
-                      maxMenuHeight={200}
-                      styles={{
-                        singleValue: (baseStyles) =>
-                          Object.assign({}, baseStyles, {
-                            fontSize: "14px",
-                          }),
-                        option: (baseStyles) =>
-                          Object.assign({}, baseStyles, {
-                            fontSize: "14px",
-                          }),
-                      }}
-                      label="Type"
-                      isDisabled={!!router}
-                      containerClassName="data-testid-field-type"
-                      options={FieldTypes}
-                      onChange={(option) => {
-                        if (!option) {
-                          return;
-                        }
-                        onChange(option.value);
-                      }}
-                      defaultValue={defaultValue}
-                    />
-                  );
-                }
-              }}
-            />
-          </div>
-          {["select", "multiselect"].includes(fieldType) ? (
-            <div className="bg-cal-muted w-full rounded-[10px] p-2">
-              <Label className="text-subtle">{t("options")}</Label>
-              <MultiOptionInput
-                fieldArrayName={`${hookFieldNamespace}.options`}
-                disabled={!!router}
-                optionPlaceholders={["< 10", "10 - 100", "100 - 500", "> 500"]}
-                defaultNumberOfOptions={4}
-                pasteDelimiters={["\n", ","]}
-                showMoveButtons={true}
-                minOptions={1}
-                addOptionLabel={t("add_an_option")}
-                addOptionButtonColor="minimal"
+                }}
+              />
+            )}
+
+            <div className="mt-6">
+              <Controller
+                name="required"
+                control={fieldForm.control}
+                render={({ field: { value, onChange } }) => (
+                  <CheckboxField
+                    data-testid="field-required"
+                    checked={!!value}
+                    onChange={(e) => onChange(e.target.checked)}
+                    description={t("make_field_required")}
+                  />
+                )}
               />
             </div>
-          ) : null}
-
-          <div className="w-[106px]">
-            <Controller
-              name={`${hookFieldNamespace}.required`}
-              control={hookForm.control}
-              defaultValue={routerField?.required}
-              render={({ field: { value, onChange } }) => {
-                return (
-                  <BooleanToggleGroupField
-                    variant="small"
-                    disabled={!!router}
-                    label={t("required")}
-                    value={value}
-                    onValueChange={onChange}
-                  />
-                );
-              }}
-            />
           </div>
-        </FormCardBody>
-      </FormCard>
-    </div>
+
+          <DialogFooter>
+            <DialogClose />
+            <Button type="submit" form="routing-form-field-builder" data-testid="field-add-save">
+              {dialog.data ? t("save") : t("add")}
+            </Button>
+          </DialogFooter>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -258,119 +225,209 @@ const FormEdit = ({
   form: inferSSRProps<typeof getServerSideProps>["form"];
   appUrl: string;
 }) => {
+  const { t } = useLocale();
   const fieldsNamespace = "fields";
   const {
     fields: hookFormFields,
     append: appendHookFormField,
     remove: removeHookFormField,
     swap: swapHookFormField,
+    update: updateHookFormField,
   } = useFieldArray({
     control: hookForm.control,
     name: fieldsNamespace,
     keyName: "_id",
   });
 
-  const [animationRef] = useAutoAnimate<HTMLDivElement>();
+  const [animationParent] = useAutoAnimate<HTMLUListElement>();
 
-  const addField = () => {
-    appendHookFormField({
-      id: uuidv4(),
-      // This is same type from react-awesome-query-builder
-      type: "text",
-      label: "",
-    });
-  };
+  const [fieldDialog, setFieldDialog] = useState<FieldDialog>({
+    isOpen: false,
+    fieldIndex: -1,
+    data: null,
+  });
 
-  // hookForm.reset(form);
   if (!form.fields) {
     form.fields = [];
   }
-  return hookFormFields.length ? (
-    <div className="w-full py-4 lg:py-8">
-      <div ref={animationRef} className="flex w-full flex-col rounded-md">
-        {hookFormFields.map((field, key) => {
-          const existingField = Boolean((form.fields || []).find((f) => f.id === field.id));
-          const hasFormResponses = (form._count?.responses ?? 0) > 0;
-          return (
-            <Field
-              appUrl={appUrl}
-              fieldIndex={key}
-              hookForm={hookForm}
-              hookFieldNamespace={`${fieldsNamespace}.${key}`}
-              disableTypeChange={existingField && hasFormResponses}
-              deleteField={{
-                check: () => hookFormFields.length > 1,
-                fn: () => {
-                  removeHookFormField(key);
-                },
-              }}
-              moveUp={{
-                check: () => key !== 0,
-                fn: () => {
-                  swapHookFormField(key, key - 1);
-                },
-              }}
-              moveDown={{
-                check: () => key !== hookFormFields.length - 1,
-                fn: () => {
-                  if (key === hookFormFields.length - 1) {
-                    return;
-                  }
-                  swapHookFormField(key, key + 1);
-                },
-              }}
-              key={field.id}
-            />
-          );
-        })}
-      </div>
-      {hookFormFields.length ? (
-        <div className={classNames("flex")}>
-          <Button data-testid="add-field" type="button" StartIcon="plus" color="secondary" onClick={addField}>
-            Add question
+
+  const openAddDialog = () => {
+    setFieldDialog({ isOpen: true, fieldIndex: -1, data: null });
+  };
+
+  const openEditDialog = (index: number, field: RoutingFormField) => {
+    setFieldDialog({ isOpen: true, fieldIndex: index, data: field });
+  };
+
+  const closeDialog = () => {
+    setFieldDialog({ isOpen: false, fieldIndex: -1, data: null });
+  };
+
+  const handleFieldSubmit: SubmitHandler<RoutingFormField> = (data) => {
+    if (fieldDialog.data) {
+      updateHookFormField(fieldDialog.fieldIndex, data as RoutingFormWithResponseCount["fields"][number]);
+    } else {
+      appendHookFormField({
+        ...data,
+        id: data.id || uuidv4(),
+        type: data.type || "text",
+      } as RoutingFormWithResponseCount["fields"][number]);
+    }
+    closeDialog();
+  };
+
+  return (
+    <>
+      {hookFormFields.length === 0 ? (
+        <div className="w-full py-4 lg:py-8">
+          <div className="border-subtle bg-cal-muted flex flex-col items-center gap-6 rounded-xl border p-11">
+            <div className="mb-3 grid">
+              {/* Icon card - Top */}
+              <div className="bg-default border-subtle z-30 col-start-1 col-end-1 row-start-1 row-end-1 h-10 w-10 transform rounded-md border shadow-sm">
+                <div className="text-emphasis flex h-full items-center justify-center">
+                  <MenuIcon className="text-emphasis h-4 w-4" />
+                </div>
+              </div>
+              {/* Left fanned card */}
+              <div
+                className="bg-default border-subtle z-20 col-start-1 col-end-1 row-start-1 row-end-1 h-10 w-10 rounded-md border shadow-sm"
+                style={{ transform: "translate(-12px, 2px) rotate(-6deg)" }}
+              />
+              {/* Right fanned card */}
+              <div
+                className="bg-default border-subtle z-10 col-start-1 col-end-1 row-start-1 row-end-1 h-10 w-10 rounded-md border shadow-sm"
+                style={{ transform: "translate(12px, 2px) rotate(6deg)" }}
+              />
+            </div>
+            <div>
+              <h1 className="text-emphasis text-center text-lg font-semibold">
+                {t("create_your_first_question")}
+              </h1>
+              <p className="text-default mt-2 text-center text-sm leading-normal">
+                {t("fields_are_form_fields_that_the_booker_would_see")}
+              </p>
+            </div>
+            <Button data-testid="add-field" onClick={openAddDialog} StartIcon="plus" className="mt-6">
+              {t("add_question")}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="w-full py-4 lg:py-8">
+          <ul ref={animationParent} className="border-subtle divide-subtle divide-y rounded-md border">
+            {hookFormFields.map((field, index) => {
+              const typedField = field as unknown as RoutingFormField;
+              const isRouterField = !!typedField.router;
+              const existingField = Boolean((form.fields || []).find((f) => f.id === typedField.id));
+              const hasFormResponses = (form._count?.responses ?? 0) > 0;
+              const disableTypeChange = existingField && hasFormResponses;
+              const fieldTypeConfig =
+                fieldTypesConfigMap[typedField.type as keyof typeof fieldTypesConfigMap];
+              const typeLabel = fieldTypeConfig?.label ?? typedField.type;
+
+              return (
+                <li
+                  key={typedField.id}
+                  data-testid="field"
+                  className="hover:bg-cal-muted group relative flex items-center justify-between p-4 transition">
+                  {!isRouterField && (
+                    <>
+                      {index >= 1 && (
+                        <button
+                          type="button"
+                          className="bg-default text-muted hover:text-emphasis disabled:hover:text-muted border-subtle hover:border-emphasis invisible absolute -left-[12px] -ml-4 -mt-4 mb-4 hidden h-6 w-6 scale-0 items-center justify-center rounded-md border p-1 transition-all hover:shadow disabled:hover:border-inherit disabled:hover:shadow-none group-hover:visible group-hover:scale-100 sm:ml-0 sm:flex"
+                          onClick={() => swapHookFormField(index, index - 1)}>
+                          <ArrowUpIcon className="h-5 w-5" />
+                        </button>
+                      )}
+                      {index < hookFormFields.length - 1 && (
+                        <button
+                          type="button"
+                          className="bg-default text-muted hover:border-emphasis border-subtle hover:text-emphasis disabled:hover:text-muted invisible absolute -left-[12px] -ml-4 mt-8 hidden h-6 w-6 scale-0 items-center justify-center rounded-md border p-1 transition-all hover:shadow disabled:hover:border-inherit disabled:hover:shadow-none group-hover:visible group-hover:scale-100 sm:ml-0 sm:flex"
+                          onClick={() => swapHookFormField(index, index + 1)}>
+                          <ArrowDownIcon className="h-5 w-5" />
+                        </button>
+                      )}
+                    </>
+                  )}
+
+                  <div>
+                    <div className="flex flex-col lg:flex-row lg:items-center">
+                      <div className="text-default text-sm font-semibold ltr:mr-2 rtl:ml-2">
+                        {typedField.label || typedField.routerField?.label || t("field")}
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <Badge
+                          variant="grayWithoutHover"
+                          data-testid={typedField.required ? "required" : "optional"}>
+                          {typedField.required ? t("required") : t("optional")}
+                        </Badge>
+                        {isRouterField && typedField.router && (
+                          <Badge variant="blue">
+                            <a href={`${appUrl}/form-edit/${typedField.router.id}`}>
+                              {typedField.router.name}
+                            </a>
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                    <p className="text-subtle pt-1 text-sm">{typeLabel}</p>
+                  </div>
+
+                  {!isRouterField && (
+                    <div className="flex items-center space-x-2">
+                      <Button
+                        data-testid="edit-field-action"
+                        color="secondary"
+                        onClick={() => openEditDialog(index, typedField)}>
+                        {t("edit")}
+                      </Button>
+                      {hookFormFields.length > 1 && (
+                        <Button
+                          data-testid="delete-field-action"
+                          color="destructive"
+                          variant="icon"
+                          StartIcon="trash-2"
+                          onClick={() => removeHookFormField(index)}
+                        />
+                      )}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+
+          <Button
+            data-testid="add-field"
+            type="button"
+            color="minimal"
+            className="mt-4"
+            StartIcon="plus"
+            onClick={openAddDialog}>
+            {t("add_question")}
           </Button>
         </div>
-      ) : null}
-    </div>
-  ) : (
-    <div className="w-full py-4 lg:py-8">
-      {/* TODO: remake empty screen for V3 */}
-      <div className="border-subtle bg-cal-muted flex flex-col items-center gap-6 rounded-xl border p-11">
-        <div className="mb-3 grid">
-          {/* Icon card - Top */}
-          <div className="bg-default border-subtle z-30 col-start-1 col-end-1 row-start-1 row-end-1 h-10 w-10 transform rounded-md border shadow-sm">
-            <div className="text-emphasis flex h-full items-center justify-center">
-              <MenuIcon className="text-emphasis h-4 w-4" />
-            </div>
-          </div>
-          {/* Left fanned card */}
-          <div
-            className="bg-default border-subtle z-20 col-start-1 col-end-1 row-start-1 row-end-1 h-10 w-10 rounded-md border shadow-sm"
-            style={{
-              transform: "translate(-12px, 2px) rotate(-6deg)",
-            }}
-          />
-          {/* Right fanned card */}
-          <div
-            className="bg-default border-subtle z-10 col-start-1 col-end-1 row-start-1 row-end-1 h-10 w-10 rounded-md border shadow-sm"
-            style={{
-              transform: "translate(12px, 2px) rotate(6deg)",
-            }}
-          />
-        </div>
-        <div>
-          <h1 className="text-emphasis text-emphasis text-center text-lg font-semibold">
-            Create your first question
-          </h1>
-          <p className="text-default mt-2 text-center text-sm leading-normal">
-            Fields are the form fields that the booker would see.
-          </p>
-        </div>
-        <Button data-testid="add-field" onClick={addField} StartIcon="plus" className="mt-6">
-          Add question
-        </Button>
-      </div>
-    </div>
+      )}
+
+      {fieldDialog.isOpen && (
+        <FieldEditDialog
+          dialog={fieldDialog}
+          onOpenChange={(isOpen) => {
+            if (!isOpen) closeDialog();
+          }}
+          handleSubmit={handleFieldSubmit}
+          disableTypeChange={
+            fieldDialog.data
+              ? Boolean(
+                  (form.fields || []).find((f) => f.id === fieldDialog.data?.id) &&
+                    (form._count?.responses ?? 0) > 0
+                )
+              : false
+          }
+        />
+      )}
+    </>
   );
 };
 

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.ts
@@ -15,6 +15,24 @@ function getWidgetsWithoutFactory(_configFor: ConfigFor) {
     email: {
       ...BasicConfig.widgets.text,
     },
+    address: {
+      ...BasicConfig.widgets.text,
+    },
+    url: {
+      ...BasicConfig.widgets.text,
+    },
+    multiemail: {
+      ...BasicConfig.widgets.text,
+    },
+    boolean: {
+      ...BasicConfig.widgets.text,
+    },
+    checkbox: {
+      ...BasicConfig.widgets.multiselect,
+    },
+    radio: {
+      ...BasicConfig.widgets.select,
+    },
   };
   return widgetsWithoutFactory;
 }
@@ -50,6 +68,46 @@ function getTypes(configFor: ConfigFor) {
           ...BasicConfig.types.multiselect.widgets.multiselect,
           operators: [...multiSelectOperators],
         },
+      },
+    },
+    address: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    url: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    multiemail: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    boolean: {
+      ...BasicConfig.types.text,
+      widgets: {
+        ...BasicConfig.types.text.widgets,
+      },
+    },
+    checkbox: {
+      ...BasicConfig.types.multiselect,
+      widgets: {
+        ...BasicConfig.types.multiselect.widgets,
+        checkbox: {
+          ...BasicConfig.types.multiselect.widgets.multiselect,
+          operators: [...multiSelectOperators],
+        },
+      },
+    },
+    radio: {
+      ...BasicConfig.types.select,
+      widgets: {
+        ...BasicConfig.types.select.widgets,
       },
     },
   };

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/uiConfig.tsx
@@ -111,6 +111,30 @@ function withFactoryWidgets(widgets: WidgetsWithoutFactory) {
       ...widgets.text,
       factory: EmailFactory,
     },
+    address: {
+      ...widgets.address,
+      factory: TextFactory,
+    },
+    url: {
+      ...widgets.url,
+      factory: TextFactory,
+    },
+    multiemail: {
+      ...widgets.multiemail,
+      factory: TextFactory,
+    },
+    boolean: {
+      ...widgets.boolean,
+      factory: TextFactory,
+    },
+    checkbox: {
+      ...widgets.checkbox,
+      factory: MultiSelectFactory,
+    } as SelectWidgetType,
+    radio: {
+      ...widgets.radio,
+      factory: SelectFactory,
+    } as SelectWidgetType,
   };
   return widgetsWithFactory;
 }

--- a/packages/app-store/routing-forms/lib/FieldTypes.ts
+++ b/packages/app-store/routing-forms/lib/FieldTypes.ts
@@ -1,4 +1,6 @@
-export const enum RoutingFormFieldType {
+import { fieldTypesConfigMap } from "@calcom/features/form-builder/fieldTypes";
+
+export enum RoutingFormFieldType {
   TEXT = "text",
   NUMBER = "number",
   TEXTAREA = "textarea",
@@ -8,45 +10,13 @@ export const enum RoutingFormFieldType {
   EMAIL = "email",
 }
 
-export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFieldType => {
-  return [
-    RoutingFormFieldType.TEXT,
-    RoutingFormFieldType.NUMBER,
-    RoutingFormFieldType.TEXTAREA,
-    RoutingFormFieldType.SINGLE_SELECT,
-    RoutingFormFieldType.MULTI_SELECT,
-    RoutingFormFieldType.PHONE,
-    RoutingFormFieldType.EMAIL,
-  ].includes(type as RoutingFormFieldType);
-};
+export const FieldTypes = Object.values(fieldTypesConfigMap)
+  .filter((fieldType) => !fieldType.systemOnly)
+  .map((fieldType) => ({
+    label: fieldType.label,
+    value: fieldType.value,
+  }));
 
-export const FieldTypes = [
-  {
-    label: "Short text",
-    value: RoutingFormFieldType.TEXT,
-  },
-  {
-    label: "Number",
-    value: RoutingFormFieldType.NUMBER,
-  },
-  {
-    label: "Long text",
-    value: RoutingFormFieldType.TEXTAREA,
-  },
-  {
-    label: "Single-choice selection",
-    value: RoutingFormFieldType.SINGLE_SELECT,
-  },
-  {
-    label: "Multiple choice selection",
-    value: RoutingFormFieldType.MULTI_SELECT,
-  },
-  {
-    label: "Phone",
-    value: RoutingFormFieldType.PHONE,
-  },
-  {
-    label: "Email",
-    value: RoutingFormFieldType.EMAIL,
-  },
-] as const;
+export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFieldType => {
+  return FieldTypes.some((f) => f.value === type);
+};

--- a/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
+++ b/packages/app-store/routing-forms/lib/formSubmissionUtils.ts
@@ -43,7 +43,7 @@ export type FORM_SUBMITTED_WEBHOOK_RESPONSES = Record<
 >;
 
 function isOptionsField(field: Pick<SerializableField, "type" | "options">) {
-  return (field.type === "select" || field.type === "multiselect") && field.options;
+  return (field.type === "select" || field.type === "multiselect" || field.type === "checkbox" || field.type === "radio") && field.options;
 }
 
 export function getFieldResponse({

--- a/packages/app-store/routing-forms/lib/getQueryBuilderConfig.ts
+++ b/packages/app-store/routing-forms/lib/getQueryBuilderConfig.ts
@@ -64,7 +64,7 @@ export function getQueryBuilderConfigForFormFields(form: Pick<RoutingForm, "fiel
         valueSources: ["value"],
         fieldSettings: {
           // IMPORTANT: listValues must be undefined for non-select/multiselect fields otherwise RAQB doesn't like it. It ends up considering all the text values as per the listValues too which could be empty as well making all values invalid
-          listValues: fieldType === "select" || fieldType === "multiselect" ? options : undefined,
+          listValues: fieldType === "select" || fieldType === "multiselect" || fieldType === "checkbox" || fieldType === "radio" ? options : undefined,
         },
       };
     } else {


### PR DESCRIPTION
## Summary

Closes #18987

This PR unifies the routing forms field editor with the event-types booking questions UI, implementing PeerRich's explicit requirement that **the systems should not be maintained individually**.

### Changes

- **Single source of truth for field types**: `FieldTypes` in `packages/app-store/routing-forms/lib/FieldTypes.ts` is now derived from `fieldTypesConfigMap` (same source event-types uses). Adding a new input type to event-types automatically makes it available in routing forms.

- **Dialog-based field editor**: Replaced the inline card editor in `FormEdit.tsx` with a dialog-based UI that mirrors the event-types FormBuilder. Fields are now shown as a list with edit/delete/reorder actions.

- **Identifier asked FIRST, not prefilled**: In the new dialog, the identifier field is shown first and starts empty (no auto-fill from label), matching event-types behavior.

- **New field types in RAQB**: Added widget and type definitions for all newly available field types (`address`, `url`, `multiemail`, `boolean`, `checkbox`, `radio`) in the react-awesome-query-builder config.

- **Options support extended**: `isOptionsField` and `listValues` now handle `checkbox` and `radio` types in addition to `select` and `multiselect`.

### Before / After

**Before**: Routing forms had 7 hardcoded field types; inline card editor; identifier auto-filled from label.

**After**: Routing forms share all non-system field types with event-types; dialog editor matching event-types FormBuilder; identifier is shown first with no prefill.

## Test plan

- [ ] Create a new routing form and click "Add question" — dialog opens with identifier field first (empty)
- [ ] Add a question of each new type (address, url, phone, email, etc.) — all should appear in the dropdown
- [ ] Add a select/multiselect/checkbox/radio question — options input should appear in the dialog
- [ ] Edit an existing field — dialog opens pre-populated with existing values
- [ ] Reorder fields with arrow buttons
- [ ] Delete a field
- [ ] Verify routing conditions (RAQB) work for all new field types
- [ ] Verify that adding a new type to `fieldTypesConfigMap` with `systemOnly: false` automatically makes it available in routing forms