### PR TITLE
fix: mock delegationCredential in getRoutedUsers test to prevent flaky worker shutdown errors

### DIFF
--- a/packages/features/users/lib/getRoutedUsers.test.ts
+++ b/packages/features/users/lib/getRoutedUsers.test.ts
@@ -7,10 +7,6 @@ vi.mock("@calcom/prisma", () => {
   };
 });
 
-// Mock delegationCredential to prevent heavy transitive imports
-// (delegationCredential -> getCalendar -> calendar.services.generated -> CalendarService -> ics/tsdav)
-// that can cause "Closing rpc while fetch was pending" flakes when the vitest worker shuts down
-// before all async module resolution completes.
 vi.mock("@calcom/app-store/delegationCredential", () => {
   return {
     enrichHostsWithDelegationCredentials: vi.fn().mockResolvedValue([]),

--- a/packages/features/users/lib/getRoutedUsers.test.ts
+++ b/packages/features/users/lib/getRoutedUsers.test.ts
@@ -1,10 +1,19 @@
-import { describe, it, expect, vi } from "vitest";
-
+import { describe, expect, it, vi } from "vitest";
 import { getRoutedUsersWithContactOwnerAndFixedUsers } from "./getRoutedUsers";
 
 vi.mock("@calcom/prisma", () => {
   return {
     default: vi.fn(),
+  };
+});
+
+// Mock delegationCredential to prevent heavy transitive imports
+// (delegationCredential -> getCalendar -> calendar.services.generated -> CalendarService -> ics/tsdav)
+// that can cause "Closing rpc while fetch was pending" flakes when the vitest worker shuts down
+// before all async module resolution completes.
+vi.mock("@calcom/app-store/delegationCredential", () => {
+  return {
+    enrichHostsWithDelegationCredentials: vi.fn().mockResolvedValue([]),
   };
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky unit test failure in `packages/features/users/lib/getRoutedUsers.test.ts` caused by:

```
Error: [vitest-worker]: Closing rpc while "fetch" was pending
 ❯ packages/lib/CalendarService.ts:22:1
This error originated in "packages/features/users/lib/getRoutedUsers.test.ts"
```

**CI evidence of flakiness** (same workflow run, same commit on #28596):
- ❌ [Failed job](https://github.com/calcom/cal.com/actions/runs/23643311921/job/68869238098?pr=28596)
- ✅ [Passed job](https://github.com/calcom/cal.com/actions/runs/23643311921/job/68870399640?pr=28596)

### Root cause

The test file only exercises `getRoutedUsersWithContactOwnerAndFixedUsers`, a pure synchronous function. However, importing `getRoutedUsers.ts` triggers a deep transitive import chain:

```
getRoutedUsers.ts
  → @calcom/app-store/delegationCredential
    → _utils/getCalendar
      → calendar.services.generated (all calendar services)
        → CalendarService.ts → ics / tsdav
```

When the vitest worker finishes the (fast, sync) tests and shuts down before all async module resolution from this chain completes, it produces the "Closing rpc while fetch was pending" error.

### Fix

Mock `@calcom/app-store/delegationCredential` in the test to cut off the heavy import chain. The tested function doesn't use any exports from that module.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the test file repeatedly and confirm no unhandled errors:

```bash
TZ=UTC yarn vitest run packages/features/users/lib/getRoutedUsers.test.ts
```

All 5 tests should pass with no "Closing rpc while fetch was pending" in the output.

## Human Review Checklist

- [ ] Verify that `getRoutedUsersWithContactOwnerAndFixedUsers` does not depend on any export from `@calcom/app-store/delegationCredential` (it doesn't — only `getNormalizedHostsWithDelegationCredentials` and `findMatchingHostsWithEventSegment` use that import, and neither is tested here).
- [ ] Consider whether future tests added to this file for other exported functions (e.g. `getNormalizedHostsWithDelegationCredentials`) would need a more complete mock — they would, but that's a bridge to cross when those tests are written.

Link to Devin session: https://app.devin.ai/sessions/2f36dc6cb3954d6da19d5e0963e80986
Requested by: @sahitya-chandra
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
