### PR TITLE
fix: align webhook edit page with PBAC middleware

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/[id]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/[id]/page.tsx
@@ -1,8 +1,15 @@
 import type { PageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
+import { cookies, headers } from "next/headers";
+import { notFound, redirect } from "next/navigation";
 
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { WebhookRepository } from "@calcom/features/webhooks/lib/repository/WebhookRepository";
 import { APP_NAME } from "@calcom/lib/constants";
+import { MembershipRole } from "@calcom/prisma/enums";
+
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
 import { EditWebhookView } from "~/webhooks/views/webhook-edit-view";
 
@@ -16,11 +23,32 @@ export const generateMetadata = async ({ params }: { params: Promise<{ id: strin
   );
 
 const Page = async ({ params: _params }: PageProps) => {
+  const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
+  if (!session?.user?.id) {
+    return redirect("/auth/login");
+  }
+
   const params = await _params;
   const id = typeof params?.id === "string" ? params.id : undefined;
 
   const webhookRepository = WebhookRepository.getInstance();
   const webhook = await webhookRepository.findByWebhookId(id);
+
+  // Ownership check: align with PBAC middleware in webhook/util.ts
+  if (webhook.teamId) {
+    const permissionService = new PermissionCheckService();
+    const hasPermission = await permissionService.checkPermission({
+      userId: session.user.id,
+      teamId: webhook.teamId,
+      permission: "webhook.read",
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER, MembershipRole.MEMBER],
+    });
+    if (!hasPermission) {
+      notFound();
+    }
+  } else if (webhook.userId !== session.user.id) {
+    notFound();
+  }
 
   return <EditWebhookView webhook={webhook} />;
 };


### PR DESCRIPTION
## What does this PR do?

Adds authentication and permission verification to the webhook edit page. The page was loading webhook data directly without verifying the current user's access, which could result in incorrect data being displayed.

### Changes

- Added session check with redirect to login (consistent with other settings pages)
- Added permission verification for team webhooks using `PermissionCheckService`
- Added direct ownership check for personal webhooks
- Returns 404 when the user doesn't have access to the requested webhook

## How should this be tested?

1. Navigate to `/settings/developer/webhooks/{id}` for your own webhook → should load normally
2. Navigate to a webhook URL you don't have access to → should show 404
3. Verify team webhooks are accessible by team admins/owners

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). 
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.