### PR TITLE
fix: use TableCell instead of div in SeparatorRowRenderer to fix invalid DOM nesting

### DIFF
--- a/apps/web/modules/data-table/components/DataTable.tsx
+++ b/apps/web/modules/data-table/components/DataTable.tsx
@@ -284,16 +284,25 @@ type RowToRender<TData> = {
   virtualItem?: VirtualItem;
 };
 
-function SeparatorRowRenderer({ separator, className }: { separator: SeparatorRow; className?: string }) {
+function SeparatorRowRenderer({
+  separator,
+  className,
+  colSpan,
+}: {
+  separator: SeparatorRow;
+  className?: string;
+  colSpan: number;
+}) {
   return (
-    <div
+    <TableCell
+      colSpan={colSpan}
       className={classNames(
         "bg-cal-muted text-emphasis w-full px-3 py-2 font-semibold",
         separator.className,
         className
       )}>
       {separator.label}
-    </div>
+    </TableCell>
   );
 }
 
@@ -384,7 +393,11 @@ function DataTableBody<TData>({
                 }),
               }}
               className="hover:bg-subtle border-muted flex w-full border-b">
-              <SeparatorRowRenderer separator={row.original as SeparatorRow} className={separatorClassName} />
+              <SeparatorRowRenderer
+                separator={row.original as SeparatorRow}
+                className={separatorClassName}
+                colSpan={table.getVisibleLeafColumns().length}
+              />
             </TableRow>
           );
         }


### PR DESCRIPTION
## Problem

Fixes #28184

`SeparatorRowRenderer` renders a `<div>` directly inside a `<tr>` (TableRow), which is invalid HTML. Only `<td>` and `<th>` elements are valid children of `<tr>`. This causes React hydration warnings and potential SSR mismatches.

## Fix

Replace the `<div>` with `<TableCell>` and add a `colSpan` prop set to `table.getVisibleLeafColumns().length` so the separator spans the full table width.

Uses `getVisibleLeafColumns()` (not total column count) to correctly account for hidden columns.

1 file changed, clean diff.

> Note: This replaces #28644 which accidentally included unrelated changes from other branches.