### PR TITLE
fix(calendar): add pointer cursor to enabled date buttons

### DIFF
--- a/packages/features/calendars/components/DatePicker.tsx
+++ b/packages/features/calendars/components/DatePicker.tsx
@@ -84,7 +84,7 @@ const Day = ({
       type="button"
       style={disabled ? { ...disabledDateButtonEmbedStyles } : { ...enabledDateButtonEmbedStyles }}
       className={classNames(
-        "disabled:text-bookinglighter absolute bottom-0 left-0 right-0 top-0 mx-auto w-full rounded-md border-2 border-transparent text-center text-sm font-medium transition disabled:cursor-default disabled:border-transparent disabled:font-light ",
+        "disabled:text-bookinglighter absolute bottom-0 left-0 right-0 top-0 mx-auto w-full cursor-pointer rounded-md border-2 border-transparent text-center text-sm font-medium transition disabled:cursor-default disabled:border-transparent disabled:font-light ",
         active
           ? "bg-brand-default text-brand"
           : !disabled


### PR DESCRIPTION
Fix issue -  #28530

Enabled (clickable) date buttons in the calendar month view were not showing a pointer cursor, leading to inconsistent UX compared to other interactive elements like time slots and navigation arrows.

This change adds `cursor-pointer` to enabled date buttons to clearly indicate interactivity.

The existing Tailwind `disabled:cursor-default` modifier ensures that disabled dates continue to show the default cursor, so no behavior for non-clickable dates is affected.

This is a minimal UI-only change with no impact on logic or functionality.