### PR TITLE
fix: prevent nested anchor elements in NavigationItem tooltip

### DIFF
--- a/apps/web/modules/shell/navigation/NavigationItem.tsx
+++ b/apps/web/modules/shell/navigation/NavigationItem.tsx
@@ -204,6 +204,7 @@ export const NavigationItem: React.FC<{
         </Tooltip>
       ) : (
         <Tooltip side="right" content={t(item.name)} className="lg:hidden">
+          <span className="flex w-full">
           <Link
             data-test-id={item.name}
             onClick={() => trackNavigationClick(item.name)}
@@ -247,6 +248,7 @@ export const NavigationItem: React.FC<{
               <SkeletonText className="h-[20px] w-full" />
             )}
           </Link>
+          </span>
         </Tooltip>
       )}
       {hasChildren && (


### PR DESCRIPTION
Fixes #27984. Wrap Link in a span so Radix Tooltip doesn't create nested anchor elements. 1 file, 2 lines. Replaces #28645 which had unrelated changes.