### PR TITLE
fix: prevent long event type title and slug from overflowing in app installation cards

### DIFF
--- a/apps/web/components/apps/installation/ConfigureStepCard.tsx
+++ b/apps/web/components/apps/installation/ConfigureStepCard.tsx
@@ -1,12 +1,3 @@
-import { zodResolver } from "@hookform/resolvers/zod";
-import type { Dispatch, SetStateAction } from "react";
-import type { FC } from "react";
-import React, { forwardRef, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { useFieldArray, useFormContext } from "react-hook-form";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
-
 import type { LocationObject } from "@calcom/app-store/locations";
 import { locationsResolver } from "@calcom/app-store/locations";
 import NoSSR from "@calcom/lib/components/NoSSR";
@@ -17,11 +8,16 @@ import { Avatar } from "@calcom/ui/components/avatar";
 import { Button } from "@calcom/ui/components/button";
 import { Form } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
-
 import EventTypeAppSettingsWrapper from "@components/apps/installation/EventTypeAppSettingsWrapper";
 import EventTypeConferencingAppSettings from "@components/apps/installation/EventTypeConferencingAppSettings";
-
-import type { TEventType, TEventTypesForm, TEventTypeGroup } from "~/apps/installation/[[...step]]/step-view";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type React from "react";
+import type { Dispatch, FC, SetStateAction } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useFieldArray, useForm, useFormContext } from "react-hook-form";
+import { z } from "zod";
+import type { TEventType, TEventTypeGroup, TEventTypesForm } from "~/apps/installation/[[...step]]/step-view";
 
 export type TFormType = {
   id: number;
@@ -93,8 +89,8 @@ const EventTypeAppSettingsForm = forwardRef<HTMLButtonElement, EventTypeAppSetti
           onSubmit({ metadata, locations, bookingFields });
         }}>
         <div>
-          <div className="sm:border-subtle bg-default relative border p-4 dark:bg-black sm:rounded-md">
-            <div>
+          <div className="sm:border-subtle bg-default relative overflow-hidden border p-4 dark:bg-black sm:rounded-md">
+            <div className="truncate pr-8">
               <span className="text-default font-semibold ltr:mr-1 rtl:ml-1">{eventType.title}</span>{" "}
               <small className="text-subtle hidden font-normal sm:inline">
                 /{eventType.team ? eventType.team.slug : props.userName}/{eventType.slug}

--- a/apps/web/components/apps/installation/EventTypesStepCard.tsx
+++ b/apps/web/components/apps/installation/EventTypesStepCard.tsx
@@ -1,8 +1,3 @@
-import type { Dispatch, SetStateAction } from "react";
-import type { FC } from "react";
-import React from "react";
-import { useFieldArray, useFormContext } from "react-hook-form";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
@@ -10,8 +5,10 @@ import { Avatar } from "@calcom/ui/components/avatar";
 import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
 import { ScrollableArea } from "@calcom/ui/components/scrollable";
-
-import type { TEventType, TEventTypesForm, TEventTypeGroup } from "~/apps/installation/[[...step]]/step-view";
+import type { Dispatch, FC, SetStateAction } from "react";
+import React from "react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import type { TEventType, TEventTypeGroup, TEventTypesForm } from "~/apps/installation/[[...step]]/step-view";
 
 type EventTypesCardProps = {
   userName: string;
@@ -56,9 +53,9 @@ const EventTypeCard: FC<EventTypeCardProps> = ({
         className="bg-default border-default h-4 w-4 shrink-0 cursor-pointer rounded-cal checked:border-transparent checked:bg-gray-800 border ring-offset-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed"
         type="checkbox"
       />
-      <label htmlFor={`${id}`} className="cursor-pointer text-sm">
+      <label htmlFor={`${id}`} className="min-w-0 cursor-pointer text-sm">
         <li>
-          <div>
+          <div className="truncate">
             <span className="text-default font-semibold ltr:mr-1 rtl:ml-1">{title}</span>{" "}
             <small className="text-subtle hidden font-normal sm:inline">
               /{team ? team.slug : userName}/{slug}


### PR DESCRIPTION
## What does this PR do?

- Fixes #28533

On the app installation page (`/apps/installation/event-types`), event types with long unbroken titles or slugs overflow their containers and break the responsive layout. This affects both the event type selection step and the app configuration step.

**Root cause:** In `EventTypesStepCard`, the `<label>` is a flex child but lacks `min-w-0`, so it cannot shrink below its content's intrinsic minimum width. The inner `<div>` containing the title and slug has no overflow constraint. `ConfigureStepCard` has the same issue, compounded by text potentially overlapping the absolutely-positioned close button.

**Fix:**
- Add `min-w-0` to the label in `EventTypesStepCard` to allow flex item shrinking
- Add `truncate` to the title/slug container `<div>` in both components to apply `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`
- Add `overflow-hidden` to the `ConfigureStepCard` card container to prevent content from escaping its rounded border
- Add `pr-8` to the title/slug div in `ConfigureStepCard` to ensure truncated text does not overlap with the close (X) button

## Visual Demo (For contributors especially)

#### Before:
Long event type names extend beyond the card container, breaking the layout and overlapping adjacent elements.

#### After:
Long event type names are cleanly truncated with an ellipsis (`...`), respecting the container bounds in both step cards.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to the app installation page: `/apps/installation/event-types?slug=discord` (or any app)
2. Ensure you have at least one event type with a very long unbroken name (e.g., `FrontendComponentRefactoringDemoSessionForAdvancedDevelopersAndEngineers`)
3. Verify the title truncates with an ellipsis in the event type selection list (Step 1)
4. Select that event type and proceed to the configuration step (Step 2)
5. Verify the title truncates in the configuration card without overlapping the X close button
6. Test on both desktop and mobile viewports to confirm responsive behavior