### PR TITLE
fix: remove shared pbac feature flag deletion from e2e test cleanup

### DIFF
--- a/apps/api/v2/src/modules/organizations/roles/organizations-roles.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/roles/organizations-roles.controller.e2e-spec.ts
@@ -626,12 +626,6 @@ describe("Organizations Roles Endpoints", () => {
       await userRepositoryFixture.deleteByEmail(pbacOrgUserWithRolePermission.email);
       await userRepositoryFixture.deleteByEmail(pbacOrgUserWithoutRolePermission.email);
       await userRepositoryFixture.deleteByEmail(nonOrgUser.email);
-
-      try {
-        await featuresRepositoryFixture.deleteBySlug("pbac");
-      } catch (error) {
-        console.error("Cleanup error:", error);
-      }
     } catch (error) {
       console.error("Cleanup error:", error);
     } finally {

--- a/apps/api/v2/src/modules/organizations/roles/permissions/organizations-roles-permissions.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/roles/permissions/organizations-roles-permissions.controller.e2e-spec.ts
@@ -382,13 +382,6 @@ describe("Organizations Roles Permissions Endpoints", () => {
 
       // Clean up user
       await userRepositoryFixture.deleteByEmail(pbacOrgUserWithRolePermission.email);
-
-      // Clean up feature definition
-      try {
-        await featuresRepositoryFixture.deleteBySlug("pbac");
-      } catch (err) {
-        console.log(err);
-      }
     } catch (err) {
       console.log(err);
     } finally {

--- a/apps/api/v2/src/modules/organizations/teams/roles/organizations-teams-roles.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/teams/roles/organizations-teams-roles.controller.e2e-spec.ts
@@ -457,12 +457,6 @@ describe("Organizations Roles Endpoints", () => {
       await userRepositoryFixture.deleteByEmail(pbacOrgUserWithRolePermission.email);
       await userRepositoryFixture.deleteByEmail(pbacOrgUserWithoutRolePermission.email);
       await userRepositoryFixture.deleteByEmail(nonOrgUser.email);
-
-      try {
-        await featuresRepositoryFixture.deleteBySlug("pbac");
-      } catch (error) {
-        console.error("Cleanup error:", error);
-      }
     } catch (error) {
       console.error("Cleanup error:", error);
     } finally {

--- a/apps/api/v2/src/modules/organizations/teams/roles/permissions/organizations-teams-roles-permissions.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/teams/roles/permissions/organizations-teams-roles-permissions.controller.e2e-spec.ts
@@ -274,13 +274,6 @@ describe("Organizations Teams Roles Permissions Endpoints", () => {
 
       // Clean up user
       await userRepositoryFixture.deleteByEmail(pbacOrgUserWithRolePermission.email);
-
-      // Clean up feature definition
-      try {
-        await featuresRepositoryFixture.deleteBySlug("pbac");
-      } catch (err) {
-        console.log(err);
-      }
     } catch (err) {
       console.log(err);
     } finally {


### PR DESCRIPTION
## What does this PR do?

Fixes flaky PBAC-related API v2 e2e tests caused by parallel test suites deleting a shared global resource.

Each PBAC e2e test suite creates the global `"pbac"` feature definition in `beforeAll` and was also deleting it in `afterAll` via `featuresRepositoryFixture.deleteBySlug("pbac")`. When multiple suites run concurrently, one suite's cleanup would delete the feature while other suites still depend on it, causing intermittent failures.

This PR removes the global feature definition deletion from `afterAll` in 4 test files. Each suite still properly cleans up its own **team-level** feature flag association (`deleteTeamFeature`), organizations, and users — only the shared global definition deletion is removed.

### Files changed:
- `organizations-roles.controller.e2e-spec.ts`
- `organizations-roles-permissions.controller.e2e-spec.ts`
- `organizations-teams-roles.controller.e2e-spec.ts`
- `organizations-teams-roles-permissions.controller.e2e-spec.ts`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the PBAC e2e test suites in parallel multiple times to confirm no more intermittent failures:

```bash
yarn test -- --testPathPattern="organizations-roles|organizations-teams-roles"
```

Previously this would intermittently fail with errors related to the `"pbac"` feature not being found. After this fix, suites no longer interfere with each other's feature flag state.

## Human Review Checklist

- [x] Verify that `featuresRepositoryFixture.create({ slug: "pbac" })` in `beforeAll` handles the already-exists case gracefully (upsert/idempotent), since no suite deletes it anymore
- [x] Confirm `deleteTeamFeature()` calls are still present in each file's `afterAll` (team-level cleanup is untouched)

Link to Devin session: https://app.devin.ai/sessions/7951183cda2a4803b1182bb346c81c47
Requested by: @emrysal