### PR TITLE
fix(bookings): return 404 when cancellation booking is missing

### DIFF
--- a/packages/features/bookings/lib/getBookingToDelete.ts
+++ b/packages/features/bookings/lib/getBookingToDelete.ts
@@ -1,9 +1,11 @@
 import { workflowSelect } from "@calcom/features/ee/workflows/lib/getAllWorkflows";
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import prisma, { bookingMinimalSelect } from "@calcom/prisma";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 
 export async function getBookingToDelete(id: number | undefined, uid: string | undefined) {
-  return await prisma.booking.findUniqueOrThrow({
+  const booking = await prisma.booking.findUnique({
     where: {
       id,
       uid,
@@ -120,6 +122,12 @@ export async function getBookingToDelete(id: number | undefined, uid: string | u
       status: true,
     },
   });
+
+  if (!booking) {
+    throw new ErrorWithCode(ErrorCode.BookingNotFound, "Booking not found");
+  }
+
+  return booking;
 }
 
 export type BookingToDelete = Awaited<ReturnType<typeof getBookingToDelete>>;


### PR DESCRIPTION
## Summary
- replace `findUniqueOrThrow` with `findUnique` in `getBookingToDelete`
- throw `ErrorWithCode(ErrorCode.BookingNotFound, \"Booking not found\")` when booking lookup returns null
- keep existing successful cancellation flow unchanged

## Why
The cancel API should return a not-found response for missing booking UIDs rather than surfacing a generic internal error from `findUniqueOrThrow`.

Fixes #28614