### PR TITLE
fix(docs): correct self-hosting troubleshooting guide based on codebase verification

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -129,7 +129,8 @@
               "self-hosting/upgrading",
               "self-hosting/sso-setup",
               "self-hosting/docker",
-              "self-hosting/license-key"
+              "self-hosting/license-key",
+              "self-hosting/troubleshooting"
             ]
           },
           {

--- a/docs/self-hosting/troubleshooting.mdx
+++ b/docs/self-hosting/troubleshooting.mdx
@@ -51,6 +51,7 @@ NEXTAUTH_URL=https://cal.yourdomain.com
 
 **Important notes:**
 - Do **not** include a trailing slash.
+- `NEXTAUTH_URL` is optional if `NEXT_PUBLIC_WEBAPP_URL` is set — it will be automatically derived as `${NEXT_PUBLIC_WEBAPP_URL}/api/auth`.
 - For Docker deployments, these must be set **before** building the image, as `NEXT_PUBLIC_WEBAPP_URL` is a build-time variable (it is inlined by Next.js during the build). Rebuild the image after changing it.
 - For Vercel deployments, you do **not** need to set `NEXTAUTH_URL` — Vercel automatically infers it from the deployment URL via the `VERCEL_URL` environment variable.
 
@@ -73,6 +74,7 @@ Related issue: [#21921](https://github.com/calcom/cal.com/issues/21921)
 REDIS_URL=redis://redis:6379
 JWT_SECRET=your_random_jwt_secret_here
 NEXTAUTH_SECRET=your_nextauth_secret_here
+CALENDSO_ENCRYPTION_KEY=your_32_character_encryption_key
 STRIPE_API_KEY=sk_test_your_stripe_key
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 
@@ -203,7 +205,7 @@ yarn workspace @calcom/prisma db-deploy
 
 3. If the issue persists after migrations, check the application logs for the specific Prisma error message — it will indicate which field or constraint is failing.
 
-> **Note:** The setup endpoint (`/api/auth/setup`) creates the first user with the `ADMIN` role. It only works when the `User` table is completely empty. If a previous setup attempt partially succeeded, you may need to manually clear the users table before retrying.
+> **Note:** The setup endpoint (`/auth/setup`) creates the first user with the `ADMIN` role. It only works when the `User` table is completely empty. If a previous setup attempt partially succeeded, you may need to manually clear the users table before retrying.
 
 ---
 

--- a/docs/self-hosting/troubleshooting.mdx
+++ b/docs/self-hosting/troubleshooting.mdx
@@ -120,13 +120,33 @@ If you use a reverse proxy (e.g., Nginx, Traefik), make sure the proxy forwards 
 
 **Symptom:** Requests fail with SSL certificate errors when Cal.com is behind a load balancer or reverse proxy that handles HTTPS termination.
 
-**Solution:** If your reverse proxy handles SSL termination and forwards traffic to Cal.com over plain HTTP internally, set:
+**Solution (choose one):**
+
+**Option 1: If your proxy forwards HTTP internally (most common)**
+
+Set `NEXTAUTH_URL` to the internal HTTP address:
+
+```env
+NEXTAUTH_URL=http://localhost:3000
+```
+
+Ensure your proxy forwards the `Host` and `X-Forwarded-Proto` headers so Cal.com generates correct external-facing URLs.
+
+**Option 2: If using self-signed certificates internally**
+
+Add your internal CA to Node's trusted certificates:
+
+```env
+NODE_EXTRA_CA_CERTS=/path/to/your-internal-ca.crt
+```
+
+**Option 3: Last resort (not recommended for production)**
 
 ```env
 NODE_TLS_REJECT_UNAUTHORIZED=0
 ```
 
-> **Warning:** Only set this if you fully trust the internal network path between your proxy and Cal.com. Do not use this in environments where internal traffic could be intercepted.
+> ⚠️ **Security Warning:** This disables **all** TLS certificate verification globally, including external API calls to Stripe, Google Calendar, and other services. This makes your instance vulnerable to man-in-the-middle attacks. Only use this in isolated development environments where you fully control all network traffic.
 
 ---
 

--- a/docs/self-hosting/troubleshooting.mdx
+++ b/docs/self-hosting/troubleshooting.mdx
@@ -106,13 +106,19 @@ request to http://<your-domain>/api/auth/session failed, reason: getaddrinfo ENO
 
 **Cause:** The Docker container cannot resolve the external hostname set in `NEXTAUTH_URL` from within the container's network.
 
-**Solution:** Set `NEXTAUTH_URL` to the internal loopback address so the container resolves itself:
+**Solution:** Add your domain to the container's `/etc/hosts` so it resolves to itself:
 
-```env
-NEXTAUTH_URL=http://localhost:3000/api/auth
+```yaml
+# docker-compose.yml
+services:
+  calcom:
+    extra_hosts:
+      - "cal.yourdomain.com:127.0.0.1"
 ```
 
-If you use a reverse proxy (e.g., Nginx, Traefik), make sure the proxy forwards the `Host` header and the `X-Forwarded-Proto` header correctly so Cal.com generates external-facing URLs properly.
+This allows the container to resolve your public domain internally while keeping `NEXTAUTH_URL` set to your public URL (required for OAuth callbacks to work).
+
+> **Why not use `localhost`?** Setting `NEXTAUTH_URL` to `localhost` would fix this DNS error, but **breaks OAuth** — external providers like Google would redirect to `localhost` instead of your domain.
 
 ---
 
@@ -124,13 +130,23 @@ If you use a reverse proxy (e.g., Nginx, Traefik), make sure the proxy forwards 
 
 **Option 1: If your proxy forwards HTTP internally (most common)**
 
-Set `NEXTAUTH_URL` to the internal HTTP address:
+Keep `NEXTAUTH_URL` set to your **public-facing HTTPS URL**:
 
 ```env
-NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL=https://cal.yourdomain.com
 ```
 
-Ensure your proxy forwards the `Host` and `X-Forwarded-Proto` headers so Cal.com generates correct external-facing URLs.
+Then configure your reverse proxy to forward these headers so internal requests work correctly:
+
+```nginx
+# Nginx example
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+```
+
+> **Why not use `localhost`?** Setting `NEXTAUTH_URL=http://localhost:3000` would fix internal SSL errors, but **breaks OAuth callbacks** — external providers (Google, Microsoft) would try to redirect users to `localhost`, which fails. Always use your public URL.
 
 **Option 2: If using self-signed certificates internally**
 

--- a/docs/self-hosting/troubleshooting.mdx
+++ b/docs/self-hosting/troubleshooting.mdx
@@ -51,7 +51,7 @@ NEXTAUTH_URL=https://cal.yourdomain.com
 
 **Important notes:**
 - Do **not** include a trailing slash.
-- `NEXTAUTH_URL` is optional if `NEXT_PUBLIC_WEBAPP_URL` is set — it will be automatically derived as `${NEXT_PUBLIC_WEBAPP_URL}/api/auth`.
+- `NEXTAUTH_URL` is optional if `NEXT_PUBLIC_WEBAPP_URL` is set — NextAuth will infer the base URL from the incoming request's `Host` header when `NEXTAUTH_URL` is not explicitly configured.
 - For Docker deployments, these must be set **before** building the image, as `NEXT_PUBLIC_WEBAPP_URL` is a build-time variable (it is inlined by Next.js during the build). Rebuild the image after changing it.
 - For Vercel deployments, you do **not** need to set `NEXTAUTH_URL` — Vercel automatically infers it from the deployment URL via the `VERCEL_URL` environment variable.
 

--- a/docs/self-hosting/troubleshooting.mdx
+++ b/docs/self-hosting/troubleshooting.mdx
@@ -1,0 +1,153 @@
+---
+title: "Troubleshooting"
+icon: "triangle-exclamation"
+---
+
+This guide covers the most common issues encountered when self-hosting Cal.com, along with their solutions.
+
+## Onboarding / Setup Issues
+
+### 500 Error During Onboarding (Missing Stripe Key)
+
+**Symptom:** After completing the initial setup wizard and logging in, you see a `500` (Internal Server Error) when accessing the onboarding flow or certain pages.
+
+**Cause:** Cal.com's onboarding flow attempts to initialize Stripe even if you don't plan to use payments. If `STRIPE_PRIVATE_KEY` (and related Stripe variables) are not set, the server throws an unhandled error.
+
+**Solution:** Add the following variables to your `.env` file. You can use placeholder values if you don't need Stripe, but the keys must be present:
+
+```env
+# Stripe (required to prevent 500 errors during onboarding)
+STRIPE_PRIVATE_KEY=sk_test_placeholder
+STRIPE_CLIENT_ID=ca_placeholder
+NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_placeholder
+STRIPE_WEBHOOK_SECRET=whsec_placeholder
+```
+
+> **Note:** For a production setup with real payments, replace these with your actual Stripe API keys from the [Stripe Dashboard](https://dashboard.stripe.com/apikeys).
+
+Related issue: [#25993](https://github.com/calcom/cal.com/issues/25993)
+
+---
+
+## URL and Redirect Issues
+
+### Redirect to `localhost:3000` After Deployment
+
+**Symptom:** After deploying Cal.com to a server or domain, login redirects or internal links point back to `http://localhost:3000` instead of your actual domain.
+
+**Cause:** The environment variables `NEXTAUTH_URL` and `NEXT_PUBLIC_WEBAPP_URL` are not set to your production domain. These variables tell Cal.com and NextAuth where the app is hosted.
+
+**Solution:** Update your `.env` file to use your actual domain:
+
+```env
+# Replace with your actual domain
+NEXT_PUBLIC_WEBAPP_URL=https://cal.yourdomain.com
+NEXTAUTH_URL=https://cal.yourdomain.com
+```
+
+**Important notes:**
+- Do **not** include a trailing slash.
+- For Docker deployments, these must be set **before** building the image, as `NEXT_PUBLIC_WEBAPP_URL` is a build-time variable. Rebuild the image after changing it.
+- For Vercel deployments, leave `NEXTAUTH_URL` **empty** — Vercel infers it automatically.
+
+Related issue: [#21921](https://github.com/calcom/cal.com/issues/21921)
+
+---
+
+## Docker-Specific Issues
+
+### API v2 Service Not Starting
+
+**Symptom:** After running `docker compose up -d`, the `calcom-api` service fails to start or immediately exits. The web app works, but API v2 endpoints (`/api/v2/...`) return connection errors.
+
+**Cause:** The API v2 service requires several environment variables that are not in the default `.env.example`. The most common missing variables are `REDIS_URL`, `JWT_SECRET`, and `WEB_APP_URL`.
+
+**Solution:** Add the following variables to your root `.env` file (the `docker-compose.yml` passes this to the `calcom-api` service):
+
+```env
+# Required for API v2
+REDIS_URL=redis://redis:6379
+JWT_SECRET=your_random_jwt_secret_here
+WEB_APP_URL=https://cal.yourdomain.com
+
+# Optional API v2 variables
+REDIS_PORT=6379
+LOG_LEVEL=warn
+```
+
+You can generate a secure `JWT_SECRET` with:
+
+```bash
+openssl rand -base64 32
+```
+
+Then restart the stack:
+
+```bash
+docker compose down && docker compose up -d
+```
+
+Check the API v2 service logs for further details if it still fails:
+
+```bash
+docker compose logs calcom-api
+```
+
+---
+
+### `CLIENT_FETCH_ERROR` in Logs
+
+**Symptom:** The following error appears in Docker logs, and login/session fails:
+
+```
+[next-auth][error][CLIENT_FETCH_ERROR]
+request to http://<your-domain>/api/auth/session failed, reason: getaddrinfo ENOTFOUND
+```
+
+**Cause:** The Docker container cannot resolve the external hostname set in `NEXTAUTH_URL` from within the container's network.
+
+**Solution:** Set `NEXTAUTH_URL` to the internal loopback address so the container resolves itself:
+
+```env
+NEXTAUTH_URL=http://localhost:3000/api/auth
+```
+
+If you use a reverse proxy (e.g., Nginx, Traefik), make sure the proxy forwards the `Host` header and the `X-Forwarded-Proto` header correctly so Cal.com generates external-facing URLs properly.
+
+---
+
+### SSL / HTTPS Issues Behind a Reverse Proxy
+
+**Symptom:** Requests fail with SSL certificate errors when Cal.com is behind a load balancer or reverse proxy that handles HTTPS termination.
+
+**Solution:** If your reverse proxy handles SSL termination and forwards traffic to Cal.com over plain HTTP internally, set:
+
+```env
+NODE_TLS_REJECT_UNAUTHORIZED=0
+```
+
+> **Warning:** Only set this if you fully trust the internal network path between your proxy and Cal.com. Do not use this in environments where internal traffic could be intercepted.
+
+---
+
+## Database Issues
+
+### `prisma.user.create()` Fails on First User Setup
+
+**Symptom:** Attempting to create the first admin user results in a Prisma validation error referencing the `metadata` field or `id` field.
+
+**Solution:**
+- Set the `metadata` field to an empty JSON object `{}` instead of leaving it null.
+- Leave the `id` field empty to allow auto-increment.
+
+This is a known issue on certain Cal.com versions. Upgrading to the latest release typically resolves it.
+
+---
+
+## Getting Further Help
+
+If your issue is not listed here:
+
+1. Search the [Cal.com GitHub Issues](https://github.com/calcom/cal.com/issues) — many common problems have documented solutions in issue threads.
+2. Check the [Cal.com Community](https://community.cal.com) forum.
+3. Review the [Docker configuration](./docker) and [Installation guide](./installation) for any steps you may have missed.

--- a/docs/self-hosting/troubleshooting.mdx
+++ b/docs/self-hosting/troubleshooting.mdx
@@ -7,23 +7,27 @@ This guide covers the most common issues encountered when self-hosting Cal.com, 
 
 ## Onboarding / Setup Issues
 
-### 500 Error During Onboarding (Missing Stripe Key)
+### Stripe Payment Features Not Working
 
-**Symptom:** After completing the initial setup wizard and logging in, you see a `500` (Internal Server Error) when accessing the onboarding flow or certain pages.
+**Symptom:** Stripe-related features (paid events, app store payment integration) are not available, or you see errors when attempting to use payment features.
 
-**Cause:** Cal.com's onboarding flow attempts to initialize Stripe even if you don't plan to use payments. If `STRIPE_PRIVATE_KEY` (and related Stripe variables) are not set, the server throws an unhandled error.
+**Cause:** The Stripe integration requires several environment variables to be configured. These variables are defined across two files: `.env` (root) and `.env.appStore`. If they are missing or empty, the Stripe app will be marked as "not installed" and payment-related features will be unavailable.
 
-**Solution:** Add the following variables to your `.env` file. You can use placeholder values if you don't need Stripe, but the keys must be present:
+**Solution:** Add the following variables to your `.env` file (root):
 
 ```env
-# Stripe (required to prevent 500 errors during onboarding)
-STRIPE_PRIVATE_KEY=sk_test_placeholder
-STRIPE_CLIENT_ID=ca_placeholder
-NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_placeholder
-STRIPE_WEBHOOK_SECRET=whsec_placeholder
+STRIPE_PRIVATE_KEY=sk_test_...
+STRIPE_CLIENT_ID=ca_...
+STRIPE_WEBHOOK_SECRET=whsec_...
 ```
 
-> **Note:** For a production setup with real payments, replace these with your actual Stripe API keys from the [Stripe Dashboard](https://dashboard.stripe.com/apikeys).
+And in your `.env.appStore` file (or `.env` if using a single file):
+
+```env
+NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_...
+```
+
+> **Note:** Replace these with your actual Stripe API keys from the [Stripe Dashboard](https://dashboard.stripe.com/apikeys). If you don't need payment features, you can safely leave these empty — the app will function without them, but Stripe-related features will be disabled.
 
 Related issue: [#25993](https://github.com/calcom/cal.com/issues/25993)
 
@@ -47,8 +51,8 @@ NEXTAUTH_URL=https://cal.yourdomain.com
 
 **Important notes:**
 - Do **not** include a trailing slash.
-- For Docker deployments, these must be set **before** building the image, as `NEXT_PUBLIC_WEBAPP_URL` is a build-time variable. Rebuild the image after changing it.
-- For Vercel deployments, leave `NEXTAUTH_URL` **empty** — Vercel infers it automatically.
+- For Docker deployments, these must be set **before** building the image, as `NEXT_PUBLIC_WEBAPP_URL` is a build-time variable (it is inlined by Next.js during the build). Rebuild the image after changing it.
+- For Vercel deployments, you do **not** need to set `NEXTAUTH_URL` — Vercel automatically infers it from the deployment URL via the `VERCEL_URL` environment variable.
 
 Related issue: [#21921](https://github.com/calcom/cal.com/issues/21921)
 
@@ -60,22 +64,27 @@ Related issue: [#21921](https://github.com/calcom/cal.com/issues/21921)
 
 **Symptom:** After running `docker compose up -d`, the `calcom-api` service fails to start or immediately exits. The web app works, but API v2 endpoints (`/api/v2/...`) return connection errors.
 
-**Cause:** The API v2 service requires several environment variables that are not in the default `.env.example`. The most common missing variables are `REDIS_URL`, `JWT_SECRET`, and `WEB_APP_URL`.
+**Cause:** The API v2 service requires several environment variables that are not in the root `.env.example`. If any required variable is missing, the service will throw a `Missing environment variable` error and exit on startup.
 
-**Solution:** Add the following variables to your root `.env` file (the `docker-compose.yml` passes this to the `calcom-api` service):
+**Solution:** Add the following variables to your root `.env` file (the `docker-compose.yml` passes these to the `calcom-api` service):
 
 ```env
-# Required for API v2
+# Required for API v2 (service will not start without these)
 REDIS_URL=redis://redis:6379
 JWT_SECRET=your_random_jwt_secret_here
-WEB_APP_URL=https://cal.yourdomain.com
+NEXTAUTH_SECRET=your_nextauth_secret_here
+STRIPE_API_KEY=sk_test_your_stripe_key
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 
-# Optional API v2 variables
+# Optional (have sensible defaults)
+WEB_APP_URL=https://cal.yourdomain.com
 REDIS_PORT=6379
 LOG_LEVEL=warn
 ```
 
-You can generate a secure `JWT_SECRET` with:
+> **Note:** `STRIPE_API_KEY` is the API v2 equivalent of `STRIPE_PRIVATE_KEY` used by the web app. Both are Stripe secret keys but are consumed by different services. If you don't need Stripe functionality in the API, you can set a placeholder value (e.g., `sk_test_placeholder`), but the variable must be present.
+
+You can generate secure secrets with:
 
 ```bash
 openssl rand -base64 32
@@ -92,6 +101,8 @@ Check the API v2 service logs for further details if it still fails:
 ```bash
 docker compose logs calcom-api
 ```
+
+> **Tip:** The API v2 service has its own `.env.example` at `apps/api/v2/.env.example` with a complete list of all supported variables. Refer to it for the full configuration reference.
 
 ---
 
@@ -117,6 +128,8 @@ services:
 ```
 
 This allows the container to resolve your public domain internally while keeping `NEXTAUTH_URL` set to your public URL (required for OAuth callbacks to work).
+
+> **Important:** This approach works when `NEXTAUTH_URL` uses HTTP (e.g., `http://cal.yourdomain.com:3000`). If your `NEXTAUTH_URL` uses HTTPS, the container will attempt to connect to `127.0.0.1:443`, while the app listens on port 3000 — this will fail. In that case, ensure your reverse proxy is also running inside the Docker network, or see the SSL section below.
 
 > **Why not use `localhost`?** Setting `NEXTAUTH_URL` to `localhost` would fix this DNS error, but **breaks OAuth** — external providers like Google would redirect to `localhost` instead of your domain.
 
@@ -162,21 +175,35 @@ NODE_EXTRA_CA_CERTS=/path/to/your-internal-ca.crt
 NODE_TLS_REJECT_UNAUTHORIZED=0
 ```
 
-> ⚠️ **Security Warning:** This disables **all** TLS certificate verification globally, including external API calls to Stripe, Google Calendar, and other services. This makes your instance vulnerable to man-in-the-middle attacks. Only use this in isolated development environments where you fully control all network traffic.
+> **Security Warning:** This disables **all** TLS certificate verification globally, including external API calls to Stripe, Google Calendar, and other services. This makes your instance vulnerable to man-in-the-middle attacks. Only use this in isolated development environments where you fully control all network traffic.
 
 ---
 
 ## Database Issues
 
-### `prisma.user.create()` Fails on First User Setup
+### First User Setup Fails
 
-**Symptom:** Attempting to create the first admin user results in a Prisma validation error referencing the `metadata` field or `id` field.
+**Symptom:** Attempting to create the first admin user via the `/setup` page results in an error.
+
+**Cause:** This can occur if the database migrations have not been applied, or if the database is in an inconsistent state.
 
 **Solution:**
-- Set the `metadata` field to an empty JSON object `{}` instead of leaving it null.
-- Leave the `id` field empty to allow auto-increment.
 
-This is a known issue on certain Cal.com versions. Upgrading to the latest release typically resolves it.
+1. Ensure database migrations are applied:
+
+```bash
+# For development
+yarn workspace @calcom/prisma db-migrate
+
+# For production / Docker
+yarn workspace @calcom/prisma db-deploy
+```
+
+2. Verify the database is accessible and the `DATABASE_URL` in your `.env` is correct.
+
+3. If the issue persists after migrations, check the application logs for the specific Prisma error message — it will indicate which field or constraint is failing.
+
+> **Note:** The setup endpoint (`/api/auth/setup`) creates the first user with the `ADMIN` role. It only works when the `User` table is completely empty. If a previous setup attempt partially succeeded, you may need to manually clear the users table before retrying.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Corrects several inaccuracies in the self-hosting troubleshooting guide (originally from #28649) after verifying each claim against the current codebase. Adds the new `docs/self-hosting/troubleshooting.mdx` page and registers it in `docs/docs.json`.

### Changes

**Stripe section** — Rewrote to accurately reflect current behavior. The original claimed the onboarding flow crashes with a 500 error if `STRIPE_PRIVATE_KEY` is missing. In the current codebase, the app gracefully handles missing keys (`|| ""` fallback in `packages/app-store/_utils/stripe.ts`) and marks Stripe as "not installed" via `_metadata.ts`. Also clarified that `NEXT_PUBLIC_STRIPE_PUBLIC_KEY` belongs in `.env.appStore`, not `.env`.

**API v2 env vars** — Added required variables that were missing from the guide but will crash the service if absent (verified via `getEnv()` with no fallback in `apps/api/v2/src/config/app.ts`):
- `NEXTAUTH_SECRET`
- `STRIPE_API_KEY`
- `STRIPE_WEBHOOK_SECRET`
- `CALENDSO_ENCRYPTION_KEY` (throws at runtime via `tokens.service.ts` if unset)

Moved `WEB_APP_URL` from "required" to "optional" since it has a fallback default (`https://app.cal.com`). Added a note explaining `STRIPE_API_KEY` vs `STRIPE_PRIVATE_KEY` distinction between services.

**CLIENT_FETCH_ERROR** — Added caveat about the `extra_hosts` approach failing when `NEXTAUTH_URL` uses HTTPS (container connects to `127.0.0.1:443` but app listens on port 3000).

**NEXTAUTH_URL note** — Corrected the derivation mechanism: NextAuth infers the base URL from the incoming request's `Host` header when `NEXTAUTH_URL` is not explicitly configured (not from `NEXT_PUBLIC_WEBAPP_URL` directly). Also clarified that Vercel infers it via the `VERCEL_URL` environment variable.

**Database section** — Replaced unverifiable advice about `metadata`/`id` fields with actionable guidance (run migrations, verify `DATABASE_URL`, check logs). The original claims couldn't be reproduced — `apps/web/app/api/auth/setup/route.ts` doesn't set `metadata` and `id` auto-increments.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). This PR is itself a docs change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — docs-only change.

## How should this be tested?

This is a documentation-only change. To verify accuracy:

1. **API v2 required vars**: Check `apps/api/v2/src/config/app.ts` — confirm that `REDIS_URL`, `NEXTAUTH_SECRET`, `STRIPE_API_KEY`, `STRIPE_WEBHOOK_SECRET` all call `getEnv()` without a fallback (meaning they throw if missing). Also check `apps/api/v2/src/modules/tokens/tokens.service.ts:33-35` for `CALENDSO_ENCRYPTION_KEY`.
2. **WEB_APP_URL optional**: Confirm `getEnv("WEB_APP_URL", "https://app.cal.com")` has a fallback in `apps/api/v2/src/config/app.ts:45`.
3. **Stripe graceful handling**: Confirm `packages/app-store/_utils/stripe.ts:69` uses `process.env.STRIPE_PRIVATE_KEY || ""` and `packages/app-store/stripepayment/_metadata.ts` sets `installed: false` when keys are missing.

### Human review checklist

- [ ] Verify required vs optional env var classification for API v2 matches `apps/api/v2/src/env.ts` and `apps/api/v2/src/config/app.ts`
- [ ] Note: `CALENDSO_ENCRYPTION_KEY` is not validated at startup via `getEnv()` — it throws at runtime when `tokens.service.ts` tries to use it. The guide lists it as "required" which is practically correct, but the failure mode is different (runtime error vs startup crash). Decide whether this nuance should be documented.
- [ ] Confirm the `NEXTAUTH_URL` Host-header inference claim aligns with the NextAuth version used by the project
- [ ] Verify linked issues (#25993, #21921) are still relevant to the described symptoms

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Link to Devin session: https://app.devin.ai/sessions/f878113940584cf8b8c0ef2f514bb4c9
Requested by: @romitg2