### PR TITLE
fix: resolve flaky API v2 slots-2024-04-15 E2E tests

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
@@ -513,6 +513,8 @@ describe("Slots 2024-04-15 Endpoints", () => {
     });
 
     it("should do a booking for seated event and slot should show attendees count and bookingUid", async () => {
+      await selectedSlotRepositoryFixture.deleteAllByUserId(user.id);
+
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
         uid: `booking-uid-seated-${seatedEventTypeId}-${randomString()}`,
@@ -548,7 +550,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
         },
       });
 
-      bookingSeatsRepositoryFixture.create({
+      await bookingSeatsRepositoryFixture.create({
         referenceUid: `seat-${randomString()}`,
         data: {},
         booking: {
@@ -596,6 +598,8 @@ describe("Slots 2024-04-15 Endpoints", () => {
     });
 
     it("should do a booking for seated event and slot should show attendees count and bookingUid in range format", async () => {
+      await selectedSlotRepositoryFixture.deleteAllByUserId(user.id);
+
       const startTime = "2050-09-05T11:00:00.000Z";
       const booking = await bookingsRepositoryFixture.create({
         uid: `booking-uid-seated-${seatedEventTypeId}-${randomString()}`,
@@ -631,7 +635,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
         },
       });
 
-      bookingSeatsRepositoryFixture.create({
+      await bookingSeatsRepositoryFixture.create({
         referenceUid: `seat-${randomString()}`,
         data: {},
         booking: {


### PR DESCRIPTION
## What does this PR do?

Fixes intermittent failures in the API v2 `slots-2024-04-15` E2E test suite. Two seated event tests were flaky:
1. `"should do a booking for seated event and slot should show attendees count and bookingUid"`
2. `"should do a booking for seated event and slot should show attendees count and bookingUid in range format"`

### Root cause

**1. Missing `await` on `bookingSeatsRepositoryFixture.create()` (race condition)**

Two calls were not awaited. The subsequent HTTP request to fetch slots could execute before the booking seat record was committed to the database, so the slot response was missing the `attendees` count and `bookingUid`.

**2. Leftover `SelectedSlots` records leaking between test groups**

The availability calculation in `_getReservedSlotsAndCleanupExpired` fetches all unexpired reserved slots by `userId` — not by `eventTypeId`. Reserved slots created by earlier regular event-type tests could appear as busy times when computing availability for the seated event type, since they share the same user. Adding `deleteAllByUserId` cleanup before each seated test ensures a clean slate.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — test-only changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This PR modifies E2E tests only. Verification requires running the test suite multiple times to confirm the flaky tests now pass consistently:

```bash
TZ=UTC yarn jest --config apps/api/v2/jest-e2e.config.ts apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
```

The two previously-flaky seated event tests should pass reliably across multiple runs.

## Human Review Checklist

- [ ] Verify the two `await` additions are on the correct `bookingSeatsRepositoryFixture.create()` calls (the ones inside the seated event tests, not elsewhere)
- [ ] Confirm the `deleteAllByUserId()` cleanup calls don't break any test that depends on having leftover `SelectedSlots` from prior tests

Link to Devin session: https://app.devin.ai/sessions/7d56174801b5418b8c570f388b632bdd
Requested by: @romitg2