### PR TITLE
docs: Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
    <img src="https://api.checklyhq.com/v1/badges/groups/1120718?style=flat&theme=default" alt="Checkly QA">
    <a href="https://status.cal.com"><img height="20px" src="https://betteruptime.com/status-badges/v1/monitor/a9kf.svg" alt="Uptime"></a>
    <a href="https://github.com/calcom/cal.com/stargazers"><img src="https://img.shields.io/github/stars/calcom/cal.com" alt="Github Stars"></a>
+   <a href="https://deepwiki.com/calcom/cal.com"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
    <a href="https://news.ycombinator.com/item?id=34507672"><img src="https://img.shields.io/badge/Hacker%20News-%231-%23FF6600" alt="Hacker News"></a>
    <a href="https://github.com/calcom/cal.com/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPLv3-purple" alt="License"></a>
    <a href="https://github.com/calcom/cal.com/pulse"><img src="https://img.shields.io/github/commit-activity/m/calcom/cal.com" alt="Commits-per-month"></a>


### PR DESCRIPTION
## What does this PR do?

Adds a **DeepWiki badge** to the `README.md` to improve visibility and provide quick access to project documentation.

- No functional changes  
- README-only update  

---

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code  
- [x] N/A  
- [x] N/A  

---

## How should this be tested?

1. Open the repository README  
2. Verify the DeepWiki badge is visible  
3. Click the badge and confirm it redirects correctly  

**Expected:** Badge renders correctly and link works  

---

## Checklist

- [x] I have read the contributing guide  
- [x] My code follows the style guidelines of this project  
- [x] No new warnings introduced  
- [x] PR is small and focused  