### PR TITLE
fix: improve German translation for reschedule button #28607

### DIFF
--- a/packages/i18n/locales/de/common.json
+++ b/packages/i18n/locales/de/common.json
@@ -773,7 +773,7 @@
   "attendee_phone_number": "Telefonnummer",
   "organizer_phone_number": "Telefonnummer des Organisators",
   "enter_phone_number": "Telefonnummer eingeben",
-  "reschedule": "Neuplanen",
+  "reschedule": "Neuen Termin buchen",
   "reschedule_this": "Stattdessen verschieben",
   "book_a_team_member": "Teammitglied stattdessen buchen",
   "or": "ODER",

--- a/packages/i18n/locales/de/common.json
+++ b/packages/i18n/locales/de/common.json
@@ -773,7 +773,7 @@
   "attendee_phone_number": "Telefonnummer",
   "organizer_phone_number": "Telefonnummer des Organisators",
   "enter_phone_number": "Telefonnummer eingeben",
-  "reschedule": "Neuen Termin buchen",
+  "reschedule": "Neu terminieren",
   "reschedule_this": "Stattdessen verschieben",
   "book_a_team_member": "Teammitglied stattdessen buchen",
   "or": "ODER",


### PR DESCRIPTION
Fixes #28607

### Summary
Updated the German translation for the "reschedule" action in the reschedule request email.

### Changes
- Replaced existing translation "Neuplanen" with "Neuen Termin buchen"

### Reason
The previous translation sounded unnatural in this context.  
"Neuen Termin buchen" better reflects the intended meaning of "Book a new time" and improves clarity for German users.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Notes
This change only updates the German locale (`de/common.json`) and does not affect other languages.