### PR TITLE
fix(paypal): throw on API failure and fix collectCard data shape

### DIFF
--- a/packages/app-store/paypal/lib/PaymentService.ts
+++ b/packages/app-store/paypal/lib/PaymentService.ts
@@ -156,7 +156,7 @@ class PaypalPaymentService implements IAbstractPaymentService {
           },
           amount: payment.amount,
           currency: payment.currency,
-          data: Object.assign({}, preference) as unknown as Prisma.InputJsonValue,
+          data: Object.assign({}, { order: preference }) as unknown as Prisma.InputJsonValue,
           fee: 0,
           refunded: false,
           success: false,

--- a/packages/app-store/paypal/lib/Paypal.ts
+++ b/packages/app-store/paypal/lib/Paypal.ts
@@ -100,25 +100,24 @@ class Paypal {
       },
     };
 
-    try {
-      const response = await this.fetcher("/v2/checkout/orders", {
-        method: "POST",
-        headers: {
-          "PayPal-Request-Id": uuidv4(),
-        },
-        body: JSON.stringify(createOrderRequestBody),
-      });
+    const response = await this.fetcher("/v2/checkout/orders", {
+      method: "POST",
+      headers: {
+        "PayPal-Request-Id": uuidv4(),
+      },
+      body: JSON.stringify(createOrderRequestBody),
+    });
 
-      if (response.ok) {
-        const createOrderResponse: CreateOrderResponse = await response.json();
-        return createOrderResponse;
-      } else {
-        console.error(`Request failed with status ${response.status}`);
-      }
-    } catch (error) {
-      console.error(error);
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`PayPal order creation failed: ${response.status} ${errorBody}`);
     }
-    return {} as CreateOrderResponse;
+
+    const createOrderResponse: CreateOrderResponse = await response.json();
+    if (!createOrderResponse.id || !createOrderResponse.links?.length) {
+      throw new Error("PayPal order response missing id or links");
+    }
+    return createOrderResponse;
   }
 
   async captureOrder(orderId: string): Promise<boolean> {


### PR DESCRIPTION
### summary

- Fix PayPal payment URL generation by correcting stored PayPal order data and improving API error handling

### Changes

- Throw when PayPal order creation API fails or returns an invalid response (instead of returning {})
- Persist HOLD payments as { order: ... } to match the expected frontend data shape (data.order.links)

### Test

- Verified PayPal flow should show the payment button instead of Couldn't obtain payment URL (manual e2e)

fix : #28513

Ctrl+K to generate command
