### PR TITLE
docs: update Docker self-hosting documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,29 @@ If you are evaluating Cal.com or running with minimal to no modifications, this 
 
    Most configurations can be left as-is, but for configuration options see [Important Run-time variables](#important-run-time-variables) below.
 
+   **Required Secret Keys**
+
+   Before starting, you must generate secure values for `NEXTAUTH_SECRET` and `CALENDSO_ENCRYPTION_KEY`. Using the default `secret` placeholder in production is a security risk.
+
+   Generate `NEXTAUTH_SECRET` (cookie encryption key):
+
+   ```bash
+   openssl rand -base64 32
+   ```
+
+   Generate `CALENDSO_ENCRYPTION_KEY` (must be 32 bytes for AES256):
+
+   ```bash
+   openssl rand -base64 24
+   ```
+
+   Update your `.env` file with these values:
+
+   ```env
+   NEXTAUTH_SECRET=<your_generated_secret>
+   CALENDSO_ENCRYPTION_KEY=<your_generated_key>
+   ```
+
    **Push Notifications (VAPID Keys)**
    If you see an error like:
 
@@ -541,6 +564,8 @@ If you are evaluating Cal.com or running with minimal to no modifications, this 
 
 6. Open a browser to [http://localhost:3000](http://localhost:3000), or your defined NEXT_PUBLIC_WEBAPP_URL. The first time you run Cal.com, a setup wizard will initialize. Define your first user, and you're ready to go!
 
+   **Note for first-time setup (Calendar integration)**: During the setup wizard, you may encounter a "Connect your Calendar" step that appears to be required. If you do not wish to connect a calendar at this time, you can skip this step by navigating directly to the dashboard at `<NEXT_PUBLIC_WEBAPP_URL>/event-types`. Calendar integrations can be added later from the Settings > Integrations page.
+
 #### Updating Cal.com
 
 1. Stop the Cal.com stack
@@ -564,31 +589,23 @@ If you are evaluating Cal.com or running with minimal to no modifications, this 
 
 #### (Advanced users) Build and Run Cal.com
 
-1. Clone calcom/docker.
+1. Clone calcom/cal.com.
 
    ```bash
-   git clone https://github.com/calcom/cal.com.git calcom-docker
+   git clone https://github.com/calcom/cal.com.git
    ```
 
 2. Change into the directory
 
    ```bash
-   cd calcom-docker
+   cd cal.com
    ```
 
-3. Update the calcom submodule. This project depends on the Cal.com source code, which is included here as a Git submodule. To make sure you get everything you need, update the submodule with the command below.
-
-   ```bash
-   git submodule update --remote --init
-   ```
-
-   Note: DO NOT use recursive submodule update, otherwise you will receive a git authentication error.
-
-4. Rename `.env.example` to `.env` and then update `.env`
+3. Rename `.env.example` to `.env` and then update `.env`
 
    For configuration options see [Build-time variables](#build-time-variables) below. Update the appropriate values in your .env file, then proceed.
 
-5. Build the Cal.com docker image:
+4. Build the Cal.com docker image:
 
    Note: Due to application configuration requirements, an available database is currently required during the build process.
 
@@ -600,13 +617,13 @@ If you are evaluating Cal.com or running with minimal to no modifications, this 
    docker compose up -d database
    ```
 
-6. Build Cal.com via docker compose (DOCKER_BUILDKIT=0 must be provided to allow a network bridge to be used at build time. This requirement will be removed in the future)
+5. Build Cal.com via docker compose (DOCKER_BUILDKIT=0 must be provided to allow a network bridge to be used at build time. This requirement will be removed in the future)
 
    ```bash
    DOCKER_BUILDKIT=0 docker compose build calcom
    ```
 
-7. Start Cal.com via docker compose
+6. Start Cal.com via docker compose
 
    (Most basic users, and for First Run) To run the complete stack, which includes a local Postgres database, Cal.com web app, and Prisma Studio:
 
@@ -628,7 +645,7 @@ If you are evaluating Cal.com or running with minimal to no modifications, this 
 
    **Note: to run in attached mode for debugging, remove `-d` from your desired run command.**
 
-8. Open a browser to [http://localhost:3000](http://localhost:3000), or your defined NEXT_PUBLIC_WEBAPP_URL. The first time you run Cal.com, a setup wizard will initialize. Define your first user, and you're ready to go!
+7. Open a browser to [http://localhost:3000](http://localhost:3000), or your defined NEXT_PUBLIC_WEBAPP_URL. The first time you run Cal.com, a setup wizard will initialize. Define your first user, and you're ready to go!
 
 #### Configuration
 
@@ -642,8 +659,8 @@ These variables must also be provided at runtime
 | CALCOM_LICENSE_KEY      | Enterprise License Key                                                                                                                                                           | optional |                                                                     |
 | NEXT_PUBLIC_WEBAPP_URL  | Base URL of the site. NOTE: if this value differs from the value used at build-time, there will be a slight delay during container start (to update the statically built files). | optional | `http://localhost:3000`                                             |
 | NEXTAUTH_URL            | Location of the auth server. By default, this is the Cal.com docker instance itself.                                                                                             | optional | `{NEXT_PUBLIC_WEBAPP_URL}/api/auth`                                 |
-| NEXTAUTH_SECRET         | must match build variable                                                                                                                                                        | required | `secret`                                                            |
-| CALENDSO_ENCRYPTION_KEY | must match build variable                                                                                                                                                        | required | `secret`                                                            |
+| NEXTAUTH_SECRET         | Cookie encryption key. Must match build variable. Generate with: `openssl rand -base64 32`                                                                                       | required | `secret`                                                            |
+| CALENDSO_ENCRYPTION_KEY | Authentication encryption key (32 bytes for AES256). Must match build variable. Generate with: `openssl rand -base64 24`                                                         | required | `secret`                                                            |
 
 ##### Build-time variables
 


### PR DESCRIPTION
## Summary

This PR updates the Docker self-hosting documentation in `README.md` to address outdated references and common user issues.

### Changes

- **Fix outdated repo reference**: The "Advanced users" section incorrectly referenced "Clone calcom/docker" and included an outdated `git submodule update` step from when Docker configs lived in a separate repository. Updated to correctly reference `calcom/cal.com` and removed the obsolete submodule step.

- **Add secret key generation instructions**: Added explicit `openssl` commands for generating secure `NEXTAUTH_SECRET` and `CALENDSO_ENCRYPTION_KEY` values in the Docker setup step, warning users that the default `secret` placeholder is a security risk in production. Also updated the runtime variables table with generation commands.

- **Add Calendar integration skip guidance**: Added a note for first-time users who get stuck on the "Connect your Calendar" wizard step (related to #25340), explaining that this step can be skipped by navigating directly to `/event-types` and that calendar integrations can be added later from Settings > Integrations.

### Related Issues

Fixes #24833

🤖 Generated with [Claude Code](https://claude.com/claude-code)