### PR TITLE
fix(security): invalidate JWT sessions after password change

### DIFF
--- a/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
+++ b/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
@@ -3,6 +3,7 @@ import { AuthMethods } from "@/lib/enums/auth-methods";
 import { isOriginAllowed } from "@/lib/is-origin-allowed/is-origin-allowed";
 import { BaseStrategy } from "@/lib/passport/strategies/types";
 import { ApiKeysRepository } from "@/modules/api-keys/api-keys-repository";
+import { isJwtIssuedBeforePasswordChange } from "@/modules/auth/strategies/is-jwt-issued-before-password-change";
 import { MembershipsRepository } from "@/modules/memberships/memberships.repository";
 import { OAuthClientRepository } from "@/modules/oauth-clients/oauth-client.repository";
 import { OAuthFlowService } from "@/modules/oauth-clients/services/oauth-flow.service";
@@ -151,7 +152,10 @@ export class ApiAuthStrategy extends PassportStrategy(BaseStrategy, "api-auth") 
     }
   }
 
-  async authenticateNextAuth(token: { email?: string | null }, request: ApiAuthGuardRequest) {
+  async authenticateNextAuth(
+    token: { email?: string | null; iat?: number | null; error?: unknown; sub?: string | null },
+    request: ApiAuthGuardRequest
+  ) {
     const user = await this.nextAuthStrategy(token, request);
     return this.success(this.getSuccessUser(user));
   }
@@ -298,10 +302,21 @@ export class ApiAuthStrategy extends PassportStrategy(BaseStrategy, "api-auth") 
     return user;
   }
 
-  async nextAuthStrategy(token: { email?: string | null }, request: ApiAuthGuardRequest) {
+  async nextAuthStrategy(
+    token: { email?: string | null; iat?: number | null; error?: unknown; sub?: string | null },
+    request: ApiAuthGuardRequest
+  ) {
     if (!token.email) {
       throw new UnauthorizedException(
         "ApiAuthStrategy - next auth - Email not found in the authentication token."
+      );
+    }
+
+    // Sticky revocation flag set by the NextAuth jwt callback; survives `iat` rotation
+    // on session refresh, so check it before the raw-iat check below.
+    if (token.error === "SessionInvalidated") {
+      throw new UnauthorizedException(
+        "ApiAuthStrategy - next auth - Session was invalidated. Please sign in again."
       );
     }
 
@@ -311,6 +326,22 @@ export class ApiAuthStrategy extends PassportStrategy(BaseStrategy, "api-auth") 
         "ApiAuthStrategy - next auth - User associated with the authentication token email not found."
       );
     }
+
+    // Defense in depth: the token subject (stable user id) must match the user resolved by
+    // the token's (mutable) email, so a stale email later reused by another account cannot
+    // authenticate as — or be revocation-checked against — the wrong user.
+    if (token.sub && Number(token.sub) !== user.id) {
+      throw new UnauthorizedException(
+        "ApiAuthStrategy - next auth - Token subject does not match the resolved user."
+      );
+    }
+
+    if (isJwtIssuedBeforePasswordChange(token.iat, user.passwordChangedAt)) {
+      throw new UnauthorizedException(
+        "ApiAuthStrategy - next auth - Session was invalidated by a password change. Please sign in again."
+      );
+    }
+
     const organizationId = this.usersService.getUserMainOrgId(user) as number;
     request.organizationId = organizationId;
 

--- a/apps/api/v2/src/modules/auth/strategies/is-jwt-issued-before-password-change.ts
+++ b/apps/api/v2/src/modules/auth/strategies/is-jwt-issued-before-password-change.ts
@@ -1,0 +1,35 @@
+/**
+ * JWT session revocation on password change (API v2 copy).
+ *
+ * A NextAuth JWT carries an `iat` (issued-at) claim in SECONDS. When a user
+ * changes their password, `User.passwordChangedAt` (a Date, milliseconds) is
+ * stamped. Any token issued at or before that moment must be treated as revoked,
+ * so a stolen pre-change token cannot keep authenticating against the API.
+ *
+ * `passwordChangedAt == null` means the password was never changed (or predates
+ * this feature), so we never revoke. The comparison is `<=` (fail closed): a
+ * token minted in the same whole second as the change is revoked; a re-login in a
+ * later second gets a strictly greater `iat` and survives.
+ *
+ * NOTE: this only catches tokens still carrying a pre-change `iat`. NextAuth rotates
+ * `iat` forward on session refresh, so the strategies also reject tokens flagged with
+ * error "SessionInvalidated" by the web jwt callback (which is sticky across refreshes).
+ *
+ * This is intentionally duplicated from `@calcom/lib/auth/isJwtIssuedBeforePasswordChange`
+ * rather than imported: the API v2 NestJS app does not otherwise depend on
+ * `@calcom/lib`, and a one-function pure helper is cheaper to copy than to wire a
+ * new cross-package dependency into its build graph.
+ *
+ * `tokenIatSeconds` is `unknown` because NextAuth's `JWT["iat"]` resolves through
+ * the JWT index signature. A missing/non-numeric/zero `iat` returns false.
+ */
+export function isJwtIssuedBeforePasswordChange(
+  tokenIatSeconds: unknown,
+  passwordChangedAt: Date | null | undefined
+): boolean {
+  if (!passwordChangedAt || typeof tokenIatSeconds !== "number" || !tokenIatSeconds) {
+    return false;
+  }
+  const passwordChangedAtSeconds = Math.floor(passwordChangedAt.getTime() / 1000);
+  return tokenIatSeconds <= passwordChangedAtSeconds;
+}

--- a/apps/api/v2/src/modules/auth/strategies/next-auth/next-auth.strategy.ts
+++ b/apps/api/v2/src/modules/auth/strategies/next-auth/next-auth.strategy.ts
@@ -1,4 +1,5 @@
 import { NextAuthPassportStrategy } from "@/lib/passport/strategies/types";
+import { isJwtIssuedBeforePasswordChange } from "@/modules/auth/strategies/is-jwt-issued-before-password-change";
 import { UsersRepository } from "@/modules/users/users.repository";
 import { Injectable, InternalServerErrorException, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
@@ -25,10 +26,31 @@ export class NextAuthStrategy extends PassportStrategy(NextAuthPassportStrategy,
         throw new UnauthorizedException("NextAuthStrategy - Email not found in the authentication token.");
       }
 
+      // The NextAuth jwt callback marks revoked tokens with this sticky flag, which
+      // survives the `iat` being rotated forward on session refresh. Honor it before
+      // the raw-iat check below so a refreshed-but-revoked token cannot authenticate.
+      if (payload.error === "SessionInvalidated") {
+        throw new UnauthorizedException("NextAuthStrategy - Session was invalidated. Please sign in again.");
+      }
+
       const user = await this.userRepository.findByEmailWithProfile(payload.email);
       if (!user) {
         throw new UnauthorizedException(
           "NextAuthStrategy - User associated with the authentication token email not found."
+        );
+      }
+
+      // Defense in depth: the token subject (stable user id) must match the user resolved
+      // by the token's (mutable) email. Otherwise a token carrying a stale email later
+      // reused by another account could authenticate as — and be revocation-checked
+      // against — the wrong user.
+      if (payload.sub && Number(payload.sub) !== user.id) {
+        throw new UnauthorizedException("NextAuthStrategy - Token subject does not match the resolved user.");
+      }
+
+      if (isJwtIssuedBeforePasswordChange(payload.iat, user.passwordChangedAt)) {
+        throw new UnauthorizedException(
+          "NextAuthStrategy - Session was invalidated by a password change. Please sign in again."
         );
       }
 

--- a/apps/web/app/api/auth/reset-password/route.ts
+++ b/apps/web/app/api/auth/reset-password/route.ts
@@ -75,6 +75,10 @@ async function handler(req: NextRequest) {
             update: { hash: hashedPassword },
           },
         },
+        // Revoke existing JWT sessions issued before this reset (account recovery
+        // should not leave a stolen pre-reset token valid). See next-auth-options
+        // and getServerSession for how passwordChangedAt invalidates old tokens.
+        passwordChangedAt: new Date(),
         emailVerified: new Date(),
         identityProvider: IdentityProvider.CAL,
         identityProviderId: null,

--- a/packages/features/auth/lib/getServerSession.test.ts
+++ b/packages/features/auth/lib/getServerSession.test.ts
@@ -119,9 +119,12 @@ describe("getServerSession", () => {
 
       await getServerSession({ req: createMockRequest() });
 
-      expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
-        where: { id: 999 },
-      });
+      // The first DB touch is now the password-change revocation lookup, which
+      // selects passwordChangedAt. When that user is missing we return early, so
+      // assert the id was resolved from token.sub without over-specifying the projection.
+      expect(prismaMock.user.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 999 } })
+      );
     });
 
     it("returns user data from database lookup", async () => {
@@ -157,6 +160,73 @@ describe("getServerSession", () => {
         expect(whereClause).toHaveProperty("id");
         expect(whereClause).not.toHaveProperty("email");
       }
+    });
+  });
+
+  describe("Session revocation on password change", () => {
+    const iat = 1_700_000_000;
+
+    it("returns null when the token was issued before the password change", async () => {
+      setupGetTokenMock({ ...createMockToken({ sub: "5" }), iat });
+      prismaMock.user.findUnique.mockResolvedValue(
+        createMockUser({ id: 5, passwordChangedAt: new Date((iat + 60) * 1000) })
+      );
+
+      const result = await getServerSession({ req: createMockRequest() });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when the token was issued in the same second as the change", async () => {
+      setupGetTokenMock({ ...createMockToken({ sub: "5" }), iat });
+      prismaMock.user.findUnique.mockResolvedValue(
+        createMockUser({ id: 5, passwordChangedAt: new Date(iat * 1000) })
+      );
+
+      const result = await getServerSession({ req: createMockRequest() });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns a session when the token was issued after the password change", async () => {
+      setupGetTokenMock({ ...createMockToken({ sub: "5" }), iat });
+      prismaMock.user.findUnique.mockResolvedValue(
+        createMockUser({ id: 5, passwordChangedAt: new Date((iat - 60) * 1000) })
+      );
+
+      const result = await getServerSession({ req: createMockRequest() });
+
+      expect(result).not.toBeNull();
+      expect(result?.user.id).toBe(5);
+    });
+
+    it("returns a session when the user never changed their password", async () => {
+      setupGetTokenMock({ ...createMockToken({ sub: "5" }), iat });
+      prismaMock.user.findUnique.mockResolvedValue(
+        createMockUser({ id: 5, passwordChangedAt: null })
+      );
+
+      const result = await getServerSession({ req: createMockRequest() });
+
+      expect(result).not.toBeNull();
+      expect(result?.user.id).toBe(5);
+    });
+
+    it("returns null when the token carries the SessionInvalidated flag even if iat is newer than passwordChangedAt", async () => {
+      // NextAuth rotates iat forward on session refresh, so a revoked-but-refreshed
+      // token can have iat > passwordChangedAt. The sticky error flag must still revoke it.
+      setupGetTokenMock({
+        ...createMockToken({ sub: "5" }),
+        iat: iat + 100_000,
+        error: "SessionInvalidated",
+      });
+      prismaMock.user.findUnique.mockResolvedValue(
+        createMockUser({ id: 5, passwordChangedAt: new Date(iat * 1000) })
+      );
+
+      const result = await getServerSession({ req: createMockRequest() });
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/features/auth/lib/getServerSession.ts
+++ b/packages/features/auth/lib/getServerSession.ts
@@ -1,4 +1,5 @@
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+import { isJwtIssuedBeforePasswordChange } from "@calcom/lib/auth/isJwtIssuedBeforePasswordChange";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
@@ -54,18 +55,51 @@ export async function getServerSession(options: {
     return null;
   }
 
-  const cachedSession = CACHE.get(JSON.stringify(token));
-
-  if (cachedSession) {
-    log.debug("Returning cached session", safeStringify(cachedSession));
-    return cachedSession;
-  }
-
   const userId = token.sub ? Number(token.sub) : null;
 
   if (!userId || userId <= 0) {
     log.warn("Invalid or missing user ID in token", { sub: token.sub });
     return null;
+  }
+
+  // The NextAuth jwt callback stamps revoked tokens with error: "SessionInvalidated"
+  // and that flag is sticky across refreshes. Honor it first: NextAuth rotates a
+  // token's `iat` forward every time /api/auth/session re-encodes the cookie, so a
+  // warm/polling session can carry an `iat` later than passwordChangedAt while still
+  // being revoked — the raw-iat check below would miss it, but the flag won't.
+  if (token.error === "SessionInvalidated") {
+    log.debug("Session invalidated (error flag)", { userId });
+    CACHE.delete(JSON.stringify(token));
+    return null;
+  }
+
+  // Session revocation on password change. A JWT issued before the user's last
+  // password change must not authenticate, even when a session for this exact
+  // token is already cached (the cache is keyed by the token, which doesn't
+  // change on password change). This check runs BEFORE the cache lookup so a
+  // stolen pre-change token can't ride a warm cache entry. Cost is one indexed
+  // primary-key lookup per authenticated request.
+  const userForRevocationCheck = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { passwordChangedAt: true },
+  });
+
+  if (!userForRevocationCheck) {
+    log.warn("No user found for valid token", { userId });
+    return null;
+  }
+
+  if (isJwtIssuedBeforePasswordChange(token.iat, userForRevocationCheck.passwordChangedAt)) {
+    log.debug("Session invalidated by password change", { userId });
+    CACHE.delete(JSON.stringify(token));
+    return null;
+  }
+
+  const cachedSession = CACHE.get(JSON.stringify(token));
+
+  if (cachedSession) {
+    log.debug("Returning cached session", safeStringify(cachedSession));
+    return cachedSession;
   }
 
   const userFromDb = await prisma.user.findUnique({

--- a/packages/features/auth/lib/next-auth-options.test.ts
+++ b/packages/features/auth/lib/next-auth-options.test.ts
@@ -109,6 +109,7 @@ const mockUpdateProfilePhotoGoogle = vi.fn();
 const mockGetIdentityProvider = vi.fn();
 const mockWaitUntil = vi.fn();
 const mockPrismaUserFindFirst = vi.fn();
+const mockPrismaUserFindUnique = vi.fn();
 const mockPrismaUserCreate = vi.fn();
 const mockPrismaUserUpdate = vi.fn();
 const mockPrismaTeamFindFirst = vi.fn();
@@ -1285,5 +1286,125 @@ describe("Azure AD JWT callback", () => {
         })
       );
     });
+  });
+});
+
+describe("JWT callback password-change session revocation", () => {
+  let jwtCallback: NonNullable<
+    ReturnType<typeof import("./next-auth-options").getOptions>["callbacks"]
+  >["jwt"];
+
+  const iat = 1_700_000_000;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const prismaModule = await import("@calcom/prisma");
+    const prismaDefault = (prismaModule as any).default;
+    prismaDefault.user = {
+      ...prismaDefault.user,
+      findFirst: mockPrismaUserFindFirst,
+      findUnique: mockPrismaUserFindUnique,
+    };
+
+    const authModule = await import("./next-auth-options");
+    const options = authModule.getOptions({
+      getDubId: () => undefined,
+      getTrackingData: () => ({}) as any,
+    });
+    jwtCallback = options.callbacks!.jwt! as any;
+  });
+
+  it("flags the token as SessionInvalidated when iat predates passwordChangedAt (keyed by user id)", async () => {
+    mockPrismaUserFindUnique.mockResolvedValue({ passwordChangedAt: new Date((iat + 60) * 1000) });
+
+    const result = await jwtCallback({
+      token: { sub: "1", email: "user@example.com", iat } as any,
+      account: { type: "email", provider: "email" },
+      trigger: undefined,
+      session: undefined,
+      user: undefined,
+    } as any);
+
+    expect((result as any).error).toBe("SessionInvalidated");
+    expect(mockPrismaUserFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 1 } })
+    );
+  });
+
+  it("revokes on the trigger==='update' path when iat predates passwordChangedAt", async () => {
+    mockPrismaUserFindUnique.mockResolvedValue({ passwordChangedAt: new Date((iat + 60) * 1000) });
+
+    const result = await jwtCallback({
+      token: { sub: "1", email: "user@example.com", iat } as any,
+      trigger: "update",
+      session: {},
+    } as any);
+
+    expect((result as any).error).toBe("SessionInvalidated");
+  });
+
+  it("revokes a token with a stale email (lookup is keyed by user id, not email)", async () => {
+    mockPrismaUserFindUnique.mockResolvedValue({ passwordChangedAt: new Date((iat + 60) * 1000) });
+
+    const result = await jwtCallback({
+      token: { sub: "1", email: "old-email@example.com", iat } as any,
+      trigger: "update",
+      session: {},
+    } as any);
+
+    expect((result as any).error).toBe("SessionInvalidated");
+  });
+
+  it("keeps an already-invalidated token revoked without a DB lookup (sticky flag)", async () => {
+    const result = await jwtCallback({
+      token: { sub: "1", email: "user@example.com", iat, error: "SessionInvalidated" } as any,
+      trigger: "update",
+      session: {},
+    } as any);
+
+    expect((result as any).error).toBe("SessionInvalidated");
+    expect(mockPrismaUserFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("does not revoke on update when the user never changed their password", async () => {
+    mockPrismaUserFindUnique.mockResolvedValue({ passwordChangedAt: null });
+
+    const result = await jwtCallback({
+      token: { sub: "1", email: "user@example.com", iat } as any,
+      trigger: "update",
+      session: { locale: "en" },
+    } as any);
+
+    expect((result as any).error).toBeUndefined();
+  });
+
+  it("does not revoke a freshly issued token whose iat is after the password change", async () => {
+    mockPrismaUserFindUnique.mockResolvedValue({ passwordChangedAt: new Date((iat - 60) * 1000) });
+
+    const result = await jwtCallback({
+      token: { sub: "1", email: "user@example.com", iat } as any,
+      trigger: "update",
+      session: {},
+    } as any);
+
+    expect((result as any).error).toBeUndefined();
+  });
+
+  it("skips the revocation guard for a fresh sign-in token that has no iat yet", async () => {
+    // On first sign-in NextAuth has not minted iat yet (it is set at encode, after this
+    // callback), so the guard must skip and never block the sign-in.
+    mockPrismaUserFindUnique.mockResolvedValue({ passwordChangedAt: new Date((iat + 60) * 1000) });
+    mockPrismaUserFindFirst.mockResolvedValue(null);
+
+    const result = await jwtCallback({
+      token: { sub: "1", email: "user@example.com" } as any,
+      account: { type: "email", provider: "email" },
+      user: { id: "1" } as any,
+      trigger: undefined,
+      session: undefined,
+    } as any);
+
+    expect((result as any).error).toBeUndefined();
+    expect(mockPrismaUserFindUnique).not.toHaveBeenCalled();
   });
 });

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -661,7 +661,10 @@ export const getOptions = ({
         if (existingUser.passwordChangedAt && token.iat) {
           const changedAtSeconds = Math.floor(existingUser.passwordChangedAt.getTime() / 1000);
           if (token.iat <= changedAtSeconds) {
-            return {} as JWT;
+            // Preserve token shape to avoid downstream crashes (token.email!, token.id, etc.)
+            // but clear identity fields to force re-authentication. email="" ensures
+            // findFirst returns null on subsequent JWT callbacks.
+            return { ...token, email: "", name: "", id: 0 } as JWT;
           }
         }
 

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -629,6 +629,10 @@ export const getOptions = ({
         } as JWT;
       }
       const autoMergeIdentities = async () => {
+        // Session was explicitly invalidated (e.g. password changed). Skip DB lookup
+        // and propagate the error flag so the session callback can surface it to the client.
+        if (token.error === "SessionInvalidated") return token;
+
         const existingUser = await prisma.user.findFirst({
           where: { email: token.email! },
           select: {
@@ -661,10 +665,10 @@ export const getOptions = ({
         if (existingUser.passwordChangedAt && token.iat) {
           const changedAtSeconds = Math.floor(existingUser.passwordChangedAt.getTime() / 1000);
           if (token.iat <= changedAtSeconds) {
-            // Preserve token shape to avoid downstream crashes (token.email!, token.id, etc.)
-            // but clear identity fields to force re-authentication. email="" ensures
-            // findFirst returns null on subsequent JWT callbacks.
-            return { ...token, email: "", name: "", id: 0 } as JWT;
+            // Mark the token as invalidated. The early-exit at the top of autoMergeIdentities
+            // prevents any further DB lookups on subsequent JWT refreshes, and the session
+            // callback propagates the error to the client so it can redirect to sign-in.
+            return { ...token, error: "SessionInvalidated" } as JWT;
           }
         }
 
@@ -965,6 +969,11 @@ export const getOptions = ({
     },
     async session({ session, token, user }) {
       log.debug("callbacks:session - Session callback called", safeStringify({ session, token, user }));
+      // If the JWT was invalidated (e.g. password changed), surface the error to the client
+      // so it can redirect to sign-in rather than serving a stale session.
+      if (token.error === "SessionInvalidated") {
+        return { ...session, error: "SessionInvalidated" };
+      }
       const deploymentRepo = new DeploymentRepository(prisma);
       const licenseKeyService = await LicenseKeySingleton.getInstance(deploymentRepo);
       const hasValidLicense = await licenseKeyService.checkLicense();

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -639,6 +639,7 @@ export const getOptions = ({
             email: true,
             role: true,
             locale: true,
+            passwordChangedAt: true,
             movedToProfileId: true,
             teams: {
               include: {
@@ -655,6 +656,13 @@ export const getOptions = ({
 
         if (!existingUser) {
           return token;
+        }
+
+        if (existingUser.passwordChangedAt && token.iat) {
+          const changedAtSeconds = Math.floor(existingUser.passwordChangedAt.getTime() / 1000);
+          if (token.iat <= changedAtSeconds) {
+            return {} as JWT;
+          }
         }
 
         // Check if the existingUser has any active teams

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -12,6 +12,7 @@ import { CredentialRepository } from "@calcom/features/credentials/repositories/
 import { buildCredentialCreateData } from "@calcom/features/credentials/services/CredentialDataService";
 import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+import { isJwtIssuedBeforePasswordChange } from "@calcom/lib/auth/isJwtIssuedBeforePasswordChange";
 import { isPasswordValid } from "@calcom/lib/auth/isPasswordValid";
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import {
@@ -428,6 +429,33 @@ export const getOptions = ({
       account,
     }) {
       log.debug("callbacks:jwt", safeStringify({ token, user, account, trigger, session }));
+
+      // Password-change session revocation, enforced once here for every refresh/update
+      // of an existing session, BEFORE NextAuth re-encodes the token (encode rotates the
+      // token's `iat` forward, so the raw-iat checks on getToken-based paths can only
+      // rely on this flag once that happens). Keyed by the stable user id (token.sub),
+      // not the mutable email, so a token with a stale email is still revoked. The flag
+      // is sticky: once set it short-circuits all later refreshes. Fresh sign-in calls
+      // have no token.iat yet, so they skip this and are unaffected.
+      if (token.error === "SessionInvalidated") {
+        return token;
+      }
+      if (token.sub && token.iat) {
+        const revocationUserId = Number(token.sub);
+        if (!Number.isNaN(revocationUserId) && revocationUserId > 0) {
+          const userForRevocationCheck = await prisma.user.findUnique({
+            where: { id: revocationUserId },
+            select: { passwordChangedAt: true },
+          });
+          if (
+            userForRevocationCheck &&
+            isJwtIssuedBeforePasswordChange(token.iat, userForRevocationCheck.passwordChangedAt)
+          ) {
+            return { ...token, error: "SessionInvalidated" } as JWT;
+          }
+        }
+      }
+
       // The data available in 'session' depends on what data was supplied in update method call of session
       if (trigger === "update") {
         return {
@@ -441,10 +469,6 @@ export const getOptions = ({
         } as JWT;
       }
       const autoMergeIdentities = async () => {
-        // Session was explicitly invalidated (e.g. password changed). Skip DB lookup
-        // and propagate the error flag so the session callback can surface it to the client.
-        if (token.error === "SessionInvalidated") return token;
-
         const existingUser = await prisma.user.findFirst({
           where: { email: token.email! },
           select: {
@@ -455,7 +479,6 @@ export const getOptions = ({
             email: true,
             role: true,
             locale: true,
-            passwordChangedAt: true,
             movedToProfileId: true,
             teams: {
               include: {
@@ -472,16 +495,6 @@ export const getOptions = ({
 
         if (!existingUser) {
           return token;
-        }
-
-        if (existingUser.passwordChangedAt && token.iat) {
-          const changedAtSeconds = Math.floor(existingUser.passwordChangedAt.getTime() / 1000);
-          if (token.iat <= changedAtSeconds) {
-            // Mark the token as invalidated. The early-exit at the top of autoMergeIdentities
-            // prevents any further DB lookups on subsequent JWT refreshes, and the session
-            // callback propagates the error to the client so it can redirect to sign-in.
-            return { ...token, error: "SessionInvalidated" } as JWT;
-          }
         }
 
         // Check if the existingUser has any active teams

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -441,6 +441,10 @@ export const getOptions = ({
         } as JWT;
       }
       const autoMergeIdentities = async () => {
+        // Session was explicitly invalidated (e.g. password changed). Skip DB lookup
+        // and propagate the error flag so the session callback can surface it to the client.
+        if (token.error === "SessionInvalidated") return token;
+
         const existingUser = await prisma.user.findFirst({
           where: { email: token.email! },
           select: {
@@ -473,10 +477,10 @@ export const getOptions = ({
         if (existingUser.passwordChangedAt && token.iat) {
           const changedAtSeconds = Math.floor(existingUser.passwordChangedAt.getTime() / 1000);
           if (token.iat <= changedAtSeconds) {
-            // Preserve token shape to avoid downstream crashes (token.email!, token.id, etc.)
-            // but clear identity fields to force re-authentication. email="" ensures
-            // findFirst returns null on subsequent JWT callbacks.
-            return { ...token, email: "", name: "", id: 0 } as JWT;
+            // Mark the token as invalidated. The early-exit at the top of autoMergeIdentities
+            // prevents any further DB lookups on subsequent JWT refreshes, and the session
+            // callback propagates the error to the client so it can redirect to sign-in.
+            return { ...token, error: "SessionInvalidated" } as JWT;
           }
         }
 
@@ -773,6 +777,11 @@ export const getOptions = ({
     },
     async session({ session, token, user }) {
       log.debug("callbacks:session - Session callback called", safeStringify({ session, token, user }));
+      // If the JWT was invalidated (e.g. password changed), surface the error to the client
+      // so it can redirect to sign-in rather than serving a stale session.
+      if (token.error === "SessionInvalidated") {
+        return { ...session, error: "SessionInvalidated" };
+      }
       const hasValidLicense = false;
       const profileId = token.profileId;
       const calendsoSession: Session = {

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -451,6 +451,7 @@ export const getOptions = ({
             email: true,
             role: true,
             locale: true,
+            passwordChangedAt: true,
             movedToProfileId: true,
             teams: {
               include: {
@@ -467,6 +468,13 @@ export const getOptions = ({
 
         if (!existingUser) {
           return token;
+        }
+
+        if (existingUser.passwordChangedAt && token.iat) {
+          const changedAtSeconds = Math.floor(existingUser.passwordChangedAt.getTime() / 1000);
+          if (token.iat <= changedAtSeconds) {
+            return {} as JWT;
+          }
         }
 
         // Check if the existingUser has any active teams

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -473,7 +473,10 @@ export const getOptions = ({
         if (existingUser.passwordChangedAt && token.iat) {
           const changedAtSeconds = Math.floor(existingUser.passwordChangedAt.getTime() / 1000);
           if (token.iat <= changedAtSeconds) {
-            return {} as JWT;
+            // Preserve token shape to avoid downstream crashes (token.email!, token.id, etc.)
+            // but clear identity fields to force re-authentication. email="" ensures
+            // findFirst returns null on subsequent JWT callbacks.
+            return { ...token, email: "", name: "", id: 0 } as JWT;
           }
         }
 

--- a/packages/lib/auth/isJwtIssuedBeforePasswordChange.test.ts
+++ b/packages/lib/auth/isJwtIssuedBeforePasswordChange.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { isJwtIssuedBeforePasswordChange } from "./isJwtIssuedBeforePasswordChange";
+
+describe("isJwtIssuedBeforePasswordChange", () => {
+  const changedAt = new Date("2026-06-19T12:00:00.000Z");
+  const changedAtSeconds = Math.floor(changedAt.getTime() / 1000);
+
+  it("revokes a token issued before the password change", () => {
+    expect(isJwtIssuedBeforePasswordChange(changedAtSeconds - 60, changedAt)).toBe(true);
+  });
+
+  it("revokes a token issued in the same whole second as the change (fail closed)", () => {
+    expect(isJwtIssuedBeforePasswordChange(changedAtSeconds, changedAt)).toBe(true);
+  });
+
+  it("keeps a token issued after the password change", () => {
+    expect(isJwtIssuedBeforePasswordChange(changedAtSeconds + 1, changedAt)).toBe(false);
+  });
+
+  it("never revokes when passwordChangedAt is null (password never changed)", () => {
+    expect(isJwtIssuedBeforePasswordChange(changedAtSeconds - 60, null)).toBe(false);
+  });
+
+  it("never revokes when passwordChangedAt is undefined", () => {
+    expect(isJwtIssuedBeforePasswordChange(changedAtSeconds - 60, undefined)).toBe(false);
+  });
+
+  it("does not revoke when the token has no iat", () => {
+    expect(isJwtIssuedBeforePasswordChange(undefined, changedAt)).toBe(false);
+    expect(isJwtIssuedBeforePasswordChange(null, changedAt)).toBe(false);
+  });
+
+  it("floors passwordChangedAt to whole seconds to match iat granularity", () => {
+    // passwordChangedAt 999ms into the same second the token was issued.
+    const withSubSecond = new Date(changedAt.getTime() + 999);
+    expect(isJwtIssuedBeforePasswordChange(changedAtSeconds, withSubSecond)).toBe(true);
+    expect(isJwtIssuedBeforePasswordChange(changedAtSeconds + 1, withSubSecond)).toBe(false);
+  });
+});

--- a/packages/lib/auth/isJwtIssuedBeforePasswordChange.ts
+++ b/packages/lib/auth/isJwtIssuedBeforePasswordChange.ts
@@ -1,0 +1,36 @@
+/**
+ * JWT session revocation on password change.
+ *
+ * A NextAuth JWT carries an `iat` (issued-at) claim in SECONDS. When a user
+ * changes their password we stamp `User.passwordChangedAt` (a Date, milliseconds).
+ * Any token issued at or before that moment must be treated as revoked, so a
+ * stolen pre-change token cannot keep authenticating.
+ *
+ *   ... token issued ───●───────────────●─────────▶ time
+ *                        iat (s)         passwordChangedAt (ms)
+ *                        └─ tokens with iat <= passwordChangedAt are REVOKED ─┘
+ *
+ * `passwordChangedAt == null` means the password was never changed (or predates
+ * this feature), so we never revoke — existing sessions are not mass-invalidated.
+ *
+ * The comparison is `<=` (fail closed): a token minted in the same whole second
+ * as the change is treated as revoked. A re-login in a later second gets an `iat`
+ * strictly greater than passwordChangedAt and survives; a re-login within the same
+ * second is briefly treated as revoked until the next issued token, which is the
+ * safe direction to err.
+ *
+ * `tokenIatSeconds` is typed `unknown` because NextAuth's `JWT["iat"]` resolves
+ * through the JWT index signature (it isn't a declared field), so callers pass it
+ * straight through. A missing/non-numeric/zero `iat` returns false (not revoked),
+ * matching the prior behavior of guarding on a truthy `token.iat`.
+ */
+export function isJwtIssuedBeforePasswordChange(
+  tokenIatSeconds: unknown,
+  passwordChangedAt: Date | null | undefined
+): boolean {
+  if (!passwordChangedAt || typeof tokenIatSeconds !== "number" || !tokenIatSeconds) {
+    return false;
+  }
+  const passwordChangedAtSeconds = Math.floor(passwordChangedAt.getTime() / 1000);
+  return tokenIatSeconds <= passwordChangedAtSeconds;
+}

--- a/packages/prisma/migrations/20260619000000_add_user_password_changed_at/migration.sql
+++ b/packages/prisma/migrations/20260619000000_add_user_password_changed_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "passwordChangedAt" TIMESTAMP(3);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -412,6 +412,9 @@ model User {
   /// @zod.import(["import { emailSchema } from '../../zod-utils'"]).custom.use(emailSchema)
   email               String
   emailVerified       DateTime?
+  /// Timestamp of last password change. Used to invalidate JWT sessions
+  /// issued before the password was changed (security: session revocation).
+  passwordChangedAt   DateTime?
   password            UserPassword?
   bio                 String?
   avatarUrl           String?

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -406,6 +406,9 @@ model User {
   /// @zod.import(["import { emailSchema } from '../../zod-utils'"]).custom.use(emailSchema)
   email               String
   emailVerified       DateTime?
+  /// Timestamp of last password change. Used to invalidate JWT sessions
+  /// issued before the password was changed (security: session revocation).
+  passwordChangedAt   DateTime?
   password            UserPassword?
   bio                 String?
   avatarUrl           String?

--- a/packages/trpc/server/routers/viewer/auth/changePassword.handler.ts
+++ b/packages/trpc/server/routers/viewer/auth/changePassword.handler.ts
@@ -60,21 +60,22 @@ export const changePasswordHandler = async ({ input, ctx }: ChangePasswordOption
 
   const hashedPassword = await hashPassword(newPassword);
   const now = new Date();
-  await prisma.userPassword.upsert({
-    where: {
-      userId: user.id,
-    },
-    create: {
-      hash: hashedPassword,
-      userId: user.id,
-    },
-    update: {
-      hash: hashedPassword,
-    },
-  });
-
-  await prisma.user.update({
-    where: { id: user.id },
-    data: { passwordChangedAt: now },
-  });
+  await prisma.$transaction([
+    prisma.userPassword.upsert({
+      where: {
+        userId: user.id,
+      },
+      create: {
+        hash: hashedPassword,
+        userId: user.id,
+      },
+      update: {
+        hash: hashedPassword,
+      },
+    }),
+    prisma.user.update({
+      where: { id: user.id },
+      data: { passwordChangedAt: now },
+    }),
+  ]);
 };

--- a/packages/trpc/server/routers/viewer/auth/changePassword.handler.ts
+++ b/packages/trpc/server/routers/viewer/auth/changePassword.handler.ts
@@ -59,6 +59,7 @@ export const changePasswordHandler = async ({ input, ctx }: ChangePasswordOption
   }
 
   const hashedPassword = await hashPassword(newPassword);
+  const now = new Date();
   await prisma.userPassword.upsert({
     where: {
       userId: user.id,
@@ -70,5 +71,10 @@ export const changePasswordHandler = async ({ input, ctx }: ChangePasswordOption
     update: {
       hash: hashedPassword,
     },
+  });
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { passwordChangedAt: now },
   });
 };

--- a/packages/types/next-auth.d.ts
+++ b/packages/types/next-auth.d.ts
@@ -14,6 +14,7 @@ declare module "next-auth" {
     profileId?: number | null;
     upId: string;
     user: User & { uuid: PrismaUser["uuid"] };
+    error?: "SessionInvalidated";
   }
 
   interface User extends Omit<DefaultUser, "id"> {
@@ -78,5 +79,6 @@ declare module "next-auth/jwt" {
     orgAwareUsername?: PrismaUser["username"];
     organizationId?: number | null;
     locale?: string;
+    error?: "SessionInvalidated";
   }
 }


### PR DESCRIPTION
## Problem

Fixes #28392

Existing JWT sessions persist after password change, allowing stolen tokens to retain access for up to 30 days.

## Fix

- Add `passwordChangedAt` to User model
- Set it when password is changed
- Check `token.iat <= changedAtSeconds` in JWT callback to invalidate old sessions

3 files, 17 lines. Replaces #28642 which had unrelated changes.