### PR TITLE
fix: harden seed script org settings upsert and P2002 error handling

### DIFF
--- a/apps/api/v1/test/lib/utils/isAdmin.integration-test.ts
+++ b/apps/api/v1/test/lib/utils/isAdmin.integration-test.ts
@@ -1,10 +1,8 @@
+import prisma from "@calcom/prisma";
 import type { Request, Response } from "express";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
-import { describe, it, expect, beforeAll } from "vitest";
-
-import prisma from "@calcom/prisma";
-
+import { describe, expect, it } from "vitest";
 import { isAdminGuard } from "../../../lib/utils/isAdmin";
 import { ScopeOfAdmin } from "../../../lib/utils/scopeOfAdmin";
 
@@ -12,53 +10,6 @@ type CustomNextApiRequest = NextApiRequest & Request;
 type CustomNextApiResponse = NextApiResponse & Response;
 
 describe("isAdmin guard", () => {
-  beforeAll(async () => {
-    const acmeOrg = await prisma.team.findFirst({
-      where: {
-        slug: "acme",
-        isOrganization: true,
-      },
-    });
-
-    if (acmeOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: acmeOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: true,
-        },
-        create: {
-          organizationId: acmeOrg.id,
-          orgAutoAcceptEmail: "acme.com",
-          isAdminAPIEnabled: true,
-        },
-      });
-    }
-
-    const dunderOrg = await prisma.team.findFirst({
-      where: {
-        slug: "dunder-mifflin",
-        isOrganization: true,
-      },
-    });
-
-    if (dunderOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: dunderOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: false,
-        },
-        create: {
-          organizationId: dunderOrg.id,
-          orgAutoAcceptEmail: "dunder-mifflin.com",
-          isAdminAPIEnabled: false,
-        },
-      });
-    }
-  });
   it("Returns false when user does not exist in the system", async () => {
     const { req } = createMocks<CustomNextApiRequest, CustomNextApiResponse>({
       method: "POST",

--- a/apps/api/v1/test/lib/utils/retrieveScopedAccessibleUsers.integration-test.ts
+++ b/apps/api/v1/test/lib/utils/retrieveScopedAccessibleUsers.integration-test.ts
@@ -1,37 +1,11 @@
-import { describe, it, expect, beforeAll } from "vitest";
-
 import prisma from "@calcom/prisma";
-
+import { describe, expect, it } from "vitest";
 import {
   getAccessibleUsers,
   retrieveOrgScopedAccessibleUsers,
 } from "../../../lib/utils/retrieveScopedAccessibleUsers";
 
 describe("retrieveScopedAccessibleUsers tests", () => {
-  beforeAll(async () => {
-    const acmeOrg = await prisma.team.findFirst({
-      where: {
-        slug: "acme",
-        isOrganization: true,
-      },
-    });
-
-    if (acmeOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: acmeOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: true,
-        },
-        create: {
-          organizationId: acmeOrg.id,
-          orgAutoAcceptEmail: "acme.com",
-          isAdminAPIEnabled: true,
-        },
-      });
-    }
-  });
   describe("getAccessibleUsers", () => {
     it("Does not return members when only admin user ID is supplied", async () => {
       const adminUser = await prisma.user.findFirstOrThrow({ where: { email: "owner1-acme@example.com" } });

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -329,7 +329,12 @@ async function createOrganizationAndAddMembersAndTeams({
   });
 
   if (existingTeam) {
-    console.log(`Organization with slug '${orgData.slug}' already exists, skipping.`);
+    console.log(`Organization with slug '${orgData.slug}' already exists, ensuring settings are up to date.`);
+    await prisma.organizationSettings.upsert({
+      where: { organizationId: existingTeam.id },
+      update: { ...orgData.organizationSettings },
+      create: { organizationId: existingTeam.id, ...orgData.organizationSettings },
+    });
     return;
   }
 
@@ -341,14 +346,13 @@ async function createOrganizationAndAddMembersAndTeams({
     };
   })[] = [];
 
-  try {
-    const batchSize = 50;
-    // Process members in batches of  in parallel
-    for (let i = 0; i < orgMembers.length; i += batchSize) {
-      const batch = orgMembers.slice(i, i + batchSize);
+  const batchSize = 50;
+  for (let i = 0; i < orgMembers.length; i += batchSize) {
+    const batch = orgMembers.slice(i, i + batchSize);
 
-      const batchResults = await Promise.all(
-        batch.map(async (member) => {
+    const batchResults = await Promise.all(
+      batch.map(async (member) => {
+        try {
           const newUser = await createUserAndEventType({
             user: {
               ...member.memberData,
@@ -375,13 +379,6 @@ async function createOrganizationAndAddMembersAndTeams({
             ],
           });
 
-          const orgMemberInDb = {
-            ...newUser,
-            inTeams: member.inTeams,
-            orgMembership: member.orgMembership,
-            orgProfile: member.orgProfile,
-          };
-
           // Create temp org redirect with upsert to handle duplicates
           await prisma.tempOrgRedirect.upsert({
             where: {
@@ -402,26 +399,31 @@ async function createOrganizationAndAddMembersAndTeams({
             },
           });
 
-          return orgMemberInDb;
-        })
-      );
+          return {
+            ...newUser,
+            inTeams: member.inTeams,
+            orgMembership: member.orgMembership,
+            orgProfile: member.orgProfile,
+          };
+        } catch (e) {
+          if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+            console.log(`Member ${member.memberData.username} already seeded, skipping`);
+            return null;
+          }
+          throw e;
+        }
+      })
+    );
 
-      orgMembersInDb.push(...batchResults);
-    }
-  } catch (e) {
-    if (e instanceof Prisma.PrismaClientKnownRequestError) {
-      if (e.code === "P2002") {
-        console.log(`One of the organization members already exists, skipping the entire seeding`);
-        return;
-      }
-    }
-    console.error(e);
+    orgMembersInDb.push(...batchResults.filter((r): r is NonNullable<typeof r> => r !== null));
   }
 
-  await Promise.all([
+  await Promise.all(
     usersOutsideOrg.map(async (user) => {
-      return await prisma.user.create({
-        data: {
+      await prisma.user.upsert({
+        where: { email_username: { email: user.email, username: user.username } },
+        update: {},
+        create: {
           username: user.username,
           name: user.name,
           email: user.email,
@@ -433,8 +435,8 @@ async function createOrganizationAndAddMembersAndTeams({
           },
         },
       });
-    }),
-  ]);
+    })
+  );
 
   const { organizationSettings, ...restOrgData } = orgData;
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -407,8 +407,22 @@ async function createOrganizationAndAddMembersAndTeams({
           };
         } catch (e) {
           if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
-            console.log(`Member ${member.memberData.username} already seeded, skipping`);
-            return null;
+            console.log("Organization member already seeded, skipping");
+            const existingUser = await prisma.user.findUnique({
+              where: {
+                email_username: {
+                  email: member.memberData.email,
+                  username: member.memberData.username,
+                },
+              },
+            });
+            if (!existingUser) throw e;
+            return {
+              ...existingUser,
+              inTeams: member.inTeams,
+              orgMembership: member.orgMembership,
+              orgProfile: member.orgProfile,
+            };
           }
           throw e;
         }


### PR DESCRIPTION
## What does this PR do?

Fixes flaky org-admin integration tests (`isAdmin`, `retrieveScopedAccessibleUsers`, `_get`, `_patch`) that fail intermittently when the CI database is cached.

**Root cause:** The seed script in `createOrganizationAndAddMembersAndTeams` had two bugs:

1. **Stale org settings on re-seed:** When an organization already existed (cached DB), the function returned immediately without ensuring `organizationSettings.isAdminAPIEnabled` was set. This caused `isAdminGuard` to return `false` for org admins.

2. **P2002 error abandoned entire org creation:** If any single org member hit a unique constraint violation, the batch-level `catch` abandoned the *entire* function — meaning the org team, memberships, profiles, and settings were never created, even though some member users already existed.

### Changes

**`scripts/seed.ts`:**
- Upsert `organizationSettings` when the org already exists, instead of silently returning
- Move P2002 error handling inside each member's callback so one member's duplicate doesn't abandon the entire org
- On P2002, recover the existing user from the DB and return it with membership metadata so downstream org setup (profiles, memberships, teams) still proceeds correctly
- Remove PII (username) from P2002 log message
- Use `prisma.user.upsert` for `usersOutsideOrg` instead of `prisma.user.create` to avoid P2002 there too

**Test files (`isAdmin.integration-test.ts`, `retrieveScopedAccessibleUsers.integration-test.ts`):**
- Remove `beforeAll` hooks that were workarounds for the seed script bug — the proper fix is in the seed script itself

### Updates since last revision

Addressed Cubic AI review feedback (confidence ≥ 9/10):
- **Violation #2 (PII logging):** Replaced `Member ${member.memberData.username} already seeded, skipping` with a generic `"Organization member already seeded, skipping"` message
- **Violation #3 (incomplete org seeding):** Instead of `return null` on P2002 (which dropped the user from org membership/profile creation), the code now fetches the existing user via `prisma.user.findUnique` and returns it with the membership data so downstream setup proceeds
- **Violation #1 (confidence 6/10):** Skipped — the `existingTeam` lookup is scoped by `slug` + `parentId: null` using org-specific slugs, so a collision with a non-org team is not a realistic concern in seeding

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — seed script and test-only changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

The integration test suite should pass consistently on both fresh and cached CI databases:

```bash
VITEST_MODE=integration yarn test apps/api/v1/test/lib/utils/isAdmin.integration-test.ts
VITEST_MODE=integration yarn test apps/api/v1/test/lib/utils/retrieveScopedAccessibleUsers.integration-test.ts
VITEST_MODE=integration yarn test apps/api/v1/test/lib/bookings/_get.integration-test.ts
VITEST_MODE=integration yarn test "apps/api/v1/test/lib/bookings/[id]/_patch.integration-test.ts"
```

To reproduce the flaky state: run the seed twice (simulating a cached DB) and verify the tests still pass on the second run.

## Human Review Checklist

- [ ] Verify the `email_username` compound unique constraint exists in the Prisma schema (used in both the `usersOutsideOrg` upsert and the P2002 recovery `findUnique`)
- [ ] Confirm `orgData.organizationSettings` shape is compatible with `prisma.organizationSettings.upsert` for both `update` and `create` fields
- [ ] Verify the P2002 recovery path: when an existing user is fetched and returned, confirm that downstream code (profile creation, membership creation, team assignment) handles it correctly — particularly that it doesn't attempt to re-create resources that already exist
- [ ] Verify removing `beforeAll` workarounds from test files is safe — integration tests should always run against a seeded DB

Link to Devin session: https://app.devin.ai/sessions/6be6fd80dedc4fc8891cb523d7d4ddbe
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
