### PR TITLE
perf(organizations): eliminate N+1 queries in listMembers and adminDelete

### DIFF
--- a/packages/trpc/server/routers/viewer/organizations/adminDelete.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/adminDelete.handler.ts
@@ -1,6 +1,7 @@
 import { deleteDomain } from "@calcom/lib/domainManager/organization";
 import logger from "@calcom/lib/logger";
 import { prisma } from "@calcom/prisma";
+import { Prisma } from "@calcom/prisma/client";
 import { RedirectType } from "@calcom/prisma/enums";
 
 import { TRPCError } from "@trpc/server";
@@ -22,10 +23,18 @@ export const adminDeleteHandler = async ({ input }: AdminDeleteOption) => {
       id: input.orgId,
       isOrganization: true,
     },
-    include: {
+    select: {
+      id: true,
+      name: true,
+      slug: true,
       members: {
         select: {
-          user: true,
+          user: {
+            select: {
+              id: true,
+              username: true,
+            },
+          },
         },
       },
     },
@@ -63,24 +72,21 @@ export const adminDeleteHandler = async ({ input }: AdminDeleteOption) => {
 export default adminDeleteHandler;
 
 async function renameUsersToAvoidUsernameConflicts(users: { id: number; username: string | null }[]) {
+  if (users.length === 0) return;
+
   for (const user of users) {
-    let currentUsername = user.username;
-
-    if (!currentUsername) {
-      currentUsername = "no-username";
-      log.warn(`User ${user.id} has no username, defaulting to ${currentUsername}`);
+    if (!user.username) {
+      log.warn(`User ${user.id} has no username, defaulting to no-username`);
     }
-
-    await prisma.user.update({
-      where: {
-        id: user.id,
-      },
-      data: {
-        // user.id being auto-incremented, we can safely assume that the username will be unique
-        username: `${currentUsername}-${user.id}`,
-      },
-    });
   }
+
+  // Batch all username updates using a single raw query instead of N individual updates.
+  // Each user gets `{currentUsername}-{userId}` to guarantee uniqueness.
+  await prisma.$executeRaw`
+    UPDATE "users"
+    SET "username" = CONCAT(COALESCE("username", 'no-username'), '-', "id"::text)
+    WHERE "id" IN (${Prisma.join(users.map((u) => u.id))})
+  `;
 }
 
 async function deleteAllRedirectsForUsers(users: { username: string | null }[]) {

--- a/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
@@ -280,96 +280,93 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
 
   const [totalCount, teamMembers] = await Promise.all([totalCountPromise, teamMembersPromise]);
 
-  const members = await Promise.all(
-    teamMembers?.map(async (membership) => {
-      const user = await new UserRepository(prisma).enrichUserWithItsProfile({ user: membership.user });
-      let attributes:
-        | Array<{
-            id: string;
-            value: string;
-            slug: string;
-            attributeId: string;
-            weight: number;
-            isGroup: boolean;
-            contains: string[];
-          }>
-        | undefined;
-
-      if (expand?.includes("attributes")) {
-        attributes = await prisma.attributeToUser
-          .findMany({
-            where: {
-              memberId: membership.id,
-            },
-            select: {
-              attributeOption: true,
-              weight: true,
-            },
-            orderBy: {
-              attributeOption: {
-                attribute: {
-                  name: "asc",
-                },
-              },
-            },
-          })
-          .then((assignedUsers) =>
-            assignedUsers.map((au) => ({
-              ...au.attributeOption,
-              weight: au.weight ?? 100,
-            }))
-          );
-      }
-
-      return {
-        id: user.id,
-        username: user.profiles[0]?.username || user.username,
-        name: user.name,
-        email: user.email,
-        timeZone: user.timeZone,
-        role: membership.role,
-        customRole: membership.customRole,
-        accepted: membership.accepted,
-        disableImpersonation: user.disableImpersonation,
-        completedOnboarding: user.completedOnboarding,
-        lastActiveAt: membership.user.lastActiveAt
-          ? new Intl.DateTimeFormat(ctx.user.locale, {
-              timeZone: ctx.user.timeZone,
-            })
-              .format(membership.user.lastActiveAt)
-              .toLowerCase()
-          : null,
-        createdAt: membership.createdAt
-          ? new Intl.DateTimeFormat(ctx.user.locale, {
-              timeZone: ctx.user.timeZone,
-            })
-              .format(membership.createdAt)
-              .toLowerCase()
-          : null,
-        updatedAt: membership.updatedAt
-          ? new Intl.DateTimeFormat(ctx.user.locale, {
-              timeZone: ctx.user.timeZone,
-            })
-              .format(membership.updatedAt)
-              .toLowerCase()
-          : null,
-        avatarUrl: user.avatarUrl,
-        ...(ctx.user.organization.isOrgAdmin && { twoFactorEnabled: user.twoFactorEnabled }),
-        teams: user.teams
-          .filter((team) => team.team.id !== organizationId) // In this context we dont want to return the org team
-          .map((team) => {
-            if (team.team.id === organizationId) return;
-            return {
-              id: team.team.id,
-              name: team.team.name,
-              slug: team.team.slug,
-            };
-          })
-          .filter((team): team is NonNullable<typeof team> => team !== undefined),
-        attributes,
-      };
-    }) || []
+  // Batch enrich all users in a single query instead of N individual calls
+  const userRepository = new UserRepository(prisma);
+  const enrichedUsers = await userRepository.enrichUsersWithTheirProfiles(
+    teamMembers.map((m) => m.user)
   );
+  const enrichedUserMap = new Map(enrichedUsers.map((u) => [u.id, u]));
+
+  // Batch fetch all attributes in a single query instead of N individual calls
+  let attributesByMemberId: Map<
+    number,
+    Array<{
+      id: string;
+      value: string;
+      slug: string;
+      attributeId: string;
+      weight: number;
+      isGroup: boolean;
+      contains: string[];
+    }>
+  > = new Map();
+
+  if (expand?.includes("attributes")) {
+    const memberIds = teamMembers.map((m) => m.id);
+    const allAttributes = await prisma.attributeToUser.findMany({
+      where: {
+        memberId: { in: memberIds },
+      },
+      select: {
+        memberId: true,
+        attributeOption: true,
+        weight: true,
+      },
+      orderBy: {
+        attributeOption: {
+          attribute: {
+            name: "asc",
+          },
+        },
+      },
+    });
+
+    for (const attr of allAttributes) {
+      const existing = attributesByMemberId.get(attr.memberId) ?? [];
+      existing.push({
+        ...attr.attributeOption,
+        weight: attr.weight ?? 100,
+      });
+      attributesByMemberId.set(attr.memberId, existing);
+    }
+  }
+
+  const dateFormatter = new Intl.DateTimeFormat(ctx.user.locale, {
+    timeZone: ctx.user.timeZone,
+  });
+
+  const members = teamMembers.map((membership) => {
+    const user = enrichedUserMap.get(membership.user.id) ?? membership.user;
+    const attributes = attributesByMemberId.get(membership.id);
+
+    return {
+      id: user.id,
+      username: ("profiles" in user && user.profiles?.[0]?.username) || user.username,
+      name: user.name,
+      email: user.email,
+      timeZone: user.timeZone,
+      role: membership.role,
+      customRole: membership.customRole,
+      accepted: membership.accepted,
+      disableImpersonation: user.disableImpersonation,
+      completedOnboarding: user.completedOnboarding,
+      lastActiveAt: membership.user.lastActiveAt
+        ? dateFormatter.format(membership.user.lastActiveAt).toLowerCase()
+        : null,
+      createdAt: membership.createdAt ? dateFormatter.format(membership.createdAt).toLowerCase() : null,
+      updatedAt: membership.updatedAt ? dateFormatter.format(membership.updatedAt).toLowerCase() : null,
+      avatarUrl: user.avatarUrl,
+      ...(ctx.user.organization.isOrgAdmin && { twoFactorEnabled: user.twoFactorEnabled }),
+      teams: user.teams
+        .filter((team) => team.team.id !== organizationId)
+        .map((team) => ({
+          id: team.team.id,
+          name: team.team.name,
+          slug: team.team.slug,
+        })),
+      attributes,
+    };
+  });
 
   return {
     rows: members || [],


### PR DESCRIPTION
## Summary
- **listMembers**: Replace per-member `enrichUserWithItsProfile()` and `attributeToUser.findMany()` calls with batch operations, reducing from 2N queries to 2 queries
- **adminDelete**: Replace N individual `prisma.user.update()` calls with a single batch `$executeRaw` UPDATE, and convert `include` to `select` to fetch only needed fields (`id`, `username`, `name`, `slug`)

## Test plan
- [ ] Verify listMembers returns the same response shape with batched enrichment
- [ ] Verify adminDelete correctly renames all users in one batch UPDATE
- [ ] Verify attribute expansion still works when `expand` includes `"attributes"`
- [ ] Run `yarn type-check:ci --force` to confirm no type regressions