### PR TITLE
fix: upgrade multer to 2.1.1 to fix resource exhaustion and incomplete cleanup vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,8 @@
     "lodash": "4.17.23",
     "lodash-es": "4.17.23",
     "@lingo.dev/_compiler/fast-xml-parser": "5.3.5",
-    "fast-xml-parser": "4.5.4"
+    "fast-xml-parser": "4.5.4",
+    "multer": "2.1.1"
   },
   "packageExtensions": {
     "ink@3.2.0": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,7 +2735,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/lib@workspace:*, @calcom/lib@workspace:packages/lib":
+"@calcom/lib@npm:*, @calcom/lib@workspace:*, @calcom/lib@workspace:packages/lib":
   version: 0.0.0-use.local
   resolution: "@calcom/lib@workspace:packages/lib"
   dependencies:
@@ -2780,9 +2780,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcom/lyra@workspace:packages/app-store/lyra"
   dependencies:
-    "@calcom/lib": "workspace:*"
-    "@calcom/prisma": "workspace:*"
-    "@calcom/types": "workspace:*"
+    "@calcom/lib": "npm:*"
+    "@calcom/prisma": "npm:*"
+    "@calcom/types": "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -2972,7 +2972,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/prisma@workspace:*, @calcom/prisma@workspace:packages/prisma":
+"@calcom/prisma@npm:*, @calcom/prisma@workspace:*, @calcom/prisma@workspace:packages/prisma":
   version: 0.0.0-use.local
   resolution: "@calcom/prisma@workspace:packages/prisma"
   dependencies:
@@ -3212,7 +3212,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/types@workspace:*, @calcom/types@workspace:packages/types":
+"@calcom/types@npm:*, @calcom/types@workspace:*, @calcom/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@calcom/types@workspace:packages/types"
   dependencies:
@@ -29506,7 +29506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^0.5.1, mkdirp@npm:^0.5.6":
+"mkdirp@npm:^0.5.1":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
   dependencies:
@@ -29802,18 +29802,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multer@npm:2.0.2":
-  version: 2.0.2
-  resolution: "multer@npm:2.0.2"
+"multer@npm:2.1.1":
+  version: 2.1.1
+  resolution: "multer@npm:2.1.1"
   dependencies:
     append-field: "npm:^1.0.0"
     busboy: "npm:^1.6.0"
     concat-stream: "npm:^2.0.0"
-    mkdirp: "npm:^0.5.6"
-    object-assign: "npm:^4.1.1"
     type-is: "npm:^1.6.18"
-    xtend: "npm:^4.0.2"
-  checksum: 10/4bdcb07138cf72f93adc08a0dc27c058faab9f6721067a58f394fa546d73d11b7f100cdd66e733d649d184f9d1b402065f6888b31ec427409f056ee92c4367a6
+  checksum: 10/fb22868caaed37d725715c14c60b740b81665265da3a026bb61954414f65b99f76b360128413b8a2a7cc1a95ecae28a42bf831fe172bb79682d19ec105b556bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

Upgrades `multer` from 2.0.2 to 2.1.1 via a yarn resolution to address resource exhaustion and incomplete cleanup vulnerabilities in the earlier version.

## Visual Demo (For contributors especially)

N/A — dependency-only change with no UI impact.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — resolution-only change; CI validates nothing breaks.

## How should this be tested?

1. Run `yarn install` — should complete without errors.
2. Verify `yarn.lock` resolves `multer` to 2.1.1 (`grep multer yarn.lock`).
3. CI build and test suite should pass as before.

## Human Review Checklist

> ⚠️ **Unintended yarn.lock changes**: The diff includes changes to `@calcom/lyra`, `@calcom/lib`, `@calcom/prisma`, and `@calcom/types` workspace resolution descriptors (adding `npm:*` alongside `workspace:*`). These appear to be yarn install artifacts and are **not** part of the intended change. Reviewer should verify these don't affect workspace resolution behavior.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/e3558211aacf45a793fc2d60428fb42e
Requested by: @sean-brydon