### PR TITLE
fix: validate location URLs using URL constructor in CalEventParser

### DIFF
--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -14,6 +14,7 @@ import type {
 } from "@calcom/types/Calendar";
 
 import { WEBAPP_URL } from "./constants";
+import { isValidHttpUrl } from "./isValidHttpUrl";
 import isSmsCalEmail from "./isSmsCalEmail";
 import {
   buildPlatformCancelLink,
@@ -205,15 +206,8 @@ export const getProviderName = (location?: string | null): string => {
     }
     return locationName[0].toUpperCase() + locationName.slice(1);
   }
-  if (location) {
-    try {
-      const url = new URL(location);
-      if (url.protocol === "http:" || url.protocol === "https:") {
-        return location;
-      }
-    } catch {
-      // Not a valid URL — fall through
-    }
+  if (location && isValidHttpUrl(location)) {
+    return location;
   }
   return "";
 };

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -205,9 +205,15 @@ export const getProviderName = (location?: string | null): string => {
     }
     return locationName[0].toUpperCase() + locationName.slice(1);
   }
-  // If location its a url, probably we should be validating it with a custom library
-  if (location && /^https?:\/\//.test(location)) {
-    return location;
+  if (location) {
+    try {
+      const url = new URL(location);
+      if (url.protocol === "http:" || url.protocol === "https:") {
+        return location;
+      }
+    } catch {
+      // Not a valid URL — fall through
+    }
   }
   return "";
 };

--- a/packages/lib/isValidHttpUrl.ts
+++ b/packages/lib/isValidHttpUrl.ts
@@ -1,0 +1,8 @@
+export function isValidHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Replaces regex-based URL check (`/^https?:\/\//`) with proper `URL` constructor validation in `getProviderName`
- Removes the stale TODO comment — `packages/lib` must not import from `@calcom/app-store` per [architecture rules](https://github.com/calcom/cal.com/blob/main/agents/rules/architecture-circular-dependencies.md)

## Context
Addresses review feedback from [#28242](https://github.com/calcom/cal.com/pull/28242#discussion_r2875970575), where @romitg2 requested using an existing library/function for URL validation rather than simply removing the comment.

The `URL` constructor is already used for validation elsewhere in `packages/lib` (e.g., `getSafeRedirectUrl.ts`) and requires no additional dependencies.

## Test plan
- [ ] No functional changes — URL validation behavior is preserved with stricter parsing
- [ ] `yarn type-check:ci --force` passes