### PR TITLE
fix: add Content-Security-Policy header for XSS defense-in-depth

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -415,6 +415,11 @@ const nextConfig = (phase: string): NextConfig => {
               key: "Referrer-Policy",
               value: "strict-origin-when-cross-origin",
             },
+            {
+              key: "Content-Security-Policy",
+              value:
+                "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; font-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'none';",
+            },
           ],
         },
         {


### PR DESCRIPTION
## Summary
- Adds a `Content-Security-Policy` header to all routes (`/:path*`) in the Next.js headers configuration
- Uses a permissive-but-protective policy: `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; font-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'none';`
- Provides defense-in-depth against XSS without breaking existing functionality

Closes #28617

## Test plan
- [ ] Verify the app loads and functions correctly with the new CSP header
- [ ] Check browser console for CSP violations that might indicate the policy is too restrictive
- [ ] Verify embedded scripts (analytics, third-party integrations) still work
- [ ] Confirm `frame-ancestors 'none'` does not conflict with the existing `X-Frame-Options: DENY` on auth pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)