### PR TITLE
fix: correct Russian translation typo in booking form

### DIFF
--- a/packages/i18n/locales/ru/common.json
+++ b/packages/i18n/locales/ru/common.json
@@ -2859,7 +2859,7 @@
   "org_team_names_example_4": "например, технический отдел",
   "org_team_names_example_5": "например, отдел анализа данных",
   "org_max_team_warnings": "Позже можно добавить другие команды.",
-  "what_is_this_meeting_about": "Чему посвязена эта встреча?",
+  "what_is_this_meeting_about": "Чему посвящена эта встреча?",
   "add_to_team": "Добавить в команду",
   "remove_users_from_org": "Удалить пользователей из организации",
   "delegation_credential": "Делегированные учетные данные",


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the Russian localization key `what_is_this_meeting_about` in the booking form.

### Changes

* Updated incorrect translation:

  * `Чему посвязена эта встреча?`

* Corrected to:

  * `Чему посвящена эта встреча?`

* File modified:

  * `common.json`

### Issue

* Fixes #28716
* Fixes CAL-XXXX (if applicable)

### Motivation / Context

This fixes a localization bug affecting Russian users in the booking form, particularly when dynamic event titles are used (e.g., routing forms or dynamic event types).
The issue was a misspelling (`з` instead of `щ`) in the translated string.

### Testing

**Manual Testing**

1. Open a dynamic booking page (routing form event type).
2. Change language to Russian.
3. Verify the label displays:

   * ✅ `Чему посвящена эта встреча?`
   * ❌ Not `Чему посвязена эта встреча?`

**Local CI**

```bash
yarn type-check:ci --force
yarn biome check --write .
```

### Visual Demo

* Before: Shows incorrect phrase (`посвязена`)
* After: Shows corrected phrase (`посвящена`)

### Checklist

* [x] I have self-reviewed the code
* [x] Docs update not required (translation-only change)
* [x] CI checks passed locally
* [x] Small diff (<500 lines, <10 files)

### PR Checklist (Contributing Guide)

* [x] Branch name follows convention (`fix/i18n-russian-typo-booking-form`)
* [x] Conventional commit title used (`fix:`)
* [x] No secrets/API keys included
* [x] Linked relevant issues (`Fixes #...`)
