### PR TITLE
fix: prevent negative wait time in rate limit error message

### DIFF
--- a/packages/lib/checkRateLimitAndThrowError.test.ts
+++ b/packages/lib/checkRateLimitAndThrowError.test.ts
@@ -67,4 +67,21 @@ describe("checkRateLimitAndThrowError", () => {
 
     await expect(checkRateLimitAndThrowError({ rateLimitingType, identifier })).resolves.not.toThrow();
   });
+  it("should not return negative wait time when reset is in the past", async () => {
+    vi.mocked(rateLimiter).mockReturnValue(() => {
+      return {
+        limit: 10,
+        remaining: -1,
+        reset: Date.now() - 5000, // past time
+        success: false,
+      } as RatelimitResponse;
+    });
+
+    const identifier = "test-identifier";
+    const rateLimitingType = "core";
+
+    await expect(
+      checkRateLimitAndThrowError({ rateLimitingType, identifier })
+    ).rejects.toThrow("0 seconds");
+  });
 });

--- a/packages/lib/checkRateLimitAndThrowError.ts
+++ b/packages/lib/checkRateLimitAndThrowError.ts
@@ -13,7 +13,7 @@ export async function checkRateLimitAndThrowError({
   const { success, reset } = response;
   if (!success) {
     const convertToSeconds = (ms: number) => Math.floor(ms / 1000);
-    const secondsToWait = convertToSeconds(reset - Date.now());
+    const secondsToWait = Math.max(0, convertToSeconds(reset - Date.now()));
     throw new HttpError({
       statusCode: 429,
       message: `Rate limit exceeded. Try again in ${secondsToWait} seconds.`,


### PR DESCRIPTION
## What does this PR do?

Fixes #28764

This PR prevents negative wait times from being displayed in the rate limit error message.

Previously, if the `reset` timestamp was in the past, the computed wait time could become negative, leading to messages like:

"Rate limit exceeded. Try again in -5 seconds."

This PR clamps the value to a minimum of `0` to ensure correct and user-friendly output.

---

## Visual Demo (For contributors especially)

N/A — this is a logic-level fix and does not require UI interaction.

---

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if required (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective

---

## How should this be tested?

1. Mock a rate limiter response where:
   - `success = false`
   - `reset < Date.now()`

2. Call:
   ```ts
   checkRateLimitAndThrowError(...)
    ```
3. Verify:

- Error message contains "0 seconds"
- No negative values appear