### PR TITLE
fix: destructure formState properties to enable proper Proxy subscription

### DIFF
--- a/apps/web/components/dialog/EditLocationDialog.tsx
+++ b/apps/web/components/dialog/EditLocationDialog.tsx
@@ -1,10 +1,3 @@
-import { ErrorMessage } from "@hookform/error-message";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { isValidPhoneNumber } from "libphonenumber-js/max";
-import { useEffect, useState } from "react";
-import { Controller, useForm, useWatch, useFormContext } from "react-hook-form";
-import { z } from "zod";
-
 import type { EventLocationType, LocationObject } from "@calcom/app-store/locations";
 import {
   getEventLocationType,
@@ -15,7 +8,6 @@ import {
   OrganizerDefaultConferencingAppType,
 } from "@calcom/app-store/locations";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import PhoneInput from "@calcom/web/components/phone-input";
 import type { LocationOption } from "@calcom/features/form/components/LocationSelect";
 import LocationSelect from "@calcom/features/form/components/LocationSelect";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -23,8 +15,14 @@ import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
 import { DialogContent, DialogFooter, DialogHeader } from "@calcom/ui/components/dialog";
 import { Form, Input } from "@calcom/ui/components/form";
+import PhoneInput from "@calcom/web/components/phone-input";
 import { MapPinIcon } from "@coss/ui/icons";
-
+import { ErrorMessage } from "@hookform/error-message";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { isValidPhoneNumber } from "libphonenumber-js/max";
+import { useEffect, useState } from "react";
+import { Controller, useForm, useFormContext, useWatch } from "react-hook-form";
+import { z } from "zod";
 import { QueryCell } from "../../lib/QueryCell";
 
 interface ISetLocationDialog {
@@ -170,6 +168,8 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
 
   const eventLocationType = getEventLocationType(selectedLocation);
 
+  const { errors } = locationFormMethods.formState;
+
   const defaultLocation = defaultValues?.find(
     (location: { type: EventLocationType["type"]; address?: string }) => {
       if (location.type === LocationType.InPerson) {
@@ -207,7 +207,7 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
               }
             />
             <ErrorMessage
-              errors={locationFormMethods.formState.errors}
+              errors={errors}
               name={eventLocationType.variable}
               className="text-error mt-1 text-sm"
               as="p"

--- a/apps/web/components/setup/AdminUser.tsx
+++ b/apps/web/components/setup/AdminUser.tsx
@@ -1,17 +1,17 @@
-import { zodResolver } from "@hookform/resolvers/zod";
-import classNames from "classnames";
-import { signIn } from "next-auth/react";
-import React from "react";
-import { Controller, FormProvider, useForm } from "react-hook-form";
-import { z } from "zod";
-
+import process from "node:process";
 import { isPasswordValid } from "@calcom/lib/auth/isPasswordValid";
 import { WEBSITE_URL } from "@calcom/lib/constants";
 import { emailRegex } from "@calcom/lib/emailSchema";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button } from "@calcom/ui/components/button";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
-import { EmailField, Label, TextField, PasswordField } from "@calcom/ui/components/form";
+import { EmailField, Label, PasswordField, TextField } from "@calcom/ui/components/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import classNames from "classnames";
+import { signIn } from "next-auth/react";
+import type React from "react";
+import { Controller, FormProvider, useForm } from "react-hook-form";
+import { z } from "zod";
 
 export const AdminUserContainer = (props: React.ComponentProps<typeof AdminUser> & { userCount: number }) => {
   const { t } = useLocale();
@@ -74,6 +74,8 @@ export const AdminUser = (props: {
   const onError = () => {
     props.onError();
   };
+
+  const { isValid, isSubmitting } = formMethods.formState;
 
   const onSubmit = formMethods.handleSubmit(async (data) => {
     props.onSubmit();
@@ -194,11 +196,7 @@ export const AdminUser = (props: {
           />
         </div>
         <div className="flex justify-end gap-2">
-          <Button
-            type="submit"
-            color="primary"
-            loading={formMethods.formState.isSubmitting}
-            disabled={!formMethods.formState.isValid || formMethods.formState.isSubmitting}>
+          <Button type="submit" color="primary" loading={isSubmitting} disabled={!isValid || isSubmitting}>
             {t("next")}
           </Button>
         </div>

--- a/apps/web/components/setup/LicenseSelection.tsx
+++ b/apps/web/components/setup/LicenseSelection.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import type { RouterInputs, RouterOutputs } from "@calcom/trpc/react";
+import { trpc } from "@calcom/trpc/react";
+import { Button } from "@calcom/ui/components/button";
+import { TextField } from "@calcom/ui/components/form";
+import { CheckIcon, LoaderIcon } from "@coss/ui/icons";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as RadioGroup from "@radix-ui/react-radio-group";
 import classNames from "classnames";
@@ -7,13 +13,6 @@ import Link from "next/link";
 import { useCallback, useState } from "react";
 import { Controller, FormProvider, useForm, useFormState } from "react-hook-form";
 import { z } from "zod";
-
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import type { RouterInputs, RouterOutputs } from "@calcom/trpc/react";
-import { trpc } from "@calcom/trpc/react";
-import { Button } from "@calcom/ui/components/button";
-import { TextField } from "@calcom/ui/components/form";
-import { CheckIcon, LoaderIcon } from "@coss/ui/icons";
 
 type LicenseSelectionFormValues = {
   licenseKey: string;
@@ -92,6 +91,7 @@ const LicenseSelection = (
   });
 
   const { isDirty, errors } = useFormState(formMethods);
+  const { isValid } = formMethods.formState;
 
   const handleRadioChange = (newValue: LicenseOption) => {
     setValue(newValue);
@@ -236,10 +236,7 @@ const LicenseSelection = (
             type="submit"
             color="primary"
             loading={checkLicenseLoading || mutation.isPending}
-            disabled={
-              value === "EXISTING" &&
-              (!formMethods.formState.isValid || checkLicenseLoading || mutation.isPending)
-            }>
+            disabled={value === "EXISTING" && (!isValid || checkLicenseLoading || mutation.isPending)}>
             {t("save_license_key")}
           </Button>
         ) : (

--- a/apps/web/modules/ee/workflows/components/agent-configuration/AgentConfigurationSheet.tsx
+++ b/apps/web/modules/ee/workflows/components/agent-configuration/AgentConfigurationSheet.tsx
@@ -1,6 +1,3 @@
-import { useState } from "react";
-import type { UseFormReturn } from "react-hook-form";
-
 import type { Language } from "@calcom/features/calAIPhone/providers/retellAI/types";
 import { restorePromptComplexity } from "@calcom/features/calAIPhone/providers/retellAI/utils/promptUtils";
 import type { FormValues } from "@calcom/features/ee/workflows/lib/types";
@@ -19,14 +16,15 @@ import type { MultiSelectCheckboxesOptionType as Option } from "@calcom/ui/compo
 import { ToggleGroup } from "@calcom/ui/components/form";
 import {
   Sheet,
+  SheetBody,
   SheetContent,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
-  SheetBody,
-  SheetFooter,
 } from "@calcom/ui/components/sheet";
 import { showToast } from "@calcom/ui/components/toast";
-
+import { useState } from "react";
+import type { UseFormReturn } from "react-hook-form";
 import { WebCallDialog } from "../WebCallDialog";
 import { IncomingCallsTab } from "./components/tabs/IncomingCallsTab";
 import { OutgoingCallsTab } from "./components/tabs/OutgoingCallsTab";
@@ -132,6 +130,9 @@ export function AgentConfigurationSheet({
     });
   };
 
+  const { isDirty: isOutboundAgentDirty } = outboundAgentForm.formState;
+  const { isDirty: isInboundAgentDirty } = inboundAgentForm.formState;
+
   return (
     <>
       <Sheet open={open} onOpenChange={onOpenChange}>
@@ -234,8 +235,8 @@ export function AgentConfigurationSheet({
               disabled={
                 readOnly ||
                 updateAgentMutation.isPending ||
-                (activeTab === "outgoingCalls" && !outboundAgentForm.formState.isDirty) ||
-                (activeTab === "incomingCalls" && !inboundAgentForm.formState.isDirty) ||
+                (activeTab === "outgoingCalls" && !isOutboundAgentDirty) ||
+                (activeTab === "incomingCalls" && !isInboundAgentDirty) ||
                 (activeTab === "outgoingCalls" && !agentId) ||
                 (activeTab === "incomingCalls" && !inboundAgentId)
               }

--- a/apps/web/modules/ee/workflows/views/WorkflowPage.tsx
+++ b/apps/web/modules/ee/workflows/views/WorkflowPage.tsx
@@ -1,18 +1,10 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useSession } from "next-auth/react";
-import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
-import { useForm, useWatch } from "react-hook-form";
-import { Toaster } from "sonner";
-
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
 import {
-  isSMSAction,
-  isSMSOrWhatsappAction,
   isCalAIAction,
   isFormTrigger,
+  isSMSAction,
+  isSMSOrWhatsappAction,
 } from "@calcom/features/ee/workflows/lib/actionHelperFunctions";
 import { formSchema } from "@calcom/features/ee/workflows/lib/schema";
 import type { FormValues } from "@calcom/features/ee/workflows/lib/types";
@@ -34,10 +26,16 @@ import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
 import type { MultiSelectCheckboxesOptionType as Option } from "@calcom/ui/components/form";
 import { Form, Input } from "@calcom/ui/components/form";
-import { PencilIcon } from "@coss/ui/icons";
 import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
-
+import { PencilIcon } from "@coss/ui/icons";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import { Toaster } from "sonner";
+import LicenseRequired from "~/ee/common/components/LicenseRequired";
 import { DeleteDialog } from "../components/DeleteDialog";
 import SkeletonLoader from "../components/SkeletonLoaderEdit";
 import WorkflowDetailsPage from "../components/WorkflowDetailsPage";
@@ -127,6 +125,8 @@ function WorkflowPage({
 
   let allEventTypeOptions = data?.eventTypeOptions ?? [];
   const distinctEventTypes = new Set();
+
+  const { isDirty } = form.formState;
 
   if (!teamId && isMixedEventType) {
     allEventTypeOptions = [...allEventTypeOptions, ...selectedOptions];
@@ -321,7 +321,7 @@ function WorkflowPage({
     },
   });
 
-  const isDisabled = permissions.readOnly || updateMutation.isPending || !form.formState.isDirty;
+  const isDisabled = permissions.readOnly || updateMutation.isPending || !isDirty;
 
   const validateAndSubmitWorkflow = async (values: FormValues): Promise<void> => {
     let isEmpty = false;

--- a/apps/web/modules/event-types/components/EventTypeLayout.tsx
+++ b/apps/web/modules/event-types/components/EventTypeLayout.tsx
@@ -1,13 +1,5 @@
-import { useMemo, useState, Suspense } from "react";
-import type { UseFormReturn } from "react-hook-form";
-
 import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
-import {
-  EventTypeEmbedButton,
-  EventTypeEmbedDialog,
-} from "@calcom/web/modules/embed/components/EventTypeEmbed";
-import type { FormValues } from "@calcom/features/eventtypes/lib/types";
-import type { EventTypeSetupProps } from "@calcom/features/eventtypes/lib/types";
+import type { EventTypeSetupProps, FormValues } from "@calcom/features/eventtypes/lib/types";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { SchedulingType } from "@calcom/prisma/enums";
 import classNames from "@calcom/ui/classNames";
@@ -16,23 +8,27 @@ import { Button } from "@calcom/ui/components/button";
 import { ButtonGroup } from "@calcom/ui/components/buttonGroup";
 import { VerticalDivider } from "@calcom/ui/components/divider";
 import {
-  DropdownMenuSeparator,
   Dropdown,
+  DropdownItem,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@calcom/ui/components/dropdown";
-import { Label } from "@calcom/ui/components/form";
-import { Switch } from "@calcom/ui/components/form";
-import { LoaderIcon } from "@coss/ui/icons";
-import { HorizontalTabs, VerticalTabs } from "@calcom/ui/components/navigation";
+import { Label, Switch } from "@calcom/ui/components/form";
 import type { VerticalTabItemProps } from "@calcom/ui/components/navigation";
+import { HorizontalTabs, VerticalTabs } from "@calcom/ui/components/navigation";
 import { Skeleton } from "@calcom/ui/components/skeleton";
 import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
+import {
+  EventTypeEmbedButton,
+  EventTypeEmbedDialog,
+} from "@calcom/web/modules/embed/components/EventTypeEmbed";
 import WebShell from "@calcom/web/modules/shell/Shell";
-
+import { LoaderIcon } from "@coss/ui/icons";
+import { Suspense, useMemo, useState } from "react";
+import type { UseFormReturn } from "react-hook-form";
 import { Shell as PlatformShell } from "../../../../../packages/platform/atoms/src/components/ui/shell";
 import { DeleteDialog } from "./dialogs/DeleteDialog";
 
@@ -101,6 +97,8 @@ function EventTypeSingleLayout({
     return isPlatform ? [PlatformShell] : [WebShell];
   }, [isPlatform]);
   const teamId = eventType.team?.id;
+
+  const { isDirty } = formMethods.formState;
 
   return (
     <Shell
@@ -282,7 +280,7 @@ function EventTypeSingleLayout({
             className="ml-4 lg:ml-0"
             type="submit"
             loading={isUpdateMutationLoading}
-            disabled={!formMethods.formState.isDirty}
+            disabled={!isDirty}
             data-testid="update-eventtype"
             form="event-type-form">
             {t("save")}

--- a/apps/web/modules/integration-attribute-sync/components/IntegrationAttributeSyncCard.tsx
+++ b/apps/web/modules/integration-attribute-sync/components/IntegrationAttributeSyncCard.tsx
@@ -1,20 +1,18 @@
-import { useEffect, useState } from "react";
-import { useForm, Controller } from "react-hook-form";
-
-import { Dialog } from "@calcom/features/components/controlled-dialog";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { Attribute } from "@calcom/app-store/routing-forms/types/types";
-import { Button } from "@calcom/ui/components/button";
-import { FormCard, FormCardBody } from "@calcom/ui/components/card";
-import { ConfirmationDialogContent } from "@calcom/ui/components/dialog";
-import { SelectField, Switch } from "@calcom/ui/components/form";
-import { KeyIcon } from "@coss/ui/icons";
-
+import { Dialog } from "@calcom/features/components/controlled-dialog";
 import {
   type IntegrationAttributeSync,
   type ISyncFormData,
   RuleOperatorEnum,
 } from "@calcom/features/ee/integration-attribute-sync/repositories/IIntegrationAttributeSyncRepository";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button } from "@calcom/ui/components/button";
+import { FormCard, FormCardBody } from "@calcom/ui/components/card";
+import { ConfirmationDialogContent } from "@calcom/ui/components/dialog";
+import { SelectField, Switch } from "@calcom/ui/components/form";
+import { KeyIcon } from "@coss/ui/icons";
+import { useEffect, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 import { FieldMappingBuilder } from "./FieldMappingBuilder";
 import { RuleBuilder } from "./RuleBuilder";
 
@@ -85,6 +83,8 @@ const IntegrationAttributeSyncCard = (props: IIntegrationAttributeSyncCardProps)
           syncFieldMappings: [],
         },
   });
+
+  const { isDirty } = form.formState;
 
   // Update form when sync prop changes (after refetch with new IDs)
   useEffect(() => {
@@ -255,7 +255,7 @@ const IntegrationAttributeSyncCard = (props: IIntegrationAttributeSyncCardProps)
                     {t("cancel")}
                   </Button>
                 )}
-                <Button type="submit" loading={isPending} disabled={!form.formState.isDirty}>
+                <Button type="submit" loading={isPending} disabled={!isDirty}>
                   {isCreateMode ? t("create") : t("save")}
                 </Button>
               </div>

--- a/apps/web/modules/onboarding/personal/settings/personal-settings-view.tsx
+++ b/apps/web/modules/onboarding/personal/settings/personal-settings-view.tsx
@@ -84,6 +84,8 @@ export const PersonalSettingsView = ({
     },
   });
 
+  const { isValid } = form.formState;
+
   async function updateProfileHandler(newAvatar: string) {
     avatarMutation.mutate({
       avatarUrl: newAvatar,
@@ -133,7 +135,7 @@ export const PersonalSettingsView = ({
                 color="primary"
                 className="rounded-[10px]"
                 loading={mutation.isPending}
-                disabled={mutation.isPending || !form.formState.isValid}>
+                disabled={mutation.isPending || !isValid}>
                 {t("continue")}
               </Button>
             </div>

--- a/apps/web/modules/settings/security/password-view.tsx
+++ b/apps/web/modules/settings/security/password-view.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import { signOut, useSession } from "next-auth/react";
-import { useState } from "react";
-import { useForm } from "react-hook-form";
-
 import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { IdentityProvider } from "@calcom/prisma/enums";
@@ -13,12 +9,12 @@ import { trpc } from "@calcom/trpc/react";
 import classNames from "@calcom/ui/classNames";
 import { Alert } from "@calcom/ui/components/alert";
 import { Button } from "@calcom/ui/components/button";
-import { Form } from "@calcom/ui/components/form";
-import { PasswordField } from "@calcom/ui/components/form";
-import { Select } from "@calcom/ui/components/form";
-import { SettingsToggle } from "@calcom/ui/components/form";
+import { Form, PasswordField, Select, SettingsToggle } from "@calcom/ui/components/form";
 import { SkeletonButton, SkeletonContainer, SkeletonText } from "@calcom/ui/components/skeleton";
 import { showToast } from "@calcom/ui/components/toast";
+import { signOut, useSession } from "next-auth/react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
 
 type ChangePasswordSessionFormValues = {
   oldPassword: string;
@@ -157,7 +153,9 @@ const PasswordView = ({ user }: PasswordViewProps) => {
     value: mins,
   }));
 
-  const isDisabled = formMethods.formState.isSubmitting || !formMethods.formState.isDirty;
+  const { isDirty, isSubmitting } = formMethods.formState;
+
+  const isDisabled = isSubmitting || !isDirty;
 
   const passwordMinLength = data?.user.role === "USER" ? 7 : 15;
   const isUser = data?.user.role === "USER";

--- a/apps/web/modules/webhooks/components/WebhookForm.tsx
+++ b/apps/web/modules/webhooks/components/WebhookForm.tsx
@@ -320,6 +320,8 @@ const WebhookForm = (props: {
   const time = formMethods.watch("time");
   const timeUnit = formMethods.watch("timeUnit");
 
+  const { isDirty } = formMethods.formState;
+
   const TIME_UNITS = [TimeUnit.MINUTE, TimeUnit.HOUR, TimeUnit.DAY] as const;
   const timeUnitItems = TIME_UNITS.map((unit) => ({
     value: unit,
@@ -368,7 +370,7 @@ const WebhookForm = (props: {
 
   const canSubmit = isCreating
     ? hasUrl && triggers.length > 0 && (!needsTime || hasTime)
-    : formMethods.formState.isDirty || changeSecret;
+    : isDirty || changeSecret;
 
   useEffect(() => {
     if (isCreating && needsTime && !time && !timeUnit) {

--- a/packages/platform/atoms/availability/AvailabilitySettings.tsx
+++ b/packages/platform/atoms/availability/AvailabilitySettings.tsx
@@ -1,22 +1,8 @@
 "use client";
 
-import type { SetStateAction, Dispatch } from "react";
-import React from "react";
-import {
-  useMemo,
-  useState,
-  useEffect,
-  forwardRef,
-  useImperativeHandle,
-  useRef,
-  useCallback,
-} from "react";
-import { Controller, useFieldArray, useForm, useFormContext, useWatch } from "react-hook-form";
-
 import dayjs from "@calcom/dayjs";
 import { BookerStoreProvider } from "@calcom/features/bookings/Booker/BookerStoreProvider";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import { TimezoneSelect as WebTimezoneSelect } from "@calcom/web/modules/timezone/components/TimezoneSelect";
 import type {
   BulkUpdatParams,
   EventTypes,
@@ -24,32 +10,32 @@ import type {
 import { BulkEditDefaultForEventsModal } from "@calcom/features/eventtypes/components/BulkEditDefaultForEventsModal";
 import DateOverrideInputDialog from "@calcom/features/schedules/components/DateOverrideInputDialog";
 import DateOverrideList from "@calcom/features/schedules/components/DateOverrideList";
-import {
-  ScheduleComponent as PlatformSchedule,
-} from "@calcom/features/schedules/components/ScheduleComponent";
-import WebSchedule from "@calcom/web/modules/schedules/components/Schedule";
+import { ScheduleComponent as PlatformSchedule } from "@calcom/features/schedules/components/ScheduleComponent";
+import type { TravelScheduleRepository } from "@calcom/features/travelSchedule/repositories/TravelScheduleRepository";
 import { availabilityAsString } from "@calcom/lib/availability";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { sortAvailabilityStrings } from "@calcom/lib/weekstart";
-import type { TravelScheduleRepository } from "@calcom/features/travelSchedule/repositories/TravelScheduleRepository";
 import type { TimeRange, WorkingHours } from "@calcom/types/schedule";
 import classNames from "@calcom/ui/classNames";
 import { Button } from "@calcom/ui/components/button";
-import { DialogTrigger, ConfirmationDialogContent } from "@calcom/ui/components/dialog";
+import { ConfirmationDialogContent, DialogTrigger } from "@calcom/ui/components/dialog";
 import { VerticalDivider } from "@calcom/ui/components/divider";
 import { EditableHeading } from "@calcom/ui/components/editable-heading";
-import { Form } from "@calcom/ui/components/form";
-import { Label } from "@calcom/ui/components/form";
-import { Switch } from "@calcom/ui/components/form";
+import { Form, Label, Switch } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
-import { SkeletonText, SelectSkeletonLoader, Skeleton } from "@calcom/ui/components/skeleton";
+import { SelectSkeletonLoader, Skeleton, SkeletonText } from "@calcom/ui/components/skeleton";
 import { Tooltip } from "@calcom/ui/components/tooltip";
+import WebSchedule from "@calcom/web/modules/schedules/components/Schedule";
 import WebShell from "@calcom/web/modules/shell/Shell";
-
+import { TimezoneSelect as WebTimezoneSelect } from "@calcom/web/modules/timezone/components/TimezoneSelect";
+import type React from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { Controller, useFieldArray, useForm, useFormContext, useWatch } from "react-hook-form";
 import { Shell as PlatformShell } from "../src/components/ui/shell";
 import { cn } from "../src/lib/utils";
 import { Timezone as PlatformTimzoneSelect } from "../timezone/index";
-import type { AvailabilityFormValues, scheduleClassNames, AvailabilitySettingsFormRef } from "./types";
+import type { AvailabilityFormValues, AvailabilitySettingsFormRef, scheduleClassNames } from "./types";
 
 export type Schedule = {
   id: number;
@@ -330,6 +316,8 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
       },
     });
 
+    const { isDirty } = form.formState;
+
     const watchedValues = useWatch({
       control: form.control,
     });
@@ -342,11 +330,14 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
     const formHasChanges = useMemo(() => {
       if (!initialValuesRef.current) return false;
       try {
-        return (JSON.stringify(form.watch("schedule")) !== JSON.stringify(initialValuesRef.current.availability) || JSON.stringify(watchedValues) !== JSON.stringify(initialValuesRef.current));
+        return (
+          JSON.stringify(form.watch("schedule")) !== JSON.stringify(initialValuesRef.current.availability) ||
+          JSON.stringify(watchedValues) !== JSON.stringify(initialValuesRef.current)
+        );
       } catch {
-        return form.formState.isDirty;
+        return isDirty;
       }
-    }, [watchedValues, form.formState.isDirty]);
+    }, [watchedValues, isDirty]);
 
     // Trigger callback whenever the form state changes
     useEffect(() => {
@@ -643,8 +634,7 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
               type="submit"
               form="availability-form"
               loading={isSaving}
-              disabled={isLoading || !formHasChanges}
-            >
+              disabled={isLoading || !formHasChanges}>
               {t("save")}
             </Button>
             <Button


### PR DESCRIPTION
## What does this PR do?

Fixes #25208

Destructures `formState` properties (`isDirty`, `isSubmitting`, `isValid`, `errors`) at the component level instead of accessing them directly through the form object.

Per [react-hook-form's documentation](https://react-hook-form.com/docs/useform/formstate), `formState` is wrapped with a Proxy and properties must be destructured to enable proper subscription and re-renders. The same fix was already applied in #25197 for routing forms — this PR extends it to all remaining instances.

**Affected files:**
- `AgentConfigurationSheet.tsx` — `isDirty` (two forms)
- `WorkflowPage.tsx` — `isDirty`
- `EventTypeLayout.tsx` — `isDirty`
- `IntegrationAttributeSyncCard.tsx` — `isDirty`
- `WebhookForm.tsx` — `isDirty`
- `AvailabilitySettings.tsx` — `isDirty`
- `PasswordView.tsx` — `isDirty`, `isSubmitting`
- `AdminUser.tsx` — `isValid`, `isSubmitting`
- `LicenseSelection.tsx` — `isValid`
- `EditLocationDialog.tsx` — `errors`

## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A — no documentation changes required.
- [x] N/A — this is a refactor that ensures correct Proxy subscription, not a behavior change. Existing tests cover form functionality.

## How should this be tested?

- No environment variables needed
- Navigate to any of the affected pages (Event Type settings, Webhooks, Availability, Workflows, Password settings)
- Verify forms load without console errors
- Verify Save/Submit buttons correctly enable when form is dirty and disable when form is clean