### PR TITLE
Correcting the block event of calender #28686

### DIFF
--- a/packages/i18n/locales/de/common.json
+++ b/packages/i18n/locales/de/common.json
@@ -773,7 +773,7 @@
   "attendee_phone_number": "Telefonnummer",
   "organizer_phone_number": "Telefonnummer des Organisators",
   "enter_phone_number": "Telefonnummer eingeben",
-  "reschedule": "Neuplanen",
+  "reschedule": "Neuen Termin buchen",
   "reschedule_this": "Stattdessen verschieben",
   "book_a_team_member": "Teammitglied stattdessen buchen",
   "or": "ODER",

--- a/packages/i18n/locales/de/common.json
+++ b/packages/i18n/locales/de/common.json
@@ -773,7 +773,7 @@
   "attendee_phone_number": "Telefonnummer",
   "organizer_phone_number": "Telefonnummer des Organisators",
   "enter_phone_number": "Telefonnummer eingeben",
-  "reschedule": "Neuen Termin buchen",
+  "reschedule": "Neu terminieren",
   "reschedule_this": "Stattdessen verschieben",
   "book_a_team_member": "Teammitglied stattdessen buchen",
   "or": "ODER",

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -681,7 +681,10 @@ export default abstract class BaseCalendarService implements Calendar {
       vevents.forEach((vevent) => {
         // if event status is free or transparent, return
         if (vevent?.getFirstPropertyValue("transp") === "TRANSPARENT") return;
-
+        if(vevent?.getFirstPropertyValue("x-microsoft-cdo-intendedstatus") === "FREE")return;
+        //this is for the free event the earlier code was only for read trans not for free event
+        if(vevent?.getFirstPropertyValue("status")==="CANCELLED") return;
+        //this is added for canclled event should not block the time
         const event = new ICAL.Event(vevent);
         const dtstartProperty = vevent.getFirstProperty("dtstart");
         const tzidFromDtstart = dtstartProperty ? (dtstartProperty as any).jCal[1].tzid : undefined;
@@ -871,6 +874,7 @@ export default abstract class BaseCalendarService implements Calendar {
   }: FetchObjectsWithOptionalExpandOptionsType): Promise<DAVObject[]> {
     const filteredCalendars = selectedCalendars.filter((sc) => sc.externalId);
     const fetchPromises = filteredCalendars.map(async (sc) => {
+      try{
       const response = await fetchCalendarObjects({
         urlFilter: (url) => this.isValidFormat(url),
         calendar: {
@@ -910,12 +914,31 @@ export default abstract class BaseCalendarService implements Calendar {
         })
       );
       return processedResponse;
+    }
+    catch(err){
+      logger.error("Enter calender object",{
+        externalId: sc.externalId,  // tell you which calendar failed
+        error: err,
+      });
+      return [];
+    }
+    // in this code you have done only resolve option by which it only fetch one calender code as another calender appear it crashes
+    //now if yourne calender fails another calender will work
     });
     const resolvedPromises = await Promise.allSettled(fetchPromises);
     const fulfilledPromises = resolvedPromises.filter(
-      (promise): promise is PromiseFulfilledResult<(DAVObject | undefined)[]> =>
-        promise.status === "fulfilled"
-    );
+      (promise): promise is PromiseFulfilledResult<(DAVObject | undefined)[]> =>{
+
+        if(promise.status== "rejected"){
+          logger.error("Failed",{
+            reason:promise.reason,
+          })
+        }
+        //why we have done this because the earlier code was only reading or storing the success full case not the failed one 
+        //By this u can store the failed case and debug it
+        return promise.status === "fulfilled"
+      
+    });
     const flatResult = fulfilledPromises.flatMap((promise) => promise.value).filter((obj) => obj !== null);
     return flatResult as DAVObject[];
   }


### PR DESCRIPTION
Fixed #28686 

When  user connects  their Nextcloud calender via caldav the event in that calender were not blocking the availability slots on the booking page. This meant the main problem was that people could book meetings even when the user already had events in their Nextcloud calendar.

Root cause:
The main cause of this was the Availability method in the CalenderService.ts . It was only checking one condition to skip free event.it was missing two important cases X-MICROSOFT-CDO-INTENDEDSTATUS:FREE , this uses as extended property to mark events as free. Cal.com was not reading this field at all, so these events were wrongly blocking slots.
STATUS:CANCELLED: Cancelled event still showing in caldav feed . Cal.com was treating them as busy and blocking slots even though the event no longer exists.

Changes:
Fix 1: Added two missing checks in Availability section to read the free and cancel condition
Fix 2: Wrapped per calender fetch in in try/ catch inside fetchobject section so if one Nextcloud calendar fails to fetch, the other calendars still work correctly.
fix 3: Added error logging for rejected fetch promises so failures are now visible in logs and can be debugged.

This is the solution for the code which I consider it correct please go through it.
Any Question are welcome
Thank you!
