### PR TITLE
feat: take into account guest's availability when rescheduling

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
+++ b/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
@@ -5,8 +5,10 @@ import type { Dayjs } from "@calcom/dayjs";
 import { checkForConflicts } from "@calcom/features/bookings/lib/conflictChecker/checkForConflicts";
 import { getBusyTimesService } from "@calcom/features/di/containers/BusyTimes";
 import { getUserAvailabilityService } from "@calcom/features/di/containers/GetUserAvailability";
+import { getUserRepository } from "@calcom/features/di/containers/UserRepository";
 import { buildDateRanges } from "@calcom/features/schedules/lib/date-ranges";
 import { ErrorCode } from "@calcom/lib/errorCodes";
+import { filterValidGuestUsers } from "@calcom/lib/availability";
 import { parseBookingLimit } from "@calcom/lib/intervalLimits/isBookingLimits";
 import { parseDurationLimit } from "@calcom/lib/intervalLimits/isDurationLimits";
 import { getPiiFreeUser } from "@calcom/lib/piiFreeData";
@@ -112,6 +114,57 @@ const _ensureAvailableUsers = async (
       busyTimesFromLimitsBookings: busyTimesFromLimitsBookingsAllUsers,
     },
   });
+
+  if (input.originalRescheduledBooking) {
+    const attendeeEmails = input.originalRescheduledBooking.attendees.map((a) => a.email);
+    const userRepo = getUserRepository();
+    const guestUsers = await userRepo.findManyByEmailsForAvailability(attendeeEmails);
+
+    if (guestUsers.length > 0) {
+      const hostEmails = eventType.users.map((u) => u.email);
+      const filteredGuestUsers = filterValidGuestUsers(guestUsers, hostEmails);
+
+      if (filteredGuestUsers.length > 0) {
+        const guestAvailabilities = await userAvailabilityService.getUsersAvailability({
+          users: filteredGuestUsers,
+          query: {
+            ...input,
+            eventTypeId: eventType.id,
+            duration: originalBookingDuration,
+            returnDateOverrides: false,
+            dateFrom: startDateTimeUtc.format(),
+            dateTo: endDateTimeUtc.format(),
+            beforeEventBuffer: eventType.beforeEventBuffer,
+            afterEventBuffer: eventType.afterEventBuffer,
+            bypassBusyCalendarTimes: false,
+            mode,
+            withSource: true,
+          },
+          initialData: {
+            eventType,
+            rescheduleUid: input.originalRescheduledBooking?.uid ?? null,
+          },
+        });
+
+        for (const guestAvail of guestAvailabilities) {
+          const { oooExcludedDateRanges: dateRanges, busy: bufferedBusyTimes } = guestAvail;
+          if (!dateRanges.length || !hasDateRangeForBooking(dateRanges, startDateTimeUtc, endDateTimeUtc)) {
+            loggerWithEventDetails.error(`Guest user does not have availability at this time.`);
+            throw new Error(ErrorCode.NoAvailableUsersFound);
+          }
+          const foundConflict = checkForConflicts({
+            busy: bufferedBusyTimes,
+            time: startDateTimeUtc,
+            eventLength: duration,
+          });
+          if (foundConflict) {
+            loggerWithEventDetails.error(`Guest user has a conflict at this time.`);
+            throw new Error(ErrorCode.NoAvailableUsersFound);
+          }
+        }
+      }
+    }
+  }
 
   const piiFreeInputDataForLogging = safeStringify({
     startDateTimeUtc,

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1327,6 +1327,41 @@ export class UserRepository {
     });
   }
 
+  async findManyByEmailsForAvailability(emails: string[]) {
+    if (!emails.length) return [];
+    const normalizedEmails = Array.from(new Set(emails.map((email) => email.toLowerCase().trim())));
+    return this.prismaClient.user.findMany({
+      where: {
+        OR: [
+          {
+            email: {
+              in: normalizedEmails,
+              mode: "insensitive",
+            },
+          },
+          {
+            secondaryEmails: {
+              some: {
+                email: {
+                  in: normalizedEmails,
+                  mode: "insensitive",
+                },
+              },
+            },
+          },
+        ],
+      },
+      select: {
+        locked: true,
+        allowDynamicBooking: true,
+        ...availabilityUserSelect,
+        credentials: {
+          select: credentialForCalendarServiceSelect,
+        },
+      },
+    });
+  }
+
   async findUsersByIds(userIds: number[]) {
     return this.prismaClient.user.findMany({
       where: {

--- a/packages/lib/availability.ts
+++ b/packages/lib/availability.ts
@@ -162,3 +162,21 @@ export function availabilityAsString(
 
   return `${weekSpan(availability)}, ${timeSpan(availability)}`;
 }
+
+export const normalizeEmail = (e: string) => e.trim().toLowerCase();
+
+/** Shared filter to identify valid Cal.com guests with connected calendars */
+export function filterValidGuestUsers<T extends { email: string; credentials?: any[] }>(
+  guestUsers: T[],
+  hostEmails: string[]
+) {
+  const hostEmailSet = new Set(hostEmails.map(normalizeEmail));
+
+  return guestUsers.filter(
+    (gu) =>
+      !hostEmailSet.has(normalizeEmail(gu.email)) &&
+      Array.isArray(gu.credentials) &&
+      gu.credentials.length > 0
+  );
+}
+

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -30,6 +30,7 @@ import type { NoSlotsNotificationService } from "@calcom/features/slots/handleNo
 import type { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { withSelectedCalendars } from "@calcom/features/users/repositories/UserRepository";
 import { filterBlockedHosts } from "@calcom/features/watchlist/operations/filter-blocked-hosts.controller";
+import { filterValidGuestUsers } from "@calcom/lib/availability";
 import { shouldIgnoreContactOwner } from "@calcom/lib/bookings/routing/utils";
 import { RESERVED_SUBDOMAINS } from "@calcom/lib/constants";
 import { getUTCOffsetByTimezone } from "@calcom/lib/dayjs";
@@ -1237,7 +1238,34 @@ export class AvailableSlotsService {
       ? await filterBlockedHosts(allFallbackRRHosts, organizationId)
       : { eligibleHosts: [] };
 
-    const allHosts = [...eligibleQualifiedRRHosts, ...eligibleFixedHosts];
+    let guestHosts: {
+      isFixed: boolean;
+      user: GetAvailabilityUserWithDelegationCredentials;
+    }[] = [];
+
+    if (input.rescheduleUid) {
+      const originalBooking = await this.dependencies.bookingRepo.findByUidIncludeEventTypeAttendeesAndUser({
+        bookingUid: input.rescheduleUid,
+      });
+
+      if (originalBooking) {
+        const attendeeEmails = originalBooking.attendees.map((a) => a.email);
+        const guestUsers = await this.dependencies.userRepo.findManyByEmailsForAvailability(attendeeEmails);
+        const hostEmails = [...qualifiedRRHosts, ...fixedHosts].map((h) => h.user.email);
+
+        const filteredGuestUsers = filterValidGuestUsers(guestUsers, hostEmails);
+
+        guestHosts = filteredGuestUsers.map((gu) => ({
+          isFixed: true,
+          user: {
+            ...gu,
+            credentials: buildNonDelegationCredentials(gu.credentials),
+          },
+        }));
+      }
+    }
+
+    const allHosts = [...eligibleQualifiedRRHosts, ...eligibleFixedHosts, ...guestHosts];
 
     // If all hosts are blocked, return empty slots
     if (allHosts.length === 0) {
@@ -1291,7 +1319,7 @@ export class AvailableSlotsService {
           const firstTwoWeeksAvailabilities = await this.calculateHostsAndAvailabilities({
             input,
             eventType,
-            hosts: [...eligibleQualifiedRRHosts, ...eligibleFixedHosts],
+            hosts: [...eligibleQualifiedRRHosts, ...eligibleFixedHosts, ...guestHosts],
             loggerWithEventDetails,
             startTime: dayjs(),
             endTime: twoWeeksFromNow,
@@ -1327,7 +1355,7 @@ export class AvailableSlotsService {
           await this.calculateHostsAndAvailabilities({
             input,
             eventType,
-            hosts: [...eligibleFallbackRRHosts, ...eligibleFixedHosts],
+            hosts: [...eligibleFallbackRRHosts, ...eligibleFixedHosts, ...guestHosts],
             loggerWithEventDetails,
             startTime,
             endTime,


### PR DESCRIPTION
/claim #16378
Rather than post-filtering slots, this PR treats Cal.com guests as fixed hosts in the availability calculation pipeline, so the entire existing availability engine handles conflict detection natively  including buffers, OOO periods, and calendar integrations

A second validation layer is also added at booking confirmation time to close any race condition between slot display and actual booking.
Changes
UserRepository.ts  Added findManyByEmailsForAvailability():

Fetches all attendees in a single batch query (no N+1)
Normalizes emails and supports secondary emails
Only selects users with connected calendar credentials

availability.ts Added filterValidGuestUsers():

Shared utility to filter out guests who are also hosts (deduplication)
Only includes guests with connected calendars

slots/util.ts  Injects valid guest users as fixed hosts into the availability calculation so mutual availability is computed natively
ensureAvailableUsers.ts  Added confirmation-time validation to ensure guest availability is re-checked when the booking is actually confirmed
Notes

Non-Cal.com guests and guests without connected calendars are gracefully skipped
The booking being rescheduled is excluded from busy time calculations