### PR TITLE
refactor: getPublicEvent to structured input and update all usages

### DIFF
--- a/apps/api/v2/src/modules/atoms/services/event-types-atom.service.ts
+++ b/apps/api/v2/src/modules/atoms/services/event-types-atom.service.ts
@@ -393,14 +393,14 @@ export class EventTypesAtomService {
     usernameOrTeamSlug = usernameOrTeamSlug.toLowerCase();
 
     try {
-      let event = await getPublicEvent(
-        usernameOrTeamSlug,
-        eventSlug,
-        isTeamEvent,
-        orgSlug,
-        this.dbRead.prisma as unknown as PrismaClient,
-        true
-      );
+      let event = await getPublicEvent({
+        username: usernameOrTeamSlug,
+        eventSlug: eventSlug,
+        isTeamEvent: isTeamEvent,
+        org: orgSlug,
+        prisma: this.dbRead.prisma as unknown as PrismaClient,
+        fromRedirectOfNonOrgLink: true
+      });
 
       const usernamePossiblyNotFromProfile = username && orgId && !event;
       if (usernamePossiblyNotFromProfile) {
@@ -408,14 +408,14 @@ export class EventTypesAtomService {
         if (user) {
           const profile = await this.usersService.getUserMainProfile(user);
           if (profile?.username) {
-            event = await getPublicEvent(
-              profile.username,
-              eventSlug,
-              isTeamEvent,
-              orgSlug,
-              this.dbRead.prisma as unknown as PrismaClient,
-              true
-            );
+            event = await getPublicEvent({
+              username: profile.username,
+              eventSlug: eventSlug,
+              isTeamEvent: isTeamEvent,
+              org: orgSlug,
+              prisma: this.dbRead.prisma as unknown as PrismaClient,
+              fromRedirectOfNonOrgLink: true
+            });
           }
         }
       }

--- a/apps/api/v2/src/modules/atoms/services/event-types-atom.service.ts
+++ b/apps/api/v2/src/modules/atoms/services/event-types-atom.service.ts
@@ -399,6 +399,8 @@ export class EventTypesAtomService {
         isTeamEvent: isTeamEvent,
         org: orgSlug,
         prisma: this.dbRead.prisma as unknown as PrismaClient,
+        // Platform and atoms access is gated behind a license, so unpublished org events can be served safely.
+        // If restriction is ever needed, introduce a `fromRedirectOfNonOrgLink` query param instead.
         fromRedirectOfNonOrgLink: true
       });
 
@@ -414,6 +416,8 @@ export class EventTypesAtomService {
               isTeamEvent: isTeamEvent,
               org: orgSlug,
               prisma: this.dbRead.prisma as unknown as PrismaClient,
+              // Platform and atoms access is gated behind a license, so unpublished org events can be served safely.
+              // If restriction is ever needed, introduce a `fromRedirectOfNonOrgLink` query param instead.
               fromRedirectOfNonOrgLink: true
             });
           }

--- a/apps/api/v2/src/platform/event-types/event-types_2024_04_15/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/platform/event-types/event-types_2024_04_15/controllers/event-types.controller.ts
@@ -134,15 +134,16 @@ export class EventTypesController_2024_04_15 {
         }
       }
 
-      const event = await getPublicEvent(
-        username.toLowerCase(),
-        eventSlug,
-        queryParams.isTeamEvent,
-        orgSlug ?? null,
-        this.prismaReadService.prisma as unknown as PrismaClient,
-        // We should be fine allowing unpublished orgs events to be servable through platform because Platform access is behind license
-        // If there is ever a need to restrict this, we can introduce a new query param `fromRedirectOfNonOrgLink`
-        true
+      const event = await getPublicEvent({
+          username: username.toLowerCase(),
+          eventSlug: eventSlug,
+          isTeamEvent: queryParams.isTeamEvent,
+          org: orgSlug ?? null,
+          prisma: this.prismaReadService.prisma as unknown as PrismaClient,
+          // We should be fine allowing unpublished orgs events to be servable through platform because Platform access is behind license
+          // If there is ever a need to restrict this, we can introduce a new query param `fromRedirectOfNonOrgLink`
+          fromRedirectOfNonOrgLink: true
+        }
       );
 
       return {

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -280,8 +280,7 @@ export async function getEventTypeHosts({
   };
 }
 
-// TODO: Convert it to accept a single parameter with structured data
-export const getPublicEvent = async (
+export type GetPublicEventParams = {
   username: string,
   eventSlug: string,
   isTeamEvent: boolean | undefined,
@@ -289,8 +288,23 @@ export const getPublicEvent = async (
   prisma: PrismaClient,
   fromRedirectOfNonOrgLink: boolean,
   currentUserId?: number,
-  fetchAllUsers = false
+  fetchAllUsers?: boolean
+}
+
+export const getPublicEvent = async (
+  params: GetPublicEventParams
 ) => {
+  const {
+    username,
+    eventSlug,
+    isTeamEvent,
+    org,
+    prisma,
+    fromRedirectOfNonOrgLink,
+    currentUserId,
+    fetchAllUsers = false
+  } = params
+
   const usernameList = getUsernameList(username);
   const orgQuery = org ? getSlugOrRequestedSlug(org) : null;
   // In case of dynamic group event, we fetch user's data and use the default event.

--- a/packages/features/eventtypes/repositories/EventRepository.ts
+++ b/packages/features/eventtypes/repositories/EventRepository.ts
@@ -11,15 +11,15 @@ export type GetPublicEventInput = {
 
 export class EventRepository {
   static async getPublicEvent(input: GetPublicEventInput, userId?: number) {
-    const event = await getPublicEvent(
-      input.username,
-      input.eventSlug,
-      input.isTeamEvent,
-      input.org,
-      prisma,
-      input.fromRedirectOfNonOrgLink,
-      userId
-    );
+    const event = await getPublicEvent({
+      username: input.username,
+      eventSlug: input.eventSlug,
+      isTeamEvent: input.isTeamEvent,
+      org: input.org,
+      prisma: prisma,
+      fromRedirectOfNonOrgLink: input.fromRedirectOfNonOrgLink,
+      currentUserId: userId
+    });
     return event;
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR refactors the `getPublicEvent` function to accept a single structured input object instead of multiple positional parameters.
It updates the `EventRepository.getPublicEvent` method and all related callees across the codebase to use the new structured input format.

The change also resolves the existing TODO in the codebase and keeps the functionality intact (`packages/features/eventtypes/lib/getPublicEvent.ts`)

<img width="852" height="324" alt="image" src="https://github.com/user-attachments/assets/f3af97e0-d5ea-4fd9-80ef-1b6fed91204f" />


#### Video Demo (if applicable):

[Screencast from 2026-03-29 13-47-52.webm](https://github.com/user-attachments/assets/7a550e8e-8bf9-47f7-a56d-93268324105c)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


