### PR TITLE
fix: disable save button in event-type page when no real changes exist

### DIFF
--- a/apps/web/modules/event-types/components/EventType.tsx
+++ b/apps/web/modules/event-types/components/EventType.tsx
@@ -64,6 +64,7 @@ export type EventTypeComponentProps = EventTypeSetupProps & {
   tabsNavigation: VerticalTabItemProps[];
   allowDelete?: boolean;
   saveButtonRef?: React.RefObject<HTMLButtonElement>;
+  hasUnsavedChanges?: boolean;
 };
 
 export const EventType = ({
@@ -83,6 +84,7 @@ export const EventType = ({
   children,
   allowDelete = true,
   saveButtonRef,
+  hasUnsavedChanges,
 }: EventTypeComponentProps) => {
   const [animationParentRef] = useAutoAnimate<HTMLDivElement>();
 
@@ -103,7 +105,8 @@ export const EventType = ({
         isPlatform={isPlatform}
         allowDelete={allowDelete}
         tabsNavigation={tabsNavigation}
-        saveButtonRef={saveButtonRef}>
+        saveButtonRef={saveButtonRef}
+        hasUnsavedChanges={hasUnsavedChanges}>
         <Form form={formMethods} id="event-type-form" handleSubmit={handleSubmit}>
           <div ref={animationParentRef}>{tabMap[tabName]}</div>
         </Form>

--- a/apps/web/modules/event-types/components/EventTypeLayout.tsx
+++ b/apps/web/modules/event-types/components/EventTypeLayout.tsx
@@ -52,6 +52,7 @@ type Props = {
   tabsNavigation: VerticalTabItemProps[];
   allowDelete?: boolean;
   saveButtonRef?: React.RefObject<HTMLButtonElement>;
+  hasUnsavedChanges?: boolean;
 };
 
 function EventTypeSingleLayout({
@@ -70,6 +71,7 @@ function EventTypeSingleLayout({
   tabsNavigation,
   allowDelete = true,
   saveButtonRef,
+  hasUnsavedChanges,
 }: Props) {
   const { t } = useLocale();
   const eventTypesLockedByOrg = eventType.team?.parent?.organizationSettings?.lockEventTypeCreationForUsers;
@@ -282,7 +284,7 @@ function EventTypeSingleLayout({
             className="ml-4 lg:ml-0"
             type="submit"
             loading={isUpdateMutationLoading}
-            disabled={!formMethods.formState.isDirty}
+            disabled={hasUnsavedChanges !== undefined ? !hasUnsavedChanges : !formMethods.formState.isDirty}
             data-testid="update-eventtype"
             form="event-type-form">
             {t("save")}

--- a/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/components/EventTypeWebWrapper.tsx
@@ -206,7 +206,7 @@ const EventTypeWeb = ({
     },
   });
 
-  const { form, handleSubmit } = useEventTypeForm({ eventType, onSubmit: updateMutation.mutate });
+  const { form, handleSubmit, hasUnsavedChanges } = useEventTypeForm({ eventType, onSubmit: updateMutation.mutate });
   const slug = form.watch("slug") ?? eventType.slug;
 
   const { data: allActiveWorkflows } = trpc.viewer.workflows.getAllActiveWorkflows.useQuery({
@@ -409,7 +409,8 @@ const EventTypeWeb = ({
       isUpdating={updateMutation.isPending}
       isPlatform={false}
       tabName={tabName}
-      tabsNavigation={tabsNavigation}>
+      tabsNavigation={tabsNavigation}
+      hasUnsavedChanges={hasUnsavedChanges}>
       <>
         {slugExistsChildrenDialogOpen.length ? (
           <ManagedEventTypeDialog

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -15,11 +15,37 @@ import { validateIntervalLimitOrder } from "@calcom/lib/intervalLimits/validateI
 import { validateBookerLayouts } from "@calcom/lib/validateBookerLayouts";
 import { eventTypeBookingFields as eventTypeBookingFieldsSchema } from "@calcom/prisma/zod-utils";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 type Fields = z.infer<typeof eventTypeBookingFieldsSchema>;
+
+/**
+ * Deep equality comparison for form values.
+ * Handles primitives, arrays, plain objects, Date objects, null, and undefined.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return a === b;
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, i) => deepEqual(item, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const objA = a as Record<string, unknown>;
+    const objB = b as Record<string, unknown>;
+    const keysA = Object.keys(objA);
+    const keysB = Object.keys(objB);
+    if (keysA.length !== keysB.length) return false;
+    return keysA.every((key) => key in objB && deepEqual(objA[key], objB[key]));
+  }
+  return false;
+}
 
 export const useEventTypeForm = ({
   eventType,
@@ -206,6 +232,24 @@ export const useEventTypeForm = ({
 
   // Watch all form values to trigger onFormStateChange on any change
   const watchedValues = form.watch();
+
+  // Track baseline values for true dirty comparison.
+  // Initialized with defaultValues and updated when the form is reset
+  // (e.g., after a successful save), so future comparisons use the
+  // post-save state as the new baseline.
+  const baselineValuesRef = useRef<unknown>(defaultValues);
+
+  useEffect(() => {
+    if (!isFormDirty) {
+      baselineValuesRef.current = form.getValues();
+    }
+  }, [isFormDirty, form]);
+
+  // True unsaved changes detection: handles the case where a user
+  // changes a field and then reverts it back to the original value.
+  // React Hook Form's isDirty stays true in that scenario, but this
+  // correctly detects that no real changes exist.
+  const hasUnsavedChanges = isFormDirty ? !deepEqual(watchedValues, baselineValuesRef.current) : false;
 
   const isObject = <T>(value: T): boolean => {
     return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -439,5 +483,5 @@ export const useEventTypeForm = ({
     }
   }, [isFormDirty, dirtyFields, watchedValues, onFormStateChange]);
 
-  return { form, handleSubmit };
+  return { form, handleSubmit, hasUnsavedChanges };
 };


### PR DESCRIPTION
## What does this PR do?

Fixes #13112 
The Save button on the event type edit page remained clickable even when no actual form changes existed. While the existing `disabled={!formMethods.formState.isDirty}` check handled the initial load state, React Hook Form's `isDirty` flag has a known limitation: once any field is touched via `setValue()` with `shouldDirty: true`, `isDirty` stays `true` - even after the user reverts the field back to its original value.

This PR replaces the unreliable `isDirty` check with true unsaved changes detection using deep equality comparison.

### How it works

1. `deepEqual()` utility - Recursively compares form values, handling primitives, arrays, nested objects, Dates, null, and undefined
2. Baseline tracking - A `useRef` stores the baseline values (initialized from `defaultValues`, updated when `form.reset()` is called after save)
3. `hasUnsavedChanges` - Computed as `isFormDirty ? !deepEqual(watchedValues, baseline) : false`
4. Backward compatible - The `hasUnsavedChanges` prop is optional with a fallback to `isDirty`, so the platform wrapper continues working unchanged
### Key behaviors
- Save button is disabled on initial page load (no changes)
- Save button enables when any field value differs from the baseline
- Save button re-disables when user reverts all changes to original values
- Save button re-disables after successful save (baseline updates via reset)
### Why the previous attempt (#13158) failed
The [previous PR](https://github.com/calcom/cal.com/pull/13158) was closed because:
- It used local state tracking that couldn't detect when users undo their changes
- The button stayed active after saving
- It didn't handle reverting fields back to their original values
This PR addresses all of those review comments.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
## How should this be tested?
1. Navigate to an existing event type
2. Verify Save button is disabled (grayed out)
3. Change the title -> verify Save enables
4. Change the title back to original -> verify Save disables again
5. Make a real change and click Save -> verify Save disables after successful save 