### PR TITLE
fix(account): remove SendGrid marketing contact on user deletion

### DIFF
--- a/packages/lib/Sendgrid.ts
+++ b/packages/lib/Sendgrid.ts
@@ -39,7 +39,41 @@ export type SendgridNewContact = {
   job_id: string;
 };
 
+type SendgridContactSearchByEmailResult = {
+  result?: Record<
+    string,
+    {
+      contact?: {
+        id?: string;
+      };
+    }
+  >;
+};
+
 const environmentApiKey = process.env.SENDGRID_SYNC_API_KEY || "";
+
+export async function deleteContactFromSendgrid(email: string) {
+  const apiKey = process.env.SENDGRID_API_KEY;
+  if (!apiKey) return;
+
+  const sendgrid = new Sendgrid(apiKey);
+  const searchResponse = await sendgrid.sendgridRequest<SendgridContactSearchByEmailResult>({
+    url: `/v3/marketing/contacts/search/emails`,
+    method: "POST",
+    body: {
+      emails: [email],
+    },
+  });
+
+  const contactResult = searchResponse.result?.[email];
+  const contactId = contactResult?.contact?.id;
+  if (!contactId) return;
+
+  await sendgrid.sendgridRequest({
+    url: `/v3/marketing/contacts?ids=${encodeURIComponent(contactId)}`,
+    method: "DELETE",
+  });
+}
 
 /**
  * This class to instance communicating to Sendgrid APIs requires an API Key.

--- a/packages/trpc/server/routers/viewer/me/deleteMe.handler.ts
+++ b/packages/trpc/server/routers/viewer/me/deleteMe.handler.ts
@@ -2,6 +2,7 @@ import { ErrorCode } from "@calcom/features/auth/lib/ErrorCode";
 import { verifyPassword } from "@calcom/features/auth/lib/verifyPassword";
 import { deleteUser } from "@calcom/features/users/lib/deleteUser";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
+import { deleteContactFromSendgrid } from "@calcom/lib/Sendgrid";
 import { HttpError } from "@calcom/lib/http-error";
 import { totpAuthenticatorCheck } from "@calcom/lib/totp";
 import { prisma } from "@calcom/prisma";
@@ -83,5 +84,12 @@ export const deleteMeHandler = async ({ ctx, input }: DeleteMeOptions) => {
   }
 
   await deleteUser(user);
+
+  try {
+    await deleteContactFromSendgrid(user.email);
+  } catch (error) {
+    console.error(`Failed to delete SendGrid contact for user ${user.id}`, error);
+  }
+
   return;
 };


### PR DESCRIPTION
## What does this PR do?

- Closes #15767
- Fixes CAL-XXXX
- Removes a user from SendGrid Marketing Contacts when account deletion succeeds.
- Uses SendGrid Marketing Contacts API endpoints:
  - POST /v3/marketing/contacts/search/emails to resolve contact ID by email
  - DELETE /v3/marketing/contacts?ids=... to delete the contact by ID
- SendGrid cleanup is non-blocking:
  - skips silently when SENDGRID_API_KEY is not set
  - wraps SendGrid cleanup in try/catch and logs errors without blocking account deletion

Maintainer confirmation / due diligence comment:
- https://github.com/calcom/cal.com/issues/15767#issuecomment-4125876418

## Visual Demo (For contributors especially)

N/A (backend behavior only)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
  - N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Set SENDGRID_API_KEY (or leave unset to validate silent skip behavior).
- Ensure the user email exists in SendGrid Marketing Contacts.
- Delete the account through the existing delete-account flow.
- Expected:
  - account deletion succeeds regardless of SendGrid result
  - with API key + existing contact: contact is removed from SendGrid
  - without API key: deletion still succeeds and SendGrid call is skipped
  - if SendGrid API fails: error is logged and deletion still succeeds

## Checklist

- I haven't read the contributing guide
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs
