### PR TITLE
fix: prevent git hook bypass via --no-verify in Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR prevents Claude Code agents from bypassing git hooks using the `--no-verify` flag.

Currently, commands like `git commit --no-verify` can skip important hooks such as `pre-commit`, `commit-msg`, and `pre-push`, which enforce linting, formatting, and commit standards.

This change introduces a safeguard by adding a `PreToolUse` Bash hook in `.claude/settings.json` using `block-no-verify`.

- Detects usage of the `--no-verify` flag in git commands executed via Claude Code
- Blocks execution by exiting with a non-zero status code
- Ensures existing environment configuration remains unchanged

- Fixes #28510

---

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):
N/A

#### Image Demo (if applicable):
N/A

---

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works

---

## How should this be tested?

1. Ensure `.claude/settings.json` includes the `PreToolUse` hook with `block-no-verify`
2. Run a command via Claude Code agent:
3. Expected result:
- Command should be blocked with an error message

4. Run a normal git command:
5. Expected result:
- Command executes successfully

**Notes:**
- This enforcement applies only within Claude Code runtime
- It will not block commands executed directly in a standard terminal

---

## Checklist

- My code follows the style guidelines of this project
- I have self-reviewed my changes
- My changes generate no new warnings
- This PR is small and focused (single file change)