### PR TITLE
fix: resolve flaky team-management E2E test

### DIFF
--- a/apps/web/playwright/organization/team-management.e2e.ts
+++ b/apps/web/playwright/organization/team-management.e2e.ts
@@ -29,8 +29,9 @@ test.describe("Teams", () => {
     await page.goto("/teams");
 
     await test.step("Can create team", async () => {
-      // Click the new team button
-      await page.locator("[data-testid=new-team-btn]").click();
+      // Click the new team button (use .first() because the fab variant button may
+      // appear twice in the DOM during Next.js streaming/hydration)
+      await page.locator("[data-testid=new-team-btn]").first().click();
       await page.waitForLoadState("networkidle");
       // Fill team name input (new onboarding-v3 style flow)
       await page.locator('[data-testid="team-name-input"]').fill(`${user.username}'s Team`);
@@ -63,7 +64,9 @@ test.describe("Teams", () => {
       await page.getByTestId("disband-team-button").click();
       await page.getByTestId("dialog-confirmation").click();
       await page.waitForURL("/teams");
-      expect(await page.locator(`text=${user.username}'s Team`).count()).toEqual(0);
+      // Use auto-retrying assertion instead of a raw count check so Playwright
+      // waits for the UI to update after the team is disbanded.
+      await expect(page.locator(`text=${user.username}'s Team`)).toBeHidden({ timeout: 10000 });
 
       // Cleanup the invited user since they were created without our fixtures
       const invitedUser = await prisma.user.findUnique({ where: { email: inviteeEmail } });

--- a/apps/web/playwright/organization/team-management.e2e.ts
+++ b/apps/web/playwright/organization/team-management.e2e.ts
@@ -29,8 +29,6 @@ test.describe("Teams", () => {
     await page.goto("/teams");
 
     await test.step("Can create team", async () => {
-      // Click the new team button (use .first() because the fab variant button may
-      // appear twice in the DOM during Next.js streaming/hydration)
       await page.locator("[data-testid=new-team-btn]").first().click();
       await page.waitForLoadState("networkidle");
       // Fill team name input (new onboarding-v3 style flow)
@@ -64,8 +62,6 @@ test.describe("Teams", () => {
       await page.getByTestId("disband-team-button").click();
       await page.getByTestId("dialog-confirmation").click();
       await page.waitForURL("/teams");
-      // Use auto-retrying assertion instead of a raw count check so Playwright
-      // waits for the UI to update after the team is disbanded.
       await expect(page.locator(`text=${user.username}'s Team`)).toBeHidden({ timeout: 10000 });
 
       // Cleanup the invited user since they were created without our fixtures


### PR DESCRIPTION
## What does this PR do?

Fixes two intermittent failure modes in the `organization/team-management.e2e.ts` "Can create teams via Wizard" test:

1. **Strict mode violation (line 32):** `locator('[data-testid=new-team-btn]')` resolves to 2 elements during Next.js streaming/hydration, causing Playwright's strict mode to reject the `.click()`. Fixed by using `.first()`.

2. **Race condition in disband assertion (line 65):** The raw `.count()` check executes immediately after `waitForURL` resolves, before the UI finishes re-rendering post-deletion. Replaced with Playwright's auto-retrying `toBeHidden()` assertion (10s timeout).

**Test-only change** — no production code modified.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — test-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the E2E test suite shard that includes `organization/team-management.e2e.ts` (shard 8/10 in CI). The test should pass consistently without strict mode violations or count assertion failures.

```bash
PLAYWRIGHT_HEADLESS=1 yarn e2e organization/team-management.e2e.ts
```

## Checklist

- [x] `.first()` is acceptable — the duplicate `[data-testid=new-team-btn]` element is a transient Next.js streaming artifact (both `<a>` tags are identical). An alternative would be to investigate the root cause in the UI layer.
- [x] `toBeHidden()` is semantically correct for the disband check. A closer 1:1 replacement would be `toHaveCount(0)` (also auto-retrying). `toBeHidden()` also passes if the element exists but is not visible, which is slightly broader but safe here since the team row is fully removed from the DOM after disbanding.

Link to Devin session: https://app.devin.ai/sessions/9bc0ddddc7654ee4ba07bc14f75c1343
Requested by: @romitg2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
