### PR TITLE
fix(ci): pin lingodotdev/lingo.dev action to SHA to prevent supply chain risk

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - uses: lingodotdev/lingo.dev@main
+      - uses: lingodotdev/lingo.dev@cee3eb86550ca4905fc99fe90786fb7523288a61 # main
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:


### PR DESCRIPTION
## Summary

- Pins `lingodotdev/lingo.dev` from `@main` (mutable branch) to `@cee3eb86550ca4905fc99fe90786fb7523288a61` (immutable SHA).

## Problem

The i18n workflow (`.github/workflows/i18n.yml`, line 33) references a third-party action pinned to a mutable branch:

```yaml
uses: lingodotdev/lingo.dev@main
```

This action runs with `contents: write` and `pull-requests: write` permissions (lines 17-18). Any commit pushed to the upstream repo's `main` branch immediately executes in cal.com's CI with write access to the repository. This is a supply chain attack vector — a compromised or malicious upstream commit could modify source code or create unauthorized PRs.

The repo already follows SHA-pinning for other sensitive actions (e.g., `actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94` on line 22 of the same file).

## Fix

Pinned to the current HEAD of `lingodotdev/lingo.dev@main` (`cee3eb86550ca4905fc99fe90786fb7523288a61`) with a `# main` comment for readability. No functional change — same code runs, but now immutable.

## Verification

1. Trigger the i18n workflow manually or via a push to main that touches `packages/i18n/`
2. Confirm the workflow still runs successfully with the SHA-pinned reference
3. Consider adding Dependabot or Renovate to manage future action version updates

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.