### PR TITLE
fix(web): add vertical padding to social login buttons

### DIFF
--- a/apps/web/modules/auth/login-view.tsx
+++ b/apps/web/modules/auth/login-view.tsx
@@ -218,7 +218,7 @@ export default function Login({
                 <div className="flex flex-col gap-2">
                   {isGoogleLoginEnabled && (
                     <Button
-                      className="w-full"
+                      className="w-full py-1"
                       disabled={formState.isSubmitting}
                       data-testid="google"
                       onClick={async (e) => {
@@ -236,7 +236,7 @@ export default function Login({
                   {isOutlookLoginEnabled && (
                     <Button
                       variant="outline"
-                      className="w-full"
+                      className="w-full py-1"
                       data-testid="microsoft"
                       onClick={async (e) => {
                         e.preventDefault();


### PR DESCRIPTION
## What does this PR do?

- Adds `py-1` to Google and Microsoft social sign-in buttons on the login page.
- This changes vertical padding for better visual spacing on `/auth/login`.

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

Before:

<img width="973" height="740" alt="Screenshot 2026-04-07 at 1 52 59 AM" src="https://github.com/user-attachments/assets/53a454ca-0ce2-4273-9e0f-6dbe43cbe4f4" />

After: 

<img width="921" height="808" alt="Screenshot 2026-04-07 at 1 52 01 AM" src="https://github.com/user-attachments/assets/02f2f141-1f33-4f97-b52f-1f84082848e5" />


## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
