### PR TITLE
fix: resolve flaky 'Book on column layout' E2E test

### DIFF
--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -1,16 +1,3 @@
-import { test, todo } from "./lib/fixtures";
-import {
-  bookFirstEvent,
-  bookOptinEvent,
-  bookTimeSlot,
-  confirmBooking,
-  confirmReschedule,
-  expectSlotNotAllowedToBook,
-  selectFirstAvailableTimeSlotNextMonth,
-  testEmail,
-  testName,
-  cancelBookingFromBookingsList,
-} from "./lib/testUtils";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { generateHashedLink } from "@calcom/lib/generateHashedLink";
 import { randomString } from "@calcom/lib/random";
@@ -18,6 +5,19 @@ import { SchedulingType } from "@calcom/prisma/enums";
 import type { Schedule, TimeRange } from "@calcom/types/schedule";
 import { expect } from "@playwright/test";
 import { JSDOM } from "jsdom";
+import { test, todo } from "./lib/fixtures";
+import {
+  bookFirstEvent,
+  bookOptinEvent,
+  bookTimeSlot,
+  cancelBookingFromBookingsList,
+  confirmBooking,
+  confirmReschedule,
+  expectSlotNotAllowedToBook,
+  selectFirstAvailableTimeSlotNextMonth,
+  testEmail,
+  testName,
+} from "./lib/testUtils";
 
 const freeUserObj = { name: `Free-user-${randomString(3)}` };
 test.describe.configure({ mode: "parallel" });
@@ -486,8 +486,6 @@ test.describe("Booking on different layouts", () => {
 
     await page.click('[data-testid="toggle-group-item-column_view"]');
 
-    // Use the standard helper to select an available time slot next month
-    // This is more robust than manually clicking incrementMonth and reloading
     await selectFirstAvailableTimeSlotNextMonth(page);
 
     // Fill what is this meeting about? name email and notes

--- a/apps/web/playwright/lib/testUtils.ts
+++ b/apps/web/playwright/lib/testUtils.ts
@@ -109,7 +109,22 @@ export async function selectFirstAvailableTimeSlotNextMonth(page: Page | Frame) 
   // Wait for the booker to be ready before interacting
   const incrementMonth = page.getByTestId("incrementMonth");
   await incrementMonth.waitFor();
+
+  // Wait for the initial schedule data to load (available days rendered in date picker).
+  // This ensures the waitForResponse listener below only catches the month-change response,
+  // not the initial page load response. Without this, column view can race: stale time slots
+  // from the current month get clicked before the new month's schedule data arrives, causing
+  // the quick availability check to permanently disable the confirm button.
+  await page.locator('[data-testid="day"][data-disabled="false"]').nth(0).waitFor();
+
+  // Listen for the getSchedule response triggered by the month change.
+  // waitForResponse is only available on Page, not Frame.
+  const scheduleResponse =
+    "waitForResponse" in page
+      ? page.waitForResponse((resp) => resp.url().includes("getSchedule") && resp.status() === 200)
+      : Promise.resolve();
   await incrementMonth.click();
+  await scheduleResponse;
 
   // Wait for available day to appear after month increment
   const firstAvailableDay = page.locator('[data-testid="day"][data-disabled="false"]').nth(0);
@@ -125,7 +140,16 @@ export async function selectSecondAvailableTimeSlotNextMonth(page: Page) {
   // Wait for the booker to be ready before interacting
   const incrementMonth = page.getByTestId("incrementMonth");
   await incrementMonth.waitFor();
+
+  // Wait for initial schedule data to load before changing month (see selectFirstAvailableTimeSlotNextMonth)
+  await page.locator('[data-testid="day"][data-disabled="false"]').nth(0).waitFor();
+
+  // Listen for the getSchedule response triggered by the month change
+  const scheduleResponse = page.waitForResponse(
+    (resp) => resp.url().includes("getSchedule") && resp.status() === 200
+  );
   await incrementMonth.click();
+  await scheduleResponse;
 
   // Wait for available day to appear after month increment
   const secondAvailableDay = page.locator('[data-testid="day"][data-disabled="false"]').nth(1);


### PR DESCRIPTION
## What does this PR do?

Fixes the flaky "Book on column layout" E2E test that intermittently fails due to a race condition in column view.

**Root cause:** In column view, time slots are always visible. `selectFirstAvailableTimeSlotNextMonth` clicks `incrementMonth` then immediately looks for a `[data-testid="time"]` element — but stale slots from the *current* month may still be in the DOM. Because `isVisitorWithinPercentage` returns `true` in E2E (`NEXT_PUBLIC_IS_E2E=1`), the quick availability check is always enabled. It calls `isTimeSlotAvailable`, which looks up the stale slot in the *new* month's schedule data, finds no match, and permanently disables the confirm button.

**Fix:** Makes `selectFirstAvailableTimeSlotNextMonth` (and `selectSecondAvailableTimeSlotNextMonth`) robust against this race by:
1. Waiting for the initial schedule to load (available days visible in the date picker)
2. Setting up a `waitForResponse` listener for `getSchedule` — only *after* step 1, so it catches the month-change response, not the initial page load
3. Clicking `incrementMonth` and awaiting the response
4. Then selecting the first available day and time slot from the now-current schedule data

Since `waitForResponse` is only available on `Page` (not `Frame`), a runtime `"waitForResponse" in page` guard falls back to `Promise.resolve()` for Frame callers (e.g. embed tests).

### Human Review Checklist
- [ ] Verify the tRPC slots endpoint URL contains `getSchedule` — if not, `waitForResponse` will time out deterministically
- [ ] Consider whether switching to column view (`toggle-group-item-column_view`) triggers its own `getSchedule` refetch that could be caught by the listener before `incrementMonth`
- [ ] The `"waitForResponse" in page` duck-typing guard is a runtime check — confirm this correctly distinguishes `Page` from `Frame` in the Playwright version used by this repo
- [ ] Since `selectFirstAvailableTimeSlotNextMonth` is called by ~20 test files, verify that the added `waitForResponse` doesn't cause timeouts in non-booker contexts (e.g. embed tests that pass a `Frame`)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — test-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the "Book on column layout" test repeatedly to verify it no longer flakes:
```bash
PLAYWRIGHT_HEADLESS=1 yarn e2e booking-pages.e2e.ts --grep "Book on column layout" --repeat-each=10
```

Also run the sibling test to confirm no regression:
```bash
PLAYWRIGHT_HEADLESS=1 yarn e2e booking-pages.e2e.ts --grep "Booking on different layouts"
```

Since `selectFirstAvailableTimeSlotNextMonth` is used widely, a broader E2E run is prudent:
```bash
PLAYWRIGHT_HEADLESS=1 yarn e2e booking-pages.e2e.ts
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/5b8996b252174266a0c6ea4e77f90afa
Requested by: @sahitya-chandra
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
