### PR TITLE
fix: hide overflow next-month dates in date override calendar

### DIFF
--- a/packages/features/calendars/components/DatePicker.tsx
+++ b/packages/features/calendars/components/DatePicker.tsx
@@ -49,6 +49,8 @@ export type DatePickerProps = {
   periodData?: PeriodData;
   // Whether this is a compact sidebar view or main monthly view
   isCompact?: boolean;
+  /** Whether to show extra days from the next month at the bottom of the calendar grid. Defaults to true. */
+  showExtraDays?: boolean;
   // Whether to show the no availability dialog
   showNoAvailabilityDialog?: boolean;
 };
@@ -191,7 +193,8 @@ const Days = ({
   const getPadding = (day: number) => (browsingDate.set("date", day).day() - weekStart + 7) % 7;
   const totalDays = daysInMonth(browsingDate);
 
-  const showNextMonthDays = isSecondWeekOver && !isCompact;
+  const showExtraDays = props.showExtraDays ?? true;
+  const showNextMonthDays = isSecondWeekOver && !isCompact && showExtraDays;
 
   // Only apply end-of-month logic for main monthly view (not compact sidebar)
   if (showNextMonthDays) {

--- a/packages/features/schedules/components/DateOverrideInputDialog.tsx
+++ b/packages/features/schedules/components/DateOverrideInputDialog.tsx
@@ -150,6 +150,7 @@ const DateOverrideForm = ({
             excludedDates={excludedDates}
             weekStart={weekStart}
             selected={selectedDates}
+            showExtraDays={false}
             onChange={(day) => {
               if (day) onDateChange(day);
             }}


### PR DESCRIPTION
## What does this PR do?

When viewing the "Select the dates to override" dialog late in a month, the calendar shows dates from the following month at the bottom of the grid. These overflow dates appear clickable but cannot be selected (no slot data exists for them), which confuses users into thinking they should be able to pick those dates.

This PR adds a `showExtraDays` prop to `DatePicker` (defaults to `true` for backward compatibility) and sets it to `false` in the `DateOverrideInputDialog`. This causes the date override calendar to use the traditional full-month grid without next-month overflow days.

**Before:** Overflow April dates shown but disabled — unclear they require switching months
![before](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2ODk0YmU4ZmU0ZTJkNDlkZmIzNzQxNTMiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi84MzM4ZmVmOS1kMmNiLTRmMmEtYTAxYy04NjVhMGE0MWVmMTQiLCJpYXQiOjE3NzQ4ODE4OTgsImV4cCI6MTc3NTQ4NjY5OH0.E1nDQx_6DhbATlce6XX7AxjSJsDACMaPhFLKsYW_0Co)

**After:** Only the current month's dates are shown; user navigates months with arrow buttons as expected.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to **Availability** → open a schedule → click **"Add an override"**
2. Navigate to a month where the current date is past the 2nd week (e.g. today, March 30)
3. Verify the calendar **no longer shows** grayed-out dates from the next month at the bottom of the grid
4. Verify the booker calendar (public booking page) **still shows** next-month overflow days as before — the change should only affect the date override dialog

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings
- [x] My PR is small and focused

### Key areas for human review

- `DatePicker.tsx`: The `showExtraDays` prop is received via `...props` spread in the `Days` component (through `Omit<DatePickerProps, ...>`). Verify this implicit plumbing is acceptable vs. destructuring it explicitly.
- Confirm no other consumers of `DatePicker` need `showExtraDays={false}`.

Link to Devin session: https://app.devin.ai/sessions/230cb3d5b8f9414cbe7179b3276e43ee
Requested by: @pasqualevitiello