### PR TITLE
fix: correct license check to use data.valid instead of data.status in API v2

### DIFF
--- a/apps/api/v2/src/modules/deployments/deployments.service.ts
+++ b/apps/api/v2/src/modules/deployments/deployments.service.ts
@@ -8,7 +8,7 @@ const CACHING_TIME = 86400000; // 24 hours in milliseconds
 const getLicenseCacheKey = (key: string) => `api-v2-license-key-goblin-url-${key}`;
 
 type LicenseCheckResponse = {
-  status: boolean;
+  valid: boolean;
 };
 @Injectable()
 export class DeploymentsService {
@@ -36,12 +36,12 @@ export class DeploymentsService {
     const licenseKeyUrl = this.configService.get("api.licenseKeyUrl") + `/${licenseKey}`;
     const cachedData = await this.redisService.redis.get(getLicenseCacheKey(licenseKey));
     if (cachedData) {
-      return (JSON.parse(cachedData) as LicenseCheckResponse)?.status;
+      return (JSON.parse(cachedData) as LicenseCheckResponse)?.valid;
     }
     const response = await fetch(licenseKeyUrl, { mode: "cors" });
     const data = (await response.json()) as LicenseCheckResponse;
     const cacheKey = getLicenseCacheKey(licenseKey);
     this.redisService.redis.set(cacheKey, JSON.stringify(data), "EX", CACHING_TIME);
-    return data.status;
+    return data.valid;
   }
 }

--- a/apps/api/v2/src/modules/deployments/deployments.service.ts
+++ b/apps/api/v2/src/modules/deployments/deployments.service.ts
@@ -8,7 +8,8 @@ const CACHING_TIME = 86400000; // 24 hours in milliseconds
 const getLicenseCacheKey = (key: string) => `api-v2-license-key-goblin-url-${key}`;
 
 type LicenseCheckResponse = {
-  valid: boolean;
+  valid?: boolean;
+  status?: boolean;
 };
 @Injectable()
 export class DeploymentsService {
@@ -36,7 +37,8 @@ export class DeploymentsService {
     const licenseKeyUrl = this.configService.get("api.licenseKeyUrl") + `/${licenseKey}`;
     const cachedData = await this.redisService.redis.get(getLicenseCacheKey(licenseKey));
     if (cachedData) {
-      return (JSON.parse(cachedData) as LicenseCheckResponse)?.valid;
+      const cached = JSON.parse(cachedData) as LicenseCheckResponse;
+      return cached.valid ?? cached.status ?? false;
     }
     const response = await fetch(licenseKeyUrl, { mode: "cors" });
     const data = (await response.json()) as LicenseCheckResponse;

--- a/apps/api/v2/src/modules/deployments/deployments.service.ts
+++ b/apps/api/v2/src/modules/deployments/deployments.service.ts
@@ -42,6 +42,6 @@ export class DeploymentsService {
     const data = (await response.json()) as LicenseCheckResponse;
     const cacheKey = getLicenseCacheKey(licenseKey);
     this.redisService.redis.set(cacheKey, JSON.stringify(data), "EX", CACHING_TIME);
-    return data.valid;
+    return data.valid ?? data.status ?? false;
   }
 }


### PR DESCRIPTION
## What does this PR do?
Fixes #26610

The `checkLicense()` method in `deployments.service.ts` was checking 
`data.status` to validate the license key, but the Cal.com license API 
returns `data.valid` (not `data.status`). This caused all API v2 
requests to fail with "Invalid or missing CALCOM_LICENSE_KEY" even 
when a valid license key was set.

## Visual Demo (For contributors especially)
N/A — single property name fix, no UI changes.

## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
1. Set a valid `CALCOM_LICENSE_KEY` in your environment
2. Make any API v2 request that requires a license check
3. Before fix: request fails with "Invalid or missing CALCOM_LICENSE_KEY"
4. After fix: request succeeds as expected

No new environment variables required.

## Checklist
- I have read the contributing guide
- My code follows the style guidelines of this project
- My changes generate no new warnings
- This PR is small (1 file, 3 lines changed)