### PR TITLE
fix(bookings): map cal-api-version 2026-02-25 to latest supported version

### DIFF
--- a/apps/api/v2/src/bootstrap.ts
+++ b/apps/api/v2/src/bootstrap.ts
@@ -5,6 +5,8 @@ import {
   API_VERSIONS_ENUM,
   CAL_API_VERSION_HEADER,
   VERSION_2024_04_15,
+  VERSION_2026_02_25,
+  VERSION_2024_08_13,
   X_CAL_CLIENT_ID,
   X_CAL_PLATFORM_EMBED,
   X_CAL_SECRET_KEY,
@@ -33,6 +35,10 @@ export const bootstrap = (app: NestExpressApplication): NestExpressApplication =
       extractor: (request: unknown) => {
         const headerVersion = (request as Request)?.headers[CAL_API_VERSION_HEADER] as string | undefined;
         if (headerVersion && API_VERSIONS.includes(headerVersion as API_VERSIONS_ENUM)) {
+          // If cal-api-version is 2026-02-25, then redirect to VERSION_2024_08_13
+          if (headerVersion === VERSION_2026_02_25) {
+            return VERSION_2024_08_13;
+          }
           return headerVersion;
         }
         return VERSION_2024_04_15;

--- a/packages/platform/constants/api.ts
+++ b/packages/platform/constants/api.ts
@@ -58,6 +58,7 @@ export const VERSION_2024_06_11 = "2024-06-11";
 export const VERSION_2024_04_15 = "2024-04-15";
 export const VERSION_2024_08_13 = "2024-08-13";
 export const VERSION_2024_09_04 = "2024-09-04";
+export const VERSION_2026_02_25 = "2026-02-25";
 
 export const API_VERSIONS = [
   VERSION_2024_06_14,
@@ -65,6 +66,7 @@ export const API_VERSIONS = [
   VERSION_2024_04_15,
   VERSION_2024_08_13,
   VERSION_2024_09_04,
+  VERSION_2026_02_25,
 ] as const;
 
 export type API_VERSIONS_ENUM = (typeof API_VERSIONS)[number];


### PR DESCRIPTION
## What does this PR do?

- Fixes #28512

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
### What I did :
Maps "cal-api-version : 2026-02-25" requests to the existing latest bookings version ie; "cal-api-version : 2024-08-13".

### Problem & Solution : 
This fixes an issue where every request with the "cal-api-version: 2026-02-25" header was passed to the api version "cal-api-version : 2024-04-15" - causing attendeeEmail filtering bug. It was fixed by redirecting the same request to the latest existing version in the api v2 ie;  "cal-api-version : 2024-08-13".

### Why choose this solution :
Did the above instead of modifying the code associated with "cal-api-version : 2024-04-15" (the Default fallback when unknown version headers are encountered) - because we can build upon this for structuring the new Api version 2026-02-25, instead of relying on changing the old version (cal-api-version : 2024-04-15) again and again whenever bugs are encountered.

##### Long term goal :
Using the above approach, we can implement a dedicated 2026-02-25 version controller if/when it's needed. 


## Visual Demo (For contributors especially)

#### Video Demo (if applicable):

### Reproduction of issue : 

The attendeeEmail query parameter on the GET /v2/bookings endpoint does not filter bookings. It returns all bookings regardless of the specified attendee email when "cal-api-version" header value is 2026-02-25.

https://github.com/user-attachments/assets/13d49706-5f87-4d6f-8af9-9ad800605dce


### After fix : 

Returns bookings only for the specified attendee email.

https://github.com/user-attachments/assets/4b4944da-2671-47b1-aa4d-c45140617df4


## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->
### Setup : 
1. Webapp ->
- yarn dx
- Generate CALCOM_API_KEY (Authorization key)
2. API V2 -> 
- yarn dev (from api/v2 package)

### Testing : 
1. Create 3 bookings with different attendee emails:
  - attendee-a@example.com
  - attendee-b@example.com
  - attendee-c@example.com
2. Call API V2:
GET /v2/bookings?take=100&eventTypeId={eventTypeId}&attendeeEmail=attendee-a%40example.com
 
 ### Before fix :
 1. Input : 
- GET /v2/bookings?take=100&eventTypeId={eventTypeId}&attendeeEmail=attendee-a%40example.com
2. Output:
 - Result contains all scheduled bookings
 
### After fix :
1. Output:
 - Result only contains the booking of `attendee-a@example.com`
