### PR TITLE
fix: add cursor:pointer to enabled date buttons in embed

### DIFF
--- a/packages/features/calendars/components/DatePicker.tsx
+++ b/packages/features/calendars/components/DatePicker.tsx
@@ -82,7 +82,7 @@ const Day = ({
   const buttonContent = (
     <button
       type="button"
-      style={disabled ? { ...disabledDateButtonEmbedStyles } : { ...enabledDateButtonEmbedStyles }}
+      style={disabled ? { ...disabledDateButtonEmbedStyles } : { ...enabledDateButtonEmbedStyles, cursor: "pointer" }}
       className={classNames(
         "disabled:text-bookinglighter absolute bottom-0 left-0 right-0 top-0 mx-auto w-full cursor-pointer rounded-md border-2 border-transparent text-center text-sm font-medium transition disabled:cursor-default disabled:border-transparent disabled:font-light ",
         active


### PR DESCRIPTION
## What does this PR do?

In the embed iframe, enabled date buttons were missing the pointer cursor, making it unclear they were clickable. The `cursor-pointer` Tailwind class was already present on the element but was being silently overridden by the inline `style` attribute (inline styles have higher CSS specificity than class-based styles).

This fix explicitly adds `cursor: "pointer"` to the inline style object for enabled date buttons, placed after the spread of `enabledDateButtonEmbedStyles` so it always wins — matching the behavior of time slot buttons and month navigation arrows in the embed.

## Steps to reproduce

1. Embed a Cal.com booking page in an iframe
2. Hover over available date buttons in the date picker
3. Observe cursor remains default arrow instead of pointer

## Fix

`packages/features/calendars/components/DatePicker.tsx` — one-line change to the `Day` component's button style:

```tsx
// Before
style={disabled ? { ...disabledDateButtonEmbedStyles } : { ...enabledDateButtonEmbedStyles }}

// After
style={disabled ? { ...disabledDateButtonEmbedStyles } : { ...enabledDateButtonEmbedStyles, cursor: "pointer" }}
```

The `EmbedStyles` type does not allow `cursor` in `enabledDateButton`, so no user-provided cursor can ever override this value.

Fixes #28530