### PR TITLE
fix: include rescheduleLink and rescheduleUid in BOOKING_CANCELLED webhook for reschedule requests

### DIFF
--- a/packages/lib/server/service/BookingWebhookFactory.ts
+++ b/packages/lib/server/service/BookingWebhookFactory.ts
@@ -55,6 +55,10 @@ interface CancelledEventPayload extends BaseWebhookPayload {
   iCalSequence?: number | null;
   eventTitle?: string | null;
   requestReschedule?: boolean;
+  /** Reschedule link for the attendee (only present when requestReschedule is true). */
+  rescheduleLink?: string | null;
+  /** UID of the cancelled booking being rescheduled (only present when requestReschedule is true). */
+  rescheduleUid?: string | null;
 }
 
 export class BookingWebhookFactory {
@@ -134,6 +138,10 @@ export class BookingWebhookFactory {
       iCalSequence: params.iCalSequence ?? null,
       eventTitle: params.eventTitle ?? null,
       requestReschedule: params.requestReschedule ?? false,
+      ...(params.requestReschedule && {
+        rescheduleLink: params.rescheduleLink ?? null,
+        rescheduleUid: params.rescheduleUid ?? null,
+      }),
     };
   }
 }

--- a/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts
@@ -280,6 +280,8 @@ export const requestRescheduleHandler = async ({ ctx, input, source, impersonate
     iCalSequence: builder.calendarEvent.iCalSequence,
     eventTitle: bookingToReschedule.eventType?.title ?? null,
     requestReschedule: true,
+    rescheduleLink: builder.rescheduleLink,
+    rescheduleUid: bookingToReschedule.uid,
   });
 
   // Send webhook


### PR DESCRIPTION
## Problem

Fixes #28543

When a host clicks "Request Reschedule," the `BOOKING_CANCELLED` webhook fires with `requestReschedule: true` but provides no way for automation consumers (Zapier, Make, n8n) to correlate the cancellation with the eventual rebooking. The `rescheduledToUid` is `null` because the new booking doesn't exist yet (the attendee hasn't picked a new time).

## Root Cause

In `requestReschedule.handler.ts`, the reschedule link is already computed (`builder.rescheduleLink`, line 242) and the booking UID is available, but neither is passed to `BookingWebhookFactory.createCancelledEventPayload()`.

## Fix

Add two fields to the `BOOKING_CANCELLED` webhook payload when `requestReschedule: true`:

- **`rescheduleLink`**: The URL the attendee uses to pick a new time (already computed, just not included)
- **`rescheduleUid`**: The UID of the cancelled booking being rescheduled, allowing consumers to match it with the subsequent `BOOKING_RESCHEDULED` event

These fields are only included when `requestReschedule` is `true` to avoid changing the payload shape for normal cancellations.

10 lines across 2 files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
