### PR TITLE
fix: return 404 instead of Prisma error when cancelling non-existent booking

### DIFF
--- a/packages/features/bookings/lib/getBookingToDelete.ts
+++ b/packages/features/bookings/lib/getBookingToDelete.ts
@@ -1,9 +1,10 @@
 import { workflowSelect } from "@calcom/features/ee/workflows/lib/getAllWorkflows";
+import { HttpError } from "@calcom/lib/http-error";
 import prisma, { bookingMinimalSelect } from "@calcom/prisma";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 
 export async function getBookingToDelete(id: number | undefined, uid: string | undefined) {
-  return await prisma.booking.findUniqueOrThrow({
+  const booking = await prisma.booking.findUnique({
     where: {
       id,
       uid,
@@ -120,6 +121,12 @@ export async function getBookingToDelete(id: number | undefined, uid: string | u
       status: true,
     },
   });
+
+  if (!booking) {
+    throw new HttpError({ statusCode: 404, message: "Booking not found" });
+  }
+
+  return booking;
 }
 
 export type BookingToDelete = Awaited<ReturnType<typeof getBookingToDelete>>;


### PR DESCRIPTION
## Summary
- Fixes #28614
- Replaces `findUniqueOrThrow` with `findUnique` + explicit null check in `getBookingToDelete`
- Non-existent booking UID now returns a clean `404 {"message": "Booking not found"}` instead of leaking a raw Prisma `NotFoundError` stack trace (or a generic "An error occurred while querying the database" in production)

## Test plan
- [ ] Send a DELETE/POST to `/api/cancel` with a non-existent booking UID and verify 404 response with `{"message": "Booking not found"}`
- [ ] Cancel an existing booking and verify it still works as before
- [ ] Type check passes (`yarn type-check:ci --force`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)