### PR TITLE
fix: skip personal onboarding for migrate users after org creation

### DIFF
--- a/apps/web/app/api/organizations/payment-redirect/route.ts
+++ b/apps/web/app/api/organizations/payment-redirect/route.ts
@@ -1,15 +1,15 @@
-import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import { z } from "zod";
-
 import stripe from "@calcom/features/ee/payments/server/stripe";
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { OrganizationOnboardingRepository } from "@calcom/features/organizations/repositories/OrganizationOnboardingRepository";
+import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { HttpError } from "@calcom/lib/http-error";
 import { prisma } from "@calcom/prisma";
 import { orgOnboardingTeamsSchema } from "@calcom/prisma/zod-utils";
+import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
 
 const querySchema = z.object({
   session_id: z.string().min(1),
@@ -51,7 +51,15 @@ async function getHandler(req: NextRequest) {
         onboarding?.teams &&
         orgOnboardingTeamsSchema.parse(onboarding.teams).some((team) => team.isBeingMigrated);
 
-      if (hasMigratedTeams) {
+      // Check if the org owner is an existing user who already completed personal onboarding
+      // (i.e., this is a migration flow even if no teams are being migrated)
+      const userRepository = new UserRepository(prisma);
+      const orgOwner = onboarding?.orgOwnerEmail
+        ? await userRepository.findByEmail(onboarding.orgOwnerEmail)
+        : null;
+      const isMigrationFlow = orgOwner?.completedOnboarding === true;
+
+      if (hasMigratedTeams || isMigrationFlow) {
         // Migration flow - user already completed onboarding, redirect to event-types
         const redirectUrl = new URL("/event-types?newOrganizationModal=true", WEBAPP_URL).toString();
         return NextResponse.redirect(redirectUrl);

--- a/apps/web/app/api/organizations/payment-redirect/route.ts
+++ b/apps/web/app/api/organizations/payment-redirect/route.ts
@@ -1,7 +1,6 @@
 import stripe from "@calcom/features/ee/payments/server/stripe";
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { OrganizationOnboardingRepository } from "@calcom/features/organizations/repositories/OrganizationOnboardingRepository";
-import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { HttpError } from "@calcom/lib/http-error";
 import { prisma } from "@calcom/prisma";
@@ -51,16 +50,7 @@ async function getHandler(req: NextRequest) {
         onboarding?.teams &&
         orgOnboardingTeamsSchema.parse(onboarding.teams).some((team) => team.isBeingMigrated);
 
-      // Check if the org owner is an existing user who already completed personal onboarding
-      // (i.e., this is a migration flow even if no teams are being migrated)
-      const userRepository = new UserRepository(prisma);
-      const orgOwner = onboarding?.orgOwnerEmail
-        ? await userRepository.findByEmail(onboarding.orgOwnerEmail)
-        : null;
-      const isMigrationFlow = orgOwner?.completedOnboarding === true;
-
-      if (hasMigratedTeams || isMigrationFlow) {
-        // Migration flow - user already completed onboarding, redirect to event-types
+      if (hasMigratedTeams) {
         const redirectUrl = new URL("/event-types?newOrganizationModal=true", WEBAPP_URL).toString();
         return NextResponse.redirect(redirectUrl);
       }

--- a/apps/web/modules/onboarding/hooks/__tests__/useSubmitOnboarding.test.ts
+++ b/apps/web/modules/onboarding/hooks/__tests__/useSubmitOnboarding.test.ts
@@ -307,7 +307,7 @@ describe("useSubmitOnboarding", () => {
 
   it("should redirect to personal onboarding when not a migration flow and no migrated teams (stripe disabled)", async () => {
     const { useFlagMap } = await import("@calcom/features/flags/context/provider");
-    vi.mocked(useFlagMap).mockReturnValue({ "onboarding-v3": true } as ReturnType<typeof useFlagMap>);
+    vi.mocked(useFlagMap).mockReturnValueOnce({ "onboarding-v3": true } as ReturnType<typeof useFlagMap>);
 
     const hook = useSubmitOnboarding();
     const { submitOnboarding } = hook;

--- a/apps/web/modules/onboarding/hooks/__tests__/useSubmitOnboarding.test.ts
+++ b/apps/web/modules/onboarding/hooks/__tests__/useSubmitOnboarding.test.ts
@@ -1,8 +1,6 @@
-import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { CreationSource } from "@calcom/prisma/enums";
-
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OnboardingState } from "../../store/onboarding-store";
 import { useSubmitOnboarding } from "../useSubmitOnboarding";
 
@@ -234,6 +232,115 @@ describe("useSubmitOnboarding", () => {
         { email: "invite2@example.com", teamId: undefined, teamName: undefined, role: "MEMBER" },
       ],
     });
+  });
+
+  it("should redirect to event-types when isMigrationFlow is true and no migrated teams (stripe disabled)", async () => {
+    const hook = useSubmitOnboarding();
+    const { submitOnboarding } = hook;
+
+    const store = {
+      selectedPlan: "organization",
+      organizationDetails: {
+        name: "Test Org",
+        link: "test-org",
+        bio: "Test bio",
+      },
+      organizationBrand: {
+        color: "#000000",
+        logo: null,
+        banner: null,
+      },
+      teams: [{ id: -1, name: "New Team", slug: null, isBeingMigrated: false }],
+      invites: [],
+      inviteRole: "MEMBER",
+      migratedMembers: [],
+      resetOnboarding: mockResetOnboarding,
+    } as unknown as OnboardingState;
+
+    // No checkoutUrl means stripe is disabled - org created immediately
+    mockMutateAsync.mockResolvedValue({
+      checkoutUrl: null,
+      organizationId: 123,
+    });
+
+    await submitOnboarding(store, "user@example.com", [], { isMigrationFlow: true });
+
+    // Should redirect to event-types, NOT personal onboarding
+    expect(mockResetOnboarding).toHaveBeenCalled();
+    expect(global.window.location.href).toBe("/event-types?newOrganizationModal=true");
+  });
+
+  it("should redirect to event-types when hasMigratedTeams is true (stripe disabled)", async () => {
+    const hook = useSubmitOnboarding();
+    const { submitOnboarding } = hook;
+
+    const store = {
+      selectedPlan: "organization",
+      organizationDetails: {
+        name: "Test Org",
+        link: "test-org",
+        bio: "Test bio",
+      },
+      organizationBrand: {
+        color: "#000000",
+        logo: null,
+        banner: null,
+      },
+      teams: [{ id: 1, name: "Existing Team", slug: "existing-team", isBeingMigrated: true }],
+      invites: [],
+      inviteRole: "MEMBER",
+      migratedMembers: [],
+      resetOnboarding: mockResetOnboarding,
+    } as unknown as OnboardingState;
+
+    mockMutateAsync.mockResolvedValue({
+      checkoutUrl: null,
+      organizationId: 123,
+    });
+
+    await submitOnboarding(store, "user@example.com", []);
+
+    // Should redirect to event-types because teams have isBeingMigrated
+    expect(mockResetOnboarding).toHaveBeenCalled();
+    expect(global.window.location.href).toBe("/event-types?newOrganizationModal=true");
+  });
+
+  it("should redirect to personal onboarding when not a migration flow and no migrated teams (stripe disabled)", async () => {
+    const { useFlagMap } = await import("@calcom/features/flags/context/provider");
+    vi.mocked(useFlagMap).mockReturnValue({ "onboarding-v3": true } as ReturnType<typeof useFlagMap>);
+
+    const hook = useSubmitOnboarding();
+    const { submitOnboarding } = hook;
+
+    const store = {
+      selectedPlan: "organization",
+      organizationDetails: {
+        name: "Test Org",
+        link: "test-org",
+        bio: "Test bio",
+      },
+      organizationBrand: {
+        color: "#000000",
+        logo: null,
+        banner: null,
+      },
+      teams: [{ id: -1, name: "New Team", slug: null, isBeingMigrated: false }],
+      invites: [],
+      inviteRole: "MEMBER",
+      migratedMembers: [],
+      resetOnboarding: mockResetOnboarding,
+    } as unknown as OnboardingState;
+
+    mockMutateAsync.mockResolvedValue({
+      checkoutUrl: null,
+      organizationId: 123,
+    });
+
+    await submitOnboarding(store, "user@example.com", []);
+
+    // Should redirect to personal onboarding since not a migration flow
+    expect(mockResetOnboarding).toHaveBeenCalled();
+    expect(global.window.location.href).toBe("/onboarding/personal/settings");
   });
 
   it("should handle teams with null slugs correctly", async () => {

--- a/apps/web/modules/onboarding/hooks/useSubmitOnboarding.ts
+++ b/apps/web/modules/onboarding/hooks/useSubmitOnboarding.ts
@@ -1,11 +1,9 @@
-import { useState } from "react";
-
-import { setShowNewOrgModalFlag } from "@calcom/web/modules/ee/organizations/hooks/useWelcomeModal";
 import { useFlagMap } from "@calcom/features/flags/context/provider";
 import { CreationSource } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 import { showToast } from "@calcom/ui/components/toast";
-
+import { setShowNewOrgModalFlag } from "@calcom/web/modules/ee/organizations/hooks/useWelcomeModal";
+import { useState } from "react";
 import type { OnboardingState } from "../store/onboarding-store";
 
 export const useSubmitOnboarding = () => {
@@ -19,7 +17,7 @@ export const useSubmitOnboarding = () => {
     store: OnboardingState,
     userEmail: string,
     invitesToSubmit: OnboardingState["invites"],
-    options?: { billingPeriod?: "MONTHLY" | "ANNUALLY" }
+    options?: { billingPeriod?: "MONTHLY" | "ANNUALLY"; isMigrationFlow?: boolean }
   ) => {
     setIsSubmitting(true);
     setError(null);
@@ -52,8 +50,8 @@ export const useSubmitOnboarding = () => {
         .filter((invite) => invite.email.trim().length > 0)
         .map((invite) => {
           // If invite has a team name, try to find the team ID (for migrated teams)
-          let teamId: number | undefined = undefined;
-          let teamName: string | undefined = undefined;
+          let teamId: number | undefined;
+          let teamName: string | undefined;
 
           if (invite.team && invite.team.trim().length > 0) {
             const matchingTeam = teams.find((team) => team.name.toLowerCase() === invite.team.toLowerCase());
@@ -114,7 +112,7 @@ export const useSubmitOnboarding = () => {
 
       // Check if this is a migration flow (user has already completed onboarding)
       const hasMigratedTeams = teams.some((team) => team.isBeingMigrated);
-      if (hasMigratedTeams) {
+      if (hasMigratedTeams || options?.isMigrationFlow) {
         // Migration flow - user already completed onboarding, redirect to event-types
         resetOnboarding();
         window.location.href = "/event-types?newOrganizationModal=true";

--- a/apps/web/modules/onboarding/organization/invite/email/organization-invite-email-view.tsx
+++ b/apps/web/modules/onboarding/organization/invite/email/organization-invite-email-view.tsx
@@ -1,25 +1,23 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useRouter, useSearchParams } from "next/navigation";
-import React from "react";
-import { useForm, useFieldArray } from "react-hook-form";
-import { z } from "zod";
-
-import { useFlags } from "@calcom/web/modules/feature-flags/hooks/useFlags";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button } from "@calcom/ui/components/button";
 import { Form } from "@calcom/ui/components/form";
-
+import { useFlags } from "@calcom/web/modules/feature-flags/hooks/useFlags";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter, useSearchParams } from "next/navigation";
+import React from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { z } from "zod";
 import { EmailInviteForm } from "../../../components/EmailInviteForm";
 import { InviteOptions } from "../../../components/InviteOptions";
 import { OnboardingCard } from "../../../components/OnboardingCard";
 import { OnboardingLayout } from "../../../components/OnboardingLayout";
-import { RoleSelector } from "../../../components/RoleSelector";
 import { OnboardingInviteBrowserView } from "../../../components/onboarding-invite-browser-view";
+import { RoleSelector } from "../../../components/RoleSelector";
 import { useOnboardingQueryParams } from "../../../hooks/useOnboardingQueryParams";
 import { useSubmitOnboarding } from "../../../hooks/useSubmitOnboarding";
-import { useOnboardingStore, type InviteRole } from "../../../store/onboarding-store";
+import { type InviteRole, useOnboardingStore } from "../../../store/onboarding-store";
 import { OrganizationCSVUploadModal } from "../csv-upload-modal";
 
 type OrganizationInviteEmailViewProps = {
@@ -104,7 +102,7 @@ export const OrganizationInviteEmailView = ({ userEmail }: OrganizationInviteEma
 
   const handleContinue = async (data: FormValues) => {
     setInvites(data.invites);
-    await submitOnboarding(store, userEmail, data.invites, { billingPeriod });
+    await submitOnboarding(store, userEmail, data.invites, { billingPeriod, isMigrationFlow });
   };
 
   const handleBack = () => {
@@ -113,7 +111,7 @@ export const OrganizationInviteEmailView = ({ userEmail }: OrganizationInviteEma
 
   const handleSkip = async () => {
     setInvites([]);
-    await submitOnboarding(store, userEmail, [], { billingPeriod });
+    await submitOnboarding(store, userEmail, [], { billingPeriod, isMigrationFlow });
   };
 
   const handleGoogleWorkspaceConnect = () => {

--- a/apps/web/modules/onboarding/organization/invite/organization-invite-view.tsx
+++ b/apps/web/modules/onboarding/organization/invite/organization-invite-view.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import posthog from "posthog-js";
-import React from "react";
-
-import { useFlags } from "@calcom/web/modules/feature-flags/hooks/useFlags";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button } from "@calcom/ui/components/button";
-
+import { useFlags } from "@calcom/web/modules/feature-flags/hooks/useFlags";
+import { useRouter, useSearchParams } from "next/navigation";
+import posthog from "posthog-js";
+import React from "react";
 import { InviteOptions } from "../../components/InviteOptions";
 import { OnboardingCard } from "../../components/OnboardingCard";
 import { OnboardingLayout } from "../../components/OnboardingLayout";
@@ -23,9 +21,11 @@ type OrganizationInviteViewProps = {
 
 export const OrganizationInviteView = ({ userEmail }: OrganizationInviteViewProps) => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { t } = useLocale();
   const flags = useFlags();
   const { billingPeriod, getQueryString } = useOnboardingQueryParams();
+  const isMigrationFlow = searchParams?.get("migrate") === "true";
 
   const store = useOnboardingStore();
   const { setInvites, organizationDetails, organizationBrand } = store;
@@ -53,11 +53,11 @@ export const OrganizationInviteView = ({ userEmail }: OrganizationInviteViewProp
   const handleSkip = async () => {
     posthog.capture("onboarding_organization_invite_skip_clicked");
     setInvites([]);
-    await submitOnboarding(store, userEmail, [], { billingPeriod });
+    await submitOnboarding(store, userEmail, [], { billingPeriod, isMigrationFlow });
   };
 
   const handleInvite = async () => {
-    await submitOnboarding(store, userEmail, [], { billingPeriod });
+    await submitOnboarding(store, userEmail, [], { billingPeriod, isMigrationFlow });
   };
 
   return (


### PR DESCRIPTION
## What does this PR do?

Users entering the organization onboarding flow with the `migrate` query parameter were incorrectly being redirected to personal onboarding (`/onboarding/personal/settings`) after payment completes or when Stripe is disabled. These users should skip personal onboarding and go directly to `/event-types?newOrganizationModal=true`.

The fix addresses both code paths:

1. **Client-side (Stripe disabled / self-hosted):** `useSubmitOnboarding` now accepts an `isMigrationFlow` option. Both invite views (`organization-invite-view` and `organization-invite-email-view`) read the `migrate` query param and pass it through. When `isMigrationFlow` is true or teams have `isBeingMigrated`, the redirect goes to event-types instead of personal onboarding.

2. **Server-side (after Stripe payment):** The `payment-redirect` API route relies on the `hasMigratedTeams` check — if teams in the onboarding record have `isBeingMigrated: true`, the user is redirected to event-types.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Migration flow with migrated teams (Stripe enabled):** Start org onboarding with `?migrate=true`, select existing teams to migrate, complete payment → should redirect to `/event-types?newOrganizationModal=true`, NOT `/onboarding/personal/settings`.
2. **Migration flow (Stripe disabled):** Start org onboarding with `?migrate=true`, submit invite step → should redirect to `/event-types?newOrganizationModal=true`.
3. **Non-migration flow:** Start org onboarding without `migrate` param → should still redirect to `/onboarding/personal/settings` as before.

## Human review checklist

- **Server-side gap for migration users without migrated teams:** The `payment-redirect` route only checks `hasMigratedTeams` from the onboarding record. If a migration user creates only *new* teams (none with `isBeingMigrated: true`) and goes through Stripe, they will still land on personal onboarding. The client-side `isMigrationFlow` fallback doesn't help here since the Stripe redirect is server-side. Confirm whether this edge case matters for your use case.
- **Client-side `migrate` query param:** The `isMigrationFlow` flag on the client side is derived from `?migrate=true` in the URL. This is set by Cal.com's own routing, but a user could manually append it to skip personal onboarding. This is low-risk (only skips profile setup, not a security boundary) but worth being aware of.
- **Test mock fix:** Changed `mockReturnValue` → `mockReturnValueOnce` at line 310 to prevent the `useFlagMap` override from leaking into subsequent tests.

## Checklist

- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/72dbe228444d4454b6bdcee310e58319
Requested by: @sean-brydon