### PR TITLE
fix(ui): truncate long slug in event type card

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -194,13 +194,13 @@ const Item = ({
   const content = (): JSX.Element => (
     <div>
       <span
-        className="text-default break-words font-semibold ltr:mr-1 rtl:ml-1"
+        className="text-default truncate font-semibold ltr:mr-1 rtl:ml-1"
         data-testid={`event-type-title-${type.id}`}>
         {type.title}
       </span>
       {group.profile.slug && type.schedulingType !== SchedulingType.MANAGED ? (
         <small
-          className="text-subtle hidden font-normal leading-4 sm:inline"
+          className="text-subtle hidden truncate font-normal leading-4 sm:inline"
           data-testid={`event-type-slug-${type.id}`}>
           {`/${group.profile.slug}/${type.slug}`}
         </small>
@@ -238,13 +238,13 @@ const Item = ({
           <Link href={`/event-types/${type.id}?tabName=setup`} title={type.title}>
             <div>
               <span
-                className="text-default break-words font-semibold ltr:mr-1 rtl:ml-1"
+                className="text-default truncate font-semibold ltr:mr-1 rtl:ml-1"
                 data-testid={`event-type-title-${type.id}`}>
                 {type.title}
               </span>
               {group.profile.slug && type.schedulingType !== SchedulingType.MANAGED ? (
                 <small
-                  className="text-subtle hidden font-normal leading-4 sm:inline"
+                  className="text-subtle hidden truncate font-normal leading-4 sm:inline"
                   data-testid={`event-type-slug-${type.id}`}>
                   {`/${group.profile.slug}/${type.slug}`}
                 </small>

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -194,13 +194,13 @@ const Item = ({
   const content = (): JSX.Element => (
     <div>
       <span
-        className="text-default truncate font-semibold ltr:mr-1 rtl:ml-1"
+        className="text-default inline-block max-w-full truncate font-semibold ltr:mr-1 rtl:ml-1"
         data-testid={`event-type-title-${type.id}`}>
         {type.title}
       </span>
       {group.profile.slug && type.schedulingType !== SchedulingType.MANAGED ? (
         <small
-          className="text-subtle hidden truncate font-normal leading-4 sm:inline"
+          className="text-subtle hidden max-w-full truncate font-normal leading-4 sm:inline-block"
           data-testid={`event-type-slug-${type.id}`}>
           {`/${group.profile.slug}/${type.slug}`}
         </small>
@@ -238,13 +238,13 @@ const Item = ({
           <Link href={`/event-types/${type.id}?tabName=setup`} title={type.title}>
             <div>
               <span
-                className="text-default truncate font-semibold ltr:mr-1 rtl:ml-1"
+                className="text-default inline-block max-w-full truncate font-semibold ltr:mr-1 rtl:ml-1"
                 data-testid={`event-type-title-${type.id}`}>
                 {type.title}
               </span>
               {group.profile.slug && type.schedulingType !== SchedulingType.MANAGED ? (
                 <small
-                  className="text-subtle hidden truncate font-normal leading-4 sm:inline"
+                  className="text-subtle hidden max-w-full truncate font-normal leading-4 sm:inline-block"
                   data-testid={`event-type-slug-${type.id}`}>
                   {`/${group.profile.slug}/${type.slug}`}
                 </small>


### PR DESCRIPTION
Fix issue-  #28533

Long slug/URL text in the event type card could overflow its container and break layout.

This change replaces `break-words` with Tailwind's `truncate` utility on the text elements to ensure long text is properly truncated with ellipsis, preventing overflow while preserving the existing layout and responsiveness.

No structural or layout changes were introduced.