### PR TITLE
chore(member-invite): early return for pending mutations while copying invite link

### DIFF
--- a/apps/web/modules/ee/teams/components/MemberInvitationModal.tsx
+++ b/apps/web/modules/ee/teams/components/MemberInvitationModal.tsx
@@ -1,7 +1,7 @@
 import { useSession } from "next-auth/react";
 import posthog from "posthog-js";
 import type { FormEvent } from "react";
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import TeamInviteFromOrg from "~/ee/organizations/components/TeamInviteFromOrg";
@@ -89,6 +89,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
   const [modalImportMode, setModalInputMode] = useState<ModalMode>(
     canSeeOrganization ? "ORGANIZATION" : "INDIVIDUAL"
   );
+  const [isCopying, setIsCopying] = useState(false);
 
   const createInviteMutation = trpc.viewer.teams.createInvite.useMutation({
     async onSuccess() {
@@ -192,6 +193,44 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
   };
 
   const importRef = useRef<HTMLInputElement | null>(null);
+
+  const handleCopyInviteLink = useCallback(async () => {
+    if (isCopying || createInviteMutation.isPending) return;
+
+    setIsCopying(true);
+    try {
+      // Required for Safari but also works on Chrome
+      // Credits to https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/
+      if (typeof ClipboardItem !== "undefined") {
+        const inviteLinkClipbardItem = new ClipboardItem({
+          //eslint-disable-next-line no-async-promise-executor
+          "text/plain": new Promise(async (resolve) => {
+            // Instead of doing async work and then writing to clipboard, do async work in clipboard API itself
+            const { inviteLink } = await createInviteMutation.mutateAsync({
+              teamId: props.teamId,
+              token: props.token,
+            });
+            showToast(t("invite_link_copied"), "success");
+            resolve(new Blob([inviteLink], { type: "text/plain" }));
+          }),
+        });
+        await navigator.clipboard.write([inviteLinkClipbardItem]);
+      } else {
+        // Fallback for browsers that don't support ClipboardItem e.g. Firefox 
+        const { inviteLink } = await createInviteMutation.mutateAsync({
+          teamId: props.teamId,
+          token: props.token,
+        });
+        await navigator.clipboard.writeText(inviteLink);
+        showToast(t("invite_link_copied"), "success");
+      }
+    } catch (e) {
+      showToast(t("something_went_wrong_on_our_end"), "error");
+      console.error(e);
+    } finally {
+      setIsCopying(false);
+    }
+  }, [isCopying, createInviteMutation, props.teamId, props.token, t]);
 
   return (
     <Dialog
@@ -412,38 +451,9 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
                   type="button"
                   color="minimal"
                   variant="icon"
-                  onClick={async function () {
-                    try {
-                      // Required for Safari but also works on Chrome
-                      // Credits to https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/
-                      if (typeof ClipboardItem !== "undefined") {
-                        const inviteLinkClipbardItem = new ClipboardItem({
-                          //eslint-disable-next-line no-async-promise-executor
-                          "text/plain": new Promise(async (resolve) => {
-                            // Instead of doing async work and then writing to clipboard, do async work in clipboard API itself
-                            const { inviteLink } = await createInviteMutation.mutateAsync({
-                              teamId: props.teamId,
-                              token: props.token,
-                            });
-                            showToast(t("invite_link_copied"), "success");
-                            resolve(new Blob([inviteLink], { type: "text/plain" }));
-                          }),
-                        });
-                        await navigator.clipboard.write([inviteLinkClipbardItem]);
-                      } else {
-                        // Fallback for browsers that don't support ClipboardItem e.g. Firefox
-                        const { inviteLink } = await createInviteMutation.mutateAsync({
-                          teamId: props.teamId,
-                          token: props.token,
-                        });
-                        await navigator.clipboard.writeText(inviteLink);
-                        showToast(t("invite_link_copied"), "success");
-                      }
-                    } catch (e) {
-                      showToast(t("something_went_wrong_on_our_end"), "error");
-                      console.error(e);
-                    }
-                  }}
+                  onClick={handleCopyInviteLink}
+                  loading={isCopying || createInviteMutation.isPending}
+                  disabled={isCopying || createInviteMutation.isPending}
                   className={classNames("gap-2", props.token && "opacity-50")}
                   StartIcon="link"
                   data-testid="copy-invite-link-button">

--- a/apps/web/modules/ee/teams/components/MemberInvitationModal.tsx
+++ b/apps/web/modules/ee/teams/components/MemberInvitationModal.tsx
@@ -194,7 +194,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
 
   const importRef = useRef<HTMLInputElement | null>(null);
 
-  const handleCopyInviteLink = useCallback(async () => {
+const handleCopyInviteLink = useCallback(async () => {
     if (isCopying || createInviteMutation.isPending) return;
 
     setIsCopying(true);
@@ -204,17 +204,21 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
       if (typeof ClipboardItem !== "undefined") {
         const inviteLinkClipboardItem = new ClipboardItem({
           //eslint-disable-next-line no-async-promise-executor
-          "text/plain": new Promise(async (resolve) => {
+          "text/plain": new Promise((resolve, reject) => {
             // Instead of doing async work and then writing to clipboard, do async work in clipboard API itself
-            const { inviteLink } = await createInviteMutation.mutateAsync({
-              teamId: props.teamId,
-              token: props.token,
-            });
-            showToast(t("invite_link_copied"), "success");
-            resolve(new Blob([inviteLink], { type: "text/plain" }));
+            createInviteMutation.mutateAsync({
+                teamId: props.teamId,
+                token: props.token,
+              }).then(({ inviteLink }) => {
+                resolve(new Blob([inviteLink], { type: "text/plain" }));
+              })
+              .catch((err) => {
+                reject(err);
+              });
           }),
         });
         await navigator.clipboard.write([inviteLinkClipboardItem]);
+        showToast(t("invite_link_copied"), "success");
       } else {
         // Fallback for browsers that don't support ClipboardItem e.g. Firefox 
         const { inviteLink } = await createInviteMutation.mutateAsync({
@@ -230,7 +234,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
     } finally {
       setIsCopying(false);
     }
-  }, [isCopying, createInviteMutation, props.teamId, props.token, t]);
+    }, [isCopying, createInviteMutation, props.teamId, props.token, t]);
 
   return (
     <Dialog

--- a/apps/web/modules/ee/teams/components/MemberInvitationModal.tsx
+++ b/apps/web/modules/ee/teams/components/MemberInvitationModal.tsx
@@ -202,7 +202,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
       // Required for Safari but also works on Chrome
       // Credits to https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/
       if (typeof ClipboardItem !== "undefined") {
-        const inviteLinkClipbardItem = new ClipboardItem({
+        const inviteLinkClipboardItem = new ClipboardItem({
           //eslint-disable-next-line no-async-promise-executor
           "text/plain": new Promise(async (resolve) => {
             // Instead of doing async work and then writing to clipboard, do async work in clipboard API itself
@@ -214,7 +214,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
             resolve(new Blob([inviteLink], { type: "text/plain" }));
           }),
         });
-        await navigator.clipboard.write([inviteLinkClipbardItem]);
+        await navigator.clipboard.write([inviteLinkClipboardItem]);
       } else {
         // Fallback for browsers that don't support ClipboardItem e.g. Firefox 
         const { inviteLink } = await createInviteMutation.mutateAsync({


### PR DESCRIPTION
## What does this PR do?

1. Early returns for mutation calls when existing mutation is in pending state
2. Moves the onClick inline code to a separate function
3. Adds useCallback

- Fixes #28752 (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

Before

https://github.com/user-attachments/assets/9738cee6-71a8-4368-9187-1c040ba5859d

After

https://github.com/user-attachments/assets/49a2d255-7c72-49fc-a8ad-44fc274872da

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Go to members of a team, selects all of them and click on add button. Then click on the left bottom copy button a few times. See the error message 

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs
