### PR TITLE
fix: ensure consistent promise handling in updateAllCalendarEvents fo…

### DIFF
--- a/packages/features/bookings/lib/EventManager.ts
+++ b/packages/features/bookings/lib/EventManager.ts
@@ -1189,14 +1189,9 @@ export default class EventManager {
       result = result.concat(
         this.calendarCredentials
           .filter((cred) => cred.type.includes("other_calendar"))
-          .map( (cred) => {
+          .map((cred) => {
             const calendarReference = booking.references.find((ref) => ref.type === cred.type);
-
             if (!calendarReference) {
-        // Ensure consistent return type:
-        // This branch previously returned a plain object, while other branches return Promises.
-        // Wrapping with Promise.resolve ensures all items in `result` are Promise-based,
-        // making Promise.all(result) behavior consistent and predictable.
               return Promise.resolve({
                 appName: cred.appName || cred.appId || "",
                 type: cred.type,
@@ -1208,11 +1203,8 @@ export default class EventManager {
             }
             const { externalCalendarId: bookingExternalCalendarId, meetingId: bookingRefUid } =
               calendarReference;
-        // Removed unnecessary async/await:
-        // updateEvent already returns a Promise, so wrapping it with async/await was redundant.
-        // Returning the Promise directly keeps the flow consistent with other parts of the function.
-
-            return  updateEvent(cred, event, bookingRefUid ?? null, bookingExternalCalendarId ?? null);
+      
+            return updateEvent(cred, event, bookingRefUid ?? null, bookingExternalCalendarId ?? null);
           }))
 
       return Promise.all(result);

--- a/packages/features/bookings/lib/EventManager.ts
+++ b/packages/features/bookings/lib/EventManager.ts
@@ -1189,24 +1189,31 @@ export default class EventManager {
       result = result.concat(
         this.calendarCredentials
           .filter((cred) => cred.type.includes("other_calendar"))
-          .map(async (cred) => {
+          .map( (cred) => {
             const calendarReference = booking.references.find((ref) => ref.type === cred.type);
 
             if (!calendarReference) {
-              return {
+        // Ensure consistent return type:
+        // This branch previously returned a plain object, while other branches return Promises.
+        // Wrapping with Promise.resolve ensures all items in `result` are Promise-based,
+        // making Promise.all(result) behavior consistent and predictable.
+              return Promise.resolve({
                 appName: cred.appName || cred.appId || "",
                 type: cred.type,
                 success: false,
                 uid: "",
                 originalEvent: event,
                 credentialId: cred.id,
-              };
+              });
             }
             const { externalCalendarId: bookingExternalCalendarId, meetingId: bookingRefUid } =
               calendarReference;
-            return await updateEvent(cred, event, bookingRefUid ?? null, bookingExternalCalendarId ?? null);
-          })
-      );
+        // Removed unnecessary async/await:
+        // updateEvent already returns a Promise, so wrapping it with async/await was redundant.
+        // Returning the Promise directly keeps the flow consistent with other parts of the function.
+
+            return  updateEvent(cred, event, bookingRefUid ?? null, bookingExternalCalendarId ?? null);
+          }))
 
       return Promise.all(result);
     } catch (error) {


### PR DESCRIPTION
fixes #28705
## What's the bug?
In `updateAllCalendarEvents()`, the `other_calendar` block used `async` 
on `.map()` which double-wraps return values in Promises. These unresolved 
Promises were concatenated directly into `result[]`, causing silent failures 
for `other_calendar` integrations.

## Root cause
`.map(async (cred) => { ... })` returns `Promise<Promise<EventResult>>[]` 
instead of `Promise<EventResult>[]`. When these land in `result[]` and 
`Promise.all(result)` runs at the end, errors are swallowed silently and 
updates are never properly awaited.

## Fix
Removed `async` from `.map()` and returned Promises explicitly — matching 
the exact same pattern used in the `for...of` loop above it.

- Early return path: wrapped in `Promise.resolve({ ... })`
- Normal path: `updateEvent()` already returns a Promise naturally

`Promise.all(result)` at the end now correctly resolves everything.

## Files changed
`packages/features/bookings/lib/EventManager.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
