### PR TITLE
fix(auth): add sign out option to profile settings to resolve trapped session loops

### DIFF
--- a/apps/web/modules/settings/my-account/profile-view.tsx
+++ b/apps/web/modules/settings/my-account/profile-view.tsx
@@ -314,6 +314,23 @@ const ProfileView = ({ user }: Props) => {
         </div>
       )}
 
+      {/* Sign Out Section */}
+      <div className="border-subtle mt-6 rounded-lg rounded-b-none border border-b-0 p-6">
+        <Label className="mb-0 text-base font-semibold">{t("sign_out")}</Label>
+        <p className="text-subtle text-sm">{t("Log out of your current session")}</p>
+
+      </div>
+      <SectionBottomActions align="end">
+        <Button
+          data-testid="sign-out-button"
+          color="secondary"
+          StartIcon="log-out"
+          onClick={() => signOut({ callbackUrl: "/auth/logout" })}>
+          {t("sign_out")}
+        </Button>
+      </SectionBottomActions>
+
+      {/* Danger Zone */}
       <div className="border-subtle mt-6 rounded-lg rounded-b-none border border-b-0 p-6">
         <Label className="mb-0 text-base font-semibold text-red-700">{t("danger_zone")}</Label>
         <p className="text-subtle text-sm">{t("account_deletion_cannot_be_undone")}</p>


### PR DESCRIPTION
## What does this PR do?

This PR addresses a critical UX issue where users felt "trapped" in a logged-in state. Previously, the only way to sign out was tucked away in the small avatar drop-down menu in the sidebar. This caused users to visit their `/settings/my-account/profile` page in an attempt to sign out, only to find the "Delete Account" function and remain stuck. 

Consequently, users attempting to navigate to the landing page and click "Sign up" were continuously redirected back to their active dashboard session, unable to create a new account.

This fix simply adds a standard `Sign out` component securely directly above the "Danger zone" inside the main Profile settings page, fixing the root cause of the UX trap.

- Fixes #28709

## Visual Demo -

<img width="1641" height="856" alt="Screenshot 2026-04-02 210429" src="https://github.com/user-attachments/assets/b9a62c4d-61d6-414b-b786-71e107e9e134" />


## Mandatory Tasks -

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Ensure your local server is successfully running (`yarn dev`).
2. Log into any account (e.g., `pro@example.com`).
3. Navigate via the sidebar to **Settings -> Profile** (`/settings/my-account/profile`).
4. Scroll to the bottom of the page and verify that the new `Sign out` section is cleanly visible right above the red "Danger zone".
5. Click **Sign out** and verify your session is safely and completely terminated.
6. Verify that you can now freely navigate to `/signup` and create a new account without a redirect trap!

