### PR TITLE
fix(team-billing): move credits when downgrading team to free

### DIFF
--- a/packages/features/ee/billing/credit-service.ts
+++ b/packages/features/ee/billing/credit-service.ts
@@ -792,6 +792,54 @@ export class CreditService {
     };
   }
 
+    async moveCreditsFromTeamToUser({teamId , userId} : {teamId : number; userId : number})  {
+    return await prisma.$transaction(async (tx) => {
+      const teamCreditBalance = await CreditsRepository.findCreditBalance({teamId}, tx);
+
+      if(!teamCreditBalance || teamCreditBalance.additionalCredits <= 0) {
+        return ; 
+      }
+
+      let userCreditBalance = await CreditsRepository.findCreditBalance({userId}, tx);
+
+      if(!userCreditBalance) {
+        userCreditBalance = await CreditsRepository.createCreditBalance(
+          {userId},
+          tx
+        );
+      }
+
+      const creditsToTransfer = teamCreditBalance.additionalCredits;
+
+      logger.info("Moving credits from team to owner" , {
+        teamId,
+        userId,
+        creditsToTransfer,
+      })
+
+      await CreditsRepository.updateCreditBalance (
+        {
+          teamId,
+          data : {additionalCredits : 0},
+        },
+        tx
+      );
+
+      await CreditsRepository.updateCreditBalance(
+        {
+          userId ,
+          data : {
+            additionalCredits : {
+              increment : creditsToTransfer,
+            },
+          },
+        },
+        tx
+      );
+      return { creditsTransferred : creditsToTransfer };
+    });
+  }
+
   async moveCreditsFromTeamToOrg({ teamId, orgId }: { teamId: number; orgId: number }) {
     return await prisma.$transaction(async (tx) => {
       // Get team's credit balance

--- a/packages/features/ee/billing/service/teams/TeamBillingService.ts
+++ b/packages/features/ee/billing/service/teams/TeamBillingService.ts
@@ -22,6 +22,8 @@ import {
   type TeamBillingInput,
   TeamBillingPublishResponseStatus,
 } from "./ITeamBillingService";
+import { MembershipRole } from "@calcom/prisma/enums";
+import { CreditService } from "../../credit-service"
 
 const log = logger.getSubLogger({ prefix: ["TeamBilling"] });
 
@@ -133,6 +135,25 @@ export class TeamBillingService implements ITeamBillingService {
   }
   async downgrade() {
     try {
+       const creditService = new CreditService();
+
+      const owner = await prisma.membership.findFirst({
+        where : {
+           teamId : this.team.id,
+           role : MembershipRole.OWNER
+        },
+      });
+
+      if(!owner) {
+        throw new Error(`No owner found for team ${this.team.id}`);
+      }
+
+      await creditService.moveCreditsFromTeamToUser({
+        teamId : this.team.id,
+        userId : owner.userId,
+      });
+      
+
       const { mergeMetadata } = getMetadataHelpers(teamPaymentMetadataSchema, this.team.metadata);
       const metadata = mergeMetadata({
         paymentId: undefined,


### PR DESCRIPTION
Summary
Fixes #28104
When a team is downgraded from Team → Free, the team subscription is removed but the remaining credits are not transferred. This can cause credits to be lost.

This PR fixes that by transferring the remaining team credits to the team owner during downgrade.

What this PR does
Finds the team owner
Transfers team credits to owner
Resets team credits to 0
Keeps behavior consistent with existing credit transfer logic

Added credit transfer logic inside TeamBillingService.downgrade()

```
const creditService = new CreditService();

const owner = await prisma.membership.findFirst({
  where: {
    teamId: this.team.id,
    role: MembershipRole.OWNER,
  },
});

if (!owner) {
  throw new Error(`No owner found for team ${this.team.id}`);
}

await creditService.moveCreditsFromTeamToUser({
  teamId: this.team.id,
  userId: owner.userId,
});
```
Why this change

Credits should not be lost when downgrading a team.
This change ensures credits are preserved and moved to the team owner.

Tested
Team with credits → credits moved to owner 
Team without credits → no errors 
Owner without credit balance → created automatically