### PR TITLE
feat: check guest (booker) availability when host reschedules booking

### DIFF
--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -2213,4 +2213,53 @@ export class BookingRepository implements IBookingRepository {
       },
     });
   }
+
+  async findAcceptedBookingsByUserIdInDateRange({
+    userId,
+    userEmail,
+    startDate,
+    endDate,
+    excludeUid,
+  }: {
+    userId: number;
+    userEmail: string;
+    startDate: Date;
+    endDate: Date;
+    excludeUid?: string | null;
+  }) {
+    const sharedWhere = {
+      status: { in: [BookingStatus.ACCEPTED] as BookingStatus[] },
+      startTime: { lte: endDate },
+      endTime: { gte: startDate },
+      ...(excludeUid ? { uid: { not: excludeUid } } : {}),
+    };
+
+    const bookingSelect = {
+      id: true,
+      uid: true,
+      startTime: true,
+      endTime: true,
+    } satisfies Prisma.BookingSelect;
+
+    const [bookingsAsHost, bookingsAsAttendee] = await Promise.all([
+      this.prismaClient.booking.findMany({
+        where: { ...sharedWhere, userId },
+        select: bookingSelect,
+      }),
+      this.prismaClient.booking.findMany({
+        where: { ...sharedWhere, attendees: { some: { email: userEmail } } },
+        select: bookingSelect,
+      }),
+    ]);
+
+    const seen = new Set<number>();
+    const allBookings = [];
+    for (const booking of [...bookingsAsHost, ...bookingsAsAttendee]) {
+      if (!seen.has(booking.id)) {
+        seen.add(booking.id);
+        allBookings.push(booking);
+      }
+    }
+    return allBookings;
+  }
 }

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1506,7 +1506,10 @@ export class AvailableSlotsService {
         bookingUid: input.rescheduleUid,
       });
 
-      if (bookingToReschedule?.attendees?.length) {
+      if (bookingToReschedule?.eventType?.id !== eventType.id) {
+        // Skip guest filtering — booking doesn't belong to the current event type,
+        // so we cannot trust it to suppress slots.
+      } else if (bookingToReschedule?.attendees?.length) {
         const userRepo = this.dependencies.userRepo;
         const attendeeUsers = (
           await Promise.all(

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1499,6 +1499,55 @@ export class AvailableSlotsService {
         );
     }
 
+    // When rescheduling, filter out slots where any Cal.com guest attendee is busy
+    if (input.rescheduleUid) {
+      const bookingRepo = this.dependencies.bookingRepo;
+      const bookingToReschedule = await bookingRepo.findByUidIncludeEventTypeAttendeesAndUser({
+        bookingUid: input.rescheduleUid,
+      });
+
+      if (bookingToReschedule?.attendees?.length) {
+        const userRepo = this.dependencies.userRepo;
+        const attendeeUsers = (
+          await Promise.all(
+            bookingToReschedule.attendees.map(async (attendee) => {
+              const user = await userRepo.findByEmail({ email: attendee.email });
+              return user ? { userId: user.id, email: user.email } : null;
+            })
+          )
+        ).filter((u): u is { userId: number; email: string } => u !== null);
+
+        if (attendeeUsers.length > 0) {
+          const eventLength = input.duration || eventType.length;
+          const attendeeBusyTimes = (
+            await Promise.all(
+              attendeeUsers.map(async ({ userId, email }) => {
+                const bookings = await bookingRepo.findAcceptedBookingsByUserIdInDateRange({
+                  userId,
+                  userEmail: email,
+                  startDate: startTime.toDate(),
+                  endDate: endTime.toDate(),
+                  excludeUid: input.rescheduleUid,
+                });
+                return bookings.map((b) => ({ start: b.startTime, end: b.endTime }));
+              })
+            )
+          ).flat();
+
+          if (attendeeBusyTimes.length > 0) {
+            availableTimeSlots = availableTimeSlots.filter(
+              (slot) =>
+                !checkForConflicts({
+                  time: slot.time,
+                  busy: attendeeBusyTimes,
+                  eventLength,
+                })
+            );
+          }
+        }
+      }
+    }
+
     // fr-CA uses YYYY-MM-DD
     const formatter = new Intl.DateTimeFormat("fr-CA", {
       year: "numeric",


### PR DESCRIPTION
## What does this PR do?

When a host reschedules a booking, the system now checks if any guest (attendee/booker) is a registered Cal.com user. If they are, their existing bookings are fetched and used to filter out time slots that conflict with their schedule — ensuring only mutually available slots are shown.

### Changes

**`BookingRepository.ts`** — Added `findAcceptedBookingsByUserIdInDateRange()`:
- Queries accepted bookings where the user is either host (`userId`) or attendee (`email`)
- Deduplicates results from both queries
- Supports excluding the booking being rescheduled (`excludeUid`)

**`AvailableSlotsService` (`util.ts`)** — Added guest availability filtering in `_getAvailableSlots`:
1. When `rescheduleUid` is present, fetches the booking being rescheduled
2. For each attendee, checks if they're a registered Cal.com user via `userRepo.findByEmail`
3. For Cal.com attendees, fetches their accepted bookings in the requested date range
4. Filters available time slots using `checkForConflicts` to remove slots where guests are busy

### How it works
- Non-Cal.com guests are completely unaffected (no availability check performed)
- The booking being rescheduled is excluded from busy time calculations
- Uses the existing `checkForConflicts` utility for consistent conflict detection

Fixes #16378

/claim #16378