### PR TITLE
feat: surface round-robin subset host info in no-slots admin email and add logging

### DIFF
--- a/packages/emails/src/templates/OrganizationAdminNoSlots.tsx
+++ b/packages/emails/src/templates/OrganizationAdminNoSlots.tsx
@@ -1,7 +1,5 @@
-import type { TFunction } from "i18next";
-
 import ServerTrans from "@calcom/lib/components/ServerTrans";
-
+import type { TFunction } from "i18next";
 import { BaseEmailHtml, CallToAction } from "../components";
 
 export type OrganizationAdminNoSlotsEmailInput = {
@@ -15,6 +13,7 @@ export type OrganizationAdminNoSlotsEmailInput = {
   endTime: string;
   editLink: string;
   teamSlug: string;
+  rrHostSubsetIds?: number[];
 };
 
 export const OrganizationAdminNoSlotsEmail = (
@@ -37,6 +36,15 @@ export const OrganizationAdminNoSlotsEmail = (
           values={{ username: props.user, slug: props.slug }}
         />
       </p>
+      {props.rrHostSubsetIds && props.rrHostSubsetIds.length > 0 && (
+        <p style={{ fontWeight: 400, fontSize: "16px", lineHeight: "24px" }}>
+          <>
+            {props.language("org_admin_no_slots|rr_subset_notice", {
+              userIds: props.rrHostSubsetIds.join(", "),
+            })}
+          </>
+        </p>
+      )}
       <div style={{ marginTop: "3rem", marginBottom: "0.75rem" }}>
         <CallToAction
           label={props.language("org_admin_no_slots|cta")}

--- a/packages/emails/templates/organization-admin-no-slots-email.ts
+++ b/packages/emails/templates/organization-admin-no-slots-email.ts
@@ -39,7 +39,9 @@ export default class OrganizationAdminNoSlotsEmail extends BaseEmail {
   protected getTextBody(): string {
     const rrSubsetNotice =
       this.adminNoSlots.rrHostSubsetIds && this.adminNoSlots.rrHostSubsetIds.length > 0
-        ? `\nNote: This booking request was restricted to a round-robin host subset (user IDs: ${this.adminNoSlots.rrHostSubsetIds.join(", ")}). Only these specific hosts were considered for availability.\n`
+        ? `\n${this.adminNoSlots.language("org_admin_no_slots|rr_subset_notice", {
+            userIds: this.adminNoSlots.rrHostSubsetIds.join(", "),
+          })}\n`
         : "";
 
     return `

--- a/packages/emails/templates/organization-admin-no-slots-email.ts
+++ b/packages/emails/templates/organization-admin-no-slots-email.ts
@@ -1,7 +1,5 @@
-import type { TFunction } from "i18next";
-
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
-
+import type { TFunction } from "i18next";
 import renderEmail from "../src/renderEmail";
 import BaseEmail from "./_base-email";
 
@@ -16,6 +14,7 @@ export type OrganizationAdminNoSlotsEmailInput = {
   endTime: string;
   teamSlug: string;
   editLink: string;
+  rrHostSubsetIds?: number[];
 };
 
 export default class OrganizationAdminNoSlotsEmail extends BaseEmail {
@@ -38,14 +37,19 @@ export default class OrganizationAdminNoSlotsEmail extends BaseEmail {
   }
 
   protected getTextBody(): string {
+    const rrSubsetNotice =
+      this.adminNoSlots.rrHostSubsetIds && this.adminNoSlots.rrHostSubsetIds.length > 0
+        ? `\nNote: This booking request was restricted to a round-robin host subset (user IDs: ${this.adminNoSlots.rrHostSubsetIds.join(", ")}). Only these specific hosts were considered for availability.\n`
+        : "";
+
     return `
 Hi Admins,
 
 It has been brought to our attention that ${this.adminNoSlots.user} has not had availability users have visited ${this.adminNoSlots.user}/${this.adminNoSlots.slug}.
-
-There’s a few reasons why this could be happening
+${rrSubsetNotice}
+There's a few reasons why this could be happening
 * The user does not have any calendars connected
-* Their schedules attached to this event are not enabled
+* Their schedules attached to this event are not enabled${this.adminNoSlots.rrHostSubsetIds?.length ? "\n* The round-robin host subset passed may be too restrictive" : ""}
 
 We recommend checking their availability to resolve this
     `;

--- a/packages/features/slots/handleNotificationWhenNoSlots.test.ts
+++ b/packages/features/slots/handleNotificationWhenNoSlots.test.ts
@@ -1,5 +1,6 @@
 import i18nMock from "@calcom/testing/lib/__mocks__/libServerI18n";
 import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
+import process from "node:process";
 import dayjs from "@calcom/dayjs";
 import * as CalcomEmails from "@calcom/emails/organization-email-service";
 import { getNoSlotsNotificationService } from "@calcom/features/di/containers/NoSlotsNotification";
@@ -489,5 +490,151 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
     expect(firstEventKey).not.toBe(secondEventKey);
     expect(firstEventKey).toContain("event1");
     expect(secondEventKey).toContain("event2");
+  });
+
+  it("Should include rrHostSubsetIds in the email payload when provided", async () => {
+    const redisService = new RedisService();
+    const mocked = vi.mocked(redisService);
+
+    prismaMock.team.findFirst.mockResolvedValue({
+      organizationSettings: {
+        adminGetsNoSlotsNotification: true,
+      },
+    });
+
+    prismaMock.membership.findMany.mockResolvedValue([
+      {
+        user: {
+          email: "admin@test.com",
+          locale: "en",
+        },
+      },
+    ]);
+
+    const eventDetails = {
+      username: "user1",
+      eventSlug: "event1",
+      startTime: dayjs(),
+      endTime: dayjs().add(1, "hour"),
+    };
+
+    const orgDetails = {
+      currentOrgDomain: "org1",
+      isValidOrgDomain: true,
+    };
+
+    mocked.lrange.mockResolvedValueOnce([""]);
+
+    const service = getNoSlotsNotificationService();
+    await service.handleNotificationWhenNoSlots({
+      eventDetails,
+      orgDetails,
+      teamId: 123,
+      rrHostSubsetIds: [10, 20, 30],
+    });
+
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledTimes(1);
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rrHostSubsetIds: [10, 20, 30],
+      })
+    );
+  });
+
+  it("Should not include rrHostSubsetIds in the email payload when not provided", async () => {
+    const redisService = new RedisService();
+    const mocked = vi.mocked(redisService);
+
+    prismaMock.team.findFirst.mockResolvedValue({
+      organizationSettings: {
+        adminGetsNoSlotsNotification: true,
+      },
+    });
+
+    prismaMock.membership.findMany.mockResolvedValue([
+      {
+        user: {
+          email: "admin@test.com",
+          locale: "en",
+        },
+      },
+    ]);
+
+    const eventDetails = {
+      username: "user1",
+      eventSlug: "event1",
+      startTime: dayjs(),
+      endTime: dayjs().add(1, "hour"),
+    };
+
+    const orgDetails = {
+      currentOrgDomain: "org1",
+      isValidOrgDomain: true,
+    };
+
+    mocked.lrange.mockResolvedValueOnce([""]);
+
+    const service = getNoSlotsNotificationService();
+    await service.handleNotificationWhenNoSlots({
+      eventDetails,
+      orgDetails,
+      teamId: 123,
+    });
+
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledTimes(1);
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rrHostSubsetIds: undefined,
+      })
+    );
+  });
+
+  it("Should not include rrHostSubsetIds in the email payload when empty array is provided", async () => {
+    const redisService = new RedisService();
+    const mocked = vi.mocked(redisService);
+
+    prismaMock.team.findFirst.mockResolvedValue({
+      organizationSettings: {
+        adminGetsNoSlotsNotification: true,
+      },
+    });
+
+    prismaMock.membership.findMany.mockResolvedValue([
+      {
+        user: {
+          email: "admin@test.com",
+          locale: "en",
+        },
+      },
+    ]);
+
+    const eventDetails = {
+      username: "user1",
+      eventSlug: "event1",
+      startTime: dayjs(),
+      endTime: dayjs().add(1, "hour"),
+    };
+
+    const orgDetails = {
+      currentOrgDomain: "org1",
+      isValidOrgDomain: true,
+    };
+
+    mocked.lrange.mockResolvedValueOnce([""]);
+
+    const service = getNoSlotsNotificationService();
+    await service.handleNotificationWhenNoSlots({
+      eventDetails,
+      orgDetails,
+      teamId: 123,
+      rrHostSubsetIds: [],
+    });
+
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledTimes(1);
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rrHostSubsetIds: undefined,
+      })
+    );
   });
 });

--- a/packages/features/slots/handleNotificationWhenNoSlots.ts
+++ b/packages/features/slots/handleNotificationWhenNoSlots.ts
@@ -1,10 +1,12 @@
+import process from "node:process";
 import type { Dayjs } from "@calcom/dayjs";
 import { sendOrganizationAdminNoSlotsNotification } from "@calcom/emails/organization-email-service";
 import type { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import type { MembershipRepository } from "@calcom/features/membership/repositories/MembershipRepository";
 import type { IRedisService } from "@calcom/features/redis/IRedisService";
-import { IS_PRODUCTION, WEBAPP_URL } from "@calcom/lib/constants";
 import { getTranslation } from "@calcom/i18n/server";
+import { IS_PRODUCTION, WEBAPP_URL } from "@calcom/lib/constants";
+import logger from "@calcom/lib/logger";
 
 type EventDetails = {
   username: string;
@@ -14,6 +16,8 @@ type EventDetails = {
   visitorTimezone?: string;
   visitorUid?: string;
 };
+
+const log = logger.getSubLogger({ prefix: ["[noSlotsNotification]"] });
 
 // Incase any updates are made - lets version the key so we can invalidate
 const REDIS_KEY_VERSION = "V1";
@@ -52,15 +56,27 @@ export class NoSlotsNotificationService {
     eventDetails,
     orgDetails,
     teamId,
+    rrHostSubsetIds,
   }: {
     eventDetails: EventDetails;
     orgDetails: { currentOrgDomain: string | null };
     teamId?: number;
+    rrHostSubsetIds?: number[];
   }) {
     // Check for org
     if (!orgDetails.currentOrgDomain || !teamId) return;
     const UPSTASH_ENV_FOUND = process.env.UPSTASH_REDIS_REST_TOKEN && process.env.UPSTASH_REDIS_REST_URL;
     if (!UPSTASH_ENV_FOUND) return;
+
+    const hasRRSubsetHosts = rrHostSubsetIds && rrHostSubsetIds.length > 0;
+    log.info("Handling no-slots notification", {
+      username: eventDetails.username,
+      eventSlug: eventDetails.eventSlug,
+      teamId,
+      orgDomain: orgDetails.currentOrgDomain,
+      hasRRSubsetHosts,
+      rrHostSubsetIds: hasRRSubsetHosts ? rrHostSubsetIds : undefined,
+    });
 
     // Check org has this setting enabled
     const orgSettings = await this.dependencies.teamRepo.findOrganizationSettingsBySlug({
@@ -111,7 +127,17 @@ export class NoSlotsNotificationService {
           // For now navigate here - when impersonation via parameter has been pushed we will impersonate and then navigate to availability
           editLink: `${WEBAPP_URL}/availability?type=team`,
           teamSlug: teamSlug?.slug ?? "",
+          rrHostSubsetIds: hasRRSubsetHosts ? rrHostSubsetIds : undefined,
         };
+
+        log.info("Sending no-slots notification email", {
+          to: admin.user.email,
+          user: eventDetails.username,
+          eventSlug: eventDetails.eventSlug,
+          teamId,
+          hasRRSubsetHosts,
+          rrHostSubsetIds: hasRRSubsetHosts ? rrHostSubsetIds : undefined,
+        });
 
         emailsToSend.push(sendOrganizationAdminNoSlotsNotification(payload));
       }

--- a/packages/features/slots/handleNotificationWhenNoSlots.ts
+++ b/packages/features/slots/handleNotificationWhenNoSlots.ts
@@ -131,7 +131,7 @@ export class NoSlotsNotificationService {
         };
 
         log.info("Sending no-slots notification email", {
-          to: admin.user.email,
+          recipientType: "org-admin",
           user: eventDetails.username,
           eventSlug: eventDetails.eventSlug,
           teamId,

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -3187,6 +3187,7 @@
   "overlaps_with_existing_schedule": "This overlaps with an existing schedule. Please select a different date.",
   "org_admin_no_slots|heading": "No availability found for {{name}}",
   "org_admin_no_slots|content": "Hello organization admins,<br /><br />Please note: It has been brought to our attention that {{username}} has not had any availability when a user has visited {{username}}/{{slug}}<br /><br />There's a few reasons why this could be happening<br />The user does not have any calendars connected<br />Their schedules attached to this event are not enabled<br /> <br />We recommend checking their availability to resolve this.",
+  "org_admin_no_slots|rr_subset_notice": "Note: This booking request was restricted to a round-robin host subset (user IDs: {{userIds}}). Only these specific hosts were considered for availability, which may explain why no slots were found.",
   "org_admin_no_slots|cta": "Open users availability",
   "organization_no_slots_notification_switch_title": "Get notifications when your team has no availability",
   "organization_no_slots_notification_switch_description": "Admins will get email notifications when a user tries to book a team member and is faced with 'No availability'. We trigger this email after two occurrences and remind you every 7 days per user.  ",

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -9,6 +9,7 @@ import type {
   GetAvailabilityUser,
   UserAvailabilityService,
 } from "@calcom/features/availability/lib/getUserAvailability";
+import type { IGetAvailableSlots } from "@calcom/features/bookings/Booker/hooks/useAvailableTimeSlots";
 import type { CheckBookingLimitsService } from "@calcom/features/bookings/lib/checkBookingLimits";
 import { checkForConflicts } from "@calcom/features/bookings/lib/conflictChecker/checkForConflicts";
 import type { QualifiedHostsService } from "@calcom/features/bookings/lib/host-filtering/findQualifiedHostsWithDelegationCredentials";
@@ -16,12 +17,14 @@ import { isEventTypeLoggingEnabled } from "@calcom/features/bookings/lib/isEvent
 import type { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
 import type { BusyTimesService } from "@calcom/features/busyTimes/services/getBusyTimes";
 import type { getBusyTimesService } from "@calcom/features/di/containers/BusyTimes";
+import type { OrgMembershipLookup } from "@calcom/features/di/modules/OrgMembershipLookup";
 import type { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { getDefaultEvent } from "@calcom/features/eventtypes/lib/defaultEvents";
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import type { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import type { PrismaOOORepository } from "@calcom/features/ooo/repositories/PrismaOOORepository";
 import type { IRedisService } from "@calcom/features/redis/IRedisService";
+import type { RoutingFormResponseRepository } from "@calcom/features/routing-forms/repositories/RoutingFormResponseRepository";
 import { buildDateRanges } from "@calcom/features/schedules/lib/date-ranges";
 import getSlots from "@calcom/features/schedules/lib/slots";
 import type { ScheduleRepository } from "@calcom/features/schedules/repositories/ScheduleRepository";
@@ -48,7 +51,6 @@ import {
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { withReporting } from "@calcom/lib/sentryWrapper";
-import type { RoutingFormResponseRepository } from "@calcom/features/routing-forms/repositories/RoutingFormResponseRepository";
 import { PeriodType, SchedulingType } from "@calcom/prisma/enums";
 import type { CalendarFetchMode, EventBusyDate, EventBusyDetails } from "@calcom/types/Calendar";
 import type { CredentialForCalendarService } from "@calcom/types/Credential";
@@ -57,8 +59,6 @@ import type { Logger } from "tslog";
 import { v4 as uuid } from "uuid";
 import type { TGetScheduleInputSchema } from "./getSchedule.schema";
 import type { GetScheduleOptions } from "./types";
-import type { OrgMembershipLookup } from "@calcom/features/di/modules/OrgMembershipLookup";
-import type { IGetAvailableSlots } from "@calcom/features/bookings/Booker/hooks/useAvailableTimeSlots";
 
 const log = logger.getSubLogger({ prefix: ["[slots/util]"] });
 const DEFAULT_SLOTS_CACHE_TTL = 2000;
@@ -1653,6 +1653,7 @@ export class AvailableSlotsService {
           },
           orgDetails,
           teamId: eventType.team?.id,
+          rrHostSubsetIds: input.rrHostSubsetIds ?? undefined,
         });
       } catch (e) {
         loggerWithEventDetails.error(


### PR DESCRIPTION
## What does this PR do?

When org admins receive the "no available slots" notification email, it now clearly indicates if a **round-robin host subset** (`rrHostSubsetIds`) was being used for the booking request. This helps admins understand that the lack of availability may be because only a restricted subset of RR hosts were considered, rather than all hosts being unavailable.

Additionally, structured logging is added around the no-slots notification flow for better observability.

### Changes:
- **`handleNotificationWhenNoSlots.ts`**: Accepts optional `rrHostSubsetIds`, adds two `log.info` calls (one when handling the notification, one per email sent) with relevant context (username, eventSlug, teamId, orgDomain, subset IDs). Logs use `recipientType` instead of email addresses to avoid PII in logs.
- **Email templates** (TSX + plaintext): Conditionally render an RR subset notice section when `rrHostSubsetIds` is present and non-empty. Both HTML and plaintext bodies use the same i18n key (`org_admin_no_slots|rr_subset_notice`) for consistent localization. The plaintext body also adds an extra possible-cause bullet about restrictive subsets.
- **`slots/util.ts`**: Passes `input.rrHostSubsetIds` through to the notification service call.
- **i18n**: New `org_admin_no_slots|rr_subset_notice` translation key.
- **Tests**: 3 new test cases covering subset IDs provided, not provided, and empty array.

### Updates since last revision:
- Removed `admin.user.email` from log output (PII concern flagged by Cubic AI review) — replaced with `recipientType: "org-admin"`
- Plaintext email body now uses the `org_admin_no_slots|rr_subset_notice` i18n key instead of a hardcoded English string, keeping localization consistent with the HTML template

## Visual Demo

N/A — server-rendered email template, no UI changes visible in the app.

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Set `UPSTASH_REDIS_REST_TOKEN` and `UPSTASH_REDIS_REST_URL` env vars.
2. Ensure an org has `adminGetsNoSlotsNotification` enabled.
3. Hit a team event type's availability endpoint with `rrHostSubsetIds` query param pointing to user IDs that have no availability.
4. After 2 no-slot occurrences, the admin email should include the RR subset notice section mentioning the specific user IDs.
5. Verify logs contain `[noSlotsNotification]` entries with the expected fields (no email addresses in log output).

**Unit tests**: `TZ=UTC yarn vitest run packages/features/slots/handleNotificationWhenNoSlots.test.ts` — all 12 tests pass.

## Important review notes

- The email displays **raw user IDs** (e.g., "user IDs: 10, 20, 30") — this matches the intent of surfacing the technical subset info for admins to debug. If usernames are preferred, that would require an additional DB lookup.
- Import reordering in email files and `import process from "node:process"` additions are from biome auto-fix (lint-staged), not manual changes.
- `input.rrHostSubsetIds ?? undefined` in `slots/util.ts` coerces a potential `null` from the input schema to `undefined` for the notification service interface.

## Human review checklist

- [ ] Verify the `org_admin_no_slots|rr_subset_notice` i18n interpolation (`{{userIds}}`) renders correctly in both HTML and plaintext email paths
- [ ] Confirm `log.info` noise level is acceptable — notification is throttled to once per 7 days per user/event combo, so volume should be low
- [ ] Confirm displaying raw user IDs (rather than usernames) is the desired UX for org admins

Link to Devin session: https://app.devin.ai/sessions/b34d10bee15b482a9eba64adb14edd25
Requested by: @joeauyeung