### PR TITLE
fix: upgrade handlebars to 4.7.9 to resolve critical vulnerability

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -92,7 +92,7 @@
     "classnames": "2.3.2",
     "dompurify": "3.3.1",
     "entities": "4.5.0",
-    "handlebars": "4.7.7",
+    "handlebars": "4.7.9",
     "i18next": "23.2.3",
     "ical.js": "1.5.0",
     "ics": "2.37.0",

--- a/packages/features/auth/package.json
+++ b/packages/features/auth/package.json
@@ -15,7 +15,7 @@
     "@calcom/ui": "workspace:*",
     "bcryptjs": "2.4.3",
     "dub": "0.59.1",
-    "handlebars": "4.7.7",
+    "handlebars": "4.7.9",
     "jose": "4.15.9",
     "lru-cache": "9.0.3",
     "next-auth": "4.24.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2506,7 +2506,7 @@ __metadata:
     "@calcom/ui": "workspace:*"
     bcryptjs: "npm:2.4.3"
     dub: "npm:0.59.1"
-    handlebars: "npm:4.7.7"
+    handlebars: "npm:4.7.9"
     jose: "npm:4.15.9"
     lru-cache: "npm:9.0.3"
     next-auth: "npm:4.24.13"
@@ -2735,7 +2735,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/lib@workspace:*, @calcom/lib@workspace:packages/lib":
+"@calcom/lib@npm:*, @calcom/lib@workspace:*, @calcom/lib@workspace:packages/lib":
   version: 0.0.0-use.local
   resolution: "@calcom/lib@workspace:packages/lib"
   dependencies:
@@ -2780,9 +2780,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcom/lyra@workspace:packages/app-store/lyra"
   dependencies:
-    "@calcom/lib": "workspace:*"
-    "@calcom/prisma": "workspace:*"
-    "@calcom/types": "workspace:*"
+    "@calcom/lib": "npm:*"
+    "@calcom/prisma": "npm:*"
+    "@calcom/types": "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -2972,7 +2972,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/prisma@workspace:*, @calcom/prisma@workspace:packages/prisma":
+"@calcom/prisma@npm:*, @calcom/prisma@workspace:*, @calcom/prisma@workspace:packages/prisma":
   version: 0.0.0-use.local
   resolution: "@calcom/prisma@workspace:packages/prisma"
   dependencies:
@@ -3212,7 +3212,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/types@workspace:*, @calcom/types@workspace:packages/types":
+"@calcom/types@npm:*, @calcom/types@workspace:*, @calcom/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@calcom/types@workspace:packages/types"
   dependencies:
@@ -3415,7 +3415,7 @@ __metadata:
     env-cmd: "npm:10.1.0"
     glob: "npm:10.4.5"
     google-auth-library: "npm:9.15.0"
-    handlebars: "npm:4.7.7"
+    handlebars: "npm:4.7.9"
     i18next: "npm:23.2.3"
     ical.js: "npm:1.5.0"
     ics: "npm:2.37.0"
@@ -24183,12 +24183,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:4.7.7":
-  version: 4.7.7
-  resolution: "handlebars@npm:4.7.7"
+"handlebars@npm:4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
-    neo-async: "npm:^2.6.0"
+    neo-async: "npm:^2.6.2"
     source-map: "npm:^0.6.1"
     uglify-js: "npm:^3.1.4"
     wordwrap: "npm:^1.0.0"
@@ -24197,7 +24197,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10/617b1e689b7577734abc74564bdb8cdaddf8fd48ce72afdb489f426e9c60a7d6ee2a2707c023720c4059070128243c948bded8f2716e4543378033e3971b85ea
+  checksum: 10/e755433d652e8a15fc02f83d7478e652359e7a4d354c4328818853ed4f8a39d4a09e1d22dad3c7213c5240864a65b3c840970b8b181745575dd957dd258f2b8d
   languageName: node
   linkType: hard
 
@@ -29987,7 +29987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neo-async@npm:^2.6.0, neo-async@npm:^2.6.2":
+"neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10/1a7948fea86f2b33ec766bc899c88796a51ba76a4afc9026764aedc6e7cde692a09067031e4a1bf6db4f978ccd99e7f5b6c03fe47ad9865c3d4f99050d67e002


### PR DESCRIPTION
## What does this PR do?

Upgrades `handlebars` from `4.7.7` to `4.7.9` in `apps/web` and `packages/features/auth` to fix critical vulnerability [GHSA-2w6w-674q-4c4q](https://github.com/advisories/GHSA-2w6w-674q-4c4q) (JavaScript Injection via AST Type Confusion, affects `>=4.0.0 <=4.7.8`).

This resolves the Security Audit CI job failure (`yarn npm audit --all --recursive --severity critical`).

## Visual Demo (For contributors especially)

N/A — dependency version bump only, no UI changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Verify the **Security Audit** CI job passes (the `yarn npm audit --all --recursive --severity critical` step should no longer report handlebars).
2. Verify no regressions in auth flows or anywhere handlebars templates are rendered.

## ⚠️ Reviewer Notes

- The `yarn.lock` diff includes a few unrelated resolution changes (e.g. `@calcom/lyra` dependencies switching from `workspace:*` to `npm:*`, and new `npm:*` aliases for `@calcom/lib`, `@calcom/prisma`, `@calcom/types`). These were generated automatically by `yarn install` and were not manually edited. Please verify these are benign.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/a529b00faa81492caddb927d2759c9d1
Requested by: @romitg2