### PR TITLE
feat(reschedule): check guest availability when host reschedules (#16378)

### DIFF
--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1568,7 +1568,10 @@ export class BookingRepository implements IBookingRepository {
                 some: { email: { in: userEmails } },
               },
               // Exclude bookings already owned by these users (avoid duplicates)
-              NOT: { userId: { in: userIds } },
+              OR: [
+                { userId: null },
+                { userId: { notIn: userIds } },
+              ],
             },
             select: { startTime: true, endTime: true },
           })

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1529,6 +1529,55 @@ export class BookingRepository implements IBookingRepository {
     });
   }
 
+  /**
+   * Fetches accepted bookings (owned or attended) for given user IDs within a date range.
+   * Used to check guest availability during reschedule slot filtering.
+   */
+  async findAcceptedBookingsForUserIdsBetween({
+    userIds,
+    userEmails,
+    startDate,
+    endDate,
+    excludeUid,
+  }: {
+    userIds: number[];
+    userEmails: string[];
+    startDate: Date;
+    endDate: Date;
+    excludeUid?: string;
+  }) {
+    if (userIds.length === 0) return [];
+
+    const sharedWhere = {
+      startTime: { lt: endDate },
+      endTime: { gt: startDate },
+      status: BookingStatus.ACCEPTED,
+      ...(excludeUid ? { uid: { not: excludeUid } } : {}),
+    };
+
+    const [ownedBookings, attendedBookings] = await Promise.all([
+      this.prismaClient.booking.findMany({
+        where: { ...sharedWhere, userId: { in: userIds } },
+        select: { startTime: true, endTime: true },
+      }),
+      userEmails.length > 0
+        ? this.prismaClient.booking.findMany({
+            where: {
+              ...sharedWhere,
+              attendees: {
+                some: { email: { in: userEmails } },
+              },
+              // Exclude bookings already owned by these users (avoid duplicates)
+              NOT: { userId: { in: userIds } },
+            },
+            select: { startTime: true, endTime: true },
+          })
+        : Promise.resolve([]),
+    ]);
+
+    return [...ownedBookings, ...attendedBookings];
+  }
+
   async getBookingForPaymentProcessing(bookingId: number) {
     return await this.prismaClient.booking.findUnique({
       where: {

--- a/packages/trpc/server/routers/viewer/slots/filterSlotsForGuestBusyTimes.ts
+++ b/packages/trpc/server/routers/viewer/slots/filterSlotsForGuestBusyTimes.ts
@@ -1,0 +1,30 @@
+import type dayjs from "@calcom/dayjs";
+
+export type GuestBusyInterval = { startTime: Date; endTime: Date };
+
+/**
+ * Filters available time slots by removing any that overlap with a guest user's
+ * existing bookings. Uses a half-open interval comparison:
+ *   conflict iff slotStart < bookingEnd && slotEnd > bookingStart
+ *
+ * @param slots             - Array of candidate time slots
+ * @param eventLengthMinutes - Duration of the event in minutes
+ * @param guestBusyBookings  - Busy intervals for guest Cal.com users
+ * @returns Slots that do not conflict with any guest busy interval
+ */
+export function filterSlotsForGuestBusyTimes(
+  slots: Array<{ time: dayjs.Dayjs }>,
+  eventLengthMinutes: number,
+  guestBusyBookings: GuestBusyInterval[]
+): Array<{ time: dayjs.Dayjs }> {
+  if (guestBusyBookings.length === 0) return slots;
+  return slots.filter((slot) => {
+    const slotStart = slot.time.valueOf();
+    const slotEnd = slotStart + eventLengthMinutes * 60 * 1000;
+    return !guestBusyBookings.some((booking) => {
+      const bookingStart = new Date(booking.startTime).valueOf();
+      const bookingEnd = new Date(booking.endTime).valueOf();
+      return slotStart < bookingEnd && slotEnd > bookingStart;
+    });
+  });
+}

--- a/packages/trpc/server/routers/viewer/slots/guestAvailability.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/guestAvailability.test.ts
@@ -7,30 +7,10 @@
  */
 import { describe, it, expect } from "vitest";
 import dayjs from "@calcom/dayjs";
-
-// ---------------------------------------------------------------------------
-// Pure helper that mirrors the slot-filtering logic added in util.ts
-// so we can unit-test it without spinning up the full service.
-// ---------------------------------------------------------------------------
-
-type BusyInterval = { startTime: Date; endTime: Date };
-
-function filterSlotsForGuestBusyTimes(
-  slots: Array<{ time: dayjs.Dayjs }>,
-  eventLengthMinutes: number,
-  guestBusyBookings: BusyInterval[]
-): Array<{ time: dayjs.Dayjs }> {
-  if (guestBusyBookings.length === 0) return slots;
-  return slots.filter((slot) => {
-    const slotStart = slot.time.valueOf();
-    const slotEnd = slotStart + eventLengthMinutes * 60 * 1000;
-    return !guestBusyBookings.some((booking) => {
-      const bookingStart = new Date(booking.startTime).valueOf();
-      const bookingEnd = new Date(booking.endTime).valueOf();
-      return slotStart < bookingEnd && slotEnd > bookingStart;
-    });
-  });
-}
+import {
+  filterSlotsForGuestBusyTimes,
+  type GuestBusyInterval,
+} from "./filterSlotsForGuestBusyTimes";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -40,7 +20,7 @@ describe("Guest availability filtering during reschedule (#16378)", () => {
   const eventLength = 30; // 30-minute meeting
 
   const slot = (isoTime: string) => ({ time: dayjs(isoTime) });
-  const busyInterval = (start: string, end: string): BusyInterval => ({
+  const busyInterval = (start: string, end: string): GuestBusyInterval => ({
     startTime: new Date(start),
     endTime: new Date(end),
   });

--- a/packages/trpc/server/routers/viewer/slots/guestAvailability.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/guestAvailability.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for guest availability filtering during reschedule (issue #16378).
+ *
+ * When a host reschedules a booking that has attendees who are also Cal.com users,
+ * the slot-fetching pipeline should filter out slots during which those guest
+ * users are already busy.
+ */
+import { describe, it, expect } from "vitest";
+import dayjs from "@calcom/dayjs";
+
+// ---------------------------------------------------------------------------
+// Pure helper that mirrors the slot-filtering logic added in util.ts
+// so we can unit-test it without spinning up the full service.
+// ---------------------------------------------------------------------------
+
+type BusyInterval = { startTime: Date; endTime: Date };
+
+function filterSlotsForGuestBusyTimes(
+  slots: Array<{ time: dayjs.Dayjs }>,
+  eventLengthMinutes: number,
+  guestBusyBookings: BusyInterval[]
+): Array<{ time: dayjs.Dayjs }> {
+  if (guestBusyBookings.length === 0) return slots;
+  return slots.filter((slot) => {
+    const slotStart = slot.time.valueOf();
+    const slotEnd = slotStart + eventLengthMinutes * 60 * 1000;
+    return !guestBusyBookings.some((booking) => {
+      const bookingStart = new Date(booking.startTime).valueOf();
+      const bookingEnd = new Date(booking.endTime).valueOf();
+      return slotStart < bookingEnd && slotEnd > bookingStart;
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Guest availability filtering during reschedule (#16378)", () => {
+  const eventLength = 30; // 30-minute meeting
+
+  const slot = (isoTime: string) => ({ time: dayjs(isoTime) });
+  const busyInterval = (start: string, end: string): BusyInterval => ({
+    startTime: new Date(start),
+    endTime: new Date(end),
+  });
+
+  it("returns all slots when there are no guest busy times", () => {
+    const slots = [
+      slot("2024-06-01T09:00:00.000Z"),
+      slot("2024-06-01T09:30:00.000Z"),
+      slot("2024-06-01T10:00:00.000Z"),
+    ];
+
+    const result = filterSlotsForGuestBusyTimes(slots, eventLength, []);
+    expect(result).toHaveLength(3);
+  });
+
+  it("filters out a slot that exactly overlaps a guest booking", () => {
+    const slots = [
+      slot("2024-06-01T09:00:00.000Z"),
+      slot("2024-06-01T09:30:00.000Z"), // guest is busy 09:30–10:00
+      slot("2024-06-01T10:00:00.000Z"),
+    ];
+
+    const guestBusy = [busyInterval("2024-06-01T09:30:00.000Z", "2024-06-01T10:00:00.000Z")];
+
+    const result = filterSlotsForGuestBusyTimes(slots, eventLength, guestBusy);
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.time.toISOString())).toEqual([
+      "2024-06-01T09:00:00.000Z",
+      "2024-06-01T10:00:00.000Z",
+    ]);
+  });
+
+  it("filters out a slot that partially overlaps a guest booking (slot starts inside booking)", () => {
+    const slots = [
+      slot("2024-06-01T09:15:00.000Z"), // 09:15–09:45 — overlaps guest's 09:00–09:30 booking
+      slot("2024-06-01T09:30:00.000Z"), // 09:30–10:00 — starts exactly when guest ends (no overlap)
+    ];
+
+    const guestBusy = [busyInterval("2024-06-01T09:00:00.000Z", "2024-06-01T09:30:00.000Z")];
+
+    const result = filterSlotsForGuestBusyTimes(slots, eventLength, guestBusy);
+    // 09:15 slot: slotEnd 09:45 > bookingStart 09:00 AND slotStart 09:15 < bookingEnd 09:30 → BLOCKED
+    // 09:30 slot: slotStart 09:30 is NOT < bookingEnd 09:30 → ALLOWED
+    expect(result).toHaveLength(1);
+    expect(result[0].time.toISOString()).toBe("2024-06-01T09:30:00.000Z");
+  });
+
+  it("filters out a slot that partially overlaps a guest booking (slot ends inside booking)", () => {
+    const slots = [
+      slot("2024-06-01T09:00:00.000Z"), // 09:00–09:30 — slot ends at start of guest booking → no overlap
+      slot("2024-06-01T09:15:00.000Z"), // 09:15–09:45 — overlaps guest's 09:30–10:00 booking
+    ];
+
+    const guestBusy = [busyInterval("2024-06-01T09:30:00.000Z", "2024-06-01T10:00:00.000Z")];
+
+    const result = filterSlotsForGuestBusyTimes(slots, eventLength, guestBusy);
+    // 09:00 slot: slotEnd 09:30 is NOT > bookingStart 09:30 → ALLOWED
+    // 09:15 slot: slotEnd 09:45 > bookingStart 09:30 AND slotStart 09:15 < bookingEnd 10:00 → BLOCKED
+    expect(result).toHaveLength(1);
+    expect(result[0].time.toISOString()).toBe("2024-06-01T09:00:00.000Z");
+  });
+
+  it("filters out multiple slots when guest has multiple bookings", () => {
+    const slots = [
+      slot("2024-06-01T08:00:00.000Z"),
+      slot("2024-06-01T09:00:00.000Z"), // blocked by first guest booking
+      slot("2024-06-01T10:00:00.000Z"),
+      slot("2024-06-01T11:00:00.000Z"), // blocked by second guest booking
+      slot("2024-06-01T12:00:00.000Z"),
+    ];
+
+    const guestBusy = [
+      busyInterval("2024-06-01T09:00:00.000Z", "2024-06-01T09:30:00.000Z"),
+      busyInterval("2024-06-01T11:00:00.000Z", "2024-06-01T11:30:00.000Z"),
+    ];
+
+    const result = filterSlotsForGuestBusyTimes(slots, eventLength, guestBusy);
+    expect(result).toHaveLength(3);
+    expect(result.map((s) => s.time.toISOString())).toEqual([
+      "2024-06-01T08:00:00.000Z",
+      "2024-06-01T10:00:00.000Z",
+      "2024-06-01T12:00:00.000Z",
+    ]);
+  });
+
+  it("keeps all slots when no guest booking overlaps", () => {
+    const slots = [
+      slot("2024-06-01T08:00:00.000Z"),
+      slot("2024-06-01T09:00:00.000Z"),
+    ];
+
+    // Guest is busy 13:00–14:00, far from our slots
+    const guestBusy = [busyInterval("2024-06-01T13:00:00.000Z", "2024-06-01T14:00:00.000Z")];
+
+    const result = filterSlotsForGuestBusyTimes(slots, eventLength, guestBusy);
+    expect(result).toHaveLength(2);
+  });
+
+  it("handles the edge case where slot ends exactly when guest booking starts (no conflict)", () => {
+    // Slot: 09:00–09:30, Guest busy: 09:30–10:00
+    const slots = [slot("2024-06-01T09:00:00.000Z")];
+    const guestBusy = [busyInterval("2024-06-01T09:30:00.000Z", "2024-06-01T10:00:00.000Z")];
+
+    const result = filterSlotsForGuestBusyTimes(slots, eventLength, guestBusy);
+    // slotEnd (09:30) is NOT > bookingStart (09:30) → no conflict
+    expect(result).toHaveLength(1);
+  });
+
+  it("handles the edge case where slot starts exactly when guest booking ends (no conflict)", () => {
+    // Slot: 10:00–10:30, Guest busy: 09:30–10:00
+    const slots = [slot("2024-06-01T10:00:00.000Z")];
+    const guestBusy = [busyInterval("2024-06-01T09:30:00.000Z", "2024-06-01T10:00:00.000Z")];
+
+    const result = filterSlotsForGuestBusyTimes(slots, eventLength, guestBusy);
+    // slotStart (10:00) is NOT < bookingEnd (10:00) → no conflict
+    expect(result).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration-level description of the full flow (documented, not executable
+// without a full DI container setup)
+// ---------------------------------------------------------------------------
+
+describe("Guest availability integration flow (documented)", () => {
+  it("describes the reschedule slot-filtering flow for cal.com guest users", () => {
+    /**
+     * When input.rescheduleUid is set:
+     *
+     * 1. bookingRepo.findOriginalRescheduledBookingUserId({ rescheduleUid })
+     *    → returns { attendees: [{ email }] }
+     *
+     * 2. For each attendee email, userRepo.findByEmail({ email })
+     *    → returns a Cal.com User if the attendee has an account, null otherwise
+     *
+     * 3. bookingRepo.findAcceptedBookingsForUserIdsBetween({
+     *      userIds, userEmails, startDate, endDate, excludeUid: rescheduleUid
+     *    })
+     *    → returns all ACCEPTED bookings (owned or attended) for those guest users
+     *      in the displayed date range (excluding the booking being rescheduled)
+     *
+     * 4. availableTimeSlots is filtered:
+     *    any slot where [slotStart, slotStart + eventLength) overlaps a guest busy
+     *    interval is removed from the result.
+     *
+     * This ensures the host only sees time slots during which ALL guests are free.
+     */
+    expect(true).toBe(true); // placeholder — the logic above is tested in pure unit tests above
+  });
+});

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1,4 +1,5 @@
 import process from "node:process";
+import { filterSlotsForGuestBusyTimes } from "./filterSlotsForGuestBusyTimes";
 import type { Dayjs } from "@calcom/dayjs";
 import dayjs from "@calcom/dayjs";
 import { orgDomainConfig } from "@calcom/ee/organizations/lib/orgDomains";
@@ -1534,16 +1535,11 @@ export class AvailableSlotsService {
 
           if (guestBusyBookings.length > 0) {
             const eventLength = input.duration || eventType.length;
-            availableTimeSlots = availableTimeSlots.filter((slot) => {
-              const slotStart = slot.time.valueOf();
-              const slotEnd = slotStart + eventLength * 60 * 1000;
-              // A slot is unavailable if it overlaps with any guest booking
-              return !guestBusyBookings.some((booking) => {
-                const bookingStart = new Date(booking.startTime).valueOf();
-                const bookingEnd = new Date(booking.endTime).valueOf();
-                return slotStart < bookingEnd && slotEnd > bookingStart;
-              });
-            });
+            availableTimeSlots = filterSlotsForGuestBusyTimes(
+              availableTimeSlots,
+              eventLength,
+              guestBusyBookings
+            );
           }
         }
       }

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1499,6 +1499,57 @@ export class AvailableSlotsService {
         );
     }
 
+    // ── Guest availability filtering (reschedule only) ──────────────────────
+    // When rescheduling, check whether attendees are Cal.com users. If so,
+    // filter out any time slots during which they have an existing booking.
+    if (input.rescheduleUid && availableTimeSlots.length > 0) {
+      const bookingRepo = this.dependencies.bookingRepo;
+      const userRepo = this.dependencies.userRepo;
+
+      // Fetch the original booking's attendees
+      const originalBooking = await bookingRepo.findOriginalRescheduledBookingUserId({
+        rescheduleUid: input.rescheduleUid,
+      });
+
+      if (originalBooking?.attendees && originalBooking.attendees.length > 0) {
+        const attendeeEmails = originalBooking.attendees.map((a) => a.email);
+
+        // Identify which attendees are Cal.com users (look them up by email)
+        const calcomGuestUsers = (
+          await Promise.all(attendeeEmails.map((email) => userRepo.findByEmail({ email })))
+        ).filter((u): u is NonNullable<typeof u> => u !== null && u !== undefined);
+
+        if (calcomGuestUsers.length > 0) {
+          const guestUserIds = calcomGuestUsers.map((u) => u.id);
+          const guestEmails = calcomGuestUsers.map((u) => u.email);
+
+          // Fetch busy times for guest Cal.com users in the slot range
+          const guestBusyBookings = await bookingRepo.findAcceptedBookingsForUserIdsBetween({
+            userIds: guestUserIds,
+            userEmails: guestEmails,
+            startDate: startTime.toDate(),
+            endDate: endTime.toDate(),
+            excludeUid: input.rescheduleUid,
+          });
+
+          if (guestBusyBookings.length > 0) {
+            const eventLength = input.duration || eventType.length;
+            availableTimeSlots = availableTimeSlots.filter((slot) => {
+              const slotStart = slot.time.valueOf();
+              const slotEnd = slotStart + eventLength * 60 * 1000;
+              // A slot is unavailable if it overlaps with any guest booking
+              return !guestBusyBookings.some((booking) => {
+                const bookingStart = new Date(booking.startTime).valueOf();
+                const bookingEnd = new Date(booking.endTime).valueOf();
+                return slotStart < bookingEnd && slotEnd > bookingStart;
+              });
+            });
+          }
+        }
+      }
+    }
+    // ────────────────────────────────────────────────────────────────────────
+
     // fr-CA uses YYYY-MM-DD
     const formatter = new Intl.DateTimeFormat("fr-CA", {
       year: "numeric",


### PR DESCRIPTION
/claim #16378

## What this PR does
When a host reschedules a booking, this PR checks if any guests/attendees are Cal.com users. If so, it fetches their availability and intersects it with the host's available slots, ensuring only mutually available times are shown.

## How it works
1. During slot fetching for reschedule (_getAvailableSlots in util.ts), looks up attendee emails from the original booking against Cal.com users via userRepo.findByEmail
2. For Cal.com user guests, fetches their busy times (owned + attended bookings) using the new ookingRepo.findAcceptedBookingsForUserIdsBetween method
3. Filters the returned vailableTimeSlots to exclude times when any guest is busy — wired directly into the existing slot pipeline

## Why previous PRs failed
All previous attempts created disconnected utility functions that were never wired into the actual reschedule flow. This PR modifies the existing _getAvailableSlots pipeline in util.ts directly, using already-injected dependencies (ookingRepo, userRepo) — no new DI wiring needed.

## Files changed
- packages/features/bookings/repositories/BookingRepository.ts — adds indAcceptedBookingsForUserIdsBetween (fetches accepted bookings owned or attended by given user IDs in a date range)
- packages/trpc/server/routers/viewer/slots/util.ts — adds guest availability filtering block inside _getAvailableSlots, triggered only when escheduleUid is present
- packages/trpc/server/routers/viewer/slots/guestAvailability.test.ts — unit tests covering the overlap-detection logic (exact overlap, partial overlap, edge cases, multiple guest bookings)

## Testing
- Added unit tests for the slot-overlap filtering logic (guestAvailability.test.ts)
- Visual demo: [will provide before/after screenshots in follow-up comment — the key observable difference is that the reschedule picker will no longer show times when an attendee who is a Cal.com user has an existing accepted booking]

Fixes #16378