### PR TITLE
fix: skip lingo.dev i18n automation when API key is not set

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   i18n:
     name: Run i18n
+    if: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY != '' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       actions: write

--- a/packages/lib/server/service/lingoDotDev.ts
+++ b/packages/lib/server/service/lingoDotDev.ts
@@ -1,13 +1,14 @@
+import { LINGO_DOT_DEV_API_KEY } from "@calcom/lib/constants";
+import logger from "@calcom/lib/logger";
 import type { LocaleCode } from "@lingo.dev/_spec";
 import { LingoDotDevEngine } from "lingo.dev/sdk";
 
-import { LINGO_DOT_DEV_API_KEY } from "@calcom/lib/constants";
-import logger from "@calcom/lib/logger";
-
 export class LingoDotDevService {
-  private static engine = new LingoDotDevEngine({
-    apiKey: LINGO_DOT_DEV_API_KEY,
-  });
+  private static engine = LINGO_DOT_DEV_API_KEY
+    ? new LingoDotDevEngine({
+        apiKey: LINGO_DOT_DEV_API_KEY,
+      })
+    : null;
 
   /**
    * Localizes text from one language to another
@@ -25,8 +26,13 @@ export class LingoDotDevService {
       return null;
     }
 
+    if (!LingoDotDevService.engine) {
+      logger.warn("LingoDotDevService.localizeText() skipped: LINGO_DOT_DEV_API_KEY is not set");
+      return null;
+    }
+
     try {
-      const result = await this.engine.localizeText(text, {
+      const result = await LingoDotDevService.engine.localizeText(text, {
         sourceLocale,
         targetLocale,
       });
@@ -50,8 +56,13 @@ export class LingoDotDevService {
     sourceLocale: string,
     targetLocales: string[]
   ): Promise<string[]> {
+    if (!LingoDotDevService.engine) {
+      logger.warn("LingoDotDevService.batchLocalizeText() skipped: LINGO_DOT_DEV_API_KEY is not set");
+      return [];
+    }
+
     try {
-      const result = await this.engine.batchLocalizeText(text, {
+      const result = await LingoDotDevService.engine.batchLocalizeText(text, {
         // TODO: LocaleCode is hacky, use our locale mapping instead.
         sourceLocale: sourceLocale as LocaleCode,
         targetLocales: targetLocales as LocaleCode[],
@@ -76,8 +87,13 @@ export class LingoDotDevService {
       return texts;
     }
 
+    if (!LingoDotDevService.engine) {
+      logger.warn("LingoDotDevService.localizeTexts() skipped: LINGO_DOT_DEV_API_KEY is not set");
+      return texts;
+    }
+
     try {
-      const result = await this.engine.localizeChat(
+      const result = await LingoDotDevService.engine.localizeChat(
         texts.map((text) => ({ name: "NO_NAME", text: text.trim() })),
         {
           sourceLocale,


### PR DESCRIPTION
## What does this PR do?

Makes the lingo.dev integration gracefully no-op when `LINGO_DOT_DEV_API_KEY` is not configured, rather than attempting to run and failing.

Two changes:

1. **`.github/workflows/i18n.yml`** — Adds a job-level `if` condition so the i18n workflow is skipped entirely when the `CI_LINGO_DOT_DEV_API_KEY` secret is not set.
2. **`packages/lib/server/service/lingoDotDev.ts`** — Conditionally instantiates `LingoDotDevEngine` only when the API key exists. All three public methods (`localizeText`, `batchLocalizeText`, `localizeTexts`) now check for a null engine and return safe defaults (same values as existing error-handling paths) with a warning log.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — guard-clause behavior matches existing error fallbacks.

## How should this be tested?

1. Verify the i18n workflow is skipped when `CI_LINGO_DOT_DEV_API_KEY` is not set in repo secrets.
2. Verify `LingoDotDevService` methods return their safe defaults (`null`, `[]`, original texts) and log a warning when the env var is unset.
3. Verify normal behavior is unchanged when the API key **is** configured.

## Human Review Checklist

- [ ] Confirm `if: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY != '' }}` is valid GitHub Actions syntax for secret presence checks
- [ ] Confirm the null-engine return values (`null`, `[]`, `texts`) match what all callers of `LingoDotDevService` expect (check `TranslationService.ts` DI module)

Link to Devin session: https://app.devin.ai/sessions/108c299722454b4aace7b6931af02a47
Requested by: @keithwillcode