### PR TITLE
fix: resolve socket.io-parser version to 4.2.6 to fix binary attachments vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,8 @@
     "lodash": "4.17.23",
     "lodash-es": "4.17.23",
     "@lingo.dev/_compiler/fast-xml-parser": "5.3.5",
-    "fast-xml-parser": "4.5.4"
+    "fast-xml-parser": "4.5.4",
+    "socket.io-parser": "4.2.6"
   },
   "packageExtensions": {
     "ink@3.2.0": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,7 +2735,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/lib@workspace:*, @calcom/lib@workspace:packages/lib":
+"@calcom/lib@npm:*, @calcom/lib@workspace:*, @calcom/lib@workspace:packages/lib":
   version: 0.0.0-use.local
   resolution: "@calcom/lib@workspace:packages/lib"
   dependencies:
@@ -2780,9 +2780,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcom/lyra@workspace:packages/app-store/lyra"
   dependencies:
-    "@calcom/lib": "workspace:*"
-    "@calcom/prisma": "workspace:*"
-    "@calcom/types": "workspace:*"
+    "@calcom/lib": "npm:*"
+    "@calcom/prisma": "npm:*"
+    "@calcom/types": "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -2972,7 +2972,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/prisma@workspace:*, @calcom/prisma@workspace:packages/prisma":
+"@calcom/prisma@npm:*, @calcom/prisma@workspace:*, @calcom/prisma@workspace:packages/prisma":
   version: 0.0.0-use.local
   resolution: "@calcom/prisma@workspace:packages/prisma"
   dependencies:
@@ -3212,7 +3212,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/types@workspace:*, @calcom/types@workspace:packages/types":
+"@calcom/types@npm:*, @calcom/types@workspace:*, @calcom/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@calcom/types@workspace:packages/types"
   dependencies:
@@ -20661,7 +20661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3, debug@npm:~4.4.1":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -35607,13 +35607,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socket.io-parser@npm:~4.2.4":
-  version: 4.2.4
-  resolution: "socket.io-parser@npm:4.2.4"
+"socket.io-parser@npm:4.2.6":
+  version: 4.2.6
+  resolution: "socket.io-parser@npm:4.2.6"
   dependencies:
     "@socket.io/component-emitter": "npm:~3.1.0"
-    debug: "npm:~4.3.1"
-  checksum: 10/4be500a9ff7e79c50ec25af11048a3ed34b4c003a9500d656786a1e5bceae68421a8394cf3eb0aa9041f85f36c1a9a737617f4aee91a42ab4ce16ffb2aa0c89c
+    debug: "npm:~4.4.1"
+  checksum: 10/cf8f3e9feee42b2405065bccef732894a0b07b7cb734c4954eb8876d7a0038e7df6e6d06fab3a25f816f5d996917391833d5f06136e8c8c6fbecf5da962c1c9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

Pins `socket.io-parser` to version 4.2.6 via yarn resolutions to address a security vulnerability related to insufficient validation of binary attachments in older versions (≤4.2.4). This ensures all transitive dependencies use the patched version.

### Changes
- Added `"socket.io-parser": "4.2.6"` to the `resolutions` section in the root `package.json`
- Updated `yarn.lock` accordingly (4.2.4 → 4.2.6)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — this is a dependency version pin; existing test suites cover runtime behavior.

## How should this be tested?

1. Run `yarn install` and verify it completes without errors.
2. Confirm `socket.io-parser` resolves to 4.2.6: `yarn why socket.io-parser`
3. Run `yarn type-check:ci --force` and `yarn test` to verify no regressions.

## ⚠️ Reviewer Notes

- The `yarn.lock` diff includes changes to `@calcom/lyra`'s dependency specifiers (`workspace:*` → `npm:*` for `@calcom/lib`, `@calcom/prisma`, `@calcom/types`). These are artifacts of yarn's resolution when adding the new resolution entry — the packages still resolve to their local workspace paths. **Please verify this doesn't affect local package resolution in the monorepo.**
- The `debug` dependency range in `socket.io-parser` changed from `~4.3.1` to `~4.4.1`, which resolves to the same `debug@4.4.3` already in the lockfile.

Link to Devin session: https://app.devin.ai/sessions/e3558211aacf45a793fc2d60428fb42e
Requested by: @sean-brydon