### PR TITLE
fix: add deterministic ordering to attendee queries in booking-seats e2e tests

### DIFF
--- a/apps/web/playwright/booking-seats.e2e.ts
+++ b/apps/web/playwright/booking-seats.e2e.ts
@@ -1,10 +1,8 @@
-import { expect } from "@playwright/test";
-import { v4 as uuidv4 } from "uuid";
-
 import { randomString } from "@calcom/lib/random";
 import prisma from "@calcom/prisma";
 import { BookingStatus } from "@calcom/prisma/enums";
-
+import { expect } from "@playwright/test";
+import { v4 as uuidv4 } from "uuid";
 import { test } from "./lib/fixtures";
 import {
   confirmReschedule,
@@ -43,6 +41,7 @@ test.describe("Booking with Seats", () => {
         name: true,
         email: true,
       },
+      orderBy: { email: "asc" },
     });
 
     const bookingSeats = bookingAttendees.map((attendee) => ({
@@ -136,6 +135,7 @@ test.describe("Reschedule for booking with seats", () => {
         name: true,
         email: true,
       },
+      orderBy: { email: "asc" },
     });
 
     const bookingSeats = bookingAttendees.map((attendee) => ({
@@ -203,6 +203,7 @@ test.describe("Reschedule for booking with seats", () => {
         name: true,
         email: true,
       },
+      orderBy: { email: "asc" },
     });
 
     const bookingSeats = bookingAttendees.map((attendee) => ({
@@ -282,6 +283,7 @@ test.describe("Reschedule for booking with seats", () => {
         name: true,
         email: true,
       },
+      orderBy: { email: "asc" },
     });
 
     const bookingSeats = bookingAttendees.map((attendee) => ({
@@ -475,6 +477,7 @@ test.describe("Reschedule for booking with seats", () => {
         name: true,
         email: true,
       },
+      orderBy: { email: "asc" },
     });
 
     const bookingSeats = bookingAttendees.map((attendee) => ({
@@ -522,6 +525,7 @@ test.describe("Reschedule for booking with seats", () => {
         name: true,
         email: true,
       },
+      orderBy: { email: "asc" },
     });
 
     const bookingSeats = bookingAttendees.map((attendee) => ({
@@ -540,10 +544,11 @@ test.describe("Reschedule for booking with seats", () => {
       data: bookingSeats,
     });
 
-    const references = await prisma.bookingSeat.findMany({
-      where: { bookingId: booking.id },
-      orderBy: { id: "asc" },
-    });
+    // Find the seat reference for the second attendee by email
+    const secondAttendeeSeat = bookingSeats.find(
+      (seat) => seat.data.responses.email === "second+seats@cal.com"
+    );
+    if (!secondAttendeeSeat) throw new Error("Could not find seat for second attendee");
 
     const secondUser = await users.create({
       name: "Jane Second",
@@ -575,7 +580,7 @@ test.describe("Reschedule for booking with seats", () => {
 
     await page.waitForURL((url) => {
       const rescheduleUid = url.searchParams.get("rescheduleUid");
-      return !!rescheduleUid && rescheduleUid === references[1].referenceUid;
+      return !!rescheduleUid && rescheduleUid === secondAttendeeSeat.referenceUid;
     });
 
     await expect(page.getByText("Seats available").first()).toBeVisible();

--- a/apps/web/playwright/booking-seats.e2e.ts
+++ b/apps/web/playwright/booking-seats.e2e.ts
@@ -544,11 +544,10 @@ test.describe("Reschedule for booking with seats", () => {
       data: bookingSeats,
     });
 
-    // Find the seat reference for the second attendee by email
-    const secondAttendeeSeat = bookingSeats.find(
-      (seat) => seat.data.responses.email === "second+seats@cal.com"
-    );
-    if (!secondAttendeeSeat) throw new Error("Could not find seat for second attendee");
+    const references = await prisma.bookingSeat.findMany({
+      where: { bookingId: booking.id },
+      orderBy: { id: "asc" },
+    });
 
     const secondUser = await users.create({
       name: "Jane Second",
@@ -580,7 +579,7 @@ test.describe("Reschedule for booking with seats", () => {
 
     await page.waitForURL((url) => {
       const rescheduleUid = url.searchParams.get("rescheduleUid");
-      return !!rescheduleUid && rescheduleUid === secondAttendeeSeat.referenceUid;
+      return !!rescheduleUid && rescheduleUid === references[1].referenceUid;
     });
 
     await expect(page.getByText("Seats available").first()).toBeVisible();


### PR DESCRIPTION
## What does this PR do?

Fixes flaky `booking-seats.e2e.ts` tests caused by non-deterministic `attendee.findMany` queries. The tests query attendees without ordering, then use array indices to build seat references and make assertions. When Postgres returns attendees in a different order, those index assumptions break — causing intermittent failures in CI.

**Changes:**

- Added `orderBy: { email: "asc" }` to all 6 `prisma.attendee.findMany` calls in the test file, ensuring deterministic attendee order

> **Note:** The import reordering in the diff is from biome auto-formatting (pre-commit hook), not a manual change.

## Visual Demo (For contributors especially)

N/A — test-only change, no UI impact.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This fix addresses flaky E2E tests. To verify:

1. Run the seated booking E2E tests multiple times — they should pass consistently:
   ```
   PLAYWRIGHT_HEADLESS=1 yarn e2e booking-seats.e2e.ts
   ```
2. The specific tests that were failing intermittently:
   - *"Should book with seats and hide attendees info from showAttendees true"*
   - *"Second attendee reschedule from /upcoming page should use correct seatReferenceUid and show attendee info"*

## Human Review Checklist

- [ ] Verify that `orderBy: { email: "asc" }` produces the expected attendee order for each test's hardcoded email addresses (e.g. `first+seats@cal.com` < `second+seats@cal.com` < `third+seats@cal.com`)
- [ ] Verify all 6 `attendee.findMany` calls were updated (no missed instances)
- [ ] In the last test ("Second attendee reschedule..."), `references[1]` still relies on positional ordering of `bookingSeat` records — confirm this is safe because the deterministic attendee order now guarantees deterministic seat creation order, making `orderBy: { id: "asc" }` on the `bookingSeat` query align correctly

Link to Devin session: https://app.devin.ai/sessions/1ce6dcc0d984483f84bfb6d58ca5841e
Requested by: @romitg2