### PR TITLE
fix: restrict webhook URLs to http/https schemes

### DIFF
--- a/packages/trpc/server/routers/viewer/webhook/create.schema.ts
+++ b/packages/trpc/server/routers/viewer/webhook/create.schema.ts
@@ -1,13 +1,16 @@
-import { z } from "zod";
-
 import { TIME_UNIT } from "@calcom/features/ee/workflows/lib/constants";
 import { WEBHOOK_TRIGGER_EVENTS } from "@calcom/features/webhooks/lib/constants";
 import { WebhookVersion } from "@calcom/features/webhooks/lib/interface/IWebhookRepository";
-
+import { z } from "zod";
 import { webhookIdAndEventTypeIdSchema } from "./types";
 
 export const ZCreateInputSchema = webhookIdAndEventTypeIdSchema.extend({
-  subscriberUrl: z.string().url(),
+  subscriberUrl: z
+    .string()
+    .url()
+    .refine((url) => url.startsWith("https://") || url.startsWith("http://"), {
+      message: "Webhook URL must use http or https protocol",
+    }),
   eventTriggers: z.enum(WEBHOOK_TRIGGER_EVENTS).array(),
   active: z.boolean(),
   payloadTemplate: z.string().nullable(),

--- a/packages/trpc/server/routers/viewer/webhook/edit.schema.ts
+++ b/packages/trpc/server/routers/viewer/webhook/edit.schema.ts
@@ -1,14 +1,18 @@
-import { z } from "zod";
-
 import { TIME_UNIT } from "@calcom/features/ee/workflows/lib/constants";
 import { WEBHOOK_TRIGGER_EVENTS } from "@calcom/features/webhooks/lib/constants";
 import { WebhookVersion } from "@calcom/features/webhooks/lib/interface/IWebhookRepository";
-
+import { z } from "zod";
 import { webhookIdAndEventTypeIdSchema } from "./types";
 
 export const ZEditInputSchema = webhookIdAndEventTypeIdSchema.extend({
   id: z.string(),
-  subscriberUrl: z.string().url().optional(),
+  subscriberUrl: z
+    .string()
+    .url()
+    .refine((url) => url.startsWith("https://") || url.startsWith("http://"), {
+      message: "Webhook URL must use http or https protocol",
+    })
+    .optional(),
   eventTriggers: z.enum(WEBHOOK_TRIGGER_EVENTS).array().optional(),
   active: z.boolean().optional(),
   payloadTemplate: z.string().nullable(),


### PR DESCRIPTION
## Summary
- Adds a `.refine()` Zod validation on `subscriberUrl` in both the webhook **create** and **edit** schemas to reject non-HTTP(S) URL schemes (e.g., `javascript:`, `ftp:`, `data:`)
- Closes #28615

## Test plan
- [ ] Verify that `https://example.com/webhook` and `http://example.com/webhook` are accepted
- [ ] Verify that `javascript:alert(1)` is rejected with the message "Webhook URL must use http or https protocol"
- [ ] Verify that `ftp://example.com` and `data:text/html,...` are rejected
- [ ] Verify that omitting `subscriberUrl` in the edit schema still works (field is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)