### PR TITLE
fix: preserve URL params when redirecting from instant meeting timeout

### DIFF
--- a/apps/web/modules/bookings/components/BookerWebWrapper.tsx
+++ b/apps/web/modules/bookings/components/BookerWebWrapper.tsx
@@ -10,22 +10,22 @@ import {
 } from "@calcom/features/bookings/Booker/BookerStoreProvider";
 import { useBookerLayout } from "@calcom/features/bookings/Booker/hooks/useBookerLayout";
 import { useBookingForm } from "@calcom/features/bookings/Booker/hooks/useBookingForm";
+import { useInitializeBookerStore } from "@calcom/features/bookings/Booker/store";
+import { useBrandColors } from "@calcom/features/bookings/Booker/utils/use-brand-colors";
+import type { getPublicEvent } from "@calcom/features/eventtypes/lib/getPublicEvent";
+import { DEFAULT_DARK_BRAND_COLOR, DEFAULT_LIGHT_BRAND_COLOR, WEBAPP_URL } from "@calcom/lib/constants";
+import { useRouterQuery } from "@calcom/lib/hooks/useRouterQuery";
+import { localStorage } from "@calcom/lib/webstorage";
+import { useEvent, useScheduleForEvent } from "@calcom/web/modules/schedules/hooks/useEvent";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useCallback, useEffect, useMemo } from "react";
+import { shallow } from "zustand/shallow";
 import { useBookings } from "../hooks/useBookings";
 import { useCalendars } from "../hooks/useCalendars";
 import { useSlots } from "../hooks/useSlots";
 import { useVerifyCode } from "../hooks/useVerifyCode";
 import { useVerifyEmail } from "../hooks/useVerifyEmail";
-import { useInitializeBookerStore } from "@calcom/features/bookings/Booker/store";
-import { useEvent, useScheduleForEvent } from "@calcom/web/modules/schedules/hooks/useEvent";
-import { useBrandColors } from "@calcom/features/bookings/Booker/utils/use-brand-colors";
-import type { getPublicEvent } from "@calcom/features/eventtypes/lib/getPublicEvent";
-import { DEFAULT_LIGHT_BRAND_COLOR, DEFAULT_DARK_BRAND_COLOR, WEBAPP_URL } from "@calcom/lib/constants";
-import { useRouterQuery } from "@calcom/lib/hooks/useRouterQuery";
-import { localStorage } from "@calcom/lib/webstorage";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useSession } from "next-auth/react";
-import { useCallback, useEffect, useMemo } from "react";
-import { shallow } from "zustand/shallow";
 import { Booker as BookerComponent } from "./Booker";
 
 export type BookerWebWrapperAtomProps = BookerProps & {
@@ -42,11 +42,11 @@ const BookerWebWrapperComponent = (props: BookerWebWrapperAtomProps): JSX.Elemen
   });
   const event = props.eventData
     ? {
-      data: props.eventData,
-      isSuccess: true,
-      isError: false,
-      isPending: false,
-    }
+        data: props.eventData,
+        isSuccess: true,
+        isError: false,
+        isPending: false,
+      }
     : clientFetchedEvent;
 
   const bookerLayout = useBookerLayout(event.data?.profile?.bookerLayouts);
@@ -215,7 +215,16 @@ const BookerWebWrapperComponent = (props: BookerWebWrapperAtomProps): JSX.Elemen
     <BookerComponent
       {...props}
       onGoBackInstantMeeting={() => {
-        if (pathname) window.location.href = pathname;
+        if (pathname) {
+          const currentParams = new URLSearchParams(window.location.search);
+          // Strip instant meeting specific params while preserving all others
+          // (e.g. routed team members, metadata, etc.)
+          currentParams.delete("isInstantMeeting");
+          currentParams.delete("bookingId");
+          currentParams.delete("bookingUid");
+          const remainingParams = currentParams.toString();
+          window.location.href = remainingParams ? `${pathname}?${remainingParams}` : pathname;
+        }
       }}
       onConnectNowInstantMeeting={() => {
         const newPath = `${pathname}?isInstantMeeting=true`;


### PR DESCRIPTION
## What does this PR do?

When an instant meeting times out and the user clicks "Schedule Instead" to fall back to the normal booking flow, the `onGoBackInstantMeeting` handler was redirecting to just `pathname`, stripping **all** URL parameters. This caused routed team members, metadata, and other booking-relevant params to be lost.

This PR preserves all URL params during the redirect, stripping only the instant-meeting-specific ones: `isInstantMeeting`, `bookingId`, and `bookingUid`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Set up an event type with instant meeting enabled and `instantMeetingParameters` configured
2. Navigate to the booking page with extra URL params (e.g. routed team member emails, metadata, etc.)
3. Trigger the instant meeting flow and wait for it to time out
4. Click "Schedule Instead" to go back to the normal booking flow
5. **Verify** the URL still contains the original params (minus `isInstantMeeting`, `bookingId`, `bookingUid`)
6. **Verify** the routed team members are still reflected in the scheduler

## Things for reviewer to verify

- [ ] Are `isInstantMeeting`, `bookingId`, and `bookingUid` the **complete** set of instant-meeting-specific params that should be stripped? Check if any other params are added during the instant meeting flow (e.g. in `useBookings.ts` via `updateQueryParam`).
- [ ] Should `onConnectNowInstantMeeting` (line 230) also preserve existing URL params when navigating **to** the instant meeting? It currently builds `${pathname}?isInstantMeeting=true`, also dropping all other params.

Link to Devin session: https://app.devin.ai/sessions/f5d4313d98254869a8ef6aa2004353ef
Requested by: @joeauyeung