### PR TITLE
fix(tests): add missing vi.mock() to prevent vitest worker shutdown flake in InstantBookingCreateService

### DIFF
--- a/packages/features/bookings/lib/service/InstantBookingCreateService.test.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.test.ts
@@ -22,6 +22,10 @@ vi.mock("@calcom/features/notifications/sendNotification", () => ({
   sendNotification: vi.fn(),
 }));
 
+vi.mock("@calcom/app-store/feishucalendar/lib/CalendarService", () => ({
+  default: class MockFeishuCalendarService {},
+}));
+
 vi.mock("@calcom/features/conferencing/lib/videoClient", () => ({
   createInstantMeetingWithCalVideo: vi.fn().mockResolvedValue({
     type: "daily_video",


### PR DESCRIPTION
## Summary

- Adds a `vi.mock()` for `@calcom/app-store/feishucalendar/lib/CalendarService` in `InstantBookingCreateService.test.ts` to prevent a vitest worker shutdown flake.

## Problem

The unit test suite intermittently fails with:

```
Error: [vitest-worker]: Closing rpc while "fetch" was pending
  at packages/app-store/feishucalendar/lib/CalendarService.ts:16:1
This error originated in "packages/features/bookings/lib/service/InstantBookingCreateService.test.ts"
```

All 6,821 tests pass, but vitest catches an unhandled rejection during worker shutdown. The feishu CalendarService imports `refreshOAuthTokens`, which triggers a transitive import chain that initiates a `fetch()` at module load time. When the vitest worker terminates before that fetch completes, the error fires.

Observed in CI runs [24052499571](https://github.com/calcom/cal.com/actions/runs/24052499571), [24052064625](https://github.com/calcom/cal.com/actions/runs/24052064625).

## Fix

Added `vi.mock("@calcom/app-store/feishucalendar/lib/CalendarService", ...)` alongside the existing mocks in the test file. This cuts off the import chain before the module that triggers the background fetch.

This is the same pattern applied in:
- #28459 (missing vi.mock() calls for worker shutdown flakiness)
- #28626 (parseFrontmatter test)
- #28603 (getRoutedUsers test)

## Verification

1. Run `yarn test packages/features/bookings/lib/service/InstantBookingCreateService.test.ts` — should pass with no "Closing rpc" errors
2. Monitor the next few `PR Update > Tests / Unit` CI runs for absence of this flake

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.