### PR TITLE
chore: remove duplicate translation keys in en/common.json

### DIFF
--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4578,7 +4578,6 @@
     "host_no_show_updated": "Host no-show updated",
     "attendee_no_show_updated": "Attendee no-show updated",
     "no_show_updated": "No-show updated",
-    "rejected": "Rejected",
     "attendee_removed": "Attendee removed",
     "reassignment": "Reassignment",
     "booking_reassigned_to_host": "Booking reassigned to {{host}}",
@@ -4591,10 +4590,7 @@
     "assignment_type_manual": "Manual",
     "assignment_type_round_robin": "Round robin",
     "actor_impersonated_by": "Impersonator",
-    "source": "Source",
     "error_processing": "Unable to load details - {{actionType}}",
-    "attendees": "Attendees",
-    "host": "Host",
     "attendee_no_show_status_yes": "{{email}}: Yes",
     "attendee_no_show_status_no": "{{email}}: No",
     "host_no_show_status_yes": "{{name}}: Yes",
@@ -4665,8 +4661,7 @@
     "event_booking_limit": "Event Booking Limit",
     "event_duration_limit": "Event Duration Limit",
     "team_booking_limit": "Team Booking Limit",
-    "buffer_time": "Buffer Time",
-    "calendar": "Calendar"
+    "buffer_time": "Buffer Time"
   },
   "invoice_number": "Invoice #",
   "payment_method": "Payment Method",


### PR DESCRIPTION
## What does this PR do?

Remove 5 duplicate translation keys in `packages/i18n/locales/en/common.json` that appear twice with identical values: `rejected`, `source`, `attendees`, `host`, and `calendar`.

JSON parsers silently use the last occurrence for duplicate keys, but duplicate keys are invalid per RFC 8259 and cause confusion when editing translations.

**What did NOT change**: No translation values were modified. Only the second (duplicate) occurrence of each key was removed. The first occurrence remains in its original position.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — removing duplicate JSON keys requires no test changes.

## How should this be tested?

1. Verify `packages/i18n/locales/en/common.json` is valid JSON: `python3 -c "import json; json.load(open('packages/i18n/locales/en/common.json'))"`
2. Verify the 5 keys (`rejected`, `source`, `attendees`, `host`, `calendar`) still exist exactly once each
3. Verify no translation behavior changes — the values are identical to what JSON.parse was already using (last occurrence)

## What I Did NOT Verify

- Other locale files (fr, de, etc.) may also have duplicate keys — this PR only addresses `en/common.json`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings