### PR TITLE
fix: add input validation to webhook subscription creation

### DIFF
--- a/packages/features/webhooks/lib/addSubscription.test.ts
+++ b/packages/features/webhooks/lib/addSubscription.test.ts
@@ -1,0 +1,87 @@
+import { validateUrlForSSRF } from "@calcom/lib/ssrfProtection";
+import { prisma } from "@calcom/prisma";
+import { WebhookTriggerEvents } from "@calcom/prisma/enums";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addSubscription } from "./scheduleTrigger";
+
+vi.mock("@calcom/lib/ssrfProtection", () => ({
+  validateUrlForSSRF: vi.fn(),
+}));
+
+vi.mock("@calcom/prisma", () => ({
+  default: {},
+  prisma: {
+    webhook: { create: vi.fn() },
+    booking: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@calcom/lib/logger", () => ({
+  default: {
+    getSubLogger: vi.fn().mockReturnValue({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("uuid", () => ({
+  v4: vi.fn().mockReturnValue("mock-uuid"),
+}));
+
+const VALID_PARAMS = {
+  triggerEvent: WebhookTriggerEvents.BOOKING_CREATED,
+  subscriberUrl: "https://hooks.zapier.com/hooks/standard/123/abc/",
+  appId: "zapier",
+  account: { id: 1, name: "Test", isTeam: false },
+};
+
+describe("addSubscription SSRF validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates webhook when URL is valid", async () => {
+    vi.mocked(validateUrlForSSRF).mockResolvedValue({ isValid: true });
+    vi.mocked(prisma.webhook.create).mockResolvedValue({
+      id: "mock-uuid",
+      subscriberUrl: VALID_PARAMS.subscriberUrl,
+    } as Awaited<ReturnType<typeof prisma.webhook.create>>);
+
+    const result = await addSubscription(VALID_PARAMS);
+
+    expect(validateUrlForSSRF).toHaveBeenCalledWith(VALID_PARAMS.subscriberUrl);
+    expect(prisma.webhook.create).toHaveBeenCalled();
+    expect(result).toBeDefined();
+  });
+
+  it("does not create webhook when URL is blocked", async () => {
+    vi.mocked(validateUrlForSSRF).mockResolvedValue({ isValid: false, error: "Blocked hostname" });
+
+    const result = await addSubscription({
+      ...VALID_PARAMS,
+      subscriberUrl: "http://169.254.169.254/latest/meta-data/",
+    });
+
+    expect(validateUrlForSSRF).toHaveBeenCalledWith("http://169.254.169.254/latest/meta-data/");
+    expect(prisma.webhook.create).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it("does not create webhook when URL resolves to private IP", async () => {
+    vi.mocked(validateUrlForSSRF).mockResolvedValue({
+      isValid: false,
+      error: "Hostname resolves to private IP",
+    });
+
+    const result = await addSubscription({
+      ...VALID_PARAMS,
+      subscriberUrl: "https://evil.example.com/",
+    });
+
+    expect(prisma.webhook.create).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -8,6 +8,7 @@ import tasker from "@calcom/features/tasker";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { withReporting } from "@calcom/lib/sentryWrapper";
+import { logBlockedSSRFAttempt, validateUrlForSSRF } from "@calcom/lib/ssrfProtection";
 import { getTranslation } from "@calcom/i18n/server";
 import { prisma } from "@calcom/prisma";
 import type { Prisma, Webhook, Booking, ApiKey } from "@calcom/prisma/client";
@@ -45,6 +46,12 @@ export async function addSubscription({
   } | null;
 }) {
   try {
+    const validation = await validateUrlForSSRF(subscriberUrl);
+    if (!validation.isValid) {
+      logBlockedSSRFAttempt(subscriberUrl, validation.error ?? "", { appId });
+      throw new Error(`Subscriber URL is not allowed: ${validation.error}`);
+    }
+
     const userId = appApiKey ? appApiKey.userId : account && !account.isTeam ? account.id : null;
     const teamId = appApiKey ? appApiKey.teamId : account && account.isTeam ? account.id : null;
 


### PR DESCRIPTION
## What does this PR do?

Adds URL validation to the `addSubscription` function in `scheduleTrigger.ts`, consistent with how the tRPC webhook create/edit handlers already validate subscriber URLs. This centralizes the check so all callers (Zapier, Make, and future integrations) inherit the validation.

### Changes

- Added URL validation before `prisma.webhook.create` in `addSubscription`
- Added unit tests covering validation behavior

## How should this be tested?

### Automated
```bash
TZ=UTC yarn vitest run packages/features/webhooks/lib/addSubscription.test.ts
```
### Manual

1. Create a Zapier/Make webhook subscription with a valid URL → should succeed
2. Verify existing Zapier/Make webhooks continue to fire normally

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.