### PR TITLE
fix: set requestReschedule=true in BOOKING_CANCELLED webhook when booking has rescheduled=true

### DIFF
--- a/packages/features/bookings/lib/getBookingToDelete.ts
+++ b/packages/features/bookings/lib/getBookingToDelete.ts
@@ -118,6 +118,7 @@ export async function getBookingToDelete(id: number | undefined, uid: string | u
       iCalUID: true,
       iCalSequence: true,
       status: true,
+      rescheduled: true,
     },
   });
 }

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -455,7 +455,7 @@ async function handler(input: CancelBookingInput, dependencies?: Dependencies) {
       status: "CANCELLED",
       smsReminderNumber: bookingToDelete.smsReminderNumber || undefined,
       cancelledBy: cancelledBy,
-      requestReschedule: false,
+      requestReschedule: bookingToDelete.rescheduled ?? false,
     }).catch((e) => {
       logger.error(
         `Error executing webhook for event: ${eventTrigger}, URL: ${webhook.subscriberUrl}, bookingId: ${evt.bookingId}, bookingUid: ${evt.uid}`,

--- a/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
+++ b/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
@@ -158,6 +158,108 @@ describe("Cancel Booking", () => {
     expectWorkflowToBeTriggered({ emailsToReceive: [organizer.email], emails });
   });
 
+  test("Should set requestReschedule=true in BOOKING_CANCELLED webhook when booking has rescheduled=true", async () => {
+    const handleCancelBooking = (await import("@calcom/features/bookings/lib/handleCancelBooking")).default;
+
+    const booker = getBooker({
+      email: "booker@example.com",
+      name: "Booker",
+    });
+
+    const organizer = getOrganizer({
+      name: "Organizer",
+      email: "organizer@example.com",
+      id: 101,
+      schedules: [TestData.schedules.IstWorkHours],
+      credentials: [getGoogleCalendarCredential()],
+      selectedCalendars: [TestData.selectedCalendars.google],
+    });
+
+    const uidOfBookingToBeCancelled = "rescheduled-booking-uid-test";
+    const idOfBookingToBeCancelled = 1021;
+    const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+
+    await createBookingScenario(
+      getScenarioData({
+        webhooks: [
+          {
+            userId: organizer.id,
+            eventTriggers: ["BOOKING_CANCELLED"],
+            subscriberUrl: "http://my-webhook.example.com",
+            active: true,
+            eventTypeId: 1,
+            appId: null,
+          },
+        ],
+        eventTypes: [
+          {
+            id: 1,
+            slotInterval: 30,
+            length: 30,
+            users: [
+              {
+                id: 101,
+              },
+            ],
+          },
+        ],
+        bookings: [
+          {
+            id: idOfBookingToBeCancelled,
+            uid: uidOfBookingToBeCancelled,
+            // rescheduled=true simulates a booking that was already marked for reschedule
+            // by requestReschedule.handler.ts before handleCancelBooking is called via
+            // another path (e.g. /api/cancel or CalendarSyncService)
+            rescheduled: true,
+            attendees: [
+              {
+                email: booker.email,
+                timeZone: "Asia/Kolkata",
+              },
+            ],
+            eventTypeId: 1,
+            userId: 101,
+            responses: {
+              email: booker.email,
+              name: booker.name,
+              location: { optionValue: "", value: BookingLocations.CalVideo },
+            },
+            status: BookingStatus.CANCELLED,
+            startTime: `${plus1DateString}T05:00:00.000Z`,
+            endTime: `${plus1DateString}T05:15:00.000Z`,
+            metadata: {
+              videoCallUrl: "https://existing-daily-video-call-url.example.com",
+            },
+          },
+        ],
+        organizer,
+        apps: [TestData.apps["daily-video"]],
+      })
+    );
+
+    await handleCancelBooking({
+      bookingData: {
+        id: idOfBookingToBeCancelled,
+        uid: uidOfBookingToBeCancelled,
+        cancelledBy: organizer.email,
+        cancellationReason: "Reschedule requested",
+      },
+      impersonatedByUserUuid: null,
+      actionSource: "WEBAPP",
+    });
+
+    expectBookingCancelledWebhookToHaveBeenFired({
+      booker,
+      organizer,
+      location: BookingLocations.CalVideo,
+      subscriberUrl: "http://my-webhook.example.com",
+      payload: {
+        cancelledBy: organizer.email,
+        requestReschedule: true,
+      },
+    });
+  });
+
   test("Should call processPaymentRefund", async () => {
     const handleCancelBooking = (await import("@calcom/features/bookings/lib/handleCancelBooking")).default;
 

--- a/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
+++ b/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
@@ -207,9 +207,12 @@ describe("Cancel Booking", () => {
           {
             id: idOfBookingToBeCancelled,
             uid: uidOfBookingToBeCancelled,
-            // rescheduled=true simulates a booking that was already marked for reschedule
-            // by requestReschedule.handler.ts before handleCancelBooking is called via
-            // another path (e.g. /api/cancel or CalendarSyncService)
+            // rescheduled=true on an ACCEPTED booking simulates the narrow race window
+            // where requestReschedule.handler.ts has set rescheduled=true but the status
+            // update to CANCELLED hasn't landed yet, and a concurrent call (e.g. via
+            // CalendarSyncService or /api/cancel) reaches handleCancelBooking first.
+            // It also covers any external/direct-DB path that sets rescheduled without
+            // updating status atomically.
             rescheduled: true,
             attendees: [
               {
@@ -224,7 +227,7 @@ describe("Cancel Booking", () => {
               name: booker.name,
               location: { optionValue: "", value: BookingLocations.CalVideo },
             },
-            status: BookingStatus.CANCELLED,
+            status: BookingStatus.ACCEPTED,
             startTime: `${plus1DateString}T05:00:00.000Z`,
             endTime: `${plus1DateString}T05:15:00.000Z`,
             metadata: {

--- a/packages/features/bookings/lib/handleSeats/cancel/cancelAttendeeSeat.ts
+++ b/packages/features/bookings/lib/handleSeats/cancel/cancelAttendeeSeat.ts
@@ -166,7 +166,7 @@ async function cancelAttendeeSeat(
     ...eventTypeInfo,
     status: "CANCELLED",
     smsReminderNumber: bookingToDelete.smsReminderNumber || undefined,
-    requestReschedule: false,
+    requestReschedule: bookingToDelete.rescheduled ?? false,
   };
 
   const promises = webhooks.map((webhook) =>


### PR DESCRIPTION
## What does this PR fix?

Fixes #28543

`handleCancelBooking.ts` hardcoded `requestReschedule: false` on line 458, meaning the `BOOKING_CANCELLED` webhook payload from that code path could never signal a reschedule-triggered cancellation — even if the booking was already marked `rescheduled: true` in the database.

The tRPC `requestReschedule.handler.ts` path (host clicks "Request Reschedule" in the UI) already correctly sends `requestReschedule: true` via `BookingWebhookFactory`. This fix closes the same gap for secondary cancellation paths that go through `handleCancelBooking.ts`:
- `/api/cancel` route
- `CalendarSyncService` (external calendar event deletion)
- Platform libraries

## Root cause

```ts
// handleCancelBooking.ts:458 — BEFORE
requestReschedule: false,  // always false, even if booking.rescheduled = true

// AFTER
requestReschedule: bookingToDelete.rescheduled ?? false,
```

`rescheduled` (the DB field) was also not fetched in `getBookingToDelete.ts`, so the fix required adding it to the Prisma select.

## Changes

- `packages/features/bookings/lib/getBookingToDelete.ts` — add `rescheduled: true` to the Prisma select
- `packages/features/bookings/lib/handleCancelBooking.ts` — read `bookingToDelete.rescheduled` instead of hardcoding `false`
- `packages/features/bookings/lib/handleSeats/cancel/cancelAttendeeSeat.ts` — same fix for the seated-event attendee cancellation path (line 169 also hardcoded `false`)
- `packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts` — regression test covering the `rescheduled=true` path

## Test plan

- [ ] Verify the new test passes: `cd packages/features/bookings && yarn test handleCancelBooking.test.ts`
- [ ] Create a confirmed booking, request a reschedule as host, check that the `BOOKING_CANCELLED` webhook payload includes `requestReschedule: true`
- [ ] Confirm normal cancellations still emit `requestReschedule: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)