### PR TITLE
test: improve matchUserToMatchingOrg coverage

### DIFF
--- a/apps/web/lib/pages/auth/verify-email.test.ts
+++ b/apps/web/lib/pages/auth/verify-email.test.ts
@@ -56,6 +56,75 @@ describe("moveUserToMatchingOrg", () => {
       ],
     };
 
+    it("should always invite as MEMBER role, not an elevated role", async() => {
+      const org = {
+        id: "org123",
+        slug: "test-org",
+        requestedSlug: null
+      }
+
+      organizationScenarios.organizationRepository.findUniqueNonPlatformOrgsByMatchingAutoAcceptEmail.fakeReturnOrganization(
+        org,
+        { email }
+      )
+
+      await moveUserToMatchingOrg({ email })
+
+      const call = vi.mocked(inviteMembersWithNoInviterPermissionCheck).mock.calls[0][0]
+      expect(call.invitations[0].role).toBe(MembershipRole.MEMBER)
+    })
+
+    it("should pass inviterName as null", async () => {
+      const org = {
+        id: "org123",
+        slug: "test-org",
+        requestedSlug: null,
+      };
+      organizationScenarios.organizationRepository.findUniqueNonPlatformOrgsByMatchingAutoAcceptEmail.fakeReturnOrganization(
+        org,
+        { email }
+      );
+ 
+      await moveUserToMatchingOrg({ email });
+ 
+      const call = vi.mocked(inviteMembersWithNoInviterPermissionCheck).mock.calls[0][0];
+      expect(call.inviterName).toBeNull();
+    });
+
+    it("should pass creationSource as WEBAPP", async () => {
+      const org = {
+        id: "org123",
+        slug: "test-org",
+        requestedSlug: null,
+      };
+      organizationScenarios.organizationRepository.findUniqueNonPlatformOrgsByMatchingAutoAcceptEmail.fakeReturnOrganization(
+        org,
+        { email }
+      );
+ 
+      await moveUserToMatchingOrg({ email });
+ 
+      const call = vi.mocked(inviteMembersWithNoInviterPermissionCheck).mock.calls[0][0];
+      expect(call.creationSource).toBe(CreationSource.WEBAPP);
+    });
+
+    it("should pass exactly one invitation", async () => {
+      const org = {
+        id: "org123",
+        slug: "test-org",
+        requestedSlug: null,
+      };
+      organizationScenarios.organizationRepository.findUniqueNonPlatformOrgsByMatchingAutoAcceptEmail.fakeReturnOrganization(
+        org,
+        { email }
+      );
+ 
+      await moveUserToMatchingOrg({ email });
+ 
+      const call = vi.mocked(inviteMembersWithNoInviterPermissionCheck).mock.calls[0][0];
+      expect(call.invitations).toHaveLength(1);
+    });
+
     it("when organization has a slug and requestedSlug(slug is used)", async () => {
       const org = {
         id: "org123",
@@ -98,4 +167,23 @@ describe("moveUserToMatchingOrg", () => {
       });
     });
   });
+
+  describe("error handling", () => {
+    it("should propagate errors thrown by inviteMembersWithNoInviterPermissionCheck", async () => {
+      const org = {
+        id: "org123",
+        slug: "test-org",
+        requestedSlug: null,
+      };
+      organizationScenarios.organizationRepository.findUniqueNonPlatformOrgsByMatchingAutoAcceptEmail.fakeReturnOrganization(
+        org,
+        { email }
+      );
+ 
+      const error = new Error("Invite failed");
+      vi.mocked(inviteMembersWithNoInviterPermissionCheck).mockRejectedValue(error);
+ 
+      await expect(moveUserToMatchingOrg({ email })).rejects.toThrow("Invite failed");
+    });
+  })
 });


### PR DESCRIPTION
## What does this PR do?

This PR improves test coverage for `moveUserToMatchingOrg` in verify-email.ts (apps/web/lib/pages/auth) by completing the existing TODO and adding missing test scenarios for organization invitation flow.

#### Image Demo (if applicable):


<img width="731" height="50" alt="Screenshot from 2026-04-03 12-57-13" src="https://github.com/user-attachments/assets/6d8082de-62b2-4253-b9d3-fcf50263c9db" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
