### PR TITLE
fix: block localhost and loopback addresses in SSRF protection

### DIFF
--- a/packages/lib/ssrfProtection.test.ts
+++ b/packages/lib/ssrfProtection.test.ts
@@ -57,15 +57,16 @@ describe("isPrivateIP", () => {
 
 describe("isBlockedHostname", () => {
   it.each([
-    "localhost", // loopback hostname
-    "127.0.0.1", // IPv4 loopback
-    "::1", // IPv6 loopback
-    "0.0.0.0", // unspecified address
-    "169.254.169.254", // AWS/Azure/DigitalOcean
-    "metadata.google.internal", // GCP
-    "169.254.169.254.", // trailing dot normalization
-    "METADATA.GOOGLE.INTERNAL", // case insensitive
-  ])("blocks cloud metadata endpoint %s", (hostname) => {
+    "localhost",
+    "127.0.0.1",
+    "::1",
+    "[::1]",
+    "0.0.0.0",
+    "169.254.169.254",
+    "metadata.google.internal",
+    "169.254.169.254.",
+    "METADATA.GOOGLE.INTERNAL",
+  ])("blocks %s", (hostname) => {
     expect(isBlockedHostname(hostname)).toBe(true);
   });
 
@@ -118,7 +119,7 @@ describe("validateUrlForSSRFSync", () => {
   });
 
   it.each([
-    ["https://[::1]/", "Private IP address"],
+    ["https://[::1]/", "Blocked hostname"],
     ["https://[fe80::1]/path", "Private IP address"],
     ["https://[fc00::1]:8080/", "Private IP address"],
     ["https://[::ffff:127.0.0.1]/", "Private IP address"],

--- a/packages/lib/ssrfProtection.test.ts
+++ b/packages/lib/ssrfProtection.test.ts
@@ -58,6 +58,9 @@ describe("isPrivateIP", () => {
 describe("isBlockedHostname", () => {
   it.each([
     "localhost", // loopback hostname
+    "127.0.0.1", // IPv4 loopback
+    "::1", // IPv6 loopback
+    "0.0.0.0", // unspecified address
     "169.254.169.254", // AWS/Azure/DigitalOcean
     "metadata.google.internal", // GCP
     "169.254.169.254.", // trailing dot normalization
@@ -104,7 +107,8 @@ describe("validateUrlForSSRFSync", () => {
     ["http://example.com/logo.png", "Only HTTPS URLs are allowed"],
     ["ftp://example.com/file", "Only HTTPS URLs are allowed"],
     ["data:text/html,<script>alert(1)</script>", "Non-image data URL"],
-    ["https://127.0.0.1/logo.png", "Private IP address"],
+    ["https://127.0.0.1/logo.png", "Blocked hostname"],
+    ["https://0.0.0.0/logo.png", "Blocked hostname"],
     ["https://169.254.169.254/latest/meta-data/", "Blocked hostname"],
     ["https://localhost/logo.png", "Blocked hostname"],
     ["not-a-url", "Invalid URL format"],

--- a/packages/lib/ssrfProtection.ts
+++ b/packages/lib/ssrfProtection.ts
@@ -31,8 +31,7 @@ const CLOUD_METADATA_ENDPOINTS: string[] = [
   "metadata.google.com", // GCP alternate
 ];
 
-// Loopback and unspecified addresses blocked by hostname (defense-in-depth on top of IP range checks)
-const LOOPBACK_HOSTNAMES: string[] = ["localhost", "127.0.0.1", "::1", "0.0.0.0"];
+const LOOPBACK_HOSTNAMES: string[] = ["localhost", "127.0.0.1", "::1", "[::1]", "0.0.0.0"];
 
 // Hostnames blocked on Cal.com SaaS (includes metadata + loopback)
 const BLOCKED_HOSTNAMES: string[] = [...CLOUD_METADATA_ENDPOINTS, ...LOOPBACK_HOSTNAMES];

--- a/packages/lib/ssrfProtection.ts
+++ b/packages/lib/ssrfProtection.ts
@@ -31,8 +31,11 @@ const CLOUD_METADATA_ENDPOINTS: string[] = [
   "metadata.google.com", // GCP alternate
 ];
 
-// Hostnames blocked on Cal.com SaaS (includes metadata + localhost)
-const BLOCKED_HOSTNAMES: string[] = [...CLOUD_METADATA_ENDPOINTS, "localhost"];
+// Loopback and unspecified addresses blocked by hostname (defense-in-depth on top of IP range checks)
+const LOOPBACK_HOSTNAMES: string[] = ["localhost", "127.0.0.1", "::1", "0.0.0.0"];
+
+// Hostnames blocked on Cal.com SaaS (includes metadata + loopback)
+const BLOCKED_HOSTNAMES: string[] = [...CLOUD_METADATA_ENDPOINTS, ...LOOPBACK_HOSTNAMES];
 
 const CAL_AVATAR_PATH_REGEX = /^\/api\/avatar\/.+\.png$/;
 


### PR DESCRIPTION
## Summary
- Adds `127.0.0.1`, `::1`, and `0.0.0.0` to the `BLOCKED_HOSTNAMES` list alongside `localhost` for defense-in-depth SSRF protection
- Previously these addresses were only caught by IP range checks; now they are also blocked at the hostname level, ensuring consistent "Blocked hostname" errors
- Adds corresponding test coverage for the new blocked hostnames

Closes #28616

## Test plan
- [x] `TZ=UTC yarn vitest run packages/lib/ssrfProtection.test.ts` -- all 59 tests pass (4 new)
- [ ] Verify no regressions in webhook URL validation
- [ ] Verify self-hosted environments still allow private IPs for internal webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)