### PR TITLE
fix: preserve array query parameters during dynamic group redirect

### DIFF
--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -109,7 +109,17 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
 
     // EXAMPLE - context.params: { orgSlug: 'acme', user: 'member0+owner1' }
     // EXAMPLE - context.query: { redirect: 'undefined', orgRedirection: 'undefined', user: 'member0+owner1' }
-    const originalQueryString = new URLSearchParams(context.query as Record<string, string>).toString();
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(context.query)) {
+      if (Array.isArray(value)) {
+        for (const v of value) {
+          searchParams.append(key, v);
+        }
+      } else if (value !== undefined) {
+        searchParams.append(key, value);
+      }
+    }
+    const originalQueryString = searchParams.toString();
     const destinationWithQuery = `${destinationUrl}?${originalQueryString}`;
     log.debug(`Dynamic group detected, redirecting to ${destinationUrl}`);
     return {


### PR DESCRIPTION
## Summary

Fixes incorrect serialization of array query parameters in the dynamic group redirect logic.

**Root cause:** In `getServerSideProps`, `context.query` is cast to `Record<string, string>` and passed to `new URLSearchParams()`. However, Next.js query params can be `string | string[]` — when a key appears multiple times (e.g. `?user=john&user=doe`), the value is an array. The cast loses this structure, producing `user=john,doe` instead of `user=john&user=doe`.

**Fix:** Iterate over `context.query` entries and use `searchParams.append()` for each value, correctly handling both single strings and arrays.

Fixes #28687

## Test plan

- [ ] Navigate to a dynamic group URL with repeated query params: `/john+doe?user=john&user=doe`
- [ ] Verify the redirect preserves both params: `?user=john&user=doe`
- [ ] Verify single-value params still work correctly: `?redirect=false`
- [ ] Verify undefined values are excluded from the redirect URL