### PR TITLE
feat(zapier): add no-show payload support [CAL-5107]

### DIFF
--- a/packages/app-store/zapier/DESCRIPTION.md
+++ b/packages/app-store/zapier/DESCRIPTION.md
@@ -4,6 +4,6 @@ items:
   - 2.jpg
 ---
 
-Connect Cal.com with 8,000+ apps through Zapier to automate your scheduling workflows. Set up triggers for booking events (created, rescheduled, cancelled, meeting ended) and integrate with popular tools like Slack, Gmail, Google Sheets, and more.
+Connect Cal.com with 8,000+ apps through Zapier to automate your scheduling workflows. Set up triggers for booking events (created, rescheduled, cancelled, no-show updated, meeting ended) and integrate with popular tools like Slack, Gmail, Google Sheets, and more.
 
 **Get started:** Click "Visit" to access the Zapier integrations page and create your first automation workflow.

--- a/packages/app-store/zapier/README.md
+++ b/packages/app-store/zapier/README.md
@@ -31,4 +31,6 @@ The following API endpoints are maintained for backward compatibility with exist
 - `DELETE /api/integrations/zapier/deleteSubscription` - Unsubscribe from webhooks
 - `GET /api/integrations/zapier/me` - Get user/team information
 
+Existing integrations can subscribe to booking no-show updates through the same webhook subscription endpoint using the `BOOKING_NO_SHOW_UPDATED` trigger.
+
 **Note:** These endpoints support both API key and OAuth authentication for existing integrations. The endpoints are dynamically routed through `/api/integrations/[...args].ts`.

--- a/packages/app-store/zapier/_metadata.ts
+++ b/packages/app-store/zapier/_metadata.ts
@@ -3,7 +3,7 @@ import type { AppMeta } from "@calcom/types/App";
 export const metadata = {
   name: "Zapier",
   description:
-    "Workflow automation for everyone. Use the Cal.com Zapier app to trigger your workflows when a booking is created, rescheduled, or cancelled, or after a meeting ends.",
+    "Workflow automation for everyone. Use the Cal.com Zapier app to trigger your workflows when a booking is created, rescheduled, cancelled, marked as no-show, or after a meeting ends.",
   installed: true,
   category: "automation",
   categories: ["automation"],

--- a/packages/app-store/zapier/config.json
+++ b/packages/app-store/zapier/config.json
@@ -9,7 +9,7 @@
   "categories": ["automation"],
   "publisher": "Cal.com",
   "email": "help@cal.com",
-  "description": "Workflow automation for everyone. Use the Cal.com Zapier app to automate your workflows when a booking is created, rescheduled, cancelled or when a meeting ends.",
+  "description": "Workflow automation for everyone. Use the Cal.com Zapier app to automate your workflows when a booking is created, rescheduled, cancelled, marked as no-show, or when a meeting ends.",
   "isTemplate": false,
   "__createdUsingCli": true,
   "__template": "link-as-an-app",

--- a/packages/features/webhooks/lib/sendPayload.test.ts
+++ b/packages/features/webhooks/lib/sendPayload.test.ts
@@ -242,4 +242,36 @@ describe("sendPayload", () => {
       expect(body.payload.assignmentReason).toEqual(reasons);
     });
   });
+
+  describe("Zapier payloads", () => {
+    it("should send no-show payloads in Zapier's raw format", async () => {
+      const webhook = {
+        subscriberUrl: "https://example.com/webhook",
+        appId: "zapier",
+        payloadTemplate: null,
+        version: WebhookVersion.V_2021_10_20,
+      };
+
+      await sendPayload("test-secret", "BOOKING_NO_SHOW_UPDATED", "2024-01-01T10:00:00Z", webhook, {
+        bookingUid: "booking-uid-123",
+        bookingId: 123,
+        attendees: [{ email: "attendee@example.com", noShow: true }],
+        message: "attendee@example.com marked as no-show",
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+
+      expect(body).toEqual({
+        bookingUid: "booking-uid-123",
+        bookingId: 123,
+        attendees: [{ email: "attendee@example.com", noShow: true }],
+        message: "attendee@example.com marked as no-show",
+        createdAt: "2024-01-01T10:00:00Z",
+      });
+      expect(body.triggerEvent).toBeUndefined();
+      expect(body.payload).toBeUndefined();
+    });
+  });
 });

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -181,6 +181,16 @@ function getZapierPayload(data: WithUTCOffsetType<EventPayloadType & { createdAt
   return JSON.stringify(body);
 }
 
+function getZapierNoShowPayload(data: BookingNoShowUpdatedPayload & { createdAt: string }): string {
+  return JSON.stringify({
+    bookingUid: data.bookingUid,
+    bookingId: data.bookingId,
+    attendees: data.attendees,
+    message: data.message,
+    createdAt: data.createdAt,
+  });
+}
+
 function applyTemplate(
   template: string,
   data: WebhookDataType | Record<string, unknown>,
@@ -256,6 +266,8 @@ const sendPayload = async (
     if (appId === "zapier") {
       body = getZapierPayload({ ...data, createdAt });
     }
+  } else if (appId === "zapier" && isNoShowPayload(data)) {
+    body = getZapierNoShowPayload({ ...data, createdAt });
   }
 
   if (body === undefined) {


### PR DESCRIPTION
Related to #18992.

## Issue being solved (CAL-5107)
Zapier integrations were not getting a Zapier-compatible payload for `BOOKING_NO_SHOW_UPDATED`.

Cal.com already emitted the no-show webhook event, but in the Zapier path we only had special raw formatting for regular booking events. No-show updates were falling back to the generic webhook envelope (`{ triggerEvent, createdAt, payload }`), which is not the expected Zapier raw body shape.

## Solution
- add Zapier-specific formatting for `BOOKING_NO_SHOW_UPDATED` so Zapier subscribers receive the raw event body
- add a regression test covering Zapier no-show payload serialization
- update Zapier app copy to mention no-show support

## Verification
- `yarn vitest run packages/features/webhooks/lib/sendPayload.test.ts`
- `yarn biome check --write packages/features/webhooks/lib/sendPayload.ts packages/features/webhooks/lib/sendPayload.test.ts packages/app-store/zapier/_metadata.ts packages/app-store/zapier/config.json`
- `yarn tsc --pretty --noEmit -p packages/app-store/tsconfig.json`

## Scope note
- I intentionally did not change the separate host-side no-show webhook gap in `handleMarkNoShow.ts` to keep this PR focused on CAL-5107.
- As an external contributor, I cannot apply the `run-ci` label; a maintainer must mark the PR trusted to run full CI.