### PR TITLE
fix: availability day toggle not marking form as dirty

### DIFF
--- a/packages/features/schedules/components/ScheduleComponent.test.tsx
+++ b/packages/features/schedules/components/ScheduleComponent.test.tsx
@@ -1,0 +1,92 @@
+import type { TimeRange } from "@calcom/types/schedule";
+import { TooltipProvider } from "@radix-ui/react-tooltip";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+import { ScheduleDay } from "./ScheduleComponent";
+
+const DEFAULT_DAY_RANGE: TimeRange = {
+  start: new Date(new Date().setUTCHours(9, 0, 0, 0)),
+  end: new Date(new Date().setUTCHours(17, 0, 0, 0)),
+};
+
+type FormValues = {
+  schedule: TimeRange[][];
+};
+
+const ScheduleDayWrapper = ({
+  initialSchedule,
+  onDirtyChange,
+}: {
+  initialSchedule: TimeRange[][];
+  onDirtyChange?: (isDirty: boolean) => void;
+}) => {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      schedule: initialSchedule,
+    },
+  });
+
+  const isDirty = form.formState.isDirty;
+
+  React.useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
+
+  return (
+    <TooltipProvider>
+      <FormProvider {...form}>
+        <ScheduleDay
+          name="schedule.0"
+          weekday="Monday"
+          control={form.control}
+          CopyButton={<div />}
+          userTimeFormat={24}
+        />
+        <div data-testid="dirty-state">{isDirty ? "dirty" : "clean"}</div>
+      </FormProvider>
+    </TooltipProvider>
+  );
+};
+
+describe("ScheduleDay", () => {
+  it("should mark form as dirty when toggling a day off", () => {
+    render(<ScheduleDayWrapper initialSchedule={[[DEFAULT_DAY_RANGE]]} />);
+
+    expect(screen.getByTestId("dirty-state")).toHaveTextContent("clean");
+
+    const toggle = screen.getByTestId("Monday-switch");
+    fireEvent.click(toggle);
+
+    expect(screen.getByTestId("dirty-state")).toHaveTextContent("dirty");
+  });
+
+  it("should mark form as dirty when toggling a day on", () => {
+    render(<ScheduleDayWrapper initialSchedule={[[]]} />);
+
+    expect(screen.getByTestId("dirty-state")).toHaveTextContent("clean");
+
+    const toggle = screen.getByTestId("Monday-switch");
+    fireEvent.click(toggle);
+
+    expect(screen.getByTestId("dirty-state")).toHaveTextContent("dirty");
+  });
+
+  it("should be clean again when toggling off then on restores original value", () => {
+    render(<ScheduleDayWrapper initialSchedule={[[DEFAULT_DAY_RANGE]]} />);
+
+    expect(screen.getByTestId("dirty-state")).toHaveTextContent("clean");
+
+    const toggle = screen.getByTestId("Monday-switch");
+
+    // Toggle off — form becomes dirty
+    fireEvent.click(toggle);
+    expect(screen.getByTestId("dirty-state")).toHaveTextContent("dirty");
+
+    // Toggle back on restores the previous value which matches the default,
+    // so react-hook-form correctly marks the form as clean
+    fireEvent.click(toggle);
+    expect(screen.getByTestId("dirty-state")).toHaveTextContent("clean");
+  });
+});

--- a/packages/features/schedules/components/ScheduleComponent.tsx
+++ b/packages/features/schedules/components/ScheduleComponent.tsx
@@ -1,3 +1,16 @@
+import process from "node:process";
+import type { scheduleClassNames } from "@calcom/atoms/availability/types";
+import type { ConfigType } from "@calcom/dayjs";
+import dayjs from "@calcom/dayjs";
+import { defaultDayRange as DEFAULT_DAY_RANGE } from "@calcom/lib/availability";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { weekdayNames } from "@calcom/lib/weekday";
+import type { TimeRange } from "@calcom/types/schedule";
+import cn from "@calcom/ui/classNames";
+import { Button } from "@calcom/ui/components/button";
+import { Dropdown, DropdownMenuContent, DropdownMenuTrigger } from "@calcom/ui/components/dropdown";
+import { CheckboxField, Select, Switch } from "@calcom/ui/components/form";
+import { SkeletonText } from "@calcom/ui/components/skeleton";
 import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   ArrayPath,
@@ -11,21 +24,6 @@ import type {
 } from "react-hook-form";
 import { Controller, useFieldArray, useFormContext } from "react-hook-form";
 import { createFilter, type GroupBase, type Props } from "react-select";
-
-import type { scheduleClassNames } from "@calcom/atoms/availability/types";
-import type { ConfigType } from "@calcom/dayjs";
-import dayjs from "@calcom/dayjs";
-import { defaultDayRange as DEFAULT_DAY_RANGE } from "@calcom/lib/availability";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { weekdayNames } from "@calcom/lib/weekday";
-import type { TimeRange } from "@calcom/types/schedule";
-import cn from "@calcom/ui/classNames";
-import { Button } from "@calcom/ui/components/button";
-import { Dropdown, DropdownMenuContent, DropdownMenuTrigger } from "@calcom/ui/components/dropdown";
-import { Select } from "@calcom/ui/components/form";
-import { CheckboxField } from "@calcom/ui/components/form";
-import { Switch } from "@calcom/ui/components/form";
-import { SkeletonText } from "@calcom/ui/components/skeleton";
 
 export type { TimeRange };
 
@@ -98,12 +96,12 @@ export const ScheduleDay = <TFieldValues extends FieldValues>({
                       previousDayRange && previousDayRange.length > 0 ? previousDayRange : [DEFAULT_DAY_RANGE]
                     ) as TFieldValues[typeof name];
 
-                    setValue(name, newValue);
+                    setValue(name, newValue, { shouldDirty: true });
                   } else {
                     if (watchDayRange && watchDayRange.length > 0) {
                       lastNonEmptyDayRangeRef.current = watchDayRange as unknown as TimeRange[];
                     }
-                    setValue(name, [] as TFieldValues[typeof name]);
+                    setValue(name, [] as TFieldValues[typeof name], { shouldDirty: true });
                   }
                 }}
               />
@@ -170,7 +168,9 @@ const CopyButton = ({
           weekStart={weekStart}
           disabled={parseInt(getValuesFromDayRange.replace(`${fieldArrayName}.`, ""), 10)}
           onClick={(selected) => {
-            selected.forEach((day) => setValue(`${fieldArrayName}.${day}`, getValues(getValuesFromDayRange)));
+            selected.forEach((day) =>
+              setValue(`${fieldArrayName}.${day}`, getValues(getValuesFromDayRange), { shouldDirty: true })
+            );
             setOpen(false);
           }}
           onCancel={() => setOpen(false)}

--- a/packages/features/schedules/components/ScheduleComponent.tsx
+++ b/packages/features/schedules/components/ScheduleComponent.tsx
@@ -1,4 +1,3 @@
-import process from "node:process";
 import type { scheduleClassNames } from "@calcom/atoms/availability/types";
 import type { ConfigType } from "@calcom/dayjs";
 import dayjs from "@calcom/dayjs";

--- a/packages/platform/atoms/availability/AvailabilitySettings.tsx
+++ b/packages/platform/atoms/availability/AvailabilitySettings.tsx
@@ -1,22 +1,8 @@
 "use client";
 
-import type { SetStateAction, Dispatch } from "react";
-import React from "react";
-import {
-  useMemo,
-  useState,
-  useEffect,
-  forwardRef,
-  useImperativeHandle,
-  useRef,
-  useCallback,
-} from "react";
-import { Controller, useFieldArray, useForm, useFormContext, useWatch } from "react-hook-form";
-
 import dayjs from "@calcom/dayjs";
 import { BookerStoreProvider } from "@calcom/features/bookings/Booker/BookerStoreProvider";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import { TimezoneSelect as WebTimezoneSelect } from "@calcom/web/modules/timezone/components/TimezoneSelect";
 import type {
   BulkUpdatParams,
   EventTypes,
@@ -24,32 +10,32 @@ import type {
 import { BulkEditDefaultForEventsModal } from "@calcom/features/eventtypes/components/BulkEditDefaultForEventsModal";
 import DateOverrideInputDialog from "@calcom/features/schedules/components/DateOverrideInputDialog";
 import DateOverrideList from "@calcom/features/schedules/components/DateOverrideList";
-import {
-  ScheduleComponent as PlatformSchedule,
-} from "@calcom/features/schedules/components/ScheduleComponent";
-import WebSchedule from "@calcom/web/modules/schedules/components/Schedule";
+import { ScheduleComponent as PlatformSchedule } from "@calcom/features/schedules/components/ScheduleComponent";
+import type { TravelScheduleRepository } from "@calcom/features/travelSchedule/repositories/TravelScheduleRepository";
 import { availabilityAsString } from "@calcom/lib/availability";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { sortAvailabilityStrings } from "@calcom/lib/weekstart";
-import type { TravelScheduleRepository } from "@calcom/features/travelSchedule/repositories/TravelScheduleRepository";
 import type { TimeRange, WorkingHours } from "@calcom/types/schedule";
 import classNames from "@calcom/ui/classNames";
 import { Button } from "@calcom/ui/components/button";
-import { DialogTrigger, ConfirmationDialogContent } from "@calcom/ui/components/dialog";
+import { ConfirmationDialogContent, DialogTrigger } from "@calcom/ui/components/dialog";
 import { VerticalDivider } from "@calcom/ui/components/divider";
 import { EditableHeading } from "@calcom/ui/components/editable-heading";
-import { Form } from "@calcom/ui/components/form";
-import { Label } from "@calcom/ui/components/form";
-import { Switch } from "@calcom/ui/components/form";
+import { Form, Label, Switch } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
-import { SkeletonText, SelectSkeletonLoader, Skeleton } from "@calcom/ui/components/skeleton";
+import { SelectSkeletonLoader, Skeleton, SkeletonText } from "@calcom/ui/components/skeleton";
 import { Tooltip } from "@calcom/ui/components/tooltip";
+import WebSchedule from "@calcom/web/modules/schedules/components/Schedule";
 import WebShell from "@calcom/web/modules/shell/Shell";
-
+import { TimezoneSelect as WebTimezoneSelect } from "@calcom/web/modules/timezone/components/TimezoneSelect";
+import type React from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { Controller, useFieldArray, useForm, useFormContext, useWatch } from "react-hook-form";
 import { Shell as PlatformShell } from "../src/components/ui/shell";
 import { cn } from "../src/lib/utils";
 import { Timezone as PlatformTimzoneSelect } from "../timezone/index";
-import type { AvailabilityFormValues, scheduleClassNames, AvailabilitySettingsFormRef } from "./types";
+import type { AvailabilityFormValues, AvailabilitySettingsFormRef, scheduleClassNames } from "./types";
 
 export type Schedule = {
   id: number;
@@ -334,19 +320,7 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
       control: form.control,
     });
 
-    const initialValuesRef = useRef<AvailabilityFormValues | null>(null);
-    useEffect(() => {
-      initialValuesRef.current = form.getValues() as AvailabilityFormValues;
-    }, [form, schedule]);
-
-    const formHasChanges = useMemo(() => {
-      if (!initialValuesRef.current) return false;
-      try {
-        return (JSON.stringify(form.watch("schedule")) !== JSON.stringify(initialValuesRef.current.availability) || JSON.stringify(watchedValues) !== JSON.stringify(initialValuesRef.current));
-      } catch {
-        return form.formState.isDirty;
-      }
-    }, [watchedValues, form.formState.isDirty]);
+    const { isDirty } = form.formState;
 
     // Trigger callback whenever the form state changes
     useEffect(() => {
@@ -375,6 +349,7 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
           form.handleSubmit(async (data) => {
             try {
               await handleSubmit(data);
+              form.reset(data);
               callbacksRef?.current?.onSuccess?.();
             } catch (error) {
               callbacksRef?.current?.onError?.(error as Error);
@@ -643,8 +618,7 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
               type="submit"
               form="availability-form"
               loading={isSaving}
-              disabled={isLoading || !formHasChanges}
-            >
+              disabled={isLoading || !isDirty}>
               {t("save")}
             </Button>
             <Button
@@ -660,8 +634,9 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
           <Form
             form={form}
             id="availability-form"
-            handleSubmit={async (props) => {
-              handleSubmit(props);
+            handleSubmit={async (values) => {
+              await handleSubmit(values);
+              form.reset(values);
             }}
             className={cn(customClassNames?.formClassName, "flex flex-col sm:mx-0 xl:flex-row xl:space-x-6")}>
             <div className="flex-1">


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where toggling a day on/off in the availability schedule editor does not enable the Save button. Editing time ranges within a day still works, but the day switch toggle has no effect on the save button's disabled state.

**Root cause:** Commit b843c19f01 (#26410) refactored the day toggle handler in `ScheduleDay` to remember previous time ranges, but the `setValue()` calls were made without `{ shouldDirty: true }`, so react-hook-form never marked the form as dirty.

Additionally, the `formHasChanges` logic in `AvailabilitySettings` (introduced in #26174) had a secondary bug: it compared `form.watch("schedule")` against `initialValuesRef.current.availability`, but `initialValuesRef` was set from `form.getValues()` which has a `schedule` field — not `availability`. This made the comparison always return `true` or behave unreliably.

**Changes:**
1. **`ScheduleComponent.tsx`** — Added `{ shouldDirty: true }` to all three `setValue` calls (day toggle on, day toggle off, copy times)
2. **`AvailabilitySettings.tsx`** — Replaced the broken `formHasChanges`/`initialValuesRef` custom dirty-check with react-hook-form's built-in `form.formState.isDirty`. Added `form.reset(values)` after successful save so the button correctly disables again. Added `await` to the `handleSubmit` call so the form only resets after save completes.
3. **`ScheduleComponent.test.tsx`** — New unit tests verifying dirty state behavior on day toggle (toggle off marks dirty, toggle on from empty marks dirty, toggle off→on restoring original value returns to clean).

Note: Import reordering in both files was applied by biome's auto-formatter during pre-commit hooks.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to **Availability** → open any schedule
2. Toggle a day's switch off → the **Save** button should become enabled
3. Toggle it back on → if the times match the original, Save should become disabled again
4. Toggle a day off and click Save → schedule saves, Save button becomes disabled
5. Edit a time range → Save button should still become enabled (existing behavior, verify no regression)
6. Use "Copy times" to copy a day's schedule → Save button should become enabled
7. Edit the schedule **name** or **timezone** → Save button should become enabled
8. Save after any change → Save button should become disabled again

## Human Review Checklist

- [ ] Verify that `form.formState.isDirty` works correctly for **all** form fields (name, timezone, isDefault, dateOverrides), not just the schedule day toggles. The previous `formHasChanges` logic, while buggy, was attempting to handle multiple field types — `isDirty` should cover these via react-hook-form's built-in tracking, but worth verifying.
- [ ] The `form.reset(values)` after save — confirm this doesn't interfere with the parent's `onSuccess` mutation callbacks (e.g., cache invalidation, toast notifications). The reset runs after `await handleSubmit(values)` completes.
- [ ] The addition of `await` before `handleSubmit(values)` in the Form's submit handler is a behavior change — previously the form reset could have fired before the mutation completed. This is intentionally safer but worth confirming no side effects.

Link to Devin session: https://app.devin.ai/sessions/96e307843e214d26ae2ab7e53f775767
Requested by: @joeauyeung
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
