### PR TITLE
fix(platform-atoms): correct copy-paste oversights in providers, hooks, and http helpers

### DIFF
--- a/packages/platform/atoms/cal-provider/CalOAuthProvider.tsx
+++ b/packages/platform/atoms/cal-provider/CalOAuthProvider.tsx
@@ -25,6 +25,9 @@ type CalOAuthProviderProps = Omit<BaseCalProviderProps, "isOAuth2">;
  * @param {string} [options.refreshUrl] - The url point to your refresh endpoint. - Optional, required if accessToken is provided.
  * @param {boolean} [autoUpdateTimezone=true] - Whether to automatically update the timezone. - Optional
  * @param {function} props.onTimezoneChange - The callback function for timezone change. - Optional
+ * @param {function} props.onTokenRefreshStart - The callback function called when token refresh starts. - Optional
+ * @param {function} props.onTokenRefreshSuccess - The callback function called when token refresh succeeds. - Optional
+ * @param {function} props.onTokenRefreshError - The callback function called when token refresh fails. - Optional
  * @param {ReactNode} props.children - The child components. - Optional
  * @returns {JSX.Element} The rendered CalProvider component.
  */
@@ -37,6 +40,9 @@ export function CalOAuthProvider({
   labels,
   language = "en",
   onTimezoneChange,
+  onTokenRefreshStart,
+  onTokenRefreshSuccess,
+  onTokenRefreshError,
   version = VERSION_2024_06_14,
   organizationId,
   isEmbed = false,
@@ -62,6 +68,9 @@ export function CalOAuthProvider({
         isOAuth2={true}
         autoUpdateTimezone={autoUpdateTimezone}
         onTimezoneChange={onTimezoneChange}
+        onTokenRefreshStart={onTokenRefreshStart}
+        onTokenRefreshSuccess={onTokenRefreshSuccess}
+        onTokenRefreshError={onTokenRefreshError}
         clientId={clientId}
         accessToken={accessToken}
         options={options}

--- a/packages/platform/atoms/hooks/event-types/private/useEventTypeById.ts
+++ b/packages/platform/atoms/hooks/event-types/private/useEventTypeById.ts
@@ -20,5 +20,6 @@ export const useEventTypeById = (id: number | null) => {
         throw new Error(res.data.error.message);
       });
     },
+    enabled: id !== null,
   });
 };

--- a/packages/platform/atoms/lib/http.ts
+++ b/packages/platform/atoms/lib/http.ts
@@ -48,11 +48,11 @@ const http = (function () {
     getPlatformEmbedHeader: () => {
       return instance.defaults.headers.common?.[X_CAL_PLATFORM_EMBED]?.toString() ?? "";
     },
-    setVersionHeader: (clientId: string) => {
-      instance.defaults.headers.common[CAL_API_VERSION_HEADER] = clientId;
+    setVersionHeader: (version: string) => {
+      instance.defaults.headers.common[CAL_API_VERSION_HEADER] = version;
     },
     getVersionHeader: () => {
-      return instance.defaults.headers.common?.[X_CAL_CLIENT_ID]?.toString() ?? "";
+      return instance.defaults.headers.common?.[CAL_API_VERSION_HEADER]?.toString() ?? "";
     },
     refreshTokens: async (refreshUrl: string): Promise<string> => {
       const response = await fetch(`${refreshUrl}`, {


### PR DESCRIPTION
## What does this PR do?

Fixes three small bugs in `packages/platform/atoms` that share a common root cause: props or constants were copied from a sibling implementation but not fully updated for the new context.

**1. CalOAuthProvider silently drops token refresh callbacks**

`CalOAuthProvider` inherits `Omit<BaseCalProviderProps, "isOAuth2">`, which includes `onTokenRefreshStart`, `onTokenRefreshSuccess`, and `onTokenRefreshError`. However, it never destructures or forwards them to `BaseCalProvider`. Consumers can pass these callbacks without a type error, but they are quietly ignored.

`CalProvider` already destructures and forwards all three — `CalOAuthProvider` was created from it as a template and these were missed. `BaseCalProvider` passes them through to [`useOAuthFlow`](https://github.com/calcom/cal.com/blob/main/packages/platform/atoms/hooks/useOAuthFlow.ts), which invokes them during the HTTP 498 token-refresh interceptor cycle, so OAuth2 consumers currently have no way to observe refresh events.

**2. `useEventTypeById` fires a request to `/event-types/null` when id is null**

The hook accepts `id: number | null` but has no `enabled` guard on its `useQuery` call. When `id` is `null` (which happens on initial render — [`BookerStore.eventId`](https://github.com/calcom/cal.com/blob/main/packages/features/bookings/Booker/store.ts#L515) initialises as `null`), the pathname resolves to the string `"/event-types/null"` and the request fails. Every other nullable-parameter hook in the same package already guards against this (`useBooking` uses `enabled: !!uid`, `useSchedule` uses `enabled: isInit`, etc.).

**3. `getVersionHeader` reads the wrong header constant**

`setVersionHeader` writes to `CAL_API_VERSION_HEADER` (`"cal-api-version"`) but `getVersionHeader` reads from `X_CAL_CLIENT_ID` (`"x-cal-client-id"`). The pair was copied from `setClientIdHeader`/`getClientIdHeader` — the setter's key was updated but the getter's key was not. The parameter name `clientId` in `setVersionHeader` is a leftover from the same copy; callers already pass it as `http.setVersionHeader(version)`. This change restores setter/getter consistency with every other header pair in the file.

## How should this be tested?

1. Render `<CalOAuthProvider>` with `onTokenRefreshStart`/`onTokenRefreshSuccess`/`onTokenRefreshError` and trigger a token refresh — the callbacks should now fire
2. Load a booking form where `eventId` starts as `null` in the booker store and check the network tab — no `/event-types/null` requests should appear
3. Call `http.setVersionHeader("2024-06-14")` followed by `http.getVersionHeader()` — it should return `"2024-06-14"`

Existing behaviour without these props/parameters is unchanged; all three are optional and guarded.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — internal platform atoms, no public docs affected.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — no existing test coverage for these files; changes are mechanical and verified against sibling implementations.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings