### PR TITLE
fix: prevent long slug/title overflow in installation step cards

### DIFF
--- a/apps/web/components/apps/installation/ConfigureStepCard.tsx
+++ b/apps/web/components/apps/installation/ConfigureStepCard.tsx
@@ -94,7 +94,7 @@ const EventTypeAppSettingsForm = forwardRef<HTMLButtonElement, EventTypeAppSetti
               <span className="text-default font-semibold ltr:mr-1 rtl:ml-1 truncate block">
                 {eventType.title}
               </span>{" "}
-              <small className="text-subtle hidden font-normal sm:inline truncate block">
+              <small className="text-subtle hidden font-normal sm:block truncate">
                 /{eventType.team ? eventType.team.slug : props.userName}/{eventType.slug}
               </small>
             </div>

--- a/apps/web/components/apps/installation/ConfigureStepCard.tsx
+++ b/apps/web/components/apps/installation/ConfigureStepCard.tsx
@@ -1,12 +1,3 @@
-import { zodResolver } from "@hookform/resolvers/zod";
-import type { Dispatch, SetStateAction } from "react";
-import type { FC } from "react";
-import React, { forwardRef, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { useFieldArray, useFormContext } from "react-hook-form";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
-
 import type { LocationObject } from "@calcom/app-store/locations";
 import { locationsResolver } from "@calcom/app-store/locations";
 import NoSSR from "@calcom/lib/components/NoSSR";
@@ -17,11 +8,16 @@ import { Avatar } from "@calcom/ui/components/avatar";
 import { Button } from "@calcom/ui/components/button";
 import { Form } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
-
 import EventTypeAppSettingsWrapper from "@components/apps/installation/EventTypeAppSettingsWrapper";
 import EventTypeConferencingAppSettings from "@components/apps/installation/EventTypeConferencingAppSettings";
-
-import type { TEventType, TEventTypesForm, TEventTypeGroup } from "~/apps/installation/[[...step]]/step-view";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type React from "react";
+import type { Dispatch, FC, SetStateAction } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useFieldArray, useForm, useFormContext } from "react-hook-form";
+import { z } from "zod";
+import type { TEventType, TEventTypeGroup, TEventTypesForm } from "~/apps/installation/[[...step]]/step-view";
 
 export type TFormType = {
   id: number;
@@ -93,10 +89,12 @@ const EventTypeAppSettingsForm = forwardRef<HTMLButtonElement, EventTypeAppSetti
           onSubmit({ metadata, locations, bookingFields });
         }}>
         <div>
-          <div className="sm:border-subtle bg-default relative border p-4 dark:bg-black sm:rounded-md">
-            <div>
-              <span className="text-default font-semibold ltr:mr-1 rtl:ml-1">{eventType.title}</span>{" "}
-              <small className="text-subtle hidden font-normal sm:inline">
+          <div className="sm:border-subtle bg-default relative border p-4 dark:bg-black sm:rounded-md overflow-hidden">
+            <div className="min-w-0">
+              <span className="text-default font-semibold ltr:mr-1 rtl:ml-1 truncate block">
+                {eventType.title}
+              </span>{" "}
+              <small className="text-subtle hidden font-normal sm:inline truncate block">
                 /{eventType.team ? eventType.team.slug : props.userName}/{eventType.slug}
               </small>
             </div>

--- a/apps/web/components/apps/installation/EventTypesStepCard.tsx
+++ b/apps/web/components/apps/installation/EventTypesStepCard.tsx
@@ -57,7 +57,7 @@ const EventTypeCard: FC<EventTypeCardProps> = ({
         <li>
           <div className="min-w-0">
             <span className="text-default font-semibold ltr:mr-1 rtl:ml-1 truncate block">{title}</span>{" "}
-            <small className="text-subtle hidden font-normal sm:inline truncate block">
+            <small className="text-subtle hidden font-normal sm:block truncate">
               /{team ? team.slug : userName}/{slug}
             </small>
           </div>

--- a/apps/web/components/apps/installation/EventTypesStepCard.tsx
+++ b/apps/web/components/apps/installation/EventTypesStepCard.tsx
@@ -1,8 +1,3 @@
-import type { Dispatch, SetStateAction } from "react";
-import type { FC } from "react";
-import React from "react";
-import { useFieldArray, useFormContext } from "react-hook-form";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
@@ -10,8 +5,10 @@ import { Avatar } from "@calcom/ui/components/avatar";
 import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
 import { ScrollableArea } from "@calcom/ui/components/scrollable";
-
-import type { TEventType, TEventTypesForm, TEventTypeGroup } from "~/apps/installation/[[...step]]/step-view";
+import type { Dispatch, FC, SetStateAction } from "react";
+import React from "react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import type { TEventType, TEventTypeGroup, TEventTypesForm } from "~/apps/installation/[[...step]]/step-view";
 
 type EventTypesCardProps = {
   userName: string;
@@ -48,7 +45,7 @@ const EventTypeCard: FC<EventTypeCardProps> = ({
   return (
     <div
       data-testid={`select-event-type-${id}`}
-      className="hover:bg-cal-muted min-h-20 box-border flex w-full cursor-pointer select-none items-center space-x-4 px-4 py-3"
+      className="hover:bg-cal-muted min-h-20 box-border flex w-full cursor-pointer select-none items-center space-x-4 px-4 py-3 overflow-hidden"
       onClick={() => handleSelect()}>
       <input
         id={`${id}`}
@@ -56,11 +53,11 @@ const EventTypeCard: FC<EventTypeCardProps> = ({
         className="bg-default border-default h-4 w-4 shrink-0 cursor-pointer rounded-cal checked:border-transparent checked:bg-gray-800 border ring-offset-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed"
         type="checkbox"
       />
-      <label htmlFor={`${id}`} className="cursor-pointer text-sm">
+      <label htmlFor={`${id}`} className="cursor-pointer text-sm min-w-0 overflow-hidden w-full">
         <li>
-          <div>
-            <span className="text-default font-semibold ltr:mr-1 rtl:ml-1">{title}</span>{" "}
-            <small className="text-subtle hidden font-normal sm:inline">
+          <div className="min-w-0">
+            <span className="text-default font-semibold ltr:mr-1 rtl:ml-1 truncate block">{title}</span>{" "}
+            <small className="text-subtle hidden font-normal sm:inline truncate block">
               /{team ? team.slug : userName}/{slug}
             </small>
           </div>


### PR DESCRIPTION
## What does this PR do?
- Fixes #28533

Long event type titles and slugs were overflowing their containers
in the Discord app installation flow, breaking the layout and
overlapping other elements on screen.

This affected two components:
- `EventTypesStepCard` (Step 1 - event type selection list)
- `ConfigureStepCard` (Step 2 - Discord configuration screen)

The fix adds `overflow-hidden` and `min-w-0` to the flex container,
label, and card div elements so long unbroken strings truncate
with `...` instead of escaping their container.

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

**Step 1 - Before & After:**
<img width="1042" height="772" alt="before_1" src="https://github.com/user-attachments/assets/d4c14881-2d9e-4726-97ad-83de3079c25c" />
<img width="1918" height="940" alt="after1" src="https://github.com/user-attachments/assets/ef621647-9ad0-47a4-a42f-c214faf59211" />

**Step 2 - Before & After:**
<img width="1455" height="838" alt="before2" src="https://github.com/user-attachments/assets/311eb8c5-2704-4aa0-a895-a78c76632fe6" />
<img width="1918" height="1010" alt="after2" src="https://github.com/user-attachments/assets/2bf7481b-1a0c-4b6f-93f0-fae03615875b" />

## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create an event type with a very long name with no spaces e.g.
   `FrontendComponentRefactoringDemosaadExtraLongNameForTesting`
2. Go to `http://localhost:3000/apps/installation/event-types?slug=discord`
3. Step 1 - Verify the long title and slug are truncated with `...`
   and stay within the card boundary
4. Select the long event type and click Save
5. Step 2 - Verify the title and slug are truncated with `...`
   and do not overflow the card

**Expected:** Text truncates with ellipsis, layout remains clean

**Before fix:** Text overflows container and breaks layout