### PR TITLE
docs: add self-hosting troubleshooting guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -129,7 +129,8 @@
               "self-hosting/upgrading",
               "self-hosting/sso-setup",
               "self-hosting/docker",
-              "self-hosting/license-key"
+              "self-hosting/license-key",
+              "self-hosting/troubleshooting"
             ]
           },
           {

--- a/docs/self-hosting/troubleshooting.mdx
+++ b/docs/self-hosting/troubleshooting.mdx
@@ -120,13 +120,33 @@ If you use a reverse proxy (e.g., Nginx, Traefik), make sure the proxy forwards 
 
 **Symptom:** Requests fail with SSL certificate errors when Cal.com is behind a load balancer or reverse proxy that handles HTTPS termination.
 
-**Solution:** If your reverse proxy handles SSL termination and forwards traffic to Cal.com over plain HTTP internally, set:
+**Solution (choose one):**
+
+**Option 1: If your proxy forwards HTTP internally (most common)**
+
+Set `NEXTAUTH_URL` to the internal HTTP address:
+
+```env
+NEXTAUTH_URL=http://localhost:3000
+```
+
+Ensure your proxy forwards the `Host` and `X-Forwarded-Proto` headers so Cal.com generates correct external-facing URLs.
+
+**Option 2: If using self-signed certificates internally**
+
+Add your internal CA to Node's trusted certificates:
+
+```env
+NODE_EXTRA_CA_CERTS=/path/to/your-internal-ca.crt
+```
+
+**Option 3: Last resort (not recommended for production)**
 
 ```env
 NODE_TLS_REJECT_UNAUTHORIZED=0
 ```
 
-> **Warning:** Only set this if you fully trust the internal network path between your proxy and Cal.com. Do not use this in environments where internal traffic could be intercepted.
+> ⚠️ **Security Warning:** This disables **all** TLS certificate verification globally, including external API calls to Stripe, Google Calendar, and other services. This makes your instance vulnerable to man-in-the-middle attacks. Only use this in isolated development environments where you fully control all network traffic.
 
 ---
 

--- a/docs/self-hosting/troubleshooting.mdx
+++ b/docs/self-hosting/troubleshooting.mdx
@@ -106,13 +106,19 @@ request to http://<your-domain>/api/auth/session failed, reason: getaddrinfo ENO
 
 **Cause:** The Docker container cannot resolve the external hostname set in `NEXTAUTH_URL` from within the container's network.
 
-**Solution:** Set `NEXTAUTH_URL` to the internal loopback address so the container resolves itself:
+**Solution:** Add your domain to the container's `/etc/hosts` so it resolves to itself:
 
-```env
-NEXTAUTH_URL=http://localhost:3000/api/auth
+```yaml
+# docker-compose.yml
+services:
+  calcom:
+    extra_hosts:
+      - "cal.yourdomain.com:127.0.0.1"
 ```
 
-If you use a reverse proxy (e.g., Nginx, Traefik), make sure the proxy forwards the `Host` header and the `X-Forwarded-Proto` header correctly so Cal.com generates external-facing URLs properly.
+This allows the container to resolve your public domain internally while keeping `NEXTAUTH_URL` set to your public URL (required for OAuth callbacks to work).
+
+> **Why not use `localhost`?** Setting `NEXTAUTH_URL` to `localhost` would fix this DNS error, but **breaks OAuth** — external providers like Google would redirect to `localhost` instead of your domain.
 
 ---
 
@@ -124,13 +130,23 @@ If you use a reverse proxy (e.g., Nginx, Traefik), make sure the proxy forwards 
 
 **Option 1: If your proxy forwards HTTP internally (most common)**
 
-Set `NEXTAUTH_URL` to the internal HTTP address:
+Keep `NEXTAUTH_URL` set to your **public-facing HTTPS URL**:
 
 ```env
-NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL=https://cal.yourdomain.com
 ```
 
-Ensure your proxy forwards the `Host` and `X-Forwarded-Proto` headers so Cal.com generates correct external-facing URLs.
+Then configure your reverse proxy to forward these headers so internal requests work correctly:
+
+```nginx
+# Nginx example
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+```
+
+> **Why not use `localhost`?** Setting `NEXTAUTH_URL=http://localhost:3000` would fix internal SSL errors, but **breaks OAuth callbacks** — external providers (Google, Microsoft) would try to redirect users to `localhost`, which fails. Always use your public URL.
 
 **Option 2: If using self-signed certificates internally**
 

--- a/docs/self-hosting/troubleshooting.mdx
+++ b/docs/self-hosting/troubleshooting.mdx
@@ -1,0 +1,153 @@
+---
+title: "Troubleshooting"
+icon: "triangle-exclamation"
+---
+
+This guide covers the most common issues encountered when self-hosting Cal.com, along with their solutions.
+
+## Onboarding / Setup Issues
+
+### 500 Error During Onboarding (Missing Stripe Key)
+
+**Symptom:** After completing the initial setup wizard and logging in, you see a `500` (Internal Server Error) when accessing the onboarding flow or certain pages.
+
+**Cause:** Cal.com's onboarding flow attempts to initialize Stripe even if you don't plan to use payments. If `STRIPE_PRIVATE_KEY` (and related Stripe variables) are not set, the server throws an unhandled error.
+
+**Solution:** Add the following variables to your `.env` file. You can use placeholder values if you don't need Stripe, but the keys must be present:
+
+```env
+# Stripe (required to prevent 500 errors during onboarding)
+STRIPE_PRIVATE_KEY=sk_test_placeholder
+STRIPE_CLIENT_ID=ca_placeholder
+NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_placeholder
+STRIPE_WEBHOOK_SECRET=whsec_placeholder
+```
+
+> **Note:** For a production setup with real payments, replace these with your actual Stripe API keys from the [Stripe Dashboard](https://dashboard.stripe.com/apikeys).
+
+Related issue: [#25993](https://github.com/calcom/cal.com/issues/25993)
+
+---
+
+## URL and Redirect Issues
+
+### Redirect to `localhost:3000` After Deployment
+
+**Symptom:** After deploying Cal.com to a server or domain, login redirects or internal links point back to `http://localhost:3000` instead of your actual domain.
+
+**Cause:** The environment variables `NEXTAUTH_URL` and `NEXT_PUBLIC_WEBAPP_URL` are not set to your production domain. These variables tell Cal.com and NextAuth where the app is hosted.
+
+**Solution:** Update your `.env` file to use your actual domain:
+
+```env
+# Replace with your actual domain
+NEXT_PUBLIC_WEBAPP_URL=https://cal.yourdomain.com
+NEXTAUTH_URL=https://cal.yourdomain.com
+```
+
+**Important notes:**
+- Do **not** include a trailing slash.
+- For Docker deployments, these must be set **before** building the image, as `NEXT_PUBLIC_WEBAPP_URL` is a build-time variable. Rebuild the image after changing it.
+- For Vercel deployments, leave `NEXTAUTH_URL` **empty** — Vercel infers it automatically.
+
+Related issue: [#21921](https://github.com/calcom/cal.com/issues/21921)
+
+---
+
+## Docker-Specific Issues
+
+### API v2 Service Not Starting
+
+**Symptom:** After running `docker compose up -d`, the `calcom-api` service fails to start or immediately exits. The web app works, but API v2 endpoints (`/api/v2/...`) return connection errors.
+
+**Cause:** The API v2 service requires several environment variables that are not in the default `.env.example`. The most common missing variables are `REDIS_URL`, `JWT_SECRET`, and `WEB_APP_URL`.
+
+**Solution:** Add the following variables to your root `.env` file (the `docker-compose.yml` passes this to the `calcom-api` service):
+
+```env
+# Required for API v2
+REDIS_URL=redis://redis:6379
+JWT_SECRET=your_random_jwt_secret_here
+WEB_APP_URL=https://cal.yourdomain.com
+
+# Optional API v2 variables
+REDIS_PORT=6379
+LOG_LEVEL=warn
+```
+
+You can generate a secure `JWT_SECRET` with:
+
+```bash
+openssl rand -base64 32
+```
+
+Then restart the stack:
+
+```bash
+docker compose down && docker compose up -d
+```
+
+Check the API v2 service logs for further details if it still fails:
+
+```bash
+docker compose logs calcom-api
+```
+
+---
+
+### `CLIENT_FETCH_ERROR` in Logs
+
+**Symptom:** The following error appears in Docker logs, and login/session fails:
+
+```
+[next-auth][error][CLIENT_FETCH_ERROR]
+request to http://<your-domain>/api/auth/session failed, reason: getaddrinfo ENOTFOUND
+```
+
+**Cause:** The Docker container cannot resolve the external hostname set in `NEXTAUTH_URL` from within the container's network.
+
+**Solution:** Set `NEXTAUTH_URL` to the internal loopback address so the container resolves itself:
+
+```env
+NEXTAUTH_URL=http://localhost:3000/api/auth
+```
+
+If you use a reverse proxy (e.g., Nginx, Traefik), make sure the proxy forwards the `Host` header and the `X-Forwarded-Proto` header correctly so Cal.com generates external-facing URLs properly.
+
+---
+
+### SSL / HTTPS Issues Behind a Reverse Proxy
+
+**Symptom:** Requests fail with SSL certificate errors when Cal.com is behind a load balancer or reverse proxy that handles HTTPS termination.
+
+**Solution:** If your reverse proxy handles SSL termination and forwards traffic to Cal.com over plain HTTP internally, set:
+
+```env
+NODE_TLS_REJECT_UNAUTHORIZED=0
+```
+
+> **Warning:** Only set this if you fully trust the internal network path between your proxy and Cal.com. Do not use this in environments where internal traffic could be intercepted.
+
+---
+
+## Database Issues
+
+### `prisma.user.create()` Fails on First User Setup
+
+**Symptom:** Attempting to create the first admin user results in a Prisma validation error referencing the `metadata` field or `id` field.
+
+**Solution:**
+- Set the `metadata` field to an empty JSON object `{}` instead of leaving it null.
+- Leave the `id` field empty to allow auto-increment.
+
+This is a known issue on certain Cal.com versions. Upgrading to the latest release typically resolves it.
+
+---
+
+## Getting Further Help
+
+If your issue is not listed here:
+
+1. Search the [Cal.com GitHub Issues](https://github.com/calcom/cal.com/issues) — many common problems have documented solutions in issue threads.
+2. Check the [Cal.com Community](https://community.cal.com) forum.
+3. Review the [Docker configuration](./docker) and [Installation guide](./installation) for any steps you may have missed.


### PR DESCRIPTION
## Summary

Adds a dedicated **Self-Hosting Troubleshooting** page to the documentation, covering the most common issues users encounter when self-hosting Cal.com.

### What's included

- **500 error during onboarding** — caused by missing Stripe environment variables, even when payments aren't needed. Fixes #25993
- **Redirect to `localhost:3000` after deployment** — caused by unset `NEXTAUTH_URL` / `NEXT_PUBLIC_WEBAPP_URL`. Fixes #21921
- **API v2 service not starting in Docker** — caused by missing `REDIS_URL`, `JWT_SECRET`, and `WEB_APP_URL` env vars
- **`CLIENT_FETCH_ERROR` in Docker logs** — NEXTAUTH_URL DNS resolution issue inside containers
- **SSL issues behind a reverse proxy** — `NODE_TLS_REJECT_UNAUTHORIZED` guidance
- **Prisma user creation failure** — metadata/id field edge case on first setup

### Files changed

| File | Change |
|------|--------|
| `docs/self-hosting/troubleshooting.mdx` | New file (~150 lines) |
| `docs/docs.json` | Added `self-hosting/troubleshooting` to Getting Started nav group |

### Related issues

- Fixes #25993 (500 error on onboarding — missing STRIPE_PRIVATE_KEY)
- Fixes #21921 (localhost redirect after deployment — missing NEXTAUTH_URL/NEXT_PUBLIC_WEBAPP_URL)

### Notes

The README is already 57KB, so a dedicated `docs/` page keeps things organized and easier to maintain going forward. The page is linked from the "Getting Started" section of the Self Hosting documentation tab.

Allow edits from maintainers ✅