### PR TITLE
fix: guard against document being undefined in embed-iframe informAboutScroll

### DIFF
--- a/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
@@ -66,6 +66,10 @@ export function keepParentInformedAboutDimensionChanges({ embedStore }: { embedS
   let isInitialDimensionPass = true;
   let isWindowLoadComplete = false;
   runAsap(function informAboutScroll() {
+    // Guard against test environment teardown where document may no longer exist
+    if (typeof document === "undefined") {
+      return;
+    }
     if (document.readyState !== "complete") {
       // Wait for window to load to correctly calculate the initial scroll height.
       runAsap(informAboutScroll);

--- a/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
@@ -66,7 +66,7 @@ export function keepParentInformedAboutDimensionChanges({ embedStore }: { embedS
   let isInitialDimensionPass = true;
   let isWindowLoadComplete = false;
   runAsap(function informAboutScroll() {
-    // Guard against test environment teardown where document may no longer exist
+    // Can't inform parent about dimensions if document doesn't exist
     if (typeof document === "undefined") {
       return;
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky unit test failure in `packages/embeds/embed-core/src/__tests__/embed-iframe.test.ts` caused by `ReferenceError: document is not defined`.

The `informAboutScroll` callback inside `keepParentInformedAboutDimensionChanges` runs on a recursive `setTimeout` loop (via `runAsap`). Some test `describe` blocks use `vi.useRealTimers()` before importing `embed-iframe`, which starts this loop with real timers. When jsdom tears down between tests, pending callbacks fire after `document` is gone, producing the `ReferenceError`.

This adds a `typeof document === "undefined"` early-return guard at the top of `informAboutScroll`, matching the existing defensive pattern in `makeBodyVisible` (`embed-iframe.ts:301`). In production browser environments this code path is never hit.

**CI evidence of flakiness** (same workflow run, same commit):
- ❌ [Failed job](https://github.com/calcom/cal.com/actions/runs/23638879602/job/68854508548?pr=28490) — 2 unhandled `ReferenceError: document is not defined` from `informAboutScroll`
- ✅ [Passed job](https://github.com/calcom/cal.com/actions/runs/23638879602/job/68855266046?pr=28490) — same tests pass cleanly

## Visual Demo (For contributors especially)

N/A — no UI changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the embed-iframe unit tests and confirm zero unhandled errors:

```bash
TZ=UTC yarn vitest run packages/embeds/embed-core/src/__tests__/embed-iframe.test.ts
```

All 20 tests should pass with no `ReferenceError: document is not defined` in the "Unhandled Errors" section.

## Human Review Checklist

- [ ] Verify the guard placement: the `typeof document === "undefined"` check is at the top of the recursive callback, before any `document` access — so all subsequent accesses in the function body are protected by the early return.
- [ ] Confirm this matches the existing pattern in `makeBodyVisible` (`embed-iframe.ts:301`).
- [ ] Consider whether the inner `setTimeout` at line 78 (which also calls `informAboutScroll`) needs a separate guard — it doesn't, because the guard runs on every entry into `informAboutScroll` regardless of how it was scheduled.

Link to Devin session: https://app.devin.ai/sessions/ce12fbe55f2940e8bb3056608783b4a3
Requested by: @sahitya-chandra
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
