### PR TITLE
feat: add Signal to conferencing category

### DIFF
--- a/packages/app-store/signal/config.json
+++ b/packages/app-store/signal/config.json
@@ -6,7 +6,7 @@
   "logo": "icon.svg",
   "url": "https://cal.com/",
   "variant": "messaging",
-  "categories": ["messaging"],
+  "categories": ["messaging","conferencing"],
   "publisher": "Cal.com, Inc.",
   "email": "support@cal.com",
   "description": "Schedule a chat with your guests or have a Signal Video call.",


### PR DESCRIPTION
## What does this PR do?

This PR correctly categorizes the **Signal** app within the "Conferencing" category in the App Store. Before this change, Signal was only listed as "Messaging," which made it difficult for users to discover it as a meeting location option for their bookings.

- **Objective**: Improve Signal’s discoverability and onboarding as a direct meeting integration.
- **Improved Workflow**: Categorizing it under "Conferencing" ensures it uses the conferencing-specific onboarding flow and appears correctly in the Event Type location selector.

Fixes #28723

## Visual Demo -

- Signal is now visible under the **Conferencing** category at `/apps/categories/conferencing`.
- Signal is now selectable under **Conferencing** in the "Add Location" modal for Event Types.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I have updated the developer docs (N/A).
- [x] I confirm manual verification has been performed.

## How should this be tested?

1.  **Metadata Verification**: Run `grep -A 10 "signal:" packages/app-store/apps.metadata.generated.ts` to ensure the registry was correctly updated.
2.  **Seeding**: Run `yarn workspace @calcom/prisma seed-app-store` to sync metadata to your local database.
3.  **UI Verification**:
    - Start the dev server (`yarn dev`).
    - Visit `http://localhost:3000/apps/categories/conferencing` and verify Signal is listed.
    - Check the location dropdown in an Event Type's settings.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
