### PR TITLE
fix: show correct message when RANGE booking window hasn't opened yet

### DIFF
--- a/packages/features/calendars/__tests__/NoAvailabilityDialog.test.tsx
+++ b/packages/features/calendars/__tests__/NoAvailabilityDialog.test.tsx
@@ -93,8 +93,9 @@ describe("NoAvailabilityOverlay", () => {
   test("Displays range not-started description when period type is RANGE and the booking window opens after the next month", () => {
     // Booking window opens 2 months out, so browsing the current month is before the window starts.
     // The dialog must say "Scheduling opens on ..." rather than the misleading "Scheduling ended on ...".
-    const startDate = dayjs().add(2, "month");
-    const endDate = dayjs().add(4, "month");
+    // Build the dates in UTC so the test matches the component's dayjs.utc formatting in any local timezone.
+    const startDate = dayjs.utc().add(2, "month").startOf("day");
+    const endDate = dayjs.utc().add(4, "month").startOf("day");
     render(
       <NoAvailabilityDialog
         {...defaultProps}

--- a/packages/features/calendars/__tests__/NoAvailabilityDialog.test.tsx
+++ b/packages/features/calendars/__tests__/NoAvailabilityDialog.test.tsx
@@ -14,6 +14,8 @@ vi.mock("@calcom/lib/hooks/useLocale", () => ({
         return `Scheduling is only available up to ${vars?.days} in advance. Please check again soon.`;
       if (key === "no_availability_range")
         return `Scheduling ended on ${vars?.date}. Please check again soon.`;
+      if (key === "no_availability_range_not_started")
+        return `Scheduling opens on ${vars?.date}. Please check again soon.`;
       if (key === "close") return "Close";
       if (key === "view_next_month") return "View next month";
       if (key === "calendar_days") return "calendar days";
@@ -81,6 +83,32 @@ describe("NoAvailabilityOverlay", () => {
     );
     expect(screen.getByRole("dialog")).toHaveTextContent(
       `Scheduling ended on ${endDate.format("MMMM D YYYY")}. Please check again soon.`
+    );
+    const nextMonthButton = screen.queryAllByTestId("view_next_month");
+    const closeButton = screen.getAllByTestId("close_dialog_button");
+    expect(nextMonthButton).toHaveLength(0);
+    expect(closeButton).toHaveLength(1);
+  });
+
+  test("Displays range not-started description when period type is RANGE and the booking window opens after the next month", () => {
+    // Booking window opens 2 months out, so browsing the current month is before the window starts.
+    // The dialog must say "Scheduling opens on ..." rather than the misleading "Scheduling ended on ...".
+    const startDate = dayjs().add(2, "month");
+    const endDate = dayjs().add(4, "month");
+    render(
+      <NoAvailabilityDialog
+        {...defaultProps}
+        browsingDate={dayjs()}
+        periodData={{
+          ...defaultProps.periodData,
+          periodType: "RANGE",
+          periodStartDate: startDate.toDate(),
+          periodEndDate: endDate.toDate(),
+        }}
+      />
+    );
+    expect(screen.getByRole("dialog")).toHaveTextContent(
+      `Scheduling opens on ${dayjs.utc(startDate.toDate()).format("MMMM D YYYY")}. Please check again soon.`
     );
     const nextMonthButton = screen.queryAllByTestId("view_next_month");
     const closeButton = screen.getAllByTestId("close_dialog_button");

--- a/packages/features/calendars/components/NoAvailabilityDialog.tsx
+++ b/packages/features/calendars/components/NoAvailabilityDialog.tsx
@@ -42,6 +42,9 @@ const useDescription = (noFutureAvailability: boolean, p: PeriodData) => {
   }
 
   if (p.periodType === "RANGE") {
+    if (p.periodStartDate && dayjs().isBefore(dayjs(p.periodStartDate))) {
+      return t("no_availability_range_not_started", { date: dayjs(p.periodStartDate).format("MMMM D YYYY") });
+    }
     return t("no_availability_range", { date: dayjs(p.periodEndDate).format("MMMM D YYYY") });
   }
 

--- a/packages/features/calendars/components/NoAvailabilityDialog.tsx
+++ b/packages/features/calendars/components/NoAvailabilityDialog.tsx
@@ -42,10 +42,12 @@ const useDescription = (noFutureAvailability: boolean, p: PeriodData) => {
   }
 
   if (p.periodType === "RANGE") {
-    if (p.periodStartDate && dayjs().isBefore(dayjs(p.periodStartDate))) {
-      return t("no_availability_range_not_started", { date: dayjs(p.periodStartDate).format("MMMM D YYYY") });
+    if (p.periodStartDate && dayjs.utc().isBefore(dayjs.utc(p.periodStartDate))) {
+      return t("no_availability_range_not_started", {
+        date: dayjs.utc(p.periodStartDate).format("MMMM D YYYY"),
+      });
     }
-    return t("no_availability_range", { date: dayjs(p.periodEndDate).format("MMMM D YYYY") });
+    return t("no_availability_range", { date: dayjs.utc(p.periodEndDate).format("MMMM D YYYY") });
   }
 
   return "";

--- a/packages/features/calendars/components/NoAvailabilityDialog.tsx
+++ b/packages/features/calendars/components/NoAvailabilityDialog.tsx
@@ -47,7 +47,10 @@ const useDescription = (noFutureAvailability: boolean, p: PeriodData) => {
         date: dayjs.utc(p.periodStartDate).format("MMMM D YYYY"),
       });
     }
-    return t("no_availability_range", { date: dayjs.utc(p.periodEndDate).format("MMMM D YYYY") });
+    if (p.periodEndDate) {
+      return t("no_availability_range", { date: dayjs.utc(p.periodEndDate).format("MMMM D YYYY") });
+    }
+    return "";
   }
 
   return "";

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -2423,6 +2423,7 @@
   "no_availability_in_month": "No availability in {{month}}",
   "no_availability_rolling": "Scheduling is only available up to {{days}} in advance. Please check again soon.",
   "no_availability_range": "Scheduling ended on {{date}}. Please check again soon.",
+  "no_availability_range_not_started": "Scheduling opens on {{date}}. Please check again soon.",
   "view_previous_month": "View previous month",
   "view_next_month": "View next month",
   "send_code": "Send code",

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -2420,6 +2420,7 @@
   "no_availability_in_month": "No availability in {{month}}",
   "no_availability_rolling": "Scheduling is only available up to {{days}} in advance. Please check again soon.",
   "no_availability_range": "Scheduling ended on {{date}}. Please check again soon.",
+  "no_availability_range_not_started": "Scheduling opens on {{date}}. Please check again soon.",
   "view_previous_month": "View previous month",
   "view_next_month": "View next month",
   "send_code": "Send code",


### PR DESCRIPTION
## What does this PR fix?

Fixes #28470

When an event type has a fixed date range (`periodType: RANGE`), the "No Availability" dialog always showed:

> "Scheduling ended on [endDate]. Please check again soon."

...even when the current date was **before** `periodStartDate` (the booking window hadn't opened yet).

## Root cause

`isTimeViolatingFutureLimit` correctly returns `true` for both:
- dates **before** `startOfRangeStartDayInEventTz` (`isBeforeRangeStart`)
- dates **after** `endOfRangeEndDayInEventTz` (`isAfterRangeEnd`)

This makes `noFutureAvailability = true` in both cases. But `useDescription` in `NoAvailabilityDialog.tsx` used a single message for the whole `RANGE` case, so users saw "Scheduling ended" even when the window hadn't started.

## Fix

In `useDescription`, check whether today is before `periodStartDate`. If so, use the new `no_availability_range_not_started` message instead:

**Before start date:**
> "Scheduling opens on [startDate]. Please check again soon."

**After end date (unchanged):**
> "Scheduling ended on [endDate]. Please check again soon."

## Changes

- `packages/features/calendars/components/NoAvailabilityDialog.tsx` — add pre-start branch in `useDescription`
- `packages/i18n/locales/en/common.json` — add `no_availability_range_not_started` key

## Test plan

- [ ] Create an event type with `periodType: RANGE`, `periodStartDate` in the future
- [ ] Open the booking page and browse to the current month (before the start)
- [ ] Verify the dialog shows **"Scheduling opens on [startDate]"** not "Scheduling ended"
- [ ] Create an event type with `periodType: RANGE`, `periodEndDate` in the past
- [ ] Verify the dialog still shows **"Scheduling ended on [endDate]"**

🤖 Generated with [Claude Code](https://claude.com/claude-code)