### PR TITLE
fix: unify webhook ID resolution across handlers

### DIFF
--- a/packages/trpc/server/routers/viewer/webhook/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/webhook/create.handler.ts
@@ -33,9 +33,10 @@ export const createHandler = async ({ ctx, input }: CreateOptions) => {
     });
   }
 
+  const { webhookId: _webhookId, ...inputWithoutWebhookId } = input;
   const webhookData: Prisma.WebhookCreateInput = {
     id: v4(),
-    ...input,
+    ...inputWithoutWebhookId,
   };
   if (input.platform && user.role !== "ADMIN") {
     throw new TRPCError({ code: "UNAUTHORIZED" });

--- a/packages/trpc/server/routers/viewer/webhook/edit.handler.ts
+++ b/packages/trpc/server/routers/viewer/webhook/edit.handler.ts
@@ -21,7 +21,7 @@ type EditOptions = {
 };
 
 export const editHandler = async ({ input, ctx }: EditOptions) => {
-  const { id, ...data } = input;
+  const { id, webhookId: _webhookId, ...data } = input;
 
   const webhook = await prisma.webhook.findUnique({
     where: {

--- a/packages/trpc/server/routers/viewer/webhook/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/webhook/get.handler.ts
@@ -11,5 +11,5 @@ type GetOptions = {
 
 export const getHandler = async ({ ctx: _ctx, input }: GetOptions) => {
   const { repository: webhookRepository } = getWebhookFeature();
-  return await webhookRepository.findByWebhookId(input.webhookId);
+  return await webhookRepository.findByWebhookId(input.id || input.webhookId);
 };

--- a/packages/trpc/server/routers/viewer/webhook/get.schema.ts
+++ b/packages/trpc/server/routers/viewer/webhook/get.schema.ts
@@ -2,8 +2,6 @@ import { z } from "zod";
 
 import { webhookIdAndEventTypeIdSchema } from "./types";
 
-export const ZGetInputSchema = webhookIdAndEventTypeIdSchema.extend({
-  webhookId: z.string().optional(),
-});
+export const ZGetInputSchema = webhookIdAndEventTypeIdSchema;
 
 export type TGetInputSchema = z.infer<typeof ZGetInputSchema>;

--- a/packages/trpc/server/routers/viewer/webhook/types.ts
+++ b/packages/trpc/server/routers/viewer/webhook/types.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 export const webhookIdAndEventTypeIdSchema = z.object({
   // Webhook ID
   id: z.string().optional(),
+  webhookId: z.string().optional(),
   eventTypeId: z.number().optional(),
   teamId: z.number().optional(),
 });

--- a/packages/trpc/server/routers/viewer/webhook/util.ts
+++ b/packages/trpc/server/routers/viewer/webhook/util.ts
@@ -22,13 +22,14 @@ export const createWebhookPbacProcedure = (
     // Endpoints that just read the logged in user's data - like 'list' don't necessarily have any input
     if (!input) return next();
 
-    const { id, teamId, eventTypeId } = input;
+    const { id, webhookId, teamId, eventTypeId } = input;
+    const lookupId = id || webhookId;
     const permissionCheckService = new PermissionCheckService();
 
-    if (id) {
+    if (lookupId) {
       // Check if user is authorized to edit webhook
       const webhook = await prisma.webhook.findUnique({
-        where: { id },
+        where: { id: lookupId },
         select: {
           id: true,
           userId: true,


### PR DESCRIPTION
## What does this PR do?

Unifies how webhook ID parameters are resolved across the webhook PBAC middleware and handlers. The `webhookId` field is now part of the base schema and the middleware resolves both `id` and `webhookId` consistently, preventing edge cases where one parameter path could bypass validation.

### Changes

- Moved `webhookId` to the base `webhookIdAndEventTypeIdSchema` (types.ts)
- Simplified `get.schema.ts` to reuse the base schema directly
- Middleware now resolves `lookupId = id || webhookId` for consistent handling
- Handlers strip `webhookId` before passing data downstream (create, edit)

## How should this be tested?

1. Create a webhook via Settings > Developer > Webhooks
2. Verify reading webhook details works via both `id` and `webhookId` parameters
3. Verify editing and deleting webhooks still works as expected

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a documentation change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.