### PR TITLE
feat: check guest availability when host reschedules a booking

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -160,6 +160,7 @@ export type GetUserAvailabilityInitialData = {
     bookingLimits?: unknown;
     includeManagedEventsInLimits: boolean;
   } | null;
+  guestBusyTimes?: EventBusyDetails[];
 };
 
 export type GetAvailabilityUser = GetUserAvailabilityInitialData["user"];
@@ -627,6 +628,7 @@ export class UserAvailabilityService {
       })),
       ...busyTimesFromLimits,
       ...busyTimesFromTeamLimits,
+      ...(initialData?.guestBusyTimes || []),
     ];
 
     const detailedBusyTimes: UserAvailabilityBusyDetails[] = withSource

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1738,6 +1738,41 @@ export class BookingRepository implements IBookingRepository {
     });
   }
 
+  /**
+   * Find accepted bookings for given user IDs or attendee emails within a date range.
+   * Used to determine guest busy times during rescheduling.
+   */
+  async findAcceptedByUserIdsOrEmails({
+    userIds,
+    emails,
+    startDate,
+    endDate,
+    excludeUid,
+  }: {
+    userIds: number[];
+    emails: string[];
+    startDate: Date;
+    endDate: Date;
+    excludeUid?: string;
+  }) {
+    if (!userIds.length && !emails.length) return [];
+    return this.prismaClient.booking.findMany({
+      where: {
+        status: BookingStatus.ACCEPTED,
+        startTime: { lte: endDate },
+        endTime: { gte: startDate },
+        ...(excludeUid ? { uid: { not: excludeUid } } : {}),
+        OR: [
+          ...(userIds.length ? [{ userId: { in: userIds } }] : []),
+          ...(emails.length
+            ? [{ attendees: { some: { email: { in: emails, mode: "insensitive" as const } } } }]
+            : []),
+        ],
+      },
+      select: { uid: true, startTime: true, endTime: true },
+    });
+  }
+
   async findByIdForReassignment(bookingId: number) {
     return await this.prismaClient.booking.findUnique({
       where: {

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1519,6 +1519,7 @@ export class UserRepository {
   /**
    * Find Cal.com users by their primary or verified secondary email addresses.
    * Used to look up guest availability during rescheduling.
+   * Reuses findVerifiedUsersByEmailsRaw to avoid duplicating the verified email lookup SQL.
    */
   async findByEmails({
     emails,
@@ -1527,22 +1528,12 @@ export class UserRepository {
   }): Promise<Array<{ id: number; email: string; matchedEmail: string }>> {
     if (!emails.length) return [];
     const normalizedEmails = emails.map((e) => e.toLowerCase());
-    const emailListSql = Prisma.join(normalizedEmails.map((e) => Prisma.sql`${e}`));
-    return this.prismaClient.$queryRaw<Array<{ id: number; email: string; matchedEmail: string }>>(Prisma.sql`
-      SELECT u."id", u."email", u."email" AS "matchedEmail"
-      FROM "public"."users" AS u
-      WHERE u."email" IN (${emailListSql})
-        AND u."emailVerified" IS NOT NULL
-        AND u."locked" = FALSE
-      UNION
-      SELECT u."id", u."email", t0."email" AS "matchedEmail"
-      FROM "public"."users" AS u
-      INNER JOIN "public"."SecondaryEmail" AS t0
-        ON t0."userId" = u."id"
-      WHERE t0."email" IN (${emailListSql})
-        AND t0."emailVerified" IS NOT NULL
-        AND u."locked" = FALSE
-    `);
+    const users = await this.findVerifiedUsersByEmailsRaw(normalizedEmails);
+    return users.map((u) => ({
+      id: u.id,
+      email: u.email,
+      matchedEmail: u.matchedEmail,
+    }));
   }
 
 }

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1515,4 +1515,34 @@ export class UserRepository {
 
     return { email: user.email, username: user.username };
   }
+
+  /**
+   * Find Cal.com users by their primary or verified secondary email addresses.
+   * Used to look up guest availability during rescheduling.
+   */
+  async findByEmails({
+    emails,
+  }: {
+    emails: string[];
+  }): Promise<Array<{ id: number; email: string; matchedEmail: string }>> {
+    if (!emails.length) return [];
+    const normalizedEmails = emails.map((e) => e.toLowerCase());
+    const emailListSql = Prisma.join(normalizedEmails.map((e) => Prisma.sql`${e}`));
+    return this.prismaClient.$queryRaw<Array<{ id: number; email: string; matchedEmail: string }>>(Prisma.sql`
+      SELECT u."id", u."email", u."email" AS "matchedEmail"
+      FROM "public"."users" AS u
+      WHERE u."email" IN (${emailListSql})
+        AND u."emailVerified" IS NOT NULL
+        AND u."locked" = FALSE
+      UNION
+      SELECT u."id", u."email", t0."email" AS "matchedEmail"
+      FROM "public"."users" AS u
+      INNER JOIN "public"."SecondaryEmail" AS t0
+        ON t0."userId" = u."id"
+      WHERE t0."email" IN (${emailListSql})
+        AND t0."emailVerified" IS NOT NULL
+        AND u."locked" = FALSE
+    `);
+  }
+
 }

--- a/packages/trpc/server/routers/viewer/slots/getGuestBusyTimesForReschedule.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/getGuestBusyTimesForReschedule.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GuestBusyTimesDeps } from "./util";
+import { getGuestBusyTimesForReschedule } from "./util";
+
+function createMockDeps(): GuestBusyTimesDeps {
+  return {
+    bookingRepo: {
+      findByUidIncludeEventType: vi.fn(),
+      findAcceptedByUserIdsOrEmails: vi.fn(),
+    },
+    userRepo: {
+      findByEmails: vi.fn(),
+    },
+  };
+}
+
+const baseArgs = {
+  rescheduleUid: "uid-123",
+  startDate: new Date("2025-06-01T00:00:00Z"),
+  endDate: new Date("2025-06-30T23:59:59Z"),
+  hostEmails: ["host@example.com"],
+};
+
+describe("getGuestBusyTimesForReschedule", () => {
+  let deps: ReturnType<typeof createMockDeps>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deps = createMockDeps();
+  });
+
+  it("returns empty array when booking is not found", async () => {
+    (deps.bookingRepo.findByUidIncludeEventType as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const result = await getGuestBusyTimesForReschedule({ ...baseArgs, ...deps });
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when booking has no attendees", async () => {
+    (deps.bookingRepo.findByUidIncludeEventType as ReturnType<typeof vi.fn>).mockResolvedValue({
+      attendees: [],
+    });
+    const result = await getGuestBusyTimesForReschedule({ ...baseArgs, ...deps });
+    expect(result).toEqual([]);
+    expect(deps.userRepo.findByEmails).not.toHaveBeenCalled();
+  });
+
+  it("returns empty array when all attendees are hosts", async () => {
+    (deps.bookingRepo.findByUidIncludeEventType as ReturnType<typeof vi.fn>).mockResolvedValue({
+      attendees: [{ email: "host@example.com" }],
+    });
+    const result = await getGuestBusyTimesForReschedule({ ...baseArgs, ...deps });
+    expect(result).toEqual([]);
+    expect(deps.userRepo.findByEmails).not.toHaveBeenCalled();
+  });
+
+  it("filters host emails case-insensitively", async () => {
+    (deps.bookingRepo.findByUidIncludeEventType as ReturnType<typeof vi.fn>).mockResolvedValue({
+      attendees: [{ email: "Host@Example.com" }, { email: "guest@example.com" }],
+    });
+    (deps.userRepo.findByEmails as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await getGuestBusyTimesForReschedule({ ...baseArgs, ...deps });
+    expect(deps.userRepo.findByEmails).toHaveBeenCalledWith({
+      emails: ["guest@example.com"],
+    });
+  });
+
+  it("returns empty array when no guests are Cal.com users", async () => {
+    (deps.bookingRepo.findByUidIncludeEventType as ReturnType<typeof vi.fn>).mockResolvedValue({
+      attendees: [{ email: "guest@example.com" }],
+    });
+    (deps.userRepo.findByEmails as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const result = await getGuestBusyTimesForReschedule({ ...baseArgs, ...deps });
+    expect(result).toEqual([]);
+    expect(deps.bookingRepo.findAcceptedByUserIdsOrEmails).not.toHaveBeenCalled();
+  });
+
+  it("returns busy times from guest bookings", async () => {
+    (deps.bookingRepo.findByUidIncludeEventType as ReturnType<typeof vi.fn>).mockResolvedValue({
+      attendees: [{ email: "guest@example.com" }],
+    });
+    (deps.userRepo.findByEmails as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 42, email: "guest@example.com", matchedEmail: "guest@example.com" },
+    ]);
+    const bookingStart = new Date("2025-06-15T10:00:00Z");
+    const bookingEnd = new Date("2025-06-15T11:00:00Z");
+    (deps.bookingRepo.findAcceptedByUserIdsOrEmails as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { uid: "other-booking", startTime: bookingStart, endTime: bookingEnd },
+    ]);
+
+    const result = await getGuestBusyTimesForReschedule({ ...baseArgs, ...deps });
+    expect(result).toEqual([
+      {
+        start: bookingStart.toISOString(),
+        end: bookingEnd.toISOString(),
+        source: "guest-availability",
+      },
+    ]);
+  });
+
+  it("excludes the current booking being rescheduled", async () => {
+    (deps.bookingRepo.findByUidIncludeEventType as ReturnType<typeof vi.fn>).mockResolvedValue({
+      attendees: [{ email: "guest@example.com" }],
+    });
+    (deps.userRepo.findByEmails as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 42, email: "guest@example.com", matchedEmail: "guest@example.com" },
+    ]);
+    (deps.bookingRepo.findAcceptedByUserIdsOrEmails as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await getGuestBusyTimesForReschedule({ ...baseArgs, ...deps });
+    expect(deps.bookingRepo.findAcceptedByUserIdsOrEmails).toHaveBeenCalledWith(
+      expect.objectContaining({ excludeUid: "uid-123" })
+    );
+  });
+
+  it("includes both primary and secondary emails in booking lookup", async () => {
+    (deps.bookingRepo.findByUidIncludeEventType as ReturnType<typeof vi.fn>).mockResolvedValue({
+      attendees: [{ email: "secondary@example.com" }],
+    });
+    (deps.userRepo.findByEmails as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 42, email: "primary@example.com", matchedEmail: "secondary@example.com" },
+    ]);
+    (deps.bookingRepo.findAcceptedByUserIdsOrEmails as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await getGuestBusyTimesForReschedule({ ...baseArgs, ...deps });
+    expect(deps.bookingRepo.findAcceptedByUserIdsOrEmails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emails: expect.arrayContaining(["primary@example.com", "secondary@example.com"]),
+      })
+    );
+  });
+
+  it("returns empty array when an error occurs (graceful degradation)", async () => {
+    (deps.bookingRepo.findByUidIncludeEventType as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("DB error")
+    );
+    const result = await getGuestBusyTimesForReschedule({ ...baseArgs, ...deps });
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -129,6 +129,67 @@ function withSlotsCache(
   };
 }
 
+export interface GuestBusyTimesDeps {
+  bookingRepo: Pick<BookingRepository, "findByUidIncludeEventType" | "findAcceptedByUserIdsOrEmails">;
+  userRepo: Pick<UserRepository, "findByEmails">;
+}
+
+/**
+ * When rescheduling, look up the original booking attendees (guests),
+ * check if any are Cal.com users, and return their accepted bookings
+ * as busy times so the host cannot double-book them.
+ */
+export async function getGuestBusyTimesForReschedule({
+  rescheduleUid,
+  startDate,
+  endDate,
+  hostEmails,
+  bookingRepo,
+  userRepo,
+}: {
+  rescheduleUid: string;
+  startDate: Date;
+  endDate: Date;
+  hostEmails: string[];
+} & GuestBusyTimesDeps): Promise<EventBusyDetails[]> {
+  try {
+    const booking = await bookingRepo.findByUidIncludeEventType({
+      bookingUid: rescheduleUid,
+    });
+    if (!booking?.attendees?.length) return [];
+
+    const hostEmailsLower = new Set(hostEmails.map((e) => e.toLowerCase()));
+    const guestEmails = booking.attendees
+      .map((a) => a.email)
+      .filter((email) => !hostEmailsLower.has(email.toLowerCase()));
+    if (!guestEmails.length) return [];
+
+    const calUsers = await userRepo.findByEmails({ emails: guestEmails });
+    if (!calUsers.length) return [];
+
+    const allEmails = [...new Set(calUsers.flatMap((u) => [u.email, u.matchedEmail]))];
+
+    const guestBookings = await bookingRepo.findAcceptedByUserIdsOrEmails({
+      userIds: calUsers.map((u) => u.id),
+      emails: allEmails,
+      startDate,
+      endDate,
+      excludeUid: rescheduleUid,
+    });
+
+    return guestBookings
+      .filter((b) => b.startTime && b.endTime)
+      .map((b) => ({
+        start: b.startTime.toISOString(),
+        end: b.endTime.toISOString(),
+        source: "guest-availability",
+      }));
+  } catch {
+    log.warn("Failed to fetch guest busy times for reschedule");
+    return [];
+  }
+}
+
 export class AvailableSlotsService {
   constructor(public readonly dependencies: IAvailableSlotsService) {}
 
@@ -1003,6 +1064,20 @@ export class AvailableSlotsService {
     const enrichUsersWithData = withReporting(_enrichUsersWithData.bind(this), "enrichUsersWithData");
     const users = enrichUsersWithData();
 
+    // Fetch guest busy times when rescheduling to avoid double-booking guests
+    let guestBusyTimes: EventBusyDetails[] = [];
+    if (input.rescheduleUid) {
+      const hostEmails = usersWithCredentials.map((u) => u.email);
+      guestBusyTimes = await getGuestBusyTimesForReschedule({
+        rescheduleUid: input.rescheduleUid,
+        startDate: startTime.toDate(),
+        endDate: endTime.toDate(),
+        hostEmails,
+        bookingRepo: this.dependencies.bookingRepo,
+        userRepo: this.dependencies.userRepo,
+      });
+    }
+
     const premappedUsersAvailability = await this.dependencies.userAvailabilityService.getUsersAvailability({
       users,
       query: {
@@ -1026,6 +1101,7 @@ export class AvailableSlotsService {
         eventTypeForLimits: eventType && (bookingLimits || durationLimits) ? eventType : null,
         teamBookingLimits: teamBookingLimitsMap,
         teamForBookingLimits: teamForBookingLimits,
+        guestBusyTimes,
       },
     });
     /* We get all users working hours and busy slots */


### PR DESCRIPTION
## Summary

When a host reschedules a booking, the system now checks if any attendees (guests) are Cal.com users and includes their accepted bookings as busy times in the slot calculation. This prevents the host from accidentally double-booking a guest during reschedule.

Fixes #16378

/claim #16378

## How it works

1. When `rescheduleUid` is present in the slot calculation, look up the booking's attendees via `findByUidIncludeEventType`
2. Filter out host emails to isolate guest-only emails
3. Look up Cal.com users matching guest emails (primary + verified secondary emails) using a raw SQL UNION query following the existing `findVerifiedUsersByEmailsRaw` pattern
4. Query their accepted bookings in the date range using overlap semantics (`startTime <= endDate AND endTime >= startDate`)
5. Inject as `guestBusyTimes` into the `initialData` passed to `getUsersAvailability`, where they are merged into `detailedBusyTimes`

## Changes (4 source files + 1 test file)

| File | Change |
|------|--------|
| `packages/features/users/repositories/UserRepository.ts` | Add `findByEmails()` — raw SQL UNION matching primary + verified secondary emails, excludes locked accounts. Follows existing `findVerifiedUsersByEmailsRaw` pattern |
| `packages/features/bookings/repositories/BookingRepository.ts` | Add `findAcceptedByUserIdsOrEmails()` — queries accepted bookings with overlap date semantics |
| `packages/features/availability/lib/getUserAvailability.ts` | Add `guestBusyTimes?` to `GetUserAvailabilityInitialData`; spread into `detailedBusyTimes` |
| `packages/trpc/server/routers/viewer/slots/util.ts` | Add `getGuestBusyTimesForReschedule()` function + call site in `calculateHostsAndAvailabilities()` |
| `packages/trpc/server/routers/viewer/slots/getGuestBusyTimesForReschedule.test.ts` | Unit tests covering 8 scenarios including edge cases and error handling |

## Design decisions

- **Raw SQL UNION for user lookup**: Follows the existing `findVerifiedUsersByEmailsRaw` pattern in `UserRepository` for performance. No `LOWER()` on columns to preserve B-tree index usage.
- **Overlap semantics for date queries**: Uses `startTime <= endDate AND endTime >= startDate` to catch bookings that partially overlap the search window.
- **Host-email exclusion**: Hosts are excluded from the guest list (case-insensitively) so a host's own calendar is not counted twice.
- **Graceful degradation**: If guest lookup fails for any reason, an empty array is returned and the system falls back to the current behavior (no guest filtering).
- **No schema/migration changes**: All changes use existing database schema.

## Test plan

- [x] Unit tests for `getGuestBusyTimesForReschedule` covering:
  - Booking not found / no attendees
  - All attendees are hosts
  - Case-insensitive host email filtering
  - No Cal.com users among guests
  - Busy times from guest bookings
  - Excluding current booking being rescheduled
  - Primary and secondary email lookup
  - Graceful error handling
- [ ] Manual testing: Host reschedules a booking where the guest is a Cal.com user with other bookings — the overlapping slots should not be shown