### PR TITLE
fix: avoid false negative in slot availability check when schedule doesn't cover date range

### DIFF
--- a/packages/features/bookings/Booker/utils/isTimeslotAvailable.test.ts
+++ b/packages/features/bookings/Booker/utils/isTimeslotAvailable.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import type { QuickAvailabilityCheck } from "../types";
 import { isTimeSlotAvailable } from "./isTimeslotAvailable";
 
@@ -201,6 +200,74 @@ describe("isTimeSlotAvailable", () => {
     });
 
     expect(result).toBe(true);
+  });
+
+  it("should return true (avoid false negative) when slot date is outside the schedule's date range", () => {
+    const slotToCheckInIso = "2024-04-15T10:30:00.000Z";
+    const quickAvailabilityChecks: QuickAvailabilityCheck[] = [];
+
+    const result = isTimeSlotAvailable({
+      scheduleData: {
+        slots: {
+          "2024-03-20": [{ time: "2024-03-20T10:30:00.000Z" }],
+          "2024-03-21": [{ time: "2024-03-21T10:30:00.000Z" }],
+        },
+      },
+      slotToCheckInIso,
+      quickAvailabilityChecks,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false when schedule is loaded but completely empty (all slots exhausted)", () => {
+    const slotToCheckInIso = "2024-02-08T10:30:00.000Z";
+    const quickAvailabilityChecks: QuickAvailabilityCheck[] = [];
+
+    const result = isTimeSlotAvailable({
+      scheduleData: {
+        slots: {},
+      },
+      slotToCheckInIso,
+      quickAvailabilityChecks,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when schedule covers the date range but slot is not present", () => {
+    const slotToCheckInIso = "2024-02-08T10:30:00.000Z";
+    const quickAvailabilityChecks: QuickAvailabilityCheck[] = [];
+
+    const result = isTimeSlotAvailable({
+      scheduleData: {
+        slots: {
+          "2024-02-08": [{ time: "2024-02-08T14:00:00.000Z" }],
+        },
+      },
+      slotToCheckInIso,
+      quickAvailabilityChecks,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when surrounding dates have no entries but date is within schedule range", () => {
+    const slotToCheckInIso = "2024-02-15T10:30:00.000Z";
+    const quickAvailabilityChecks: QuickAvailabilityCheck[] = [];
+
+    const result = isTimeSlotAvailable({
+      scheduleData: {
+        slots: {
+          "2024-02-10": [{ time: "2024-02-10T10:30:00.000Z" }],
+          "2024-02-20": [{ time: "2024-02-20T10:30:00.000Z" }],
+        },
+      },
+      slotToCheckInIso,
+      quickAvailabilityChecks,
+    });
+
+    expect(result).toBe(false);
   });
 
   it("should return true(give a false positive) when the date string is not in the expected format", () => {

--- a/packages/features/bookings/Booker/utils/isTimeslotAvailable.ts
+++ b/packages/features/bookings/Booker/utils/isTimeslotAvailable.ts
@@ -1,5 +1,4 @@
 import dayjs from "@calcom/dayjs";
-
 import type { QuickAvailabilityCheck } from "../types";
 import { isSlotEquivalent, isValidISOFormat } from "./isSlotEquivalent";
 
@@ -50,6 +49,33 @@ function _isSlotPresentInSchedule({
   const slotsInIsoForDate = scheduleData.slots[dateInGMT] as Maybe<SlotsInIso>;
   const slotsInIsoForDateBefore = scheduleData.slots[dateBefore] as Maybe<SlotsInIso>;
   const slotsInIsoForDateAfter = scheduleData.slots[dateAfter] as Maybe<SlotsInIso>;
+
+  // When none of the 3 surrounding dates have slot entries, determine whether the
+  // schedule simply doesn't cover this date range (stale data from a different view,
+  // e.g. column view month navigation with keepPreviousData) vs. the date range is
+  // covered but all slots are genuinely exhausted (e.g. booking/duration limits hit).
+  if (!slotsInIsoForDate && !slotsInIsoForDateBefore && !slotsInIsoForDateAfter) {
+    const scheduleDates = Object.keys(scheduleData.slots);
+
+    if (scheduleDates.length === 0) {
+      return false;
+    }
+
+    // YYYY-MM-DD sorts lexicographically
+    let minDate = scheduleDates[0];
+    let maxDate = scheduleDates[0];
+    for (const d of scheduleDates) {
+      if (d < minDate) minDate = d;
+      if (d > maxDate) maxDate = d;
+    }
+
+    // All 3 surrounding dates fall outside the schedule's coverage
+    if (dateAfter < minDate || dateBefore > maxDate) {
+      return true;
+    }
+
+    return false;
+  }
 
   const matchFoundOnDate = _isSlotPresent(slotsInIsoForDate, slotToCheckInIso);
   if (matchFoundOnDate) return true;


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky E2E test failure in `booking-pages.e2e.ts › Book on column layout` caused by a false negative in `_isSlotPresentInSchedule`.

**Root cause:** In column view, when the user navigates to a different month, React Query's `keepPreviousData` keeps the old schedule data while the new data loads. A slot selected from the UI (rendered from newer data) has its date outside the old schedule's range, so `_isSlotPresentInSchedule` returns `false` — incorrectly disabling the confirm button → timeout waiting for `/api/book/event`.

- Failed run: https://github.com/calcom/cal.com/actions/runs/23796620272/job/69345732878?pr=28682
- Passed (on retry): https://github.com/calcom/cal.com/actions/runs/23796620272/job/69347730339?pr=28682

**Fix:** When none of the 3 surrounding dates (target ± 1 day) have entries in the schedule, the function now distinguishes:

| Scenario | Result | Rationale |
|---|---|---|
| Empty schedule `{}` | `false` | Loaded but genuinely exhausted |
| Target date outside schedule's min/max range | `true` | Stale data — avoid false negative |
| Target date within range but no nearby entries | `false` | Genuinely unavailable |

Per the function contract: *"It should never give false negative, false positives are fine."*

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the unit tests:
   ```bash
   TZ=UTC npx vitest run packages/features/bookings/Booker/utils/isTimeslotAvailable.test.ts
   ```
   All 14 tests should pass (10 existing + 4 new).

2. The 4 new test cases cover:
   - Slot date outside schedule range → `true` (avoid false negative)
   - Empty schedule `{}` → `false` (genuinely exhausted)
   - Schedule covers the date but slot time doesn't match → `false`
   - Surrounding dates empty but date within schedule range → `false`

### Human Review Checklist
- [ ] Verify the boundary logic (`dateAfter < minDate || dateBefore > maxDate`) correctly identifies when all 3 surrounding dates fall outside the schedule's coverage
- [ ] Confirm that `scheduleData.slots = {}` only occurs after the schedule has loaded (not during loading — `null` handles that case at the caller level)
- [ ] Consider whether remaining column view flakiness could stem from a separate UI timing issue beyond this function's scope

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/63561c7d27a5447b86dfcda90982e73d
Requested by: @sahitya-chandra