### PR TITLE
fix: add missing vi.mock() calls to parseFrontmatter test to prevent vitest worker shutdown flakiness

### DIFF
--- a/apps/web/lib/apps/[slug]/__tests__/parseFrontmatter.test.ts
+++ b/apps/web/lib/apps/[slug]/__tests__/parseFrontmatter.test.ts
@@ -1,4 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@calcom/prisma", () => ({
+  default: {},
+  prisma: {},
+}));
+
+vi.mock("@calcom/app-store/_appRegistry", () => ({
+  getAppWithMetadata: vi.fn(),
+}));
+
 import { parseFrontmatter } from "../getStaticProps";
 
 describe("parseFrontmatter", () => {


### PR DESCRIPTION
## What does this PR do?

Adds `vi.mock()` calls for `@calcom/prisma` and `@calcom/app-store/_appRegistry` to `parseFrontmatter.test.ts`, preventing the vitest worker from crashing with:

```
Error: [vitest-worker]: Closing rpc while "fetch" was pending
 ❯ packages/features/tasker/tasker-factory.ts:1:1
 ❯ packages/features/tasker/index.ts:2:1
```

This test file was missed in #28459, which applied the same fix to ~70 other test files. The test only exercises `parseFrontmatter` (a pure regex + YAML function), but importing from `../getStaticProps` transitively loads `@calcom/prisma` and `@calcom/app-store/_appRegistry`, which pull in the tasker module and trigger background fetch/pg.Pool connections that outlive the vitest worker.

## Visual Demo (For contributors especially)

N/A — test-only change, no UI impact.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the full unit test suite: `TZ=UTC yarn test` — the `parseFrontmatter.test.ts` file should pass without "Closing rpc while fetch was pending" errors.
2. Run just this test: `TZ=UTC yarn vitest run parseFrontmatter` — all 8 tests should pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings

### Human Review Checklist
- [ ] Verify the two mocked modules (`@calcom/prisma`, `@calcom/app-store/_appRegistry`) are indeed the ones causing the transitive tasker/fetch import chain
- [ ] Confirm no other exports from `@calcom/app-store/_appRegistry` are needed by the `parseFrontmatter` function under test (they shouldn't be — it's a pure function)

Link to Devin session: https://app.devin.ai/sessions/40b60da1b28643f38e969b7f5ca38237
Requested by: @romitg2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
