### PR TITLE
feat: take into account guest availability when host reschedules

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -160,6 +160,7 @@ export type GetUserAvailabilityInitialData = {
     bookingLimits?: unknown;
     includeManagedEventsInLimits: boolean;
   } | null;
+  guestBusyTimes?: { start: Date; end: Date }[];
 };
 
 export type GetAvailabilityUser = GetUserAvailabilityInitialData["user"];
@@ -627,6 +628,12 @@ export class UserAvailabilityService {
       })),
       ...busyTimesFromLimits,
       ...busyTimesFromTeamLimits,
+      ...(initialData?.guestBusyTimes ?? []).map((t) => ({
+        start: dayjs(t.start).toISOString(),
+        end: dayjs(t.end).toISOString(),
+        title: "Guest busy",
+        source: withSource ? ("guest-availability" as const) : undefined,
+      })),
     ];
 
     const detailedBusyTimes: UserAvailabilityBusyDetails[] = withSource

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -2213,4 +2213,49 @@ export class BookingRepository implements IBookingRepository {
       },
     });
   }
+
+  /**
+   * Find a booking by UID and include its attendees' emails.
+   * Used to determine who to check availability for when rescheduling.
+   */
+  async findByUidForAttendeeEmails({ uid }: { uid: string }) {
+    return this.prismaClient.booking.findUnique({
+      where: { uid },
+      select: {
+        uid: true,
+        attendees: {
+          select: { email: true },
+        },
+      },
+    });
+  }
+
+  /**
+   * Find accepted bookings for the given user IDs within a date range.
+   * Used to build guest busy times when the host reschedules.
+   */
+  async findAcceptedBookingsByUserIdsInRange({
+    userIds,
+    startTime,
+    endTime,
+  }: {
+    userIds: number[];
+    startTime: Date;
+    endTime: Date;
+  }) {
+    if (!userIds.length) return [];
+    return this.prismaClient.booking.findMany({
+      where: {
+        userId: { in: userIds },
+        status: BookingStatus.ACCEPTED,
+        startTime: { lt: endTime },
+        endTime: { gt: startTime },
+      },
+      select: {
+        uid: true,
+        startTime: true,
+        endTime: true,
+      },
+    });
+  }
 }

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -2233,20 +2233,36 @@ export class BookingRepository implements IBookingRepository {
   /**
    * Find accepted bookings for the given user IDs within a date range.
    * Used to build guest busy times when the host reschedules.
+   *
+   * Checks both organizer role (userId) and attendee role so bookings where
+   * the Cal user was invited—rather than hosting—are also captured.
    */
   async findAcceptedBookingsByUserIdsInRange({
     userIds,
+    userEmails,
     startTime,
     endTime,
   }: {
     userIds: number[];
+    userEmails: string[];
     startTime: Date;
     endTime: Date;
   }) {
     if (!userIds.length) return [];
     return this.prismaClient.booking.findMany({
       where: {
-        userId: { in: userIds },
+        OR: [
+          { userId: { in: userIds } },
+          ...(userEmails.length
+            ? [
+                {
+                  attendees: {
+                    some: { email: { in: userEmails, mode: "insensitive" as const } },
+                  },
+                },
+              ]
+            : []),
+        ],
         status: BookingStatus.ACCEPTED,
         startTime: { lt: endTime },
         endTime: { gt: startTime },

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1519,15 +1519,26 @@ export class UserRepository {
   /**
    * Find Cal.com users by their email addresses (case-insensitive).
    * Used to identify which attendees are Cal.com users when rescheduling.
+   *
+   * Checks both the primary email and any verified secondary emails so that
+   * attendees who booked with a secondary address are still matched.
    */
   async findCalUsersByEmails({ emails }: { emails: string[] }) {
     if (!emails.length) return [];
+    const normalizedEmails = emails.map((e) => e.toLowerCase());
     return this.prismaClient.user.findMany({
       where: {
-        email: {
-          in: emails.map((e) => e.toLowerCase()),
-          mode: "insensitive",
-        },
+        OR: [
+          { email: { in: normalizedEmails, mode: "insensitive" } },
+          {
+            secondaryEmails: {
+              some: {
+                email: { in: normalizedEmails, mode: "insensitive" },
+                emailVerified: { not: null },
+              },
+            },
+          },
+        ],
       },
       select: {
         id: true,

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1515,4 +1515,24 @@ export class UserRepository {
 
     return { email: user.email, username: user.username };
   }
+
+  /**
+   * Find Cal.com users by their email addresses (case-insensitive).
+   * Used to identify which attendees are Cal.com users when rescheduling.
+   */
+  async findCalUsersByEmails({ emails }: { emails: string[] }) {
+    if (!emails.length) return [];
+    return this.prismaClient.user.findMany({
+      where: {
+        email: {
+          in: emails.map((e) => e.toLowerCase()),
+          mode: "insensitive",
+        },
+      },
+      select: {
+        id: true,
+        email: true,
+      },
+    });
+  }
 }

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -829,6 +829,57 @@ export class AvailableSlotsService {
   }
   private getOOODates = withReporting(this._getOOODates.bind(this), "getOOODates");
 
+  /**
+   * When the host reschedules, look up the original booking's attendees, find which ones
+   * are Cal.com users, and return their existing bookings as busy times. This ensures
+   * the host can only pick a time slot that works for all attendees.
+   *
+   * Skip for COLLECTIVE events (already handled by host availability).
+   */
+  private async _getGuestBusyTimesForReschedule({
+    rescheduleUid,
+    schedulingType,
+    startTime,
+    endTime,
+  }: {
+    rescheduleUid: string | null | undefined;
+    schedulingType: SchedulingType | null;
+    startTime: Date;
+    endTime: Date;
+  }): Promise<{ start: Date; end: Date }[]> {
+    if (!rescheduleUid || schedulingType === SchedulingType.COLLECTIVE) {
+      return [];
+    }
+
+    const originalBooking = await this.dependencies.bookingRepo.findByUidForAttendeeEmails({
+      uid: rescheduleUid,
+    });
+    if (!originalBooking?.attendees?.length) return [];
+
+    const attendeeEmails = originalBooking.attendees
+      .map((a) => a.email)
+      .filter((e): e is string => Boolean(e));
+    if (!attendeeEmails.length) return [];
+
+    const guestUsers = await this.dependencies.userRepo.findCalUsersByEmails({ emails: attendeeEmails });
+    if (!guestUsers.length) return [];
+
+    const guestBookings = await this.dependencies.bookingRepo.findAcceptedBookingsByUserIdsInRange({
+      userIds: guestUsers.map((u) => u.id),
+      startTime,
+      endTime,
+    });
+
+    // Exclude the booking being rescheduled so its time slot remains selectable
+    return guestBookings
+      .filter((b) => b.uid !== rescheduleUid)
+      .map((b) => ({ start: b.startTime, end: b.endTime }));
+  }
+  private getGuestBusyTimesForReschedule = withReporting(
+    this._getGuestBusyTimesForReschedule.bind(this),
+    "getGuestBusyTimesForReschedule"
+  );
+
   private _getUsersWithCredentials({
     hosts,
   }: {
@@ -903,7 +954,7 @@ export class AvailableSlotsService {
     const allUserIds = Array.from(userIdAndEmailMap.keys());
 
     const bookingRepo = this.dependencies.bookingRepo;
-    const [currentBookingsAllUsers, outOfOfficeDaysAllUsers] = await Promise.all([
+    const [currentBookingsAllUsers, outOfOfficeDaysAllUsers, guestBusyTimes] = await Promise.all([
       bookingRepo.findAllExistingBookingsForEventTypeBetween({
         startDate: startTimeDate,
         endDate: endTimeDate,
@@ -912,6 +963,12 @@ export class AvailableSlotsService {
         userIdAndEmailMap,
       }),
       this.getOOODates(startTimeDate, endTimeDate, allUserIds),
+      this.getGuestBusyTimesForReschedule({
+        rescheduleUid: input.rescheduleUid,
+        schedulingType: eventType.schedulingType,
+        startTime: startTimeDate,
+        endTime: endTimeDate,
+      }),
     ]);
 
     const bookingLimits =
@@ -1026,6 +1083,7 @@ export class AvailableSlotsService {
         eventTypeForLimits: eventType && (bookingLimits || durationLimits) ? eventType : null,
         teamBookingLimits: teamBookingLimitsMap,
         teamForBookingLimits: teamForBookingLimits,
+        guestBusyTimes,
       },
     });
     /* We get all users working hours and busy slots */

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -866,6 +866,7 @@ export class AvailableSlotsService {
 
     const guestBookings = await this.dependencies.bookingRepo.findAcceptedBookingsByUserIdsInRange({
       userIds: guestUsers.map((u) => u.id),
+      userEmails: guestUsers.map((u) => u.email),
       startTime,
       endTime,
     });


### PR DESCRIPTION
Fixes #16378

## What it does

When a host reschedules a booking, this change checks whether any attendee is a registered Cal.com user and excludes their existing bookings from the available time slots. This ensures the host can only pick a time that works for all attendees — preventing double-booking from the guest's perspective.

## How it works

The change adds a new step to the slot computation pipeline that runs in parallel with the existing data fetches:

1. **Look up original booking's attendees** — `BookingRepository.findByUidForAttendeeEmails` fetches attendee emails for the booking being rescheduled
2. **Resolve to Cal.com users** — `UserRepository.findCalUsersByEmails` checks which attendees have Cal.com accounts (case-insensitive match)
3. **Fetch guest busy times** — `BookingRepository.findAcceptedBookingsByUserIdsInRange` returns accepted bookings for those users in the reschedule window
4. **Exclude rescheduled slot** — The original booking's time slot is excluded so it remains selectable
5. **Merge into availability** — Guest busy times are passed as `guestBusyTimes` in `getUserAvailability`'s `initialData`, where they're merged into the host's busy times before slot filtering

### Edge cases handled
- Non-Cal.com attendees (no account) are silently skipped
- Collective events are skipped (all host availability is already combined)
- `null`/missing `rescheduleUid` gracefully returns empty (no-op for new bookings)
- The original booking's own time slot is never blocked (filter by uid)

## Files changed

| File | Change |
|------|--------|
| `packages/features/availability/lib/getUserAvailability.ts` | Add `guestBusyTimes` field to `GetUserAvailabilityInitialData`; merge into busy times |
| `packages/features/bookings/repositories/BookingRepository.ts` | Add `findByUidForAttendeeEmails` and `findAcceptedBookingsByUserIdsInRange` |
| `packages/features/users/repositories/UserRepository.ts` | Add `findCalUsersByEmails` (case-insensitive, primary email) |
| `packages/trpc/server/routers/viewer/slots/util.ts` | Add `_getGuestBusyTimesForReschedule` method; integrate into Promise.all; pass `guestBusyTimes` to initialData |
