### PR TITLE
fix: consider guest availability when rescheduling events

### DIFF
--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -3,6 +3,7 @@ import type { Dayjs } from "@calcom/dayjs";
 import dayjs from "@calcom/dayjs";
 import { orgDomainConfig } from "@calcom/ee/organizations/lib/orgDomains";
 import { getAggregatedAvailability } from "@calcom/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability";
+import { findUsersForAvailabilityCheck } from "@calcom/features/availability/lib/findUsersForAvailabilityCheck";
 import type {
   CurrentSeats,
   EventType,
@@ -883,6 +884,31 @@ export class AvailableSlotsService {
     const usersWithCredentials = this.getUsersWithCredentials({
       hosts,
     });
+        // When rescheduling, also consider attendees' availability if they are platform users.
+        // This ensures guests' calendars are checked, not just the organizer's.
+        if (input.rescheduleUid) {
+          const rescheduleBookingInfo = await this.dependencies.bookingRepo.findOriginalRescheduledBookingUserId({
+            rescheduleUid: input.rescheduleUid,
+          });
+          if (rescheduleBookingInfo?.attendees?.length) {
+            const attendeeEmails = rescheduleBookingInfo.attendees.map((a) => a.email);
+            for (const email of attendeeEmails) {
+              const attendeeUser = await findUsersForAvailabilityCheck({
+                where: { email: { equals: email, mode: "insensitive" } },
+              });
+              if (attendeeUser) {
+                const alreadyIncluded = usersWithCredentials.some((u) => u.id === attendeeUser.id);
+                if (!alreadyIncluded) {
+                  usersWithCredentials.push({
+                    ...attendeeUser,
+                    isFixed: undefined,
+                    groupId: null,
+                  });
+                }
+              }
+            }
+          }
+        }
 
     loggerWithEventDetails.debug("Using users", {
       usersWithCredentials: usersWithCredentials.map((user) => user.email),


### PR DESCRIPTION
## Fixes calcom#16378

### Problem
When rescheduling an event, available slots were only filtered based on the organizer's calendar/availability. Guest attendees who are also platform users had their availability ignored.

### Solution
In `calculateHostsAndAvailabilities()`, when `input.rescheduleUid` is present, fetch the original booking's attendees and for any who are platform users, load their full credentials and include them in the availability calculation via `findUsersAndForAvailabilityCheck()`. This ensures all attendees' calendars are considered when computing available slots during reschedule.

### Changes
- **File**: `packages/trpc/server/routers/viewer/slots/util.ts`
  - Added import for `findUsersForAvailabilityCheck`
  - Added logic in `calculateHostsAndAvailabilities()` to resolve attendee emails to platform users and add their credentials to the availability check

### Testing
- Existing slot availability tests should continue to pass
- Manual testing: reschedule an event with platform user attendees and verify their calendars are checked
