### PR TITLE
fix: mock @calcom/lib/i18n in EventManager.test.ts to prevent vitest worker shutdown flake

### DIFF
--- a/packages/features/bookings/lib/EventManager.test.ts
+++ b/packages/features/bookings/lib/EventManager.test.ts
@@ -18,9 +18,6 @@ vi.mock("@calcom/features/watchlist/operations/check-if-users-are-blocked.contro
 vi.mock("@calcom/features/watchlist/lib/telemetry", () => ({
   sentrySpan: vi.fn(),
 }));
-// Prevent vitest worker shutdown race condition: TranslationService transitively imports
-// @calcom/lib/i18n which triggers slow module resolution via vite's RPC. When the worker
-// shuts down before it completes, it causes "Closing rpc while fetch was pending" errors.
 vi.mock("@calcom/lib/i18n", () => ({
   locales: ["en"],
   localeOptions: [{ value: "en", label: "English" }],

--- a/packages/features/bookings/lib/EventManager.test.ts
+++ b/packages/features/bookings/lib/EventManager.test.ts
@@ -18,6 +18,14 @@ vi.mock("@calcom/features/watchlist/operations/check-if-users-are-blocked.contro
 vi.mock("@calcom/features/watchlist/lib/telemetry", () => ({
   sentrySpan: vi.fn(),
 }));
+// Prevent vitest worker shutdown race condition: TranslationService transitively imports
+// @calcom/lib/i18n which triggers slow module resolution via vite's RPC. When the worker
+// shuts down before it completes, it causes "Closing rpc while fetch was pending" errors.
+vi.mock("@calcom/lib/i18n", () => ({
+  locales: ["en"],
+  localeOptions: [{ value: "en", label: "English" }],
+  defaultLocaleOption: { value: "en", label: "English" },
+}));
 
 import process from "node:process";
 import { CredentialRepository } from "@calcom/features/credentials/repositories/CredentialRepository";


### PR DESCRIPTION
## What does this PR do?

Fixes the intermittent "Closing rpc while fetch was pending" errors (3 instances) in `EventManager.test.ts` CI runs.

`TranslationService` transitively imports `@calcom/lib/i18n`, which triggers slow module resolution via Vite's RPC. When the vitest worker shuts down before that resolution completes, it surfaces as unhandled rejection errors — even though all 28 tests pass.

Adding `vi.mock("@calcom/lib/i18n", ...)` prevents the actual module resolution during test loading, eliminating the race condition.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — test-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the unit test and confirm no "Closing rpc" errors appear:

```bash
TZ=UTC yarn vitest run packages/features/bookings/lib/EventManager.test.ts
```

All 28 tests should pass cleanly with no unhandled errors.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

## Human Review Checklist

- [ ] Verify the mock return shape (`locales`, `localeOptions`, `defaultLocaleOption`) matches the actual `@calcom/lib/i18n` exports — if any additional named exports are consumed transitively during test execution, they would be `undefined`
- [ ] Confirm mocking this module doesn't inadvertently suppress a real failure path in EventManager tests (e.g. if any EventManager logic branches on locale data)

Link to Devin session: https://app.devin.ai/sessions/453ef4b8b8d64c659fb6655ec08c28ba
Requested by: @romitg2