### PR TITLE
feat: add tooltips for Insights no-show metrics

### DIFF
--- a/apps/web/modules/insights/components/KPICard.tsx
+++ b/apps/web/modules/insights/components/KPICard.tsx
@@ -1,16 +1,16 @@
 "use client";
 
+import { calculateDeltaType, valueFormatter } from "@calcom/features/insights/lib";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Badge } from "@calcom/ui/components/badge";
 import { Icon } from "@calcom/ui/components/icon";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 
-import { calculateDeltaType, valueFormatter } from "@calcom/features/insights/lib";
-
 export const KPICard = ({
   title,
   previousMetricData,
   previousDateRange,
+  tooltip,
 }: {
   title: string;
   previousMetricData: {
@@ -18,6 +18,7 @@ export const KPICard = ({
     deltaPrevious: number;
   };
   previousDateRange: { startDate: string; endDate: string };
+  tooltip?: string;
 }) => {
   const { t } = useLocale();
 
@@ -58,7 +59,14 @@ export const KPICard = ({
 
   return (
     <div>
-      <div className="text-default text-sm">{title}</div>
+      <div className="text-default flex items-center gap-1 text-sm">
+        {title}
+        {tooltip && (
+          <Tooltip content={tooltip}>
+            <Icon name="info" className="text-subtle h-3.5 w-3.5 cursor-pointer" />
+          </Tooltip>
+        )}
+      </div>
       <div className="flex items-baseline justify-start space-x-3 truncate">
         <div className="text-emphasis text-2xl font-semibold">{valueFormatter(previousMetricData.count)}</div>
       </div>

--- a/apps/web/modules/insights/components/booking/BookingKPICards.tsx
+++ b/apps/web/modules/insights/components/booking/BookingKPICards.tsx
@@ -4,7 +4,6 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import classNames from "@calcom/ui/classNames";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
-
 import { useInsightsBookingParameters } from "@calcom/web/modules/insights/hooks/useInsightsBookingParameters";
 import { ChartCard } from "../ChartCard";
 import { KPICard } from "../KPICard";
@@ -49,6 +48,7 @@ export const BookingKPICards = () => {
   const performanceCategories: {
     title: string;
     index: "rating" | "no_show" | "no_show_guest" | "csat";
+    tooltip?: string;
   }[] = [
     {
       title: t("event_ratings"),
@@ -57,10 +57,12 @@ export const BookingKPICards = () => {
     {
       title: t("event_no_show"),
       index: "no_show",
+      tooltip: t("event_no_show_host_tooltip"),
     },
     {
       title: t("event_no_show_guest"),
       index: "no_show_guest",
+      tooltip: t("event_no_show_guest_tooltip"),
     },
     {
       title: t("csat_score"),
@@ -105,6 +107,7 @@ export const BookingKPICards = () => {
                 title={item.title}
                 previousMetricData={data[item.index]}
                 previousDateRange={data.previousRange}
+                tooltip={item.tooltip}
               />
             </StatItem>
           ))}

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -3297,6 +3297,8 @@
   "event_ratings": "Average ratings",
   "event_no_show": "No-Show (Host)",
   "event_no_show_guest": "No-Show (Guest)",
+  "event_no_show_host_tooltip": "Counted per booking. If the host doesn't show up, the booking is marked as a host no-show.",
+  "event_no_show_guest_tooltip": "Counted per attendee. If multiple guests don't show up in a single booking, each guest counts separately.",
   "recent_ratings": "Recent ratings",
   "no_ratings": "No ratings submitted",
   "no_ratings_description": "Add a workflow with 'Rating' to collect ratings after meetings",


### PR DESCRIPTION
## What does this PR do?

Adds info icon tooltips to the "No-Show (Host)" and "No-Show (Guest)" KPI cards on the `/insights` page to clarify how each metric is counted:

- **No-Show (Host)**: Counted per booking — if the host doesn't show up, the booking is marked as a host no-show.
- **No-Show (Guest)**: Counted per attendee — if multiple guests don't show up in a single booking, each guest counts separately.

- Fixes ENG-662

### Implementation

- Added an optional `tooltip` prop to `KPICard`. When provided, an info icon with a hover tooltip renders next to the card title.
- Added two new i18n keys (`event_no_show_host_tooltip`, `event_no_show_guest_tooltip`) to the English locale.
- Passed tooltip text from `BookingKPICards` only for the two no-show performance categories.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to `/insights`
2. In the **Performance** section, hover over the info icon next to "No-Show (Host)" — verify the tooltip appears with the correct explanation
3. Hover over the info icon next to "No-Show (Guest)" — verify the tooltip appears with the correct explanation
4. Confirm the other two Performance cards (Average ratings, CSAT Score) do **not** show an info icon
5. Confirm the Events section cards are unaffected

## Human Review Checklist

- [ ] Verify tooltip text accurately describes the actual no-show counting logic in the backend
- [ ] Check that the info icon aligns well with the title text and doesn't cause layout shifts
- [ ] Confirm tooltip hover/dismiss behavior works correctly on both desktop and mobile

Link to Devin session: https://app.devin.ai/sessions/5022cab8643f4b9f80d9d2a98a84c797
Requested by: @eunjae-lee
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
