### PR TITLE
fix: availability save button stays enabled after saving

### DIFF
--- a/apps/web/modules/availability/[schedule]/schedule-view.tsx
+++ b/apps/web/modules/availability/[schedule]/schedule-view.tsx
@@ -122,14 +122,16 @@ export const AvailabilitySettingsWebWrapper = ({
       handleSubmit={async ({ dateOverrides, ...values }) => {
         if (!values.name.trim()) {
           showToast(t("schedule_name_cannot_be_empty"), "error");
-          return;
+          return "skipped";
         }
-        scheduleId &&
-          updateMutation.mutate({
+        if (scheduleId) {
+          await updateMutation.mutateAsync({
             scheduleId,
             dateOverrides: dateOverrides.flatMap((override) => override.ranges),
             ...values,
           });
+        }
+        return "saved";
       }}
       bulkUpdateModalProps={{
         isOpen: isBulkUpdateModalOpen,

--- a/apps/web/playwright/availability.e2e.ts
+++ b/apps/web/playwright/availability.e2e.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 import dayjs from "@calcom/dayjs";
@@ -5,6 +6,16 @@ import dayjs from "@calcom/dayjs";
 import { test } from "./lib/fixtures";
 import { localize } from "./lib/localize";
 import { submitAndWaitForResponse } from "./lib/testUtils";
+
+const SCHEDULE_UPDATE_URL = "/api/trpc/availability/schedule.update?batch=1";
+
+/** Wait for a date override auto-save and assert the response status. */
+async function waitForAutoSave(page: Page, trigger: () => Promise<void>) {
+  const responsePromise = page.waitForResponse(SCHEDULE_UPDATE_URL);
+  await trigger();
+  const response = await responsePromise;
+  expect(response.status()).toBe(200);
+}
 
 test.describe.configure({ mode: "parallel" });
 
@@ -26,16 +37,17 @@ test.describe("Availability", () => {
     await page.locator('[data-testid="Sunday-switch"]').first().click();
     await page.locator('[data-testid="Saturday-switch"]').first().click();
 
-    await page.getByTestId("add-override").click();
-    await page.locator('[id="modal-title"]').waitFor();
-    await page.getByTestId("incrementMonth").click();
-    await page.locator('[data-testid="day"][data-disabled="false"]').first().click();
-    await page.getByTestId("date-override-mark-unavailable").click();
-    await page.getByTestId("add-override-submit-btn").click();
-    await page.getByTestId("dialog-rejection").click();
-    await expect(page.locator('[data-testid="date-overrides-list"] > li')).toHaveCount(1);
-    await submitAndWaitForResponse(page, "/api/trpc/availability/schedule.update?batch=1", {
-      action: () => page.locator('[form="availability-form"][type="submit"]').click(),
+    // Date overrides auto-save when added, so we wait for the API response
+    // instead of clicking the Save button (which is disabled after auto-save)
+    await waitForAutoSave(page, async () => {
+      await page.getByTestId("add-override").click();
+      await page.locator('[id="modal-title"]').waitFor();
+      await page.getByTestId("incrementMonth").click();
+      await page.locator('[data-testid="day"][data-disabled="false"]').first().click();
+      await page.getByTestId("date-override-mark-unavailable").click();
+      await page.getByTestId("add-override-submit-btn").click();
+      await page.getByTestId("dialog-rejection").click();
+      await expect(page.locator('[data-testid="date-overrides-list"] > li')).toHaveCount(1);
     });
     const nextMonth = dayjs().add(1, "month").startOf("month");
     const troubleshooterURL = `/availability/troubleshoot?date=${nextMonth.format("YYYY-MM-DD")}`;
@@ -45,44 +57,50 @@ test.describe("Availability", () => {
 
   test("it can delete date overrides", async ({ page }) => {
     await page.getByTestId("schedules").first().click();
-    await page.getByTestId("add-override").click();
-    await page.locator('[id="modal-title"]').waitFor();
-    // always go to the next month so there's enough slots regardless of current time.
-    await page.getByTestId("incrementMonth").click();
 
-    await page.locator('[data-testid="day"][data-disabled="false"]').first().click();
-    await page.locator('[data-testid="day"][data-disabled="false"]').nth(4).click();
-    await page.locator('[data-testid="day"][data-disabled="false"]').nth(12).click();
-    await page.getByTestId("date-override-mark-unavailable").click();
-    await page.getByTestId("add-override-submit-btn").click();
-    await page.getByTestId("dialog-rejection").click();
-    await expect(page.locator('[data-testid="date-overrides-list"] > li')).toHaveCount(3);
-    await page.locator('[form="availability-form"][type="submit"]').click();
+    // Add first batch of overrides (auto-saves)
+    await waitForAutoSave(page, async () => {
+      await page.getByTestId("add-override").click();
+      await page.locator('[id="modal-title"]').waitFor();
+      // always go to the next month so there's enough slots regardless of current time.
+      await page.getByTestId("incrementMonth").click();
 
-    await page.getByTestId("add-override").click();
-    await page.locator('[id="modal-title"]').waitFor();
+      await page.locator('[data-testid="day"][data-disabled="false"]').first().click();
+      await page.locator('[data-testid="day"][data-disabled="false"]').nth(4).click();
+      await page.locator('[data-testid="day"][data-disabled="false"]').nth(12).click();
+      await page.getByTestId("date-override-mark-unavailable").click();
+      await page.getByTestId("add-override-submit-btn").click();
+      await page.getByTestId("dialog-rejection").click();
+      await expect(page.locator('[data-testid="date-overrides-list"] > li')).toHaveCount(3);
+    });
 
-    // always go to the next month so there's enough slots regardless of current time.
-    await page.getByTestId("incrementMonth").click();
+    // Add another override (auto-saves)
+    await waitForAutoSave(page, async () => {
+      await page.getByTestId("add-override").click();
+      await page.locator('[id="modal-title"]').waitFor();
 
-    await page.locator('[data-testid="day"][data-disabled="false"]').nth(2).click();
-    await page.getByTestId("date-override-mark-unavailable").click();
-    await page.getByTestId("add-override-submit-btn").click();
-    await page.getByTestId("dialog-rejection").click();
+      // always go to the next month so there's enough slots regardless of current time.
+      await page.getByTestId("incrementMonth").click();
+
+      await page.locator('[data-testid="day"][data-disabled="false"]').nth(2).click();
+      await page.getByTestId("date-override-mark-unavailable").click();
+      await page.getByTestId("add-override-submit-btn").click();
+      await page.getByTestId("dialog-rejection").click();
+
+      const dateOverrideList = page.locator('[data-testid="date-overrides-list"] > li');
+
+      await expect(dateOverrideList).toHaveCount(4);
+    });
 
     const dateOverrideList = page.locator('[data-testid="date-overrides-list"] > li');
-
-    await expect(dateOverrideList).toHaveCount(4);
-
-    await page.locator('[form="availability-form"][type="submit"]').click();
-
     const deleteButton = dateOverrideList.nth(1).getByTestId("delete-button");
     // we cannot easily predict the title, as this changes throughout the year.
     const deleteButtonTitle = (await deleteButton.getAttribute("title")) as string;
     // press the delete button (should remove the .nth 1 element & trigger reorder)
-    await deleteButton.click();
-
-    await page.locator('[form="availability-form"][type="submit"]').click();
+    // Deleting a date override auto-saves
+    await waitForAutoSave(page, async () => {
+      await deleteButton.click();
+    });
 
     await expect(dateOverrideList).toHaveCount(3);
     await expect(page.getByTitle(deleteButtonTitle)).toBeHidden();
@@ -99,14 +117,15 @@ test.describe("Availability", () => {
     await page.locator("[id=timeZone-lg-viewport]").fill("New");
     await page.getByTestId("select-option-America/New_York").click();
 
-    // Add override for today
-    await page.getByTestId("add-override").click();
-    await page.locator('[id="modal-title"]').waitFor();
-    await page.locator('[data-testid="day"][data-disabled="false"]').first().click();
-    await page.getByTestId("add-override-submit-btn").click();
-    await page.getByTestId("dialog-rejection").click();
+    // Add override for today (auto-saves)
+    await waitForAutoSave(page, async () => {
+      await page.getByTestId("add-override").click();
+      await page.locator('[id="modal-title"]').waitFor();
+      await page.locator('[data-testid="day"][data-disabled="false"]').first().click();
+      await page.getByTestId("add-override-submit-btn").click();
+      await page.getByTestId("dialog-rejection").click();
+    });
 
-    await page.locator('[form="availability-form"][type="submit"]').click();
     await page.reload();
     await expect(page.locator('[data-testid="date-overrides-list"] > li')).toHaveCount(1);
   });
@@ -186,13 +205,20 @@ test.describe("Availability", () => {
     await page.locator("[id=timeZone-lg-viewport]").fill("Braz");
     await page.getByTestId("select-option-America/Sao_Paulo").click();
     await submitAndWaitForResponse(page, "/api/trpc/availability/schedule.update?batch=1");
-    await page.getByTestId("add-override").click();
-    await page.getByTestId("incrementMonth").click();
-    await page.getByRole("button", { name: "20" }).click();
-    await page.getByTestId("date-override-mark-unavailable").click();
-    await page.getByTestId("add-override-submit-btn").click();
-    await page.getByTestId("dialog-rejection").click();
-    await page.getByTestId("date-overrides-list").getByRole("button").nth(1).click();
-    await submitAndWaitForResponse(page, "/api/trpc/availability/schedule.update?batch=1");
+
+    // Date overrides auto-save, so we wait for the API response directly
+    await waitForAutoSave(page, async () => {
+      await page.getByTestId("add-override").click();
+      await page.getByTestId("incrementMonth").click();
+      await page.getByRole("button", { name: "20" }).click();
+      await page.getByTestId("date-override-mark-unavailable").click();
+      await page.getByTestId("add-override-submit-btn").click();
+      await page.getByTestId("dialog-rejection").click();
+    });
+
+    // Deleting a date override also auto-saves
+    await waitForAutoSave(page, async () => {
+      await page.getByTestId("date-overrides-list").getByRole("button").nth(1).click();
+    });
   });
 });

--- a/packages/platform/atoms/availability/AvailabilitySettings.tsx
+++ b/packages/platform/atoms/availability/AvailabilitySettings.tsx
@@ -111,7 +111,7 @@ type AvailabilitySettingsProps = {
   timeFormat: number | null;
   weekStart: string;
   backPath: string | boolean;
-  handleSubmit: (data: AvailabilityFormValues) => Promise<void>;
+  handleSubmit: (data: AvailabilityFormValues) => Promise<"saved" | "skipped">;
   isPlatform?: boolean;
   customClassNames?: CustomClassNames;
   disableEditableHeading?: boolean;
@@ -126,7 +126,6 @@ type AvailabilitySettingsProps = {
     isEventTypesFetching?: boolean;
     handleBulkEditDialogToggle: () => void;
   };
-  callbacksRef?: React.MutableRefObject<{ onSuccess?: () => void; onError?: (error: Error) => void }>;
   isDryRun?: boolean;
 };
 
@@ -206,20 +205,27 @@ const DateOverride = ({
     description?: string;
     button?: string;
   };
-  handleSubmit: (data: AvailabilityFormValues) => Promise<void>;
+  handleSubmit: (data: AvailabilityFormValues) => Promise<"saved" | "skipped">;
   isDryRun?: boolean;
 }) => {
   const { append, replace, fields } = useFieldArray<AvailabilityFormValues, "dateOverrides">({
     name: "dateOverrides",
   });
-  const { getValues } = useFormContext();
+  const { getValues, reset } = useFormContext();
   const excludedDates = useExcludedDates();
   const { t } = useLocale();
 
-  const handleAvailabilityUpdate = () => {
+  const handleAvailabilityUpdate = async () => {
     const updatedValues = getValues() as AvailabilityFormValues;
     if (!isDryRun) {
-      handleSubmit(updatedValues);
+      try {
+        const result = await handleSubmit(updatedValues);
+        if (result === "saved") {
+          reset(updatedValues);
+        }
+      } catch {
+        // error already handled by mutation's onError callback
+      }
     }
   };
 
@@ -314,7 +320,6 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
       bulkUpdateModalProps,
       allowSetToDefault = true,
       allowDelete = true,
-      callbacksRef,
       isDryRun,
     } = props;
     const [openSidebar, setOpenSidebar] = useState(false);
@@ -334,19 +339,7 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
       control: form.control,
     });
 
-    const initialValuesRef = useRef<AvailabilityFormValues | null>(null);
-    useEffect(() => {
-      initialValuesRef.current = form.getValues() as AvailabilityFormValues;
-    }, [form, schedule]);
-
-    const formHasChanges = useMemo(() => {
-      if (!initialValuesRef.current) return false;
-      try {
-        return (JSON.stringify(form.watch("schedule")) !== JSON.stringify(initialValuesRef.current.availability) || JSON.stringify(watchedValues) !== JSON.stringify(initialValuesRef.current));
-      } catch {
-        return form.formState.isDirty;
-      }
-    }, [watchedValues, form.formState.isDirty]);
+    const { isDirty } = form.formState;
 
     // Trigger callback whenever the form state changes
     useEffect(() => {
@@ -362,27 +355,31 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
     }, [isPlatform]);
 
     const saveButtonRef = useRef<HTMLButtonElement>(null);
+    const callbacksRef = useRef<{ onSuccess?: () => void; onError?: (error: Error) => void }>({});
 
     const handleFormSubmit = useCallback(
       (customCallbacks?: { onSuccess?: () => void; onError?: (error: Error) => void }) => {
-        if (callbacksRef && customCallbacks) {
-          callbacksRef.current = customCallbacks;
-        }
+        callbacksRef.current = customCallbacks || {};
 
-        if (saveButtonRef.current) {
+        if (saveButtonRef.current && !saveButtonRef.current.disabled) {
           saveButtonRef.current.click();
         } else {
           form.handleSubmit(async (data) => {
             try {
-              await handleSubmit(data);
-              callbacksRef?.current?.onSuccess?.();
+              const result = await handleSubmit(data);
+              if (result === "saved") {
+                form.reset(data);
+                callbacksRef.current?.onSuccess?.();
+              }
             } catch (error) {
-              callbacksRef?.current?.onError?.(error as Error);
+              callbacksRef.current?.onError?.(error as Error);
+            } finally {
+              callbacksRef.current = {};
             }
           })();
         }
       },
-      [form, handleSubmit, callbacksRef]
+      [form, handleSubmit]
     );
 
     const validateForm = useCallback(async () => {
@@ -643,7 +640,7 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
               type="submit"
               form="availability-form"
               loading={isSaving}
-              disabled={isLoading || !formHasChanges}
+              disabled={isLoading || !isDirty}
             >
               {t("save")}
             </Button>
@@ -661,7 +658,17 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
             form={form}
             id="availability-form"
             handleSubmit={async (props) => {
-              handleSubmit(props);
+              try {
+                const result = await handleSubmit(props);
+                if (result === "saved") {
+                  form.reset(props);
+                  callbacksRef.current?.onSuccess?.();
+                }
+              } catch (error) {
+                callbacksRef.current?.onError?.(error as Error);
+              } finally {
+                callbacksRef.current = {};
+              }
             }}
             className={cn(customClassNames?.formClassName, "flex flex-col sm:mx-0 xl:flex-row xl:space-x-6")}>
             <div className="flex-1">

--- a/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { forwardRef, useRef } from "react";
+import { forwardRef } from "react";
 
 import type { ScheduleLabelsType } from "@calcom/features/schedules/components/ScheduleComponent";
 import type { UpdateScheduleResponse } from "@calcom/features/schedules/services/ScheduleService";
@@ -84,9 +84,7 @@ export const AvailabilitySettingsPlatformWrapper = forwardRef<
     },
   });
 
-  const callbacksRef = useRef<{ onSuccess?: () => void; onError?: (error: Error) => void }>({});
-
-  const { mutate: updateSchedule, isPending: isSavingInProgress } = useAtomUpdateSchedule({
+  const { mutateAsync: updateSchedule, isPending: isSavingInProgress } = useAtomUpdateSchedule({
     onSuccess: (res) => {
       onUpdateSuccess?.(res);
       if (!disableToasts) {
@@ -94,7 +92,6 @@ export const AvailabilitySettingsPlatformWrapper = forwardRef<
           description: "Schedule updated successfully",
         });
       }
-      callbacksRef.current?.onSuccess?.();
     },
     onError: (err) => {
       onUpdateError?.(err);
@@ -103,7 +100,6 @@ export const AvailabilitySettingsPlatformWrapper = forwardRef<
           description: "Could not update schedule",
         });
       }
-      callbacksRef.current?.onError?.(err);
     },
   });
 
@@ -111,22 +107,25 @@ export const AvailabilitySettingsPlatformWrapper = forwardRef<
     await deleteSchedule({ id });
   };
 
-  const handleUpdate = async (id: number, body: AvailabilityFormValues) => {
+  const handleUpdate = async (id: number, body: AvailabilityFormValues): Promise<"saved" | "skipped"> => {
     let canUpdate = true;
 
     if (onBeforeUpdate) {
       canUpdate = await onBeforeUpdate(body);
     }
 
-    if (canUpdate) {
-      updateSchedule({
-        scheduleId: id,
-        body: {
-          ...body,
-          dateOverrides: body.dateOverrides.flatMap((override) => override.ranges),
-        },
-      });
+    if (!canUpdate) {
+      return "skipped";
     }
+
+    await updateSchedule({
+      scheduleId: id,
+      body: {
+        ...body,
+        dateOverrides: body.dateOverrides.flatMap((override) => override.ranges),
+      },
+    });
+    return "saved";
   };
 
   if (isLoading) {
@@ -166,11 +165,13 @@ export const AvailabilitySettingsPlatformWrapper = forwardRef<
             toast({
               description: "Schedule updated successfully",
             });
+            return "saved";
           }
 
           if (!isDryRun && atomSchedule.id) {
-            handleUpdate(atomSchedule.id, data);
+            return await handleUpdate(atomSchedule.id, data);
           }
+          return "skipped";
         }}
         weekStart={me?.data?.weekStart || "Sunday"}
         timeFormat={timeFormat}
@@ -202,7 +203,6 @@ export const AvailabilitySettingsPlatformWrapper = forwardRef<
         allowDelete={allowDelete}
         allowSetToDefault={allowSetToDefault}
         onFormStateChange={onFormStateChange}
-        callbacksRef={callbacksRef}
         isDryRun={isDryRun}
       />
     </AtomsWrapper>


### PR DESCRIPTION
Draft PR to verify CI — same changes as #26709 but from the main repo to rule out fork-related CI issues.

Fixes #26708
Fixes CAL-7051

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Availability Save button staying enabled by using `isDirty` and resetting the form only after a confirmed save. Aligns date override auto-save (add/delete) with proper reset; addresses CAL-7051 and #26708.

- **Bug Fixes**
  - Use React Hook Form `isDirty` for the Save button; fall back to `form.handleSubmit` when the button is disabled.
  - Await saves via `mutateAsync` and reset with submitted values only when `handleSubmit` returns `"saved"`.
  - Make `handleSubmit` return `"saved" | "skipped"` across web and platform to avoid resets on validation failures or skipped updates.
  - Ensure date override auto-save (add/delete) triggers a form reset after successful save.
  - Update E2E tests to wait for `/api/trpc/availability/schedule.update?batch=1` via a `waitForAutoSave` helper instead of clicking a disabled Save button.

<sup>Written for commit f31977dcd99b3bbdf1a6de21c93d2df307916762. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

