### PR TITLE
fix: pass booking date to getUTCOffsetByTimezone to handle DST correctly

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/validateBookingTimeIsNotOutOfBounds.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/validateBookingTimeIsNotOutOfBounds.test.ts
@@ -1,0 +1,136 @@
+import { PeriodType } from "@calcom/prisma/enums";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@calcom/lib/dayjs", () => ({
+  getUTCOffsetByTimezone: vi.fn(),
+}));
+
+vi.mock("@calcom/lib/isOutOfBounds", () => ({
+  default: vi.fn().mockReturnValue(false),
+  BookingDateInPastError: class BookingDateInPastError extends Error {},
+}));
+
+vi.mock("@calcom/lib/sentryWrapper", () => ({
+  withReporting: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+}));
+
+import { getUTCOffsetByTimezone } from "@calcom/lib/dayjs";
+import isOutOfBounds from "@calcom/lib/isOutOfBounds";
+import { validateBookingTimeIsNotOutOfBounds } from "./validateBookingTimeIsNotOutOfBounds";
+
+const mockLogger = {
+  warn: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as unknown as Parameters<typeof validateBookingTimeIsNotOutOfBounds>[4];
+
+const baseEventType = {
+  id: 1,
+  title: "Test Event",
+  eventName: "Test",
+  periodType: PeriodType.UNLIMITED,
+  periodDays: null,
+  periodEndDate: null,
+  periodStartDate: null,
+  periodCountCalendarDays: null,
+  minimumBookingNotice: 0,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getUTCOffsetByTimezone).mockReturnValue(0);
+  vi.mocked(isOutOfBounds).mockReturnValue(false);
+});
+
+describe("validateBookingTimeIsNotOutOfBounds", () => {
+  it("passes the booking start time to getUTCOffsetByTimezone for booker timezone", async () => {
+    const bookingStart = "2024-07-15T16:00:00.000Z";
+
+    await validateBookingTimeIsNotOutOfBounds(
+      bookingStart,
+      "America/Los_Angeles",
+      baseEventType,
+      "Asia/Kolkata",
+      mockLogger
+    );
+
+    expect(getUTCOffsetByTimezone).toHaveBeenCalledWith("America/Los_Angeles", bookingStart);
+  });
+
+  it("passes the booking start time to getUTCOffsetByTimezone for event timezone", async () => {
+    const bookingStart = "2024-07-15T16:00:00.000Z";
+
+    await validateBookingTimeIsNotOutOfBounds(
+      bookingStart,
+      "America/Los_Angeles",
+      baseEventType,
+      "Asia/Kolkata",
+      mockLogger
+    );
+
+    expect(getUTCOffsetByTimezone).toHaveBeenCalledWith("Asia/Kolkata", bookingStart);
+  });
+
+  it("uses the same booking date for both offset calculations", async () => {
+    const bookingStart = "2024-07-15T16:00:00.000Z";
+
+    await validateBookingTimeIsNotOutOfBounds(
+      bookingStart,
+      "America/Los_Angeles",
+      baseEventType,
+      "Asia/Kolkata",
+      mockLogger
+    );
+
+    const calls = vi.mocked(getUTCOffsetByTimezone).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0][1]).toBe(bookingStart);
+    expect(calls[1][1]).toBe(bookingStart);
+  });
+
+  it("forwards computed offsets to isOutOfBounds", async () => {
+    vi.mocked(getUTCOffsetByTimezone).mockImplementation((tz) => {
+      if (tz === "America/Los_Angeles") return -420; // PDT
+      if (tz === "Asia/Kolkata") return 330;
+      return 0;
+    });
+
+    await validateBookingTimeIsNotOutOfBounds(
+      "2024-07-15T16:00:00.000Z",
+      "America/Los_Angeles",
+      baseEventType,
+      "Asia/Kolkata",
+      mockLogger
+    );
+
+    expect(isOutOfBounds).toHaveBeenCalledWith(
+      "2024-07-15T16:00:00.000Z",
+      expect.objectContaining({
+        bookerUtcOffset: -420,
+        eventUtcOffset: 330,
+      }),
+      0
+    );
+  });
+
+  it("uses 0 for eventUtcOffset when eventTimeZone is null", async () => {
+    vi.mocked(getUTCOffsetByTimezone).mockReturnValue(-420);
+
+    await validateBookingTimeIsNotOutOfBounds(
+      "2024-07-15T16:00:00.000Z",
+      "America/Los_Angeles",
+      baseEventType,
+      null,
+      mockLogger
+    );
+
+    expect(isOutOfBounds).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        eventUtcOffset: 0,
+      }),
+      expect.any(Number)
+    );
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/validateBookingTimeIsNotOutOfBounds.ts
+++ b/packages/features/bookings/lib/handleNewBooking/validateBookingTimeIsNotOutOfBounds.ts
@@ -1,11 +1,10 @@
-import type { Logger } from "tslog";
-
 import { getUTCOffsetByTimezone } from "@calcom/lib/dayjs";
 import { ErrorCode } from "@calcom/lib/errorCodes";
 import { HttpError } from "@calcom/lib/http-error";
 import isOutOfBounds, { BookingDateInPastError } from "@calcom/lib/isOutOfBounds";
 import { withReporting } from "@calcom/lib/sentryWrapper";
 import type { EventType } from "@calcom/prisma/client";
+import type { Logger } from "tslog";
 
 type ValidateBookingTimeEventType = Pick<
   EventType,
@@ -38,8 +37,8 @@ const _validateBookingTimeIsNotOutOfBounds = async <T extends ValidateBookingTim
         periodEndDate: eventType.periodEndDate,
         periodStartDate: eventType.periodStartDate,
         periodCountCalendarDays: eventType.periodCountCalendarDays,
-        bookerUtcOffset: getUTCOffsetByTimezone(reqBodyTimeZone) ?? 0,
-        eventUtcOffset: eventTimeZone ? (getUTCOffsetByTimezone(eventTimeZone) ?? 0) : 0,
+        bookerUtcOffset: getUTCOffsetByTimezone(reqBodyTimeZone, reqBodyStartTime) ?? 0,
+        eventUtcOffset: eventTimeZone ? (getUTCOffsetByTimezone(eventTimeZone, reqBodyStartTime) ?? 0) : 0,
       },
       eventType.minimumBookingNotice
     );

--- a/packages/lib/dayjs/getUTCOffsetByTimezone.test.ts
+++ b/packages/lib/dayjs/getUTCOffsetByTimezone.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { getUTCOffsetByTimezone } from "./index";
+
+describe("getUTCOffsetByTimezone", () => {
+  describe("DST-aware behavior when date is provided", () => {
+    it("returns PST offset (-480) for America/Los_Angeles in January", () => {
+      const january = "2024-01-15T12:00:00Z";
+      expect(getUTCOffsetByTimezone("America/Los_Angeles", january)).toBe(-480);
+    });
+
+    it("returns PDT offset (-420) for America/Los_Angeles in July", () => {
+      const july = "2024-07-15T12:00:00Z";
+      expect(getUTCOffsetByTimezone("America/Los_Angeles", july)).toBe(-420);
+    });
+
+    it("returns different offsets for the same timezone across DST boundary", () => {
+      const winter = "2024-01-15T12:00:00Z";
+      const summer = "2024-07-15T12:00:00Z";
+      const winterOffset = getUTCOffsetByTimezone("America/Los_Angeles", winter);
+      const summerOffset = getUTCOffsetByTimezone("America/Los_Angeles", summer);
+      expect(winterOffset).not.toBe(summerOffset);
+      expect((summerOffset ?? 0) - (winterOffset ?? 0)).toBe(60);
+    });
+
+    it("returns EST offset (-300) for America/New_York in January", () => {
+      expect(getUTCOffsetByTimezone("America/New_York", "2024-01-15T12:00:00Z")).toBe(-300);
+    });
+
+    it("returns EDT offset (-240) for America/New_York in July", () => {
+      expect(getUTCOffsetByTimezone("America/New_York", "2024-07-15T12:00:00Z")).toBe(-240);
+    });
+  });
+
+  describe("non-DST timezones return consistent offsets regardless of date", () => {
+    it("returns +330 for Asia/Kolkata in both January and July", () => {
+      const january = "2024-01-15T12:00:00Z";
+      const july = "2024-07-15T12:00:00Z";
+      expect(getUTCOffsetByTimezone("Asia/Kolkata", january)).toBe(330);
+      expect(getUTCOffsetByTimezone("Asia/Kolkata", july)).toBe(330);
+    });
+
+    it("returns 0 for UTC in both January and July", () => {
+      expect(getUTCOffsetByTimezone("UTC", "2024-01-15T12:00:00Z")).toBe(0);
+      expect(getUTCOffsetByTimezone("UTC", "2024-07-15T12:00:00Z")).toBe(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns null for empty timezone string", () => {
+      expect(getUTCOffsetByTimezone("")).toBeNull();
+    });
+
+    it("accepts a Date object as the date parameter", () => {
+      const date = new Date("2024-07-15T12:00:00Z");
+      expect(getUTCOffsetByTimezone("America/Los_Angeles", date)).toBe(-420);
+    });
+
+    it("uses current time when date is omitted", () => {
+      const offset = getUTCOffsetByTimezone("Asia/Kolkata");
+      expect(offset).toBe(330);
+    });
+  });
+});

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -9,6 +9,7 @@ import type {
   GetAvailabilityUser,
   UserAvailabilityService,
 } from "@calcom/features/availability/lib/getUserAvailability";
+import type { IGetAvailableSlots } from "@calcom/features/bookings/Booker/hooks/useAvailableTimeSlots";
 import type { CheckBookingLimitsService } from "@calcom/features/bookings/lib/checkBookingLimits";
 import { checkForConflicts } from "@calcom/features/bookings/lib/conflictChecker/checkForConflicts";
 import type { QualifiedHostsService } from "@calcom/features/bookings/lib/host-filtering/findQualifiedHostsWithDelegationCredentials";
@@ -16,12 +17,14 @@ import { isEventTypeLoggingEnabled } from "@calcom/features/bookings/lib/isEvent
 import type { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
 import type { BusyTimesService } from "@calcom/features/busyTimes/services/getBusyTimes";
 import type { getBusyTimesService } from "@calcom/features/di/containers/BusyTimes";
+import type { OrgMembershipLookup } from "@calcom/features/di/modules/OrgMembershipLookup";
 import type { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { getDefaultEvent } from "@calcom/features/eventtypes/lib/defaultEvents";
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import type { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import type { PrismaOOORepository } from "@calcom/features/ooo/repositories/PrismaOOORepository";
 import type { IRedisService } from "@calcom/features/redis/IRedisService";
+import type { RoutingFormResponseRepository } from "@calcom/features/routing-forms/repositories/RoutingFormResponseRepository";
 import { buildDateRanges } from "@calcom/features/schedules/lib/date-ranges";
 import getSlots from "@calcom/features/schedules/lib/slots";
 import type { ScheduleRepository } from "@calcom/features/schedules/repositories/ScheduleRepository";
@@ -48,7 +51,6 @@ import {
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { withReporting } from "@calcom/lib/sentryWrapper";
-import type { RoutingFormResponseRepository } from "@calcom/features/routing-forms/repositories/RoutingFormResponseRepository";
 import { PeriodType, SchedulingType } from "@calcom/prisma/enums";
 import type { CalendarFetchMode, EventBusyDate, EventBusyDetails } from "@calcom/types/Calendar";
 import type { CredentialForCalendarService } from "@calcom/types/Credential";
@@ -57,8 +59,6 @@ import type { Logger } from "tslog";
 import { v4 as uuid } from "uuid";
 import type { TGetScheduleInputSchema } from "./getSchedule.schema";
 import type { GetScheduleOptions } from "./types";
-import type { OrgMembershipLookup } from "@calcom/features/di/modules/OrgMembershipLookup";
-import type { IGetAvailableSlots } from "@calcom/features/bookings/Booker/hooks/useAvailableTimeSlots";
 
 const log = logger.getSubLogger({ prefix: ["[slots/util]"] });
 const DEFAULT_SLOTS_CACHE_TTL = 2000;
@@ -1562,8 +1562,10 @@ export class AvailableSlotsService {
     const eventTimeZone =
       eventType.timeZone || eventType?.schedule?.timeZone || allUsersAvailability?.[0]?.timeZone;
 
-    const eventUtcOffset = getUTCOffsetByTimezone(eventTimeZone) ?? 0;
-    const bookerUtcOffset = input.timeZone ? (getUTCOffsetByTimezone(input.timeZone) ?? 0) : 0;
+    const eventUtcOffset = getUTCOffsetByTimezone(eventTimeZone, input.startTime) ?? 0;
+    const bookerUtcOffset = input.timeZone
+      ? (getUTCOffsetByTimezone(input.timeZone, input.startTime) ?? 0)
+      : 0;
     const periodLimits = calculatePeriodLimits({
       periodType: eventType.periodType,
       periodDays: eventType.periodDays,


### PR DESCRIPTION
## What does this PR do?

Fixes a DST timezone offset bug where `getUTCOffsetByTimezone()` was called without a date, causing it to use the **current moment's** UTC offset instead of the **booking date's** offset.

For DST-observing timezones (e.g. `America/Los_Angeles`), the UTC offset differs between PST (-480 min) and PDT (-420 min). When the booking date falls in a different DST period than "now", the wrong offset was fed into `calculatePeriodLimits` and `isOutOfBounds`, shifting period boundaries and causing bookings to appear at incorrect times for cross-timezone users (e.g. PDT booker → IST host).

## What changed?

- **`validateBookingTimeIsNotOutOfBounds.ts`**: Pass `reqBodyStartTime` (already available as a parameter) to `getUTCOffsetByTimezone` so the offset matches the booking date, not the current date
- **`slots/util.ts`**: Pass `input.startTime` to `getUTCOffsetByTimezone` so slot period limits use the correct DST offset

Both are 2-line changes. The `getUTCOffsetByTimezone` function already accepts an optional `date` parameter — it just wasn't being used at these call sites.

## How to test

1. Set host timezone to `Asia/Kolkata` (IST)
2. Set booker timezone to `America/Los_Angeles`
3. Book a slot in July (PDT) — verify the time shows correctly in IST
4. Book a slot in January (PST) — verify the time shows correctly in IST
5. Run unit tests:
   ```bash
   TZ=UTC yarn vitest run packages/lib/dayjs/getUTCOffsetByTimezone.test.ts
   TZ=UTC yarn vitest run packages/features/bookings/lib/handleNewBooking/validateBookingTimeIsNotOutOfBounds.test.ts
   ```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent PR review)
- [x] I have updated the developer docs (if relevant)
- [x] I have added tests to cover my changes (if relevant)
- [x] I have run the relevant tests and they pass

Made with [Cursor](https://cursor.com)