### PR TITLE
feat: take into account guest availability when host reschedules

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -160,6 +160,7 @@ export type GetUserAvailabilityInitialData = {
     bookingLimits?: unknown;
     includeManagedEventsInLimits: boolean;
   } | null;
+  guestBusyTimes?: { start: Date; end: Date }[];
 };
 
 export type GetAvailabilityUser = GetUserAvailabilityInitialData["user"];
@@ -617,6 +618,15 @@ export class UserAvailabilityService {
       };
     }
 
+    const guestBusyTimesFormatted: EventBusyDetails[] = (initialData?.guestBusyTimes ?? []).map(
+      (t) => ({
+        start: dayjs(t.start).toISOString(),
+        end: dayjs(t.end).toISOString(),
+        title: "Guest busy",
+        source: withSource ? "guest-availability" : undefined,
+      })
+    );
+
     const detailedBusyTimesWithSource: EventBusyDetails[] = [
       ...busyTimes.map((a) => ({
         ...a,
@@ -627,6 +637,7 @@ export class UserAvailabilityService {
       })),
       ...busyTimesFromLimits,
       ...busyTimesFromTeamLimits,
+      ...guestBusyTimesFormatted,
     ];
 
     const detailedBusyTimes: UserAvailabilityBusyDetails[] = withSource

--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -620,8 +620,8 @@ export class UserAvailabilityService {
 
     const guestBusyTimesFormatted: EventBusyDetails[] = (initialData?.guestBusyTimes ?? []).map(
       (t) => ({
-        start: dayjs(t.start).toISOString(),
-        end: dayjs(t.end).toISOString(),
+        start: dayjs.utc(t.start).toISOString(),
+        end: dayjs.utc(t.end).toISOString(),
         title: "Guest busy",
         source: withSource ? "guest-availability" : undefined,
       })

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -2213,4 +2213,50 @@ export class BookingRepository implements IBookingRepository {
       },
     });
   }
+
+  async findByUidIncludeAttendeeEmails({ uid }: { uid: string }) {
+    return this.prismaClient.booking.findUnique({
+      where: { uid },
+      select: {
+        id: true,
+        uid: true,
+        attendees: { select: { email: true } },
+      },
+    });
+  }
+
+  async findByUserIdsAndDateRange({
+    userIds,
+    userEmails,
+    dateFrom,
+    dateTo,
+  }: {
+    userIds: number[];
+    userEmails: string[];
+    dateFrom: Date;
+    dateTo: Date;
+  }) {
+    if (!userIds.length && !userEmails.length) return [];
+
+    return this.prismaClient.booking.findMany({
+      where: {
+        status: { in: [BookingStatus.ACCEPTED, BookingStatus.PENDING] },
+        AND: [{ startTime: { lt: dateTo } }, { endTime: { gt: dateFrom } }],
+        OR: [
+          ...(userIds.length > 0 ? [{ userId: { in: userIds } }] : []),
+          ...(userEmails.length > 0
+            ? [{ attendees: { some: { email: { in: userEmails, mode: "insensitive" as const } } } }]
+            : []),
+        ],
+      },
+      select: {
+        uid: true,
+        startTime: true,
+        endTime: true,
+        title: true,
+        userId: true,
+        status: true,
+      },
+    });
+  }
 }

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1519,24 +1519,25 @@ export class UserRepository {
   async findByEmails({ emails }: { emails: string[] }) {
     if (!emails.length) return [];
 
-    const normalized = emails.map((e) => e.toLowerCase());
+    const normalized = [...new Set(emails.map((e) => e.toLowerCase()))];
 
-    const byPrimary = await this.prismaClient.user.findMany({
-      where: { email: { in: normalized, mode: "insensitive" } },
-      select: { id: true, email: true },
-    });
-
-    const bySecondary = await this.prismaClient.user.findMany({
-      where: {
-        secondaryEmails: {
-          some: {
-            email: { in: normalized, mode: "insensitive" },
-            emailVerified: { not: null },
+    const [byPrimary, bySecondary] = await Promise.all([
+      this.prismaClient.user.findMany({
+        where: { email: { in: normalized, mode: "insensitive" } },
+        select: { id: true, email: true },
+      }),
+      this.prismaClient.user.findMany({
+        where: {
+          secondaryEmails: {
+            some: {
+              email: { in: normalized, mode: "insensitive" },
+              emailVerified: { not: null },
+            },
           },
         },
-      },
-      select: { id: true, email: true },
-    });
+        select: { id: true, email: true },
+      }),
+    ]);
 
     const seen = new Map<number, { id: number; email: string }>();
     for (const u of [...byPrimary, ...bySecondary]) {

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1515,4 +1515,33 @@ export class UserRepository {
 
     return { email: user.email, username: user.username };
   }
+
+  async findByEmails({ emails }: { emails: string[] }) {
+    if (!emails.length) return [];
+
+    const normalized = emails.map((e) => e.toLowerCase());
+
+    const byPrimary = await this.prismaClient.user.findMany({
+      where: { email: { in: normalized, mode: "insensitive" } },
+      select: { id: true, email: true },
+    });
+
+    const bySecondary = await this.prismaClient.user.findMany({
+      where: {
+        secondaryEmails: {
+          some: {
+            email: { in: normalized, mode: "insensitive" },
+            emailVerified: { not: null },
+          },
+        },
+      },
+      select: { id: true, email: true },
+    });
+
+    const seen = new Map<number, { id: number; email: string }>();
+    for (const u of [...byPrimary, ...bySecondary]) {
+      if (!seen.has(u.id)) seen.set(u.id, u);
+    }
+    return Array.from(seen.values());
+  }
 }

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -829,6 +829,55 @@ export class AvailableSlotsService {
   }
   private getOOODates = withReporting(this._getOOODates.bind(this), "getOOODates");
 
+  /**
+   * When the host reschedules, check if any attendee is a Cal.com user
+   * and collect their busy times so the host only sees mutually available slots.
+   */
+  private async _getGuestBusyTimesForReschedule({
+    rescheduleUid,
+    schedulingType,
+    dateFrom,
+    dateTo,
+  }: {
+    rescheduleUid: string | null | undefined;
+    schedulingType: SchedulingType | null;
+    dateFrom: Date;
+    dateTo: Date;
+  }): Promise<{ start: Date; end: Date }[]> {
+    if (!rescheduleUid || schedulingType === SchedulingType.COLLECTIVE) {
+      return [];
+    }
+
+    const original = await this.dependencies.bookingRepo.findByUidIncludeAttendeeEmails({
+      uid: rescheduleUid,
+    });
+    if (!original?.attendees?.length) return [];
+
+    const emails = original.attendees
+      .map((a) => a.email)
+      .filter((e): e is string => Boolean(e));
+    if (!emails.length) return [];
+
+    const calUsers = await this.dependencies.userRepo.findByEmails({ emails });
+    if (!calUsers.length) return [];
+
+    const guestBookings = await this.dependencies.bookingRepo.findByUserIdsAndDateRange({
+      userIds: calUsers.map((u) => u.id),
+      userEmails: calUsers.map((u) => u.email),
+      dateFrom,
+      dateTo,
+    });
+
+    // Keep the rescheduled booking's own slot available
+    return guestBookings
+      .filter((b) => b.uid !== rescheduleUid)
+      .map((b) => ({ start: b.startTime, end: b.endTime }));
+  }
+  private getGuestBusyTimesForReschedule = withReporting(
+    this._getGuestBusyTimesForReschedule.bind(this),
+    "getGuestBusyTimesForReschedule"
+  );
+
   private _getUsersWithCredentials({
     hosts,
   }: {
@@ -903,7 +952,7 @@ export class AvailableSlotsService {
     const allUserIds = Array.from(userIdAndEmailMap.keys());
 
     const bookingRepo = this.dependencies.bookingRepo;
-    const [currentBookingsAllUsers, outOfOfficeDaysAllUsers] = await Promise.all([
+    const [currentBookingsAllUsers, outOfOfficeDaysAllUsers, guestBusyTimes] = await Promise.all([
       bookingRepo.findAllExistingBookingsForEventTypeBetween({
         startDate: startTimeDate,
         endDate: endTimeDate,
@@ -912,6 +961,12 @@ export class AvailableSlotsService {
         userIdAndEmailMap,
       }),
       this.getOOODates(startTimeDate, endTimeDate, allUserIds),
+      this.getGuestBusyTimesForReschedule({
+        rescheduleUid: input.rescheduleUid,
+        schedulingType: eventType.schedulingType,
+        dateFrom: startTimeDate,
+        dateTo: endTimeDate,
+      }),
     ]);
 
     const bookingLimits =
@@ -1026,6 +1081,7 @@ export class AvailableSlotsService {
         eventTypeForLimits: eventType && (bookingLimits || durationLimits) ? eventType : null,
         teamBookingLimits: teamBookingLimitsMap,
         teamForBookingLimits: teamForBookingLimits,
+        guestBusyTimes,
       },
     });
     /* We get all users working hours and busy slots */

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -863,7 +863,7 @@ export class AvailableSlotsService {
 
     const guestBookings = await this.dependencies.bookingRepo.findByUserIdsAndDateRange({
       userIds: calUsers.map((u) => u.id),
-      userEmails: calUsers.map((u) => u.email),
+      userEmails: emails,
       dateFrom,
       dateTo,
     });


### PR DESCRIPTION
Fixes #16378

## What it does

When a host reschedules a booking, the system now checks if any attendee is a Cal.com user and excludes their busy times from the available slots. This means the host can only pick a time that works for both parties.

## How it works

The change adds a new step in the slot computation pipeline that runs in parallel with the existing data fetches:

1. **Look up the original booking's attendees** via `BookingRepository.findByUidIncludeAttendeeEmails`
2. **Resolve attendee emails to Cal.com users** via `UserRepository.findByEmails` — checks both primary and verified secondary emails, case-insensitive
3. **Fetch the guest users' existing bookings** in the reschedule date range via `BookingRepository.findByUserIdsAndDateRange`
4. **Pass these as `guestBusyTimes`** into `getUserAvailability`, where they get merged into the combined busy times array

The rescheduled booking's own time slot is excluded from the guest's busy times so it remains selectable.

### Scope

- Only runs during **host-initiated reschedule** (not when attendees reschedule themselves, per @CarinaWolli's clarification)
- Skipped for **COLLECTIVE** scheduling type where all participants' availability is already checked
- No UI changes needed — unavailable slots are simply filtered out as usual

### Files changed

| File | What changed |
|------|-------------|
| `UserRepository.ts` | Added `findByEmails` — email-to-user lookup with secondary email support |
| `BookingRepository.ts` | Added `findByUidIncludeAttendeeEmails` and `findByUserIdsAndDateRange` |
| `getUserAvailability.ts` | Added `guestBusyTimes` to initial data type and merged into busy times |
| `slots/util.ts` | Added `_getGuestBusyTimesForReschedule` orchestration method |

## Self-review notes

- Repository methods follow naming conventions (no entity name prefix, `Include` keyword for relations)
- Uses `select` everywhere, no `include`
- Case-insensitive email matching handles mixed-case addresses
- Guest busy times fetched in parallel with existing queries (no added latency on the happy path)
- The rescheduled booking itself is filtered out so its slot stays available

/claim #16378