### PR TITLE
feat: mapping routing form fields to booking questions (#18987)

### DIFF
--- a/README_BOUNTY.md
+++ b/README_BOUNTY.md
@@ -1,0 +1,44 @@
+# Bounty #18987: Add "Booking Questions" directly into Routing Forms
+
+This bounty implements the ability to map Routing Form fields directly to Booking Form fields. When a user is redirected from a Routing Form to a Booking Page, the mapped fields will be pre-filled automatically.
+
+## Changes
+
+### 1. Schema Extension
+- Modified `packages/features/routing-forms/lib/zod.ts` to add `mappedBookingField: z.string().optional()` to the `zodNonRouterField` schema. This allows storing the target booking field name for each routing form question.
+
+### 2. UI Update (Form Builder)
+- Updated `apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx` to include a new "Map to Booking Field" input for each question in the Routing Form builder.
+- Users can now specify the identifier of the booking field they want to pre-fill (e.g., `name`, `email`, `location`, or any custom field identifier).
+
+### 3. Submission Logic (Pre-filling)
+- Updated `packages/features/routing-forms/lib/getUrlSearchParamsToForward.ts` to handle the mapping during redirection.
+- When generating the redirect URL to the booking page, the logic now checks if a `mappedBookingField` is defined for a routing form field.
+- If defined, the routing form response value is appended to the URL search parameters using the `mappedBookingField` as the key.
+- This ensures that Cal.com's booking page can pick up these parameters and pre-fill the corresponding fields.
+
+## How to Test
+
+1. **Create a Routing Form:**
+   - Go to Routing Forms and create a new form.
+   - Add a "Text" question with the label "Your Name".
+   - In the "Map to Booking Field" input, enter `name`.
+   - Add another "Email" question and map it to `email`.
+   - Add a "Text" question for "Reason for meeting" and map it to `notes`.
+
+2. **Set up Routing:**
+   - Set up a route that redirects to an existing Event Type.
+
+3. **Submit the Form:**
+   - Open the public Routing Form link.
+   - Fill in the values (e.g., Name: "John Doe", Email: "john@example.com", Reason: "Project Discussion").
+   - Submit the form.
+
+4. **Verify Pre-filling:**
+   - You should be redirected to the Booking Page.
+   - Verify that the "Name", "Email", and "Additional Notes" (if mapped to `notes`) fields on the booking page are pre-filled with the values you entered in the Routing Form.
+
+## Technical Details
+- The implementation leverages existing `URLSearchParams` forwarding logic in `getUrlSearchParamsToForward`.
+- It supports all field types, including selects and multi-selects (where labels are forwarded).
+- By adding this to `getUrlSearchParamsToForward`, it automatically works for both standard redirects and embed scenarios.

--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
@@ -225,6 +225,16 @@ function Field({
             </div>
           ) : null}
 
+          <div className="mb-3 w-full">
+            <TextField
+              disabled={!!router}
+              label={t("map_to_booking_field")}
+              hint={t("map_to_booking_field_hint")}
+              {...hookForm.register(`${hookFieldNamespace}.mappedBookingField`)}
+              placeholder="e.g. name, email, location, notes"
+            />
+          </div>
+
           <div className="w-[106px]">
             <Controller
               name={`${hookFieldNamespace}.required`}

--- a/packages/features/routing-forms/lib/getUrlSearchParamsToForward.ts
+++ b/packages/features/routing-forms/lib/getUrlSearchParamsToForward.ts
@@ -84,6 +84,11 @@ export function getUrlSearchParamsToForward({
     }
     paramsFromResponse[getFieldIdentifier(foundField) as keyof typeof paramsFromResponse] =
       valueAsStringOrStringArray;
+
+    if (foundField.mappedBookingField) {
+      paramsFromResponse[foundField.mappedBookingField as keyof typeof paramsFromResponse] =
+        valueAsStringOrStringArray;
+    }
   });
 
   // Build query params from current URL. It excludes route params

--- a/packages/features/routing-forms/lib/zod.ts
+++ b/packages/features/routing-forms/lib/zod.ts
@@ -32,6 +32,7 @@ export const zodNonRouterField = z.object({
   selectText: z.string().optional(),
   required: z.boolean().optional(),
   deleted: z.boolean().optional(),
+  mappedBookingField: z.string().optional(),
   options: z
     .array(
       z.object({


### PR DESCRIPTION
## Summary
This PR addresses issue #18987 by adding the ability to map Routing Form fields directly to Booking Question fields. This ensures that information collected during the routing phase is automatically carried over to the booking page, improving the user experience and reducing duplicate data entry.

## Changes
- **Schema**: Added `mappedBookingField` to `zodNonRouterField` in `packages/features/routing-forms/lib/zod.ts`.
- **UI**: Added "Map to Booking Field" input in the Routing Form builder (`FormEdit.tsx`).
- **Logic**: Updated `getUrlSearchParamsToForward.ts` to include mapped field values in the redirect URL as query parameters.

## Testing
1. Create/Edit a Routing Form.
2. For a field (e.g., "Full Name"), set "Map to Booking Field" to `name`.
3. Set a route to redirect to an Event Type.
4. Fill the form and submit.
5. Verify the booking page has the `name` field pre-filled with the value from the routing form.

/claim #18987