### PR TITLE
feat: add option to remove instant meeting availability on team event types

### DIFF
--- a/apps/web/modules/event-types/components/tabs/instant/InstantEventController.tsx
+++ b/apps/web/modules/event-types/components/tabs/instant/InstantEventController.tsx
@@ -1,13 +1,6 @@
-import { useSession } from "next-auth/react";
-import { useState } from "react";
-import { useFormContext, Controller } from "react-hook-form";
-import { components } from "react-select";
-import type { OptionProps, SingleValueProps } from "react-select";
-
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
 import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
-import type { EventTypeSetup, FormValues, AvailabilityOption } from "@calcom/features/eventtypes/lib/types";
+import type { AvailabilityOption, EventTypeSetup, FormValues } from "@calcom/features/eventtypes/lib/types";
 import { subscriberUrlReserved } from "@calcom/features/webhooks/lib/subscriberUrlReserved";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
@@ -18,12 +11,14 @@ import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
 import { DialogContent } from "@calcom/ui/components/dialog";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
-import { Label } from "@calcom/ui/components/form";
-import { TextField } from "@calcom/ui/components/form";
-import { Select } from "@calcom/ui/components/form";
-import { SettingsToggle } from "@calcom/ui/components/form";
+import { Label, Select, SettingsToggle, TextField } from "@calcom/ui/components/form";
 import { showToast } from "@calcom/ui/components/toast";
-
+import { useSession } from "next-auth/react";
+import { useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import type { OptionProps, SingleValueProps } from "react-select";
+import { components } from "react-select";
+import LicenseRequired from "~/ee/common/components/LicenseRequired";
 import { WebhookForm } from "~/webhooks/components";
 import type { TWebhook, WebhookFormSubmitData } from "~/webhooks/components/WebhookForm";
 import WebhookListItem from "~/webhooks/components/WebhookListItem";
@@ -161,11 +156,16 @@ export default function InstantEventController({
                                   options={options}
                                   isDisabled={shouldLockDisableProps("instantMeetingSchedule").disabled}
                                   isSearchable={false}
+                                  isClearable={true}
                                   onChange={(selected) => {
-                                    if (selected) onChange(selected.value);
+                                    if (selected) {
+                                      onChange(selected.value);
+                                    } else {
+                                      onChange(null);
+                                    }
                                   }}
                                   className="mb-4 block w-full min-w-0 flex-1 rounded-sm text-sm"
-                                  value={optionValue}
+                                  value={optionValue ?? null}
                                   components={{ Option, SingleValue }}
                                   isMulti={false}
                                 />

--- a/packages/features/eventtypes/lib/types.ts
+++ b/packages/features/eventtypes/lib/types.ts
@@ -6,7 +6,12 @@ import type { ChildrenEventType } from "@calcom/features/eventtypes/lib/children
 import type { IntervalLimit } from "@calcom/lib/intervalLimits/intervalLimitSchema";
 import type { AttributesQueryValue } from "@calcom/lib/raqb/types";
 import type { EventTypeTranslation } from "@calcom/prisma/client";
-import type { CancellationReasonRequirement, MembershipRole, PeriodType, SchedulingType } from "@calcom/prisma/enums";
+import type {
+  CancellationReasonRequirement,
+  MembershipRole,
+  PeriodType,
+  SchedulingType,
+} from "@calcom/prisma/enums";
 import type {
   BookerLayoutSettings,
   CustomInputSchema,
@@ -106,6 +111,7 @@ export type FormValues = {
   isInstantEvent: boolean;
   instantMeetingParameters: string[];
   instantMeetingExpiryTimeOffsetInSeconds: number;
+  instantMeetingSchedule: number | null;
   length: number;
   offsetStart: number;
   description: string;
@@ -497,7 +503,7 @@ export type SelectClassNames = {
 };
 
 // Re-export schemas from server-safe location
-export { EventTypeDuplicateInput, createEventTypeInput } from "./schemas";
+export { createEventTypeInput, EventTypeDuplicateInput } from "./schemas";
 
 export type FormValidationResult = {
   isValid: boolean;

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
@@ -368,7 +368,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
         id: instantMeetingSchedule,
       },
     };
-  } else if (schedule === null) {
+  } else if (instantMeetingSchedule === null || schedule === null) {
     data.instantMeetingSchedule = {
       disconnect: true,
     };


### PR DESCRIPTION
## What does this PR do?

Adds the ability to **remove/clear** the "Instant meeting availability" schedule selection on team event type instant meeting settings. Previously, once a schedule was selected, there was no way to unset it from the UI.

### Changes:

1. **Frontend** – Made the schedule `Select` clearable (`isClearable={true}`) and handled the `onChange(null)` case when the user clears the selection.
2. **Types** – Added the missing `instantMeetingSchedule: number | null` field to `FormValues`.
3. **Backend** – Fixed the disconnect logic in `update.handler.ts`: previously the instant meeting schedule was only disconnected when the *main* schedule (`schedule`) was set to `null`. Now it also disconnects when `instantMeetingSchedule` itself is explicitly `null`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to a **team** event type → Instant tab (org required).
2. Enable the "Instant meeting" toggle.
3. Select a schedule under "Instant meeting availability".
4. Save.
5. Re-open the form → verify the schedule is shown.
6. **Click the clear (×) button** on the schedule select → Save.
7. Re-open the form → verify the schedule selection is now empty.

## Human Review Checklist

- [ ] Verify the backend change at `update.handler.ts:371`: the new condition `instantMeetingSchedule === null || schedule === null` correctly disconnects the instant meeting schedule without unintended side effects.
- [ ] Verify that `null` flows correctly through the form submission pipeline (`getDirtyFields` → `handleSubmit` → `filteredPayload`) and is not accidentally filtered out.
- [ ] Confirm `isClearable` + `value={optionValue ?? null}` works correctly with the `Select` component (react-select).

## Checklist

- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/f40e51cb1efc48959b26668efaef45f1
Requested by: @Udit-takkar