### PR TITLE
fix(prisma): align docker postgres DB with env defaults

### DIFF
--- a/packages/prisma/docker-compose.yml
+++ b/packages/prisma/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - db_data:/var/lib/postgresql
     environment:
-      POSTGRES_DB: "cal-saml"
+      POSTGRES_DB: "calendso"
       POSTGRES_PASSWORD: ""
       POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:


### PR DESCRIPTION
## Summary
- update `packages/prisma/docker-compose.yml` to set `POSTGRES_DB` to `calendso`
- align local docker helper database name with `.env.example` `DATABASE_URL`

## Why
New local setups can fail or behave inconsistently when docker initializes `cal-saml` but local env defaults target `calendso`.

Fixes #28635