### PR TITLE
feat(reschedule): respect guest availability during host-initiated rescheduling

### DIFF
--- a/apps/api/v2/src/lib/modules/available-slots.module.ts
+++ b/apps/api/v2/src/lib/modules/available-slots.module.ts
@@ -11,6 +11,7 @@ import { PrismaTeamRepository } from "@/lib/repositories/prisma-team.repository"
 import { PrismaUserRepository } from "@/lib/repositories/prisma-user.repository";
 import { AvailableSlotsService } from "@/lib/services/available-slots.service";
 import { BusyTimesService } from "@/lib/services/busy-times.service";
+import { GuestBusyTimesService } from "@/lib/services/guest-busy-times.service";
 import { CheckBookingLimitsService } from "@/lib/services/check-booking-limits.service";
 import { FilterHostsService } from "@/lib/services/filter-hosts.service";
 import { NoSlotsNotificationService } from "@/lib/services/no-slots-notification.service";
@@ -40,6 +41,7 @@ import { Module } from "@nestjs/common";
     AvailableSlotsService,
     UserAvailabilityService,
     BusyTimesService,
+    GuestBusyTimesService,
     FilterHostsService,
     QualifiedHostsService,
     NoSlotsNotificationService,

--- a/apps/api/v2/src/lib/services/available-slots.service.ts
+++ b/apps/api/v2/src/lib/services/available-slots.service.ts
@@ -8,6 +8,7 @@ import { PrismaSelectedSlotRepository } from "@/lib/repositories/prisma-selected
 import { PrismaTeamRepository } from "@/lib/repositories/prisma-team.repository";
 import { PrismaUserRepository } from "@/lib/repositories/prisma-user.repository";
 import { BusyTimesService } from "@/lib/services/busy-times.service";
+import { GuestBusyTimesService } from "@/lib/services/guest-busy-times.service";
 import { CheckBookingLimitsService } from "@/lib/services/check-booking-limits.service";
 import { NoSlotsNotificationService } from "@/lib/services/no-slots-notification.service";
 import { OrgMembershipLookupService } from "@/lib/services/org-membership-lookup.service";
@@ -36,6 +37,7 @@ export class AvailableSlotsService extends BaseAvailableSlotsService {
     checkBookingLimitsService: CheckBookingLimitsService,
     userAvailabilityService: UserAvailabilityService,
     busyTimesService: BusyTimesService,
+    guestBusyTimesService: GuestBusyTimesService,
     noSlotsNotificationService: NoSlotsNotificationService,
     orgMembershipLookupService: OrgMembershipLookupService
   ) {
@@ -52,6 +54,7 @@ export class AvailableSlotsService extends BaseAvailableSlotsService {
       checkBookingLimitsService,
       userAvailabilityService,
       busyTimesService,
+      guestBusyTimesService,
       qualifiedHostsService,
       featuresRepo: featuresRepository,
       noSlotsNotificationService,

--- a/apps/api/v2/src/lib/services/guest-busy-times.service.ts
+++ b/apps/api/v2/src/lib/services/guest-busy-times.service.ts
@@ -1,0 +1,13 @@
+import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
+import { Injectable } from "@nestjs/common";
+
+import { GuestBusyTimesService as BaseGuestBusyTimesService } from "@calcom/platform-libraries/slots";
+
+@Injectable()
+export class GuestBusyTimesService extends BaseGuestBusyTimesService {
+  constructor(prismaWriteService: PrismaWriteService) {
+    super({
+      prisma: prismaWriteService.prisma,
+    });
+  }
+}

--- a/da
+++ b/da
@@ -1,0 +1,929 @@
+  1006	Peer Richelsen
+   991	Alex van Andel
+   856	Hariom Balhara
+   781	zomars
+   764	Crowdin Bot
+   682	sean-brydon
+   639	Omar López
+   570	Udit Takkar
+   559	Benny Joo
+   525	Anik Dhabal Babu
+   514	Keith Williams
+   480	Joe Au-Yeung
+   465	Agusti Fernandez Pardo
+   423	Carina Wollendorfer
+   419	Morgan
+   384	Syed Ali Shahbaz
+   337	Bailey Pumfleet
+   316	Lauris Skraucis
+   304	Eunjae Lee
+   301	github-actions[bot]
+   202	Nafees Nazik
+   195	Rajiv Sahal
+   190	Leo Giovanetti
+   171	alannnc
+   147	GitHub Actions
+   136	Somay Chauhan
+   127	nicolas
+   126	Volnei Munhoz
+   120	GitStart-Cal.com
+   119	Amit Sharma
+   118	Calcom Bot
+   116	Dhairyashil Shinde
+   107	devin-ai-integration[bot]
+   105	Alex Johansson
+    98	Jeroen Reumkens
+    94	emrysal
+    85	Agusti Fernandez
+    62	Peer_Rich
+    57	GitStart
+    51	Pedro Castro
+    51	Vijay
+    44	Mihai C
+    43	Romit
+    40	Malte Delfs
+    39	dependabot[bot]
+    36	Efraín Rochín
+    36	Erik
+    35	amrit
+    33	DmytroHryshyn
+    32	Kartik Labhshetwar
+    29	Kartik Saini
+    27	Anwar Sadath
+    25	gitstart-app[bot]
+    23	Femi Odugbesan
+    23	Richard Poelderl
+    23	femyeda
+    22	Tushar Bhatt
+    20	Sahitya Chandra
+    19	Anshumancanrock
+    19	Demian Caldelas
+    18	Kartik
+    18	Ujwal Kumar
+    17	Beto
+    17	Mehul
+    17	chauhan_s
+    17	mintlify[bot]
+    17	spandev
+    15	luzpaz
+    14	Greg Pabian
+    14	Pallav
+    13	Afzal Sayed
+    13	Anirban Singha
+    13	Harsh Singh
+    13	Joe
+    13	cal-com-ci[bot]
+    13	depfu[bot]
+    12	Jamie Pine
+    12	Nizzy
+    12	Pradumn Kumar
+    12	Shivam Kalra
+    11	Abhishek
+    11	Bandhan Majumder
+    11	Eesh Midha
+    11	Jaideep Guntupalli
+    11	Siddharth Movaliya
+    11	Steven Tey
+    11	mihaic195
+    11	nicktrn
+    10	Deepanshu
+    10	Hichem Fantar
+    10	Riddhesh Mahajan
+     9	Devanshu Sharma
+     9	DexterStorey
+     9	Jeff Loiselle
+     9	Kiran K
+     9	Ram Shukla
+     9	Shaik-Sirajuddin
+     9	Vachmara
+     9	Yagiz Nizipli
+     8	Aldrin
+     8	Anton Podviaznikov
+     8	Ben Hybert
+     8	Ciarán Hanrahan
+     8	Miguel Nieto A
+     8	Monto
+     8	Om Ray
+     8	Pasquale Vitiello
+     8	Rama Krishna Reddy
+     8	René Müller
+     8	Sarthak Kapila
+     8	Souptik Datta
+     8	abhix4
+     7	Abhay Mishra
+     7	Abhijeet Singh
+     7	Chiranjeev Vishnoi
+     7	Chris
+     7	Deepak Prabhakara
+     7	Imamuzzaki Abu Salam
+     7	KATT
+     7	Yadong (Adam) Zhang
+     7	buschco
+     7	hariombalhara
+     7	mohammed hussam
+     6	Adarsh Tiwari
+     6	Ash Davis
+     6	Bill Gale
+     6	Esaú Morais
+     6	Hashen
+     6	Julius Marminge
+     6	Krunal Shah
+     6	Lucas Smith
+     6	Nathaniel
+     6	Rob Jackson
+     6	Rodrigo Ehlers
+     6	Sai Deepesh
+     6	Sasha
+     6	Shane Maglangit
+     6	an_ifrah24
+     6	jemiluv8
+     6	沙什瓦特
+     5	Ahmad Yasser
+     5	Arya
+     5	Ayush Mainali
+     5	Cao Hoang
+     5	Cheng CHENG
+     5	Gaurav Verma
+     5	Manpreet Singh
+     5	Maximilian Franzke
+     5	Mohammed Cherfaoui
+     5	Parteek malik
+     5	Patel Divyesh
+     5	Pranav Rajveer
+     5	Raghul
+     5	Ritik Kumar
+     5	Roland
+     5	Romit Gabani
+     5	Rushikesh
+     5	Ryan Jung
+     5	Shrey-Sutariya
+     5	Steve Xu
+     5	Tamal Chakraborty
+     5	Vishnu
+     5	Wesley
+     5	cal.com
+     5	joshsny
+     5	keithwillcode
+     5	simiondolha
+     4	Aaron Presley
+     4	Abdurrahman Rajab
+     4	Adam Garbowski
+     4	Andreas Thomas
+     4	Arthur Denner
+     4	Damian Harateh
+     4	Danila
+     4	Denzil Samuel
+     4	Edward Fernández
+     4	Flemming
+     4	Joe Shajan
+     4	Joel Lu
+     4	Julián David Sánchez Gallego
+     4	Leonardo Stenico
+     4	Lola
+     4	Manas Kenge
+     4	Max Prilutskiy
+     4	Miguel Nieto
+     4	Noah
+     4	Philipp Dormann
+     4	Pritam
+     4	Romit.
+     4	Sanchit Tewari
+     4	Saurabh Singh
+     4	Shyam Raghuwanshi
+     4	Soham Datta
+     4	Sourav
+     4	Sy Sagar
+     4	Vikas Patil
+     4	Vincent Lam
+     4	Vinoth Kumar V
+     4	aar2dee2
+     4	hexcowboy
+     4	iamkun
+     4	nizzy
+     4	sydwardrae
+     4	vklimontovich
+     3	Abir Roy
+     3	Alex / KATT
+     3	Anit Jha
+     3	Ansari
+     3	Choongkyu Kim
+     3	CodeShakingSheep
+     3	Colin Griffin
+     3	Daniel Roe
+     3	Dilpreet Singh
+     3	Faiz
+     3	Fernando Barrios
+     3	Harshit Singh
+     3	Heath Daniel
+     3	Hemant M Mehta
+     3	Henrik Klee
+     3	Jatin Sandilya
+     3	Jon@1599
+     3	Juan Esteban Nieto Cifuentes
+     3	Lars Artmann
+     3	Lucas
+     3	Manavpreet Singh
+     3	Marc Seitz
+     3	Martin Sione
+     3	Matt Nicolls
+     3	Matt Pocock
+     3	Mohit
+     3	Muhammad Aiman Sulaiman
+     3	Nayan Bagale
+     3	Nick Holden
+     3	Nico
+     3	Nikeshkumar TK
+     3	Nishan Singh
+     3	Pavan Naik
+     3	Pavel Shapel
+     3	Praash
+     3	Pranav Patil
+     3	Pratik Kumar
+     3	Rajdeep Das
+     3	Shaunak Das
+     3	Shivam Jadhav
+     3	Shrey Gupta
+     3	Suyash Srivastava
+     3	Vansh Gilhotra
+     3	VasuDevrani
+     3	Vibhor Phalke
+     3	Vladimir Klimontovich
+     3	Yash
+     3	Zain Gulbaz
+     3	Zeeshan Bhati
+     3	darshan
+     3	milospuac
+     3	swalihkolakkadan
+     2	Abhinav-Developer-23
+     2	Aditya Pandey
+     2	Adrien La
+     2	Afrie Irham
+     2	Ajeet Pratap Singh
+     2	Akarsh Jain
+     2	Akash Kinkar Pandey
+     2	Albin_Baby
+     2	Ali Nawaz
+     2	Amir Fakhrullah
+     2	Anmol Mahajan
+     2	Aritra Dey
+     2	Ashish manhas
+     2	Ashray Shetty
+     2	Aswath S
+     2	Avishay Maor
+     2	Ayanava Karmakar
+     2	Ayush Mhetre
+     2	BHARGAVA_GONUGUNTA
+     2	Balveer Singh Rao
+     2	Benedikt Hopmann
+     2	Bhargav
+     2	Chris Benseler
+     2	Chukwuleta Tobechi
+     2	Curious George
+     2	David Johnson
+     2	David Somers
+     2	Deepak Rudra Paul
+     2	Doug Andrade
+     2	Edgar Allan Glez
+     2	Egor Zaitsev
+     2	Emmanuel Isenah
+     2	Eric Dantas
+     2	Ethan Chen
+     2	Everton Resende
+     2	Giridhar
+     2	Guilherme Santos
+     2	Gurkiran Singh
+     2	Haran Rajkumar
+     2	Hariom
+     2	Harsh Jadhav
+     2	Harshith Kumar
+     2	Harshith Pabbati
+     2	Heaust Azure
+     2	Hitesh Sisara
+     2	Jagadish Madavalkar
+     2	Jakob
+     2	Jatin Ranka
+     2	Josh Avant
+     2	Julian Benegas
+     2	Julián Sánchez
+     2	Kaiwalya Koparkar
+     2	Kaleem
+     2	Kemil Beltre
+     2	Ken Miller
+     2	Kevin Crimi
+     2	Kinjalk Bajpai
+     2	Koushik Sai
+     2	Layan Jyoti Dutta
+     2	LoneRifle
+     2	Louis Haftmann
+     2	MOHD RAZA
+     2	Madhav Kumar
+     2	Mahesh Bansode
+     2	Manjunath Reddy
+     2	Matti Nannt
+     2	Max Oehrlein
+     2	Meenu Yadav
+     2	Meet Patel
+     2	Moon Patel
+     2	Muhammad Usman
+     2	NETRAKAMAL BARUA
+     2	Natnael Yilma
+     2	Nikolay Rademacher
+     2	Ninad Trivedi
+     2	Olga Stogova
+     2	Oscar Dominguez
+     2	Paras Gupta
+     2	Parship Chowdhury
+     2	Parth Sharma
+     2	Piyush Garg
+     2	Pradip Chaudhary
+     2	Praneeth Bhogaraju
+     2	Pranjal Goyal
+     2	Prateek Dwivedi
+     2	Prateek Jain
+     2	Praveen Kumar D
+     2	Purushottam Khedre
+     2	Rahul Roy
+     2	Riyan Mohammad
+     2	Ronit Raj
+     2	Rory Hughes
+     2	Sahil Padvi
+     2	Satya Nishanth
+     2	Saurabh Jaswal
+     2	Shivraj Vinayak Darekar
+     2	Shrey Tanna
+     2	Shreya Agarwal
+     2	Shubham Palriwala
+     2	SuPrabhu
+     2	Sumedh
+     2	TachyonicBytes
+     2	Ted Spare
+     2	Tim Neutkens
+     2	Utkersh Rajvenshi
+     2	Vedant Jain
+     2	Vikas  Verma
+     2	Vinicius Vieira
+     2	Vitor Monteiro
+     2	Yassin Eldeeb
+     2	Yuvraj Angad Singh
+     2	Zoheb Ahmed
+     2	andreaestefania12
+     2	avnish100
+     2	checkly[bot]
+     2	ddoemonn
+     2	firefox341
+     2	hallidayo
+     2	iqram magdon-ismail
+     2	keerthi vardhan
+     2	kusiewicz
+     2	neo773
+     2	noobyogi0010
+     2	shaharyarshamshi
+     2	shivambhatia604
+     2	smitgol
+     2	techknowlogick
+     2	yuriisilkov1986
+     2	Özer
+     1	0xIvan
+     1	ABDERRAHMANI IDRISSI HAMZA
+     1	ASHOK-SINGH
+     1	Aashish Upadhyay
+     1	Abdallah Alsamman
+     1	Abdullah Arif
+     1	Abhilash Sampath
+     1	Abhinav
+     1	Abhishek Gurav
+     1	Abhishek Singh
+     1	Abhishek Sunil
+     1	Abhisht Singh
+     1	Abhiuday Gupta
+     1	Abul Hassan Sathuli
+     1	Achraf
+     1	Adam Azzam
+     1	Adam Basha
+     1	Adam Spiers
+     1	Adarsh Singh
+     1	Adit Luhadia
+     1	Adithya Krishna
+     1	Aditya Ghadge
+     1	Aditya Nikam
+     1	Aditya Raj
+     1	Aditya Vyas
+     1	Adugna Tadesse
+     1	Afrin Nahar
+     1	Ahmad
+     1	Ahsan Ahmad
+     1	Akash Jayan
+     1	Akash Rajpurohit
+     1	Akshat Bajetha
+     1	Akshay
+     1	Alan Daniel
+     1	Albert Borsos
+     1	Alex P. Gates
+     1	Alexander Zeitler
+     1	Alexey Pavlov
+     1	Alfred Louis
+     1	Alimurtuza
+     1	Amin Jaoui
+     1	Amir Elemam
+     1	Amitabh Sahu
+     1	Anant Jain
+     1	Anas Najam
+     1	Andres Vargas
+     1	Andrew Milich
+     1	André Ricardo
+     1	Ankit Das
+     1	Ankit Gordhandas
+     1	Ankit Singh
+     1	Ankit Sridhar
+     1	Ankit Yadav
+     1	Anne Deepa Prasanna
+     1	Annlee Fores
+     1	Anshuman
+     1	Anshuman Pandey
+     1	Antcar
+     1	Arindam Biswas
+     1	Arnab Tarwani
+     1	Arnav Nath
+     1	Arthur Cruz
+     1	Artur Ampilogov
+     1	Arun Kumar
+     1	Ashher Ali
+     1	Ashutosh Sangwan
+     1	Atchyut Preetham Pulavarthi
+     1	Augusto Miranda Galego
+     1	Avnish Jha
+     1	Axl
+     1	Ayush Acharya
+     1	Ayush Agarwal
+     1	Ayush Kumar
+     1	Ayush Mukkanwar
+     1	BEK Service GmbH
+     1	Babis Digos
+     1	Balaji Krishnamurthy
+     1	Balthasar Huber
+     1	Barath Raj
+     1	Barry de Graaff
+     1	Ben Lam
+     1	Benjamin Babic
+     1	Bennet Robin Fabian
+     1	Bhanu Singh
+     1	Bhavya Bhardwaj
+     1	Bijoy Sijo
+     1	Bodhi Russell Silberling
+     1	Brace Sproul
+     1	Bram Verstraten
+     1	Brendan Woodward
+     1	Brijendra Singh
+     1	Brijesh Thummar
+     1	Bruno Wego
+     1	Candous
+     1	Carles Mitjans
+     1	Carlos Gabriel
+     1	Carlos Panato
+     1	Cassidy Williams
+     1	Chad Robinson
+     1	Chai
+     1	Chaithanya Reddy
+     1	Charlie Harrington
+     1	Cherish
+     1	Chinmay Patil
+     1	Chris S
+     1	Christian Emmert
+     1	Christoffer Bjelke
+     1	Christoph Heike
+     1	Clark Weckmann
+     1	CodeWithAdnan
+     1	Conor Meagher
+     1	Cory Dransfeldt
+     1	D. Domig
+     1	DUDHAT HEMIL PRAVINKUMAR
+     1	Dallen Pyrah
+     1	Dan
+     1	Daniel Adeboye
+     1	Daniel McGowan
+     1	Darshan Kumar A
+     1	Darshan Subedi
+     1	Darshil Mharaur
+     1	David Oksman
+     1	Deepak Sharma
+     1	Deepak gupta
+     1	Deepesh Bind
+     1	Dewansh Chaudhari
+     1	Dexter Storey
+     1	Dhairya Modi
+     1	Diego Fernando Nieto
+     1	Dolev Hadar
+     1	Eduardo M
+     1	Emilio Degiovanni
+     1	Esteban Dalel R
+     1	Evan Liu
+     1	Ezhil Shanmugham
+     1	Fabio Carballo
+     1	Faraz Patankar
+     1	Farhan Javed
+     1	Felipe
+     1	Francisco Lourenço
+     1	Frank Greco Jr
+     1	Fábio Galiano
+     1	Gabbar
+     1	Gabriel Hall
+     1	Gaurav Goswami
+     1	Gaurav Suthar
+     1	Gene Parmesan Thomas
+     1	Gergő Móricz
+     1	GermaVinsmoke
+     1	GlitchWitch
+     1	Guillaume RODRIGUEZ
+     1	Gus
+     1	Guvanch Gurbandurdyyev
+     1	Gwenaël Gallon
+     1	Gyan
+     1	Hamza Fouad
+     1	Harman Batheja
+     1	Harold Thétiot
+     1	Harry Dobrev
+     1	Harsh Thakur
+     1	Harshit Sharma
+     1	Heath Henley
+     1	Heiki
+     1	Hem Bahadur Pun
+     1	Hemanth Rachapalli
+     1	Henrique Pacheco
+     1	Henry Kwon
+     1	Herbert Mühlburger
+     1	Hichem
+     1	Hiten
+     1	Hiten Vats
+     1	Hosmel Quintana
+     1	Husni Abad
+     1	Ignite_99
+     1	Igor Perzic
+     1	Ikko Eltociear Ashimine
+     1	Ilya Katz
+     1	InD3v
+     1	Isaiah Hamilton
+     1	JA
+     1	JAVI
+     1	Jack
+     1	Jacob Wolf
+     1	Jake Cooper
+     1	Jake Hebert
+     1	James Garbutt
+     1	James George
+     1	James P
+     1	James Vansteenkiste
+     1	Jamie
+     1	Jan Piotrowski
+     1	Jan Vereecken
+     1	Janakiram Yellapu
+     1	Jannes Blobel
+     1	Jas Krrish Singh
+     1	Jay Pitroda
+     1	Jeremiah Ajayi
+     1	Jesse Klotz
+     1	Jevtić Nenad
+     1	Jithil P Ponnan
+     1	Joachim Violon
+     1	Joe Cohen
+     1	Johannes Maendle
+     1	Johannes Zellner
+     1	John Afolabi
+     1	John Forte
+     1	John Victor
+     1	Jonathan Giardino
+     1	Jonathan Ng
+     1	Jordan Vohwinkel
+     1	Joshua Snyder
+     1	JunYu
+     1	Justin Mitchell
+     1	Kacper
+     1	Kamalika
+     1	Kamil B. Demirci
+     1	Kanji Keraliya
+     1	Karl
+     1	Kavan Gandhi
+     1	Kay
+     1	Kedar Choudhary
+     1	Kelvin F. Alfaro
+     1	Keon
+     1	Keyur Patel
+     1	Kinbaum
+     1	Kirankumar Ambati
+     1	Kirat
+     1	Kiss Benedek Máté
+     1	Konstantin Nosov
+     1	Krishnendu Sukumar
+     1	Kszemi
+     1	Kunall Banerjee
+     1	Kushagra Mathur
+     1	LAVIN RAJ MOHAN
+     1	Lachlan Harris
+     1	Lane
+     1	Lawrence Christian
+     1	Leandro Miguel Narciso
+     1	Lee Salminen
+     1	Lennart Gastler
+     1	Levent Deniz
+     1	Louis
+     1	Lucas Víctor Ferreira de Araújo
+     1	Luis Cadillo
+     1	Maaz Ahmed Khan
+     1	Mackenly Jones
+     1	Madhan Kumar
+     1	Mahmoud Abdel Wahab
+     1	Maidul Islam
+     1	Manav Gupta
+     1	Manish Roy
+     1	Manish Singh Bisht
+     1	Marlo Kesser
+     1	Masumi Kawasaki
+     1	Matt
+     1	Matt Hamilton
+     1	Matthias Gemperli
+     1	Mauryan Kansara
+     1	Maxim G
+     1	Maximous Black
+     1	Mayowa Ojo
+     1	MeenuyD
+     1	Meeran E Mandhini
+     1	Meet Mota
+     1	Mehmet Sungur
+     1	Mehran Shahbaz
+     1	Mendy Landa
+     1	Mihir thakur
+     1	Mike Casey
+     1	Mike Zhou
+     1	Mingjie Jiang
+     1	Mitchell Moore
+     1	Mithun Prabhu
+     1	Mohammad Aquib
+     1	Mohd Afzal Khan
+     1	Mohit Balwani
+     1	Mohit Yadav
+     1	Moritz
+     1	Moulibrota Das
+     1	MrBirb
+     1	Muhammad
+     1	Muhammad Ali
+     1	Muhammad Redho Ayassa
+     1	Murtaja Ziad
+     1	NISHANT SINGH
+     1	Naaajii
+     1	Nadav Schwartz
+     1	Nadeem Ashraf
+     1	Nate Grift
+     1	Nathan
+     1	Neel Patel
+     1	Neha Prasad
+     1	Nic Wortel
+     1	Nicolaos Moscholios
+     1	Nikhil Anand
+     1	Nils Jacobsen
+     1	Nischal Gautam
+     1	Nishith Munda
+     1	NitinPSingh
+     1	Obaidullah Ishfaq
+     1	Osama Jandali
+     1	Pablo Castellano
+     1	Papageorgiou Nikos
+     1	Parthib
+     1	Parvat Raj Singh
+     1	Pascal
+     1	Pat
+     1	Patrick Arminio
+     1	Patrick Göler von Ravensburg
+     1	Pedro Duarte
+     1	Pedro Henrique Braga
+     1	Peter Crosthwaite
+     1	Peter Körner
+     1	Philip Niedertscheider
+     1	Piyanshu Saini
+     1	Piyush Pandey
+     1	Ponikar
+     1	Prabhat
+     1	Pranav Gawande
+     1	Prateek Sachan
+     1	Pratheek Ravikumar
+     1	Praveen Dias
+     1	Priyansh
+     1	Punit Kumar Ojha
+     1	Radhey Mugdal
+     1	Rahil Ansari
+     1	Raihanullah Shamsi
+     1	Raj Patel
+     1	Rajat.S
+     1	Rajdeep Ghosh
+     1	Rajesh Jonnalagadda
+     1	Raju kadel
+     1	Rakshit
+     1	Rakshit Sisodiya
+     1	Ramiro Berrelleza
+     1	Ramsay Sewell
+     1	Raunak Singh Jolly
+     1	Ravan
+     1	Rebecca
+     1	Reckson Zirsangzela Khiangte
+     1	Regina Liu
+     1	Renan Cleyson
+     1	René Aaron
+     1	Replexica Bot
+     1	Richard Henkenjohann
+     1	Rinku Chaudhari
+     1	Ritesh Kumar
+     1	Ritesh Patil
+     1	Ritik Sharma
+     1	Robbie
+     1	Rohan Advani
+     1	Rohan Gupta
+     1	Rohit Saini
+     1	Roland Weisleder
+     1	Ronit Panda
+     1	Rouh
+     1	Rrrricky
+     1	Rudra Gupta
+     1	Russ Mitchell
+     1	Ryukemeister
+     1	S K B
+     1	SDeVuyst
+     1	Sachin Siddhu
+     1	Sachin Yadav
+     1	Sagar
+     1	Sagar Singh Negi
+     1	Sagnik Pal
+     1	Sahil Lather
+     1	Sai Krishna
+     1	Saket kumar singh
+     1	Samuel Stroschein
+     1	Samyabrata Maji
+     1	Sangboak Lee
+     1	Sangram Bahadur
+     1	Santosh Kuchetti
+     1	Sanu Dutta
+     1	Saquib Ali
+     1	Sarvesh Bajaj
+     1	Sascha Foerster
+     1	Sascha Schworm
+     1	Satyam Singh
+     1	Sean Brydon
+     1	Sebastian Brunow
+     1	Seydi Charyyev
+     1	Shafkathullah Ihsan
+     1	Shakti Nayak
+     1	Shashank Gupta
+     1	Shashank Kaul
+     1	Shashank Kumar
+     1	Shashwatt
+     1	Shawn Caza
+     1	Shikhar Varshney
+     1	Shivang Goliyan
+     1	Shivang Sharma
+     1	Shivangi Sharma
+     1	Shivansh Kumar
+     1	Shoaib Akhtar Ansari
+     1	Shobana Chandrasekaran
+     1	Shubham Padia
+     1	Shubham Singh
+     1	Shubham kumar
+     1	Siddhant Khare
+     1	SiderealArt
+     1	Som
+     1	Soumik Patra
+     1	Sparky_Autonomous
+     1	Srijan Mukherjee
+     1	Srimoyee
+     1	Stefan Florea
+     1	Stefano Maffeis
+     1	Steven Adger
+     1	Stout Ni
+     1	Subhojit-Dey
+     1	Sujal Lokhande
+     1	Sujit Ale Magar
+     1	Surya Ashish
+     1	Swain Molster
+     1	Taha
+     1	Tangerine Kugelmann
+     1	Thang Vu
+     1	Thanh Nguyen
+     1	TheOnlyWayUp
+     1	Thefcraft
+     1	Thibault Mathian
+     1	Thomas Brodusch
+     1	Tiago Cruz
+     1	TomBoss
+     1	Toon Toetenel
+     1	Trillium S
+     1	Ujjwal Garg
+     1	Ujjwal Goyal
+     1	Umair Farooq
+     1	Utkarsh
+     1	Utkarsh Mishra
+     1	VIneet Pradhan
+     1	VIvek Chavan
+     1	Vadim Rusin
+     1	Vaibhav
+     1	Vaibhav-Kumar-K-R
+     1	Vamshi Maskuri
+     1	Varun Prahlad Balani
+     1	Varun Thummar
+     1	Velmurugan R
+     1	Venkata Rohan Kambhampati
+     1	Veronica Prilutskaya
+     1	Vichea វិជ្ជា
+     1	Vicolas Akoh
+     1	Vishal Bisht
+     1	Vishwajeet Chauhan
+     1	Vlad
+     1	Warren
+     1	Will Gittoes
+     1	Xavier B
+     1	YM
+     1	YONGJAE LEE(이용재)
+     1	Yadong (Adam)
+     1	Yamini K
+     1	Yash Garg
+     1	Yash Gupta
+     1	Yash Raj
+     1	Yashwanth sai
+     1	Yatendra
+     1	Yevhen Laichenkov
+     1	Yuki Sugaya
+     1	Zach Waterfield
+     1	Zachary Jia
+     1	Zahid Dodiya
+     1	Zayd Krunz
+     1	Zenrac
+     1	abhi-slash-git
+     1	ajayjha1
+     1	aku019
+     1	albanobattistella
+     1	aman sagar
+     1	anushka-0099
+     1	asadath1395
+     1	coderabbitai[bot]
+     1	copoer
+     1	devklepacki
+     1	dhruveshmishra
+     1	dihedral
+     1	dillonstreator
+     1	dolmasherpa123455
+     1	emmanuel
+     1	fiskare
+     1	greatmaxy
+     1	harsh11101
+     1	hiteshbedre
+     1	il3ven
+     1	jasmeetsohal
+     1	jen chan
+     1	joonkyu
+     1	khushal-winner
+     1	korrica1-design
+     1	kremedev
+     1	lambertrocher
+     1	m4tze
+     1	manthansubhash01
+     1	manuelgu
+     1	manurana26770
+     1	martincollignon
+     1	mdm317
+     1	michaelvalette
+     1	mischarouleaux
+     1	mixelburg
+     1	mohamed nasser
+     1	mokkin
+     1	murtaza030
+     1	nav
+     1	nidhi sharma
+     1	nitinpanghal
+     1	omahs
+     1	ozer
+     1	paridhi7
+     1	r
+     1	ravi kunwar
+     1	sajanlamsal
+     1	samaR
+     1	saptarshi-bose
+     1	sateshcharan
+     1	satya-nutella
+     1	sebzz
+     1	sec0ndhand
+     1	shaik-zeeshan
+     1	shashank-100
+     1	sid0jack
+     1	sumit shinde ( Roni )
+     1	suraj
+     1	swaraj bachu
+     1	tap0212
+     1	thegrasshopper104
+     1	thekeviv
+     1	tony83033
+     1	tyjkerr
+     1	uday
+     1	vaibhav bisht
+     1	vikcodes
+     1	vikrant845
+     1	vishwajeett007
+     1	wilson gumba
+     1	xDipzz
+     1	xylon
+     1	zerone0x
+     1	zomars@users.noreply.github.com

--- a/packages/features/busyTimes/services/getGuestBusyTimes.test.ts
+++ b/packages/features/busyTimes/services/getGuestBusyTimes.test.ts
@@ -96,7 +96,7 @@ describe("GuestBusyTimesService", () => {
         ],
       });
       mockPrisma.user.findMany.mockResolvedValue([]);
-      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       const result = await service.getGuestBusyTimes({
         rescheduleUid: "test-uid",
@@ -122,7 +122,8 @@ describe("GuestBusyTimesService", () => {
       });
 
       mockPrisma.user.findMany.mockResolvedValue([{ id: guestUserId, email: guestEmail }]);
-      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      // First call for unmatched emails (none), second call for all verified secondaries
+      mockPrisma.secondaryEmail.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       mockPrisma.booking.findMany.mockResolvedValue([
         {
@@ -164,12 +165,19 @@ describe("GuestBusyTimesService", () => {
       // Not found by primary email
       mockPrisma.user.findMany.mockResolvedValue([]);
 
-      // Found by secondary email
-      mockPrisma.secondaryEmail.findMany.mockResolvedValue([
-        {
-          user: { id: guestUserId, email: primaryEmail },
-        },
-      ]);
+      // Found by secondary email (first call), then fetch all verified secondaries (second call)
+      mockPrisma.secondaryEmail.findMany
+        .mockResolvedValueOnce([
+          {
+            user: { id: guestUserId, email: primaryEmail },
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            userId: guestUserId,
+            email: secondaryEmail,
+          },
+        ]);
 
       mockPrisma.booking.findMany.mockResolvedValue([]);
 
@@ -194,7 +202,7 @@ describe("GuestBusyTimesService", () => {
       });
 
       mockPrisma.user.findMany.mockResolvedValue([{ id: guestUserId, email: "guest@cal.com" }]);
-      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       mockPrisma.booking.findMany.mockResolvedValue([
         {
@@ -249,7 +257,7 @@ describe("GuestBusyTimesService", () => {
       });
 
       mockPrisma.user.findMany.mockResolvedValue([{ id: guestUserId, email: "guest@cal.com" }]);
-      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
       mockPrisma.booking.findMany.mockResolvedValue([]);
 
       await service.getGuestBusyTimes({
@@ -289,7 +297,8 @@ describe("GuestBusyTimesService", () => {
         { id: 100, email: "caluser1@cal.com" },
         { id: 101, email: "caluser2@cal.com" },
       ]);
-      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      // First call for unmatched emails, second call for all verified secondaries
+      mockPrisma.secondaryEmail.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       // Set up bookings for each user
       let callCount = 0;
@@ -347,12 +356,19 @@ describe("GuestBusyTimesService", () => {
       // Found by primary email
       mockPrisma.user.findMany.mockResolvedValue([{ id: userId, email: primaryEmail }]);
 
-      // Also found by secondary email (same user)
-      mockPrisma.secondaryEmail.findMany.mockResolvedValue([
-        {
-          user: { id: userId, email: primaryEmail },
-        },
-      ]);
+      // Also found by secondary email (same user), then fetch all verified secondaries
+      mockPrisma.secondaryEmail.findMany
+        .mockResolvedValueOnce([
+          {
+            user: { id: userId, email: primaryEmail },
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            userId: userId,
+            email: secondaryEmail,
+          },
+        ]);
 
       mockPrisma.booking.findMany.mockResolvedValue([]);
 
@@ -378,7 +394,7 @@ describe("GuestBusyTimesService", () => {
       });
 
       mockPrisma.user.findMany.mockResolvedValue([{ id: 100, email: "guest@cal.com" }]);
-      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
       mockPrisma.booking.findMany.mockResolvedValue([
         {
           id: 10,
@@ -427,7 +443,7 @@ describe("GuestBusyTimesService", () => {
       });
 
       mockPrisma.user.findMany.mockResolvedValue([{ id: guestUserId, email: "guest@cal.com" }]);
-      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
       mockPrisma.booking.findMany.mockResolvedValue([]);
 
       await service.getGuestBusyTimes({
@@ -463,7 +479,7 @@ describe("GuestBusyTimesService", () => {
       });
 
       mockPrisma.user.findMany.mockResolvedValue([{ id: 100, email: "guest@cal.com" }]);
-      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
       mockPrisma.booking.findMany.mockResolvedValue([]);
 
       const result = await service.getGuestBusyTimes({

--- a/packages/features/busyTimes/services/getGuestBusyTimes.test.ts
+++ b/packages/features/busyTimes/services/getGuestBusyTimes.test.ts
@@ -1,0 +1,481 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+import dayjs from "@calcom/dayjs";
+import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
+
+import { GuestBusyTimesService, type IGuestBusyTimesService } from "./getGuestBusyTimes";
+
+// Mock Prisma client
+const mockPrisma = {
+  booking: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+  },
+  user: {
+    findMany: vi.fn(),
+  },
+  secondaryEmail: {
+    findMany: vi.fn(),
+  },
+};
+
+const startOfTomorrow = dayjs().add(1, "day").startOf("day");
+const endOfTomorrow = dayjs().add(1, "day").endOf("day");
+
+describe("GuestBusyTimesService", () => {
+  let service: GuestBusyTimesService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GuestBusyTimesService({
+      prisma: mockPrisma as unknown as IGuestBusyTimesService["prisma"],
+    });
+  });
+
+  describe("getGuestBusyTimes", () => {
+    it("should return empty for COLLECTIVE events", async () => {
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: SchedulingType.COLLECTIVE,
+      });
+
+      expect(result).toEqual({
+        busyTimes: [],
+        calComUserCount: 0,
+        totalAttendeeCount: 0,
+      });
+      // Should not even query the database
+      expect(mockPrisma.booking.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("should return empty when booking is not found", async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue(null);
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "nonexistent-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      expect(result).toEqual({
+        busyTimes: [],
+        calComUserCount: 0,
+        totalAttendeeCount: 0,
+      });
+    });
+
+    it("should return empty when booking has no attendees", async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [],
+      });
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      expect(result).toEqual({
+        busyTimes: [],
+        calComUserCount: 0,
+        totalAttendeeCount: 0,
+      });
+    });
+
+    it("should return empty when no attendees are Cal.com users", async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [
+          { email: "external@gmail.com", name: "External User", timeZone: "UTC" },
+          { email: "another@yahoo.com", name: "Another External", timeZone: "UTC" },
+        ],
+      });
+      mockPrisma.user.findMany.mockResolvedValue([]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      expect(result).toEqual({
+        busyTimes: [],
+        calComUserCount: 0,
+        totalAttendeeCount: 2,
+      });
+    });
+
+    it("should find Cal.com user by primary email (case-insensitive)", async () => {
+      const guestEmail = "guest@cal.com";
+      const guestUserId = 100;
+
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [{ email: guestEmail.toUpperCase(), name: "Guest User", timeZone: "America/New_York" }],
+      });
+
+      mockPrisma.user.findMany.mockResolvedValue([{ id: guestUserId, email: guestEmail }]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+
+      mockPrisma.booking.findMany.mockResolvedValue([
+        {
+          id: 10,
+          uid: "guest-booking-1",
+          startTime: startOfTomorrow.set("hour", 14).toDate(),
+          endTime: startOfTomorrow.set("hour", 15).toDate(),
+          title: "Guest's existing meeting",
+          status: BookingStatus.ACCEPTED,
+        },
+      ]);
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      expect(result.calComUserCount).toBe(1);
+      expect(result.totalAttendeeCount).toBe(1);
+      expect(result.busyTimes).toHaveLength(1);
+      expect(result.busyTimes[0]).toMatchObject({
+        title: "Guest's existing meeting",
+        source: "guest-booking-guest-booking-1",
+      });
+    });
+
+    it("should find Cal.com user by verified secondary email", async () => {
+      const secondaryEmail = "secondary@company.com";
+      const primaryEmail = "primary@cal.com";
+      const guestUserId = 100;
+
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [{ email: secondaryEmail, name: "Guest User", timeZone: "UTC" }],
+      });
+
+      // Not found by primary email
+      mockPrisma.user.findMany.mockResolvedValue([]);
+
+      // Found by secondary email
+      mockPrisma.secondaryEmail.findMany.mockResolvedValue([
+        {
+          user: { id: guestUserId, email: primaryEmail },
+        },
+      ]);
+
+      mockPrisma.booking.findMany.mockResolvedValue([]);
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      expect(result.calComUserCount).toBe(1);
+      expect(result.totalAttendeeCount).toBe(1);
+      expect(result.busyTimes).toHaveLength(0);
+    });
+
+    it("should include PENDING bookings as busy times", async () => {
+      const guestUserId = 100;
+
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [{ email: "guest@cal.com", name: "Guest", timeZone: "UTC" }],
+      });
+
+      mockPrisma.user.findMany.mockResolvedValue([{ id: guestUserId, email: "guest@cal.com" }]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+
+      mockPrisma.booking.findMany.mockResolvedValue([
+        {
+          id: 10,
+          uid: "pending-booking",
+          startTime: startOfTomorrow.set("hour", 10).toDate(),
+          endTime: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Pending meeting",
+          status: BookingStatus.PENDING,
+        },
+        {
+          id: 11,
+          uid: "accepted-booking",
+          startTime: startOfTomorrow.set("hour", 14).toDate(),
+          endTime: startOfTomorrow.set("hour", 15).toDate(),
+          title: "Accepted meeting",
+          status: BookingStatus.ACCEPTED,
+        },
+      ]);
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      expect(result.busyTimes).toHaveLength(2);
+      // Verify the query includes both PENDING and ACCEPTED
+      expect(mockPrisma.booking.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                status: {
+                  in: [BookingStatus.ACCEPTED, BookingStatus.PENDING],
+                },
+              }),
+            ]),
+          }),
+        })
+      );
+    });
+
+    it("should exclude the booking being rescheduled from busy times", async () => {
+      const rescheduleUid = "booking-being-rescheduled";
+      const guestUserId = 100;
+
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [{ email: "guest@cal.com", name: "Guest", timeZone: "UTC" }],
+      });
+
+      mockPrisma.user.findMany.mockResolvedValue([{ id: guestUserId, email: "guest@cal.com" }]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      mockPrisma.booking.findMany.mockResolvedValue([]);
+
+      await service.getGuestBusyTimes({
+        rescheduleUid,
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      // Verify the rescheduleUid is excluded from the query
+      expect(mockPrisma.booking.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                uid: {
+                  not: rescheduleUid,
+                },
+              }),
+            ]),
+          }),
+        })
+      );
+    });
+
+    it("should handle multiple attendees - some Cal.com users, some not", async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [
+          { email: "caluser1@cal.com", name: "Cal User 1", timeZone: "UTC" },
+          { email: "external@gmail.com", name: "External User", timeZone: "UTC" },
+          { email: "caluser2@cal.com", name: "Cal User 2", timeZone: "UTC" },
+        ],
+      });
+
+      mockPrisma.user.findMany.mockResolvedValue([
+        { id: 100, email: "caluser1@cal.com" },
+        { id: 101, email: "caluser2@cal.com" },
+      ]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+
+      // Set up bookings for each user
+      let callCount = 0;
+      mockPrisma.booking.findMany.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve([
+            {
+              id: 10,
+              uid: "user1-booking",
+              startTime: startOfTomorrow.set("hour", 10).toDate(),
+              endTime: startOfTomorrow.set("hour", 11).toDate(),
+              title: "User 1 meeting",
+              status: BookingStatus.ACCEPTED,
+            },
+          ]);
+        }
+        return Promise.resolve([
+          {
+            id: 11,
+            uid: "user2-booking",
+            startTime: startOfTomorrow.set("hour", 14).toDate(),
+            endTime: startOfTomorrow.set("hour", 15).toDate(),
+            title: "User 2 meeting",
+            status: BookingStatus.ACCEPTED,
+          },
+        ]);
+      });
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      expect(result.calComUserCount).toBe(2);
+      expect(result.totalAttendeeCount).toBe(3);
+      expect(result.busyTimes).toHaveLength(2);
+    });
+
+    it("should deduplicate users found by both primary and secondary email", async () => {
+      const userId = 100;
+      const primaryEmail = "user@cal.com";
+      const secondaryEmail = "user.work@company.com";
+
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [
+          { email: primaryEmail, name: "User Primary", timeZone: "UTC" },
+          { email: secondaryEmail, name: "User Secondary", timeZone: "UTC" },
+        ],
+      });
+
+      // Found by primary email
+      mockPrisma.user.findMany.mockResolvedValue([{ id: userId, email: primaryEmail }]);
+
+      // Also found by secondary email (same user)
+      mockPrisma.secondaryEmail.findMany.mockResolvedValue([
+        {
+          user: { id: userId, email: primaryEmail },
+        },
+      ]);
+
+      mockPrisma.booking.findMany.mockResolvedValue([]);
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      // Should only count the user once
+      expect(result.calComUserCount).toBe(1);
+      expect(result.totalAttendeeCount).toBe(2);
+
+      // Should only query bookings once for this user
+      expect(mockPrisma.booking.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it("should work with ROUND_ROBIN scheduling type", async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [{ email: "guest@cal.com", name: "Guest", timeZone: "UTC" }],
+      });
+
+      mockPrisma.user.findMany.mockResolvedValue([{ id: 100, email: "guest@cal.com" }]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      mockPrisma.booking.findMany.mockResolvedValue([
+        {
+          id: 10,
+          uid: "booking-1",
+          startTime: startOfTomorrow.set("hour", 10).toDate(),
+          endTime: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Meeting",
+          status: BookingStatus.ACCEPTED,
+        },
+      ]);
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: SchedulingType.ROUND_ROBIN,
+      });
+
+      expect(result.busyTimes).toHaveLength(1);
+    });
+
+    it("should fail gracefully on database errors", async () => {
+      mockPrisma.booking.findUnique.mockRejectedValue(new Error("Database connection failed"));
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      // Should return empty result, not throw
+      expect(result).toEqual({
+        busyTimes: [],
+        calComUserCount: 0,
+        totalAttendeeCount: 0,
+      });
+    });
+
+    it("should find bookings where guest is the owner", async () => {
+      const guestUserId = 100;
+
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [{ email: "guest@cal.com", name: "Guest", timeZone: "UTC" }],
+      });
+
+      mockPrisma.user.findMany.mockResolvedValue([{ id: guestUserId, email: "guest@cal.com" }]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      mockPrisma.booking.findMany.mockResolvedValue([]);
+
+      await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      // Verify query checks for both userId AND attendee email
+      expect(mockPrisma.booking.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                OR: [
+                  { userId: guestUserId },
+                  expect.objectContaining({
+                    attendees: expect.anything(),
+                  }),
+                ],
+              }),
+            ]),
+          }),
+        })
+      );
+    });
+
+    it("should handle null scheduling type (personal event)", async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 1,
+        attendees: [{ email: "guest@cal.com", name: "Guest", timeZone: "UTC" }],
+      });
+
+      mockPrisma.user.findMany.mockResolvedValue([{ id: 100, email: "guest@cal.com" }]);
+      mockPrisma.secondaryEmail.findMany.mockResolvedValue([]);
+      mockPrisma.booking.findMany.mockResolvedValue([]);
+
+      const result = await service.getGuestBusyTimes({
+        rescheduleUid: "test-uid",
+        startTime: startOfTomorrow.toDate(),
+        endTime: endOfTomorrow.toDate(),
+        schedulingType: null,
+      });
+
+      // Should process normally, not skip
+      expect(mockPrisma.booking.findUnique).toHaveBeenCalled();
+      expect(result.calComUserCount).toBe(1);
+    });
+  });
+});

--- a/packages/features/busyTimes/services/getGuestBusyTimes.test.ts
+++ b/packages/features/busyTimes/services/getGuestBusyTimes.test.ts
@@ -1,8 +1,6 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
-
 import dayjs from "@calcom/dayjs";
 import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
-
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GuestBusyTimesService, type IGuestBusyTimesService } from "./getGuestBusyTimes";
 
 // Mock Prisma client
@@ -162,20 +160,24 @@ describe("GuestBusyTimesService", () => {
         attendees: [{ email: secondaryEmail, name: "Guest User", timeZone: "UTC" }],
       });
 
-      // Not found by primary email
+      // Found by secondary email lookup (not by primary - user's primary email is different)
       mockPrisma.user.findMany.mockResolvedValue([]);
 
-      // Found by secondary email (first call), then fetch all verified secondaries (second call)
+      // Found by secondary email (first call to secondaryEmail.findMany)
+      // Second call fetches all verified secondaries for found users
       mockPrisma.secondaryEmail.findMany
         .mockResolvedValueOnce([
           {
             user: { id: guestUserId, email: primaryEmail },
+            email: secondaryEmail,
+            emailVerified: new Date(),
           },
         ])
         .mockResolvedValueOnce([
           {
             userId: guestUserId,
             email: secondaryEmail,
+            emailVerified: new Date(),
           },
         ]);
 

--- a/packages/features/busyTimes/services/getGuestBusyTimes.ts
+++ b/packages/features/busyTimes/services/getGuestBusyTimes.ts
@@ -1,4 +1,3 @@
-import dayjs from "@calcom/dayjs";
 import logger from "@calcom/lib/logger";
 import type { PrismaClient } from "@calcom/prisma";
 import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
@@ -262,7 +261,7 @@ export class GuestBusyTimesService {
 
     // Build map of userId -> all verified emails
     const userEmailsMap = new Map<number, string[]>();
-    for (const user of uniqueUsersMap.values()) {
+    for (const user of Array.from(uniqueUsersMap.values())) {
       userEmailsMap.set(user.id, [user.email]); // Start with primary email
     }
 

--- a/packages/features/busyTimes/services/getGuestBusyTimes.ts
+++ b/packages/features/busyTimes/services/getGuestBusyTimes.ts
@@ -21,6 +21,8 @@ export interface BookingAttendee {
 interface CalComUser {
   id: number;
   email: string;
+  /** All verified emails for this user (primary + verified secondaries) */
+  allEmails: string[];
 }
 
 /**
@@ -126,7 +128,7 @@ export class GuestBusyTimesService {
       for (const user of calComUsers) {
         const userBusyTimes = await this.getUserBookingBusyTimes({
           userId: user.id,
-          userEmail: user.email,
+          userEmails: user.allEmails,
           startTime,
           endTime,
           excludeBookingUid: rescheduleUid,
@@ -144,7 +146,11 @@ export class GuestBusyTimesService {
       };
     } catch (error) {
       // Fail gracefully - never block rescheduling on errors
-      log.error("Error fetching guest busy times, failing open", { error, rescheduleUid });
+      log.error("Error fetching guest busy times, failing open", {
+        errorName: error instanceof Error ? error.name : "UnknownError",
+        errorMessage: error instanceof Error ? error.message : String(error),
+        rescheduleUid,
+      });
       return {
         busyTimes: [],
         calComUserCount: 0,
@@ -178,7 +184,7 @@ export class GuestBusyTimesService {
 
   /**
    * Finds Cal.com users among the attendees using case-insensitive email matching.
-   * Also checks secondary verified emails.
+   * Also checks secondary verified emails and returns all verified emails for each user.
    */
   private async findCalComUsersFromAttendees(attendees: BookingAttendee[]): Promise<CalComUser[]> {
     const attendeeEmails = attendees.map((a) => a.email.toLowerCase());
@@ -201,7 +207,7 @@ export class GuestBusyTimesService {
     const unmatchedEmails = attendeeEmails.filter((email) => !foundPrimaryEmails.has(email));
 
     // Query 2: Find users by verified secondary email for unmatched emails
-    let usersBySecondaryEmail: CalComUser[] = [];
+    let usersBySecondaryEmail: { id: number; email: string }[] = [];
 
     if (unmatchedEmails.length > 0) {
       const secondaryEmailMatches = await this.dependencies.prisma.secondaryEmail.findMany({
@@ -229,34 +235,70 @@ export class GuestBusyTimesService {
 
     // Combine and deduplicate by user ID
     const allUsers = [...usersByPrimaryEmail, ...usersBySecondaryEmail];
-    const uniqueUsers = new Map<number, CalComUser>();
+    const uniqueUsersMap = new Map<number, { id: number; email: string }>();
 
     for (const user of allUsers) {
-      if (!uniqueUsers.has(user.id)) {
-        uniqueUsers.set(user.id, user);
+      if (!uniqueUsersMap.has(user.id)) {
+        uniqueUsersMap.set(user.id, user);
       }
     }
 
-    return Array.from(uniqueUsers.values());
+    // Query 3: For each unique user, fetch all their verified emails (primary + verified secondaries)
+    const userIds = Array.from(uniqueUsersMap.keys());
+    const allSecondaryEmails = await this.dependencies.prisma.secondaryEmail.findMany({
+      where: {
+        userId: {
+          in: userIds,
+        },
+        emailVerified: {
+          not: null,
+        },
+      },
+      select: {
+        userId: true,
+        email: true,
+      },
+    });
+
+    // Build map of userId -> all verified emails
+    const userEmailsMap = new Map<number, string[]>();
+    for (const user of uniqueUsersMap.values()) {
+      userEmailsMap.set(user.id, [user.email]); // Start with primary email
+    }
+
+    for (const secondaryEmail of allSecondaryEmails) {
+      const emails = userEmailsMap.get(secondaryEmail.userId);
+      if (emails) {
+        emails.push(secondaryEmail.email);
+      }
+    }
+
+    // Build final CalComUser array with all emails
+    return Array.from(uniqueUsersMap.values()).map((user) => ({
+      id: user.id,
+      email: user.email,
+      allEmails: userEmailsMap.get(user.id) || [user.email],
+    }));
   }
 
   /**
    * Fetches busy times from a user's bookings.
    * Includes both ACCEPTED and PENDING bookings.
    * Excludes the booking being rescheduled.
+   * Checks against all verified emails (primary + verified secondaries).
    */
   private async getUserBookingBusyTimes(params: {
     userId: number;
-    userEmail: string;
+    userEmails: string[];
     startTime: Date;
     endTime: Date;
     excludeBookingUid: string;
   }): Promise<EventBusyDetails[]> {
-    const { userId, userEmail, startTime, endTime, excludeBookingUid } = params;
+    const { userId, userEmails, startTime, endTime, excludeBookingUid } = params;
 
     // Find all bookings where the user is either:
     // 1. The owner (userId matches)
-    // 2. An attendee (email matches in attendees)
+    // 2. An attendee (any of their emails match in attendees)
     const bookings = await this.dependencies.prisma.booking.findMany({
       where: {
         AND: [
@@ -287,7 +329,7 @@ export class GuestBusyTimesService {
                 attendees: {
                   some: {
                     email: {
-                      equals: userEmail,
+                      in: userEmails, // Check against all verified emails
                       mode: "insensitive",
                     },
                   },

--- a/packages/features/busyTimes/services/getGuestBusyTimes.ts
+++ b/packages/features/busyTimes/services/getGuestBusyTimes.ts
@@ -1,0 +1,324 @@
+import dayjs from "@calcom/dayjs";
+import logger from "@calcom/lib/logger";
+import type { PrismaClient } from "@calcom/prisma";
+import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
+import type { EventBusyDetails } from "@calcom/types/Calendar";
+
+const log = logger.getSubLogger({ prefix: ["[getGuestBusyTimes]"] });
+
+/**
+ * Attendee information from the original booking
+ */
+export interface BookingAttendee {
+  email: string;
+  name: string | null;
+  timeZone: string;
+}
+
+/**
+ * Cal.com user found from attendee email lookup
+ */
+interface CalComUser {
+  id: number;
+  email: string;
+}
+
+/**
+ * Parameters for fetching guest busy times
+ */
+export interface GetGuestBusyTimesParams {
+  /** UID of the booking being rescheduled */
+  rescheduleUid: string;
+  /** Start of the date range to check */
+  startTime: Date;
+  /** End of the date range to check */
+  endTime: Date;
+  /** Scheduling type of the event being rescheduled */
+  schedulingType: SchedulingType | null;
+}
+
+/**
+ * Result from guest busy times lookup
+ */
+export interface GuestBusyTimesResult {
+  /** Combined busy times from all Cal.com user guests */
+  busyTimes: EventBusyDetails[];
+  /** Number of attendees who are Cal.com users */
+  calComUserCount: number;
+  /** Total number of attendees in the booking */
+  totalAttendeeCount: number;
+}
+
+export interface IGuestBusyTimesService {
+  prisma: PrismaClient;
+}
+
+/**
+ * Service for fetching busy times of guests (attendees) when rescheduling a booking.
+ *
+ * This is used to ensure that when a host reschedules a booking, they can only
+ * select time slots where the guest (if they're a Cal.com user) is also available.
+ *
+ * Key behaviors:
+ * - Only applies when host reschedules (not attendee reschedule)
+ * - Checks both ACCEPTED and PENDING bookings as busy
+ * - Excludes the current booking being rescheduled
+ * - Uses case-insensitive email matching
+ * - Supports secondary/verified emails
+ * - Skips for COLLECTIVE events (already coordinated)
+ * - Fails gracefully (never blocks rescheduling on errors)
+ */
+export class GuestBusyTimesService {
+  constructor(private readonly dependencies: IGuestBusyTimesService) {}
+
+  /**
+   * Fetches busy times for all Cal.com user guests of a booking being rescheduled.
+   *
+   * @param params - Parameters including rescheduleUid and date range
+   * @returns Combined busy times from all Cal.com user guests, or empty array on error
+   */
+  async getGuestBusyTimes(params: GetGuestBusyTimesParams): Promise<GuestBusyTimesResult> {
+    const { rescheduleUid, startTime, endTime, schedulingType } = params;
+
+    // Skip for COLLECTIVE events - they already coordinate multiple hosts
+    if (schedulingType === SchedulingType.COLLECTIVE) {
+      log.debug("Skipping guest availability check for COLLECTIVE event");
+      return {
+        busyTimes: [],
+        calComUserCount: 0,
+        totalAttendeeCount: 0,
+      };
+    }
+
+    try {
+      // Step 1: Get the booking and its attendees
+      const booking = await this.getBookingWithAttendees(rescheduleUid);
+
+      if (!booking || !booking.attendees || booking.attendees.length === 0) {
+        log.debug("No booking or attendees found for rescheduleUid", { rescheduleUid });
+        return {
+          busyTimes: [],
+          calComUserCount: 0,
+          totalAttendeeCount: 0,
+        };
+      }
+
+      const attendees = booking.attendees;
+      const totalAttendeeCount = attendees.length;
+
+      // Step 2: Find Cal.com users among attendees
+      const calComUsers = await this.findCalComUsersFromAttendees(attendees);
+
+      if (calComUsers.length === 0) {
+        log.debug("No Cal.com users found among attendees");
+        return {
+          busyTimes: [],
+          calComUserCount: 0,
+          totalAttendeeCount,
+        };
+      }
+
+      log.debug(`Found ${calComUsers.length} Cal.com user(s) among ${totalAttendeeCount} attendee(s)`);
+
+      // Step 3: Fetch busy times for each Cal.com user guest
+      const allBusyTimes: EventBusyDetails[] = [];
+
+      for (const user of calComUsers) {
+        const userBusyTimes = await this.getUserBookingBusyTimes({
+          userId: user.id,
+          userEmail: user.email,
+          startTime,
+          endTime,
+          excludeBookingUid: rescheduleUid,
+        });
+
+        allBusyTimes.push(...userBusyTimes);
+      }
+
+      log.debug(`Found ${allBusyTimes.length} busy time slot(s) from guest(s)`);
+
+      return {
+        busyTimes: allBusyTimes,
+        calComUserCount: calComUsers.length,
+        totalAttendeeCount,
+      };
+    } catch (error) {
+      // Fail gracefully - never block rescheduling on errors
+      log.error("Error fetching guest busy times, failing open", { error, rescheduleUid });
+      return {
+        busyTimes: [],
+        calComUserCount: 0,
+        totalAttendeeCount: 0,
+      };
+    }
+  }
+
+  /**
+   * Fetches the booking and its attendees by UID.
+   */
+  private async getBookingWithAttendees(
+    bookingUid: string
+  ): Promise<{ id: number; attendees: BookingAttendee[] } | null> {
+    const booking = await this.dependencies.prisma.booking.findUnique({
+      where: { uid: bookingUid },
+      select: {
+        id: true,
+        attendees: {
+          select: {
+            email: true,
+            name: true,
+            timeZone: true,
+          },
+        },
+      },
+    });
+
+    return booking;
+  }
+
+  /**
+   * Finds Cal.com users among the attendees using case-insensitive email matching.
+   * Also checks secondary verified emails.
+   */
+  private async findCalComUsersFromAttendees(attendees: BookingAttendee[]): Promise<CalComUser[]> {
+    const attendeeEmails = attendees.map((a) => a.email.toLowerCase());
+
+    // Query 1: Find users by primary email (case-insensitive)
+    const usersByPrimaryEmail = await this.dependencies.prisma.user.findMany({
+      where: {
+        email: {
+          in: attendeeEmails,
+          mode: "insensitive",
+        },
+      },
+      select: {
+        id: true,
+        email: true,
+      },
+    });
+
+    const foundPrimaryEmails = new Set(usersByPrimaryEmail.map((u) => u.email.toLowerCase()));
+    const unmatchedEmails = attendeeEmails.filter((email) => !foundPrimaryEmails.has(email));
+
+    // Query 2: Find users by verified secondary email for unmatched emails
+    let usersBySecondaryEmail: CalComUser[] = [];
+
+    if (unmatchedEmails.length > 0) {
+      const secondaryEmailMatches = await this.dependencies.prisma.secondaryEmail.findMany({
+        where: {
+          email: {
+            in: unmatchedEmails,
+            mode: "insensitive",
+          },
+          emailVerified: {
+            not: null, // Only verified secondary emails
+          },
+        },
+        select: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+            },
+          },
+        },
+      });
+
+      usersBySecondaryEmail = secondaryEmailMatches.map((match) => match.user);
+    }
+
+    // Combine and deduplicate by user ID
+    const allUsers = [...usersByPrimaryEmail, ...usersBySecondaryEmail];
+    const uniqueUsers = new Map<number, CalComUser>();
+
+    for (const user of allUsers) {
+      if (!uniqueUsers.has(user.id)) {
+        uniqueUsers.set(user.id, user);
+      }
+    }
+
+    return Array.from(uniqueUsers.values());
+  }
+
+  /**
+   * Fetches busy times from a user's bookings.
+   * Includes both ACCEPTED and PENDING bookings.
+   * Excludes the booking being rescheduled.
+   */
+  private async getUserBookingBusyTimes(params: {
+    userId: number;
+    userEmail: string;
+    startTime: Date;
+    endTime: Date;
+    excludeBookingUid: string;
+  }): Promise<EventBusyDetails[]> {
+    const { userId, userEmail, startTime, endTime, excludeBookingUid } = params;
+
+    // Find all bookings where the user is either:
+    // 1. The owner (userId matches)
+    // 2. An attendee (email matches in attendees)
+    const bookings = await this.dependencies.prisma.booking.findMany({
+      where: {
+        AND: [
+          {
+            uid: {
+              not: excludeBookingUid, // Exclude the booking being rescheduled
+            },
+          },
+          {
+            status: {
+              in: [BookingStatus.ACCEPTED, BookingStatus.PENDING], // Both accepted and pending
+            },
+          },
+          {
+            startTime: {
+              lt: endTime, // Booking starts before our end time
+            },
+          },
+          {
+            endTime: {
+              gt: startTime, // Booking ends after our start time
+            },
+          },
+          {
+            OR: [
+              { userId }, // User owns the booking
+              {
+                attendees: {
+                  some: {
+                    email: {
+                      equals: userEmail,
+                      mode: "insensitive",
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      select: {
+        id: true,
+        uid: true,
+        startTime: true,
+        endTime: true,
+        title: true,
+        status: true,
+      },
+    });
+
+    return bookings.map((booking) => ({
+      start: booking.startTime,
+      end: booking.endTime,
+      title: booking.title || "Busy",
+      source: `guest-booking-${booking.uid}`,
+    }));
+  }
+}
+
+/**
+ * Creates an instance of GuestBusyTimesService with the given Prisma client.
+ */
+export function createGuestBusyTimesService(prisma: PrismaClient): GuestBusyTimesService {
+  return new GuestBusyTimesService({ prisma });
+}

--- a/packages/features/di/containers/AvailableSlots.ts
+++ b/packages/features/di/containers/AvailableSlots.ts
@@ -7,6 +7,7 @@ import { createContainer, type Container } from "../di";
 import { availableSlotsModule } from "../modules/AvailableSlots";
 import { bookingRepositoryModule } from "../modules/Booking";
 import { busyTimesModule } from "../modules/BusyTimes";
+import { guestBusyTimesModule } from "../modules/GuestBusyTimes";
 import { checkBookingLimitsModule } from "../modules/CheckBookingLimits";
 import { eventTypeRepositoryModule } from "../modules/EventType";
 import { featuresRepositoryModule } from "../modules/FeaturesRepository";
@@ -41,7 +42,7 @@ container.load(DI_TOKENS.CHECK_BOOKING_LIMITS_SERVICE_MODULE, checkBookingLimits
 container.load(DI_TOKENS.AVAILABLE_SLOTS_SERVICE_MODULE, availableSlotsModule);
 container.load(DI_TOKENS.GET_USER_AVAILABILITY_SERVICE_MODULE, getUserAvailabilityModule);
 container.load(DI_TOKENS.BUSY_TIMES_SERVICE_MODULE, busyTimesModule);
-container.load(DI_TOKENS.BUSY_TIMES_SERVICE_MODULE, busyTimesModule);
+container.load(DI_TOKENS.GUEST_BUSY_TIMES_SERVICE_MODULE, guestBusyTimesModule);
 container.load(DI_TOKENS.FILTER_HOSTS_SERVICE_MODULE, filterHostsModule);
 container.load(DI_TOKENS.QUALIFIED_HOSTS_SERVICE_MODULE, qualifiedHostsModule);
 container.load(DI_TOKENS.NO_SLOTS_NOTIFICATION_SERVICE_MODULE, noSlotsNotificationModule);

--- a/packages/features/di/modules/AvailableSlots.ts
+++ b/packages/features/di/modules/AvailableSlots.ts
@@ -18,6 +18,7 @@ availableSlotsModule.bind(DI_TOKENS.AVAILABLE_SLOTS_SERVICE).toClass(AvailableSl
   checkBookingLimitsService: DI_TOKENS.CHECK_BOOKING_LIMITS_SERVICE,
   userAvailabilityService: DI_TOKENS.GET_USER_AVAILABILITY_SERVICE,
   busyTimesService: DI_TOKENS.BUSY_TIMES_SERVICE,
+  guestBusyTimesService: DI_TOKENS.GUEST_BUSY_TIMES_SERVICE,
   featuresRepo: DI_TOKENS.FEATURES_REPOSITORY,
   qualifiedHostsService: DI_TOKENS.QUALIFIED_HOSTS_SERVICE,
   noSlotsNotificationService: DI_TOKENS.NO_SLOTS_NOTIFICATION_SERVICE,

--- a/packages/features/di/modules/GuestBusyTimes.ts
+++ b/packages/features/di/modules/GuestBusyTimes.ts
@@ -1,0 +1,10 @@
+import type { IGuestBusyTimesService } from "@calcom/features/busyTimes/services/getGuestBusyTimes";
+import { GuestBusyTimesService } from "@calcom/features/busyTimes/services/getGuestBusyTimes";
+
+import { createModule } from "../di";
+import { DI_TOKENS } from "../tokens";
+
+export const guestBusyTimesModule = createModule();
+guestBusyTimesModule.bind(DI_TOKENS.GUEST_BUSY_TIMES_SERVICE).toClass(GuestBusyTimesService, {
+  prisma: DI_TOKENS.PRISMA_CLIENT,
+} satisfies Record<keyof IGuestBusyTimesService, symbol>);

--- a/packages/features/di/tokens.ts
+++ b/packages/features/di/tokens.ts
@@ -50,6 +50,8 @@ export const DI_TOKENS = {
   GET_USER_AVAILABILITY_SERVICE_MODULE: Symbol("GetUserAvailabilityModule"),
   BUSY_TIMES_SERVICE: Symbol("BusyTimesService"),
   BUSY_TIMES_SERVICE_MODULE: Symbol("BusyTimesServiceModule"),
+  GUEST_BUSY_TIMES_SERVICE: Symbol("GuestBusyTimesService"),
+  GUEST_BUSY_TIMES_SERVICE_MODULE: Symbol("GuestBusyTimesServiceModule"),
   QUALIFIED_HOSTS_SERVICE: Symbol("QualifiedHostsService"),
   QUALIFIED_HOSTS_SERVICE_MODULE: Symbol("QualifiedHostsServiceModule"),
   FILTER_HOSTS_SERVICE: Symbol("FilterHostsService"),

--- a/packages/platform/libraries/slots.ts
+++ b/packages/platform/libraries/slots.ts
@@ -1,6 +1,7 @@
 import { FilterHostsService } from "@calcom/features/bookings/lib/host-filtering/filterHostsBySameRoundRobinHost";
 import { QualifiedHostsService } from "@calcom/features/bookings/lib/host-filtering/findQualifiedHostsWithDelegationCredentials";
 import { BusyTimesService } from "@calcom/features/busyTimes/services/getBusyTimes";
+import { GuestBusyTimesService } from "@calcom/features/busyTimes/services/getGuestBusyTimes";
 import { validateRoundRobinSlotAvailability } from "@calcom/features/ee/round-robin/utils/validateRoundRobinSlotAvailability";
 import { NoSlotsNotificationService } from "@calcom/features/slots/handleNotificationWhenNoSlots";
 import { AvailableSlotsService } from "@calcom/trpc/server/routers/viewer/slots/util";
@@ -8,6 +9,8 @@ import { AvailableSlotsService } from "@calcom/trpc/server/routers/viewer/slots/
 export { AvailableSlotsService };
 
 export { BusyTimesService };
+
+export { GuestBusyTimesService };
 
 export { QualifiedHostsService };
 

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1536,10 +1536,14 @@ export class AvailableSlotsService {
         }
       } catch (error) {
         // Fail gracefully - don't block rescheduling if guest availability check fails
-        loggerWithEventDetails.error("Failed to check guest availability during reschedule, continuing with host slots only", {
-          error,
-          rescheduleUid: input.rescheduleUid,
-        });
+        loggerWithEventDetails.error(
+          "Failed to check guest availability during reschedule, continuing with host slots only",
+          {
+            errorName: error instanceof Error ? error.name : "UnknownError",
+            errorMessage: error instanceof Error ? error.message : String(error),
+            rescheduleUid: input.rescheduleUid,
+          }
+        );
       }
     }
 

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -15,6 +15,7 @@ import type { QualifiedHostsService } from "@calcom/features/bookings/lib/host-f
 import { isEventTypeLoggingEnabled } from "@calcom/features/bookings/lib/isEventTypeLoggingEnabled";
 import type { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
 import type { BusyTimesService } from "@calcom/features/busyTimes/services/getBusyTimes";
+import type { GuestBusyTimesService } from "@calcom/features/busyTimes/services/getGuestBusyTimes";
 import type { getBusyTimesService } from "@calcom/features/di/containers/BusyTimes";
 import type { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { getDefaultEvent } from "@calcom/features/eventtypes/lib/defaultEvents";
@@ -83,6 +84,7 @@ export interface IAvailableSlotsService {
   checkBookingLimitsService: CheckBookingLimitsService;
   userAvailabilityService: UserAvailabilityService;
   busyTimesService: BusyTimesService;
+  guestBusyTimesService: GuestBusyTimesService;
   redisClient: IRedisService;
   featuresRepo: FeaturesRepository;
   qualifiedHostsService: QualifiedHostsService;
@@ -1497,6 +1499,48 @@ export class AvailableSlotsService {
             return !!item;
           }
         );
+    }
+
+    // Filter out slots where guests (Cal.com users) are busy during reschedule
+    // This only applies when host reschedules - we check if attendees are Cal.com users
+    // and filter out slots that conflict with their bookings
+    if (input.rescheduleUid) {
+      try {
+        const guestBusyTimesResult = await this.dependencies.guestBusyTimesService.getGuestBusyTimes({
+          rescheduleUid: input.rescheduleUid,
+          startTime: startTime.toDate(),
+          endTime: endTime.toDate(),
+          schedulingType: eventType.schedulingType,
+        });
+
+        if (guestBusyTimesResult.busyTimes.length > 0) {
+          loggerWithEventDetails.debug(
+            `Filtering ${guestBusyTimesResult.busyTimes.length} guest busy time(s) from ${guestBusyTimesResult.calComUserCount} Cal.com user guest(s)`
+          );
+
+          availableTimeSlots = availableTimeSlots.filter((slot) => {
+            const slotStart = slot.time;
+            const slotEnd = slot.time.add(input.duration || eventType.length, "minute");
+
+            // Check if slot overlaps with any guest busy time
+            const hasConflict = guestBusyTimesResult.busyTimes.some((busy) => {
+              const busyStart = dayjs(busy.start);
+              const busyEnd = dayjs(busy.end);
+
+              // Overlap exists if slot starts before busy ends AND slot ends after busy starts
+              return slotStart.isBefore(busyEnd) && slotEnd.isAfter(busyStart);
+            });
+
+            return !hasConflict;
+          });
+        }
+      } catch (error) {
+        // Fail gracefully - don't block rescheduling if guest availability check fails
+        loggerWithEventDetails.error("Failed to check guest availability during reschedule, continuing with host slots only", {
+          error,
+          rescheduleUid: input.rescheduleUid,
+        });
+      }
     }
 
     // fr-CA uses YYYY-MM-DD

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -9,6 +9,7 @@ import type {
   GetAvailabilityUser,
   UserAvailabilityService,
 } from "@calcom/features/availability/lib/getUserAvailability";
+import type { IGetAvailableSlots } from "@calcom/features/bookings/Booker/hooks/useAvailableTimeSlots";
 import type { CheckBookingLimitsService } from "@calcom/features/bookings/lib/checkBookingLimits";
 import { checkForConflicts } from "@calcom/features/bookings/lib/conflictChecker/checkForConflicts";
 import type { QualifiedHostsService } from "@calcom/features/bookings/lib/host-filtering/findQualifiedHostsWithDelegationCredentials";
@@ -17,12 +18,14 @@ import type { BookingRepository } from "@calcom/features/bookings/repositories/B
 import type { BusyTimesService } from "@calcom/features/busyTimes/services/getBusyTimes";
 import type { GuestBusyTimesService } from "@calcom/features/busyTimes/services/getGuestBusyTimes";
 import type { getBusyTimesService } from "@calcom/features/di/containers/BusyTimes";
+import type { OrgMembershipLookup } from "@calcom/features/di/modules/OrgMembershipLookup";
 import type { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { getDefaultEvent } from "@calcom/features/eventtypes/lib/defaultEvents";
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import type { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import type { PrismaOOORepository } from "@calcom/features/ooo/repositories/PrismaOOORepository";
 import type { IRedisService } from "@calcom/features/redis/IRedisService";
+import type { RoutingFormResponseRepository } from "@calcom/features/routing-forms/repositories/RoutingFormResponseRepository";
 import { buildDateRanges } from "@calcom/features/schedules/lib/date-ranges";
 import getSlots from "@calcom/features/schedules/lib/slots";
 import type { ScheduleRepository } from "@calcom/features/schedules/repositories/ScheduleRepository";
@@ -49,7 +52,6 @@ import {
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { withReporting } from "@calcom/lib/sentryWrapper";
-import type { RoutingFormResponseRepository } from "@calcom/features/routing-forms/repositories/RoutingFormResponseRepository";
 import { PeriodType, SchedulingType } from "@calcom/prisma/enums";
 import type { CalendarFetchMode, EventBusyDate, EventBusyDetails } from "@calcom/types/Calendar";
 import type { CredentialForCalendarService } from "@calcom/types/Credential";
@@ -58,8 +60,6 @@ import type { Logger } from "tslog";
 import { v4 as uuid } from "uuid";
 import type { TGetScheduleInputSchema } from "./getSchedule.schema";
 import type { GetScheduleOptions } from "./types";
-import type { OrgMembershipLookup } from "@calcom/features/di/modules/OrgMembershipLookup";
-import type { IGetAvailableSlots } from "@calcom/features/bookings/Booker/hooks/useAvailableTimeSlots";
 
 const log = logger.getSubLogger({ prefix: ["[slots/util]"] });
 const DEFAULT_SLOTS_CACHE_TTL = 2000;
@@ -84,7 +84,7 @@ export interface IAvailableSlotsService {
   checkBookingLimitsService: CheckBookingLimitsService;
   userAvailabilityService: UserAvailabilityService;
   busyTimesService: BusyTimesService;
-  guestBusyTimesService: GuestBusyTimesService;
+  guestBusyTimesService?: GuestBusyTimesService;
   redisClient: IRedisService;
   featuresRepo: FeaturesRepository;
   qualifiedHostsService: QualifiedHostsService;
@@ -1501,10 +1501,10 @@ export class AvailableSlotsService {
         );
     }
 
-    // Filter out slots where guests (Cal.com users) are busy during reschedule
-    // This only applies when host reschedules - we check if attendees are Cal.com users
-    // and filter out slots that conflict with their bookings
-    if (input.rescheduleUid) {
+    // Filter out slots where guests (Cal.com users) are busy during reschedule.
+    // This runs whenever a reschedule UID is present; we check whether attendees are
+    // Cal.com users and filter out slots that conflict with their bookings.
+    if (input.rescheduleUid && this.dependencies.guestBusyTimesService) {
       try {
         const guestBusyTimesResult = await this.dependencies.guestBusyTimesService.getGuestBusyTimes({
           rescheduleUid: input.rescheduleUid,
@@ -1518,17 +1518,19 @@ export class AvailableSlotsService {
             `Filtering ${guestBusyTimesResult.busyTimes.length} guest busy time(s) from ${guestBusyTimesResult.calComUserCount} Cal.com user guest(s)`
           );
 
+          // Pre-normalize busy times to milliseconds for efficient comparisons
+          const guestBusyTimeRanges = guestBusyTimesResult.busyTimes.map((busy) => ({
+            startMs: dayjs(busy.start).valueOf(),
+            endMs: dayjs(busy.end).valueOf(),
+          }));
+
           availableTimeSlots = availableTimeSlots.filter((slot) => {
-            const slotStart = slot.time;
-            const slotEnd = slot.time.add(input.duration || eventType.length, "minute");
+            const slotStartMs = slot.time.valueOf();
+            const slotEndMs = slot.time.add(input.duration || eventType.length, "minute").valueOf();
 
-            // Check if slot overlaps with any guest busy time
-            const hasConflict = guestBusyTimesResult.busyTimes.some((busy) => {
-              const busyStart = dayjs(busy.start);
-              const busyEnd = dayjs(busy.end);
-
-              // Overlap exists if slot starts before busy ends AND slot ends after busy starts
-              return slotStart.isBefore(busyEnd) && slotEnd.isAfter(busyStart);
+            // Overlap exists if slot starts before busy ends AND slot ends after busy starts
+            const hasConflict = guestBusyTimeRanges.some((busy) => {
+              return slotStartMs < busy.endMs && slotEndMs > busy.startMs;
             });
 
             return !hasConflict;


### PR DESCRIPTION
/claim #16378

Adds guest availability awareness to host-initiated rescheduling.

The system now intersects host availability with guest busy times (for Cal.com users), preventing invalid slot selection. Handles edge cases like pending bookings, secondary emails, and excludes the current booking.

Includes tests and integrates cleanly with the existing availability pipeline.