### PR TITLE
fix: correct routing form field reference in e2e test for queued response creation

### DIFF
--- a/apps/api/v2/src/modules/organizations/teams/routing-forms/controllers/organizations-teams-routing-forms-responses.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/teams/routing-forms/controllers/organizations-teams-routing-forms-responses.controller.e2e-spec.ts
@@ -163,7 +163,7 @@ describe("Organizations Teams Routing Forms Responses", () => {
               "rule-1": {
                 type: "rule",
                 properties: {
-                  field: "question1",
+                  field: "question2-field",
                   operator: "equal",
                   value: ["answer1"],
                   valueSrc: ["value"],
@@ -434,6 +434,7 @@ describe("Organizations Teams Routing Forms Responses", () => {
         .set({ Authorization: `Bearer cal_test_${apiKeyString}` })
         .send({
           participant: "test-participant",
+          question2: "answer1",
         })
         .expect(201)
         .then((response) => {


### PR DESCRIPTION
## What does this PR do?

Fixes a broken e2e test (`should handle queued response creation`) in the organizations teams routing forms responses controller.

The test's routing form had `route-1` referencing field `"question1"` in its `queryValue`, but the form only defines fields `"participant-field"` and `"question2-field"`. This mismatch meant:
1. Route-1 could never match (the field doesn't exist), so the fallback `customPageMessage` route was always selected
2. The assertion `expect(data.routing?.queuedResponseId).toBeDefined()` would always fail because `customPageMessage` responses don't include routing/queuedResponseId data
3. With upcoming validation that rejects forms where routes reference non-existent fields (PR #24593), this also causes a 400 error before even reaching routing logic

**Fix:**
- Changed route-1's field reference from `"question1"` → `"question2-field"` (a field that exists in the form)
- Added `question2: "answer1"` to the test request body so route-1 actually matches, routing to `eventTypeRedirectUrl` and producing a `queuedResponseId`

## Visual Demo (For contributors especially)

N/A — test-only change, no UI impact.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the API v2 e2e test suite for routing forms:
```bash
yarn jest --config apps/api/v2/jest-e2e.json organizations-teams-routing-forms-responses.controller.e2e-spec.ts
```

The `should handle queued response creation` test should pass with a 201 response and `data.routing.queuedResponseId` defined.

## Important Review Notes

- **Verify the field reference**: Confirm `"question2-field"` matches an actual field ID in the routing form created at line 149 of the test file
- **Verify the test exercises the right path**: With `question2: "answer1"` in the body, route-1 (`question2-field == answer1`) should match → `eventTypeRedirectUrl` action → queued response with `queuedResponseId`
- **Other tests unaffected**: The remaining `field: "question1"` references in this file (lines 466, 558, 633) are in self-contained routing forms that define their own `id: "question1"` field, so they are correctly configured

Link to Devin session: https://app.devin.ai/sessions/3a1f511642844a8a93537b33703093d6
Requested by: @romitg2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
