### PR TITLE
perf(prisma): add composite indexes for User and Availability tables

### DIFF
--- a/packages/prisma/migrations/20260407000000_add_composite_indexes_for_scale/migration.sql
+++ b/packages/prisma/migrations/20260407000000_add_composite_indexes_for_scale/migration.sql
@@ -1,0 +1,16 @@
+-- User: optimize login/verification lookups.
+-- The User table has low write volume (account creation/updates) relative to
+-- the high read frequency of auth queries, making this a safe addition.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "users_email_emailVerified_idx"
+ON "users" ("email", "emailVerified");
+
+-- Availability: optimize schedule-based date range lookups.
+-- Availability has 3 existing indexes. This composite covers the common
+-- query pattern of fetching schedule slots within a date range.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Availability_scheduleId_date_idx"
+ON "Availability" ("scheduleId", "date");
+
+-- Availability: optimize user-based date range lookups.
+-- Covers the common pattern of fetching a user's availability for a date range.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Availability_userId_date_idx"
+ON "Availability" ("userId", "date");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -531,6 +531,7 @@ model User {
   @@index([emailVerified])
   @@index([identityProvider])
   @@index([identityProviderId])
+  @@index([email, emailVerified])
   @@map(name: "users")
 }
 
@@ -998,6 +999,8 @@ model Availability {
   @@index([userId])
   @@index([eventTypeId])
   @@index([scheduleId])
+  @@index([scheduleId, date])
+  @@index([userId, date])
 }
 
 model SelectedCalendar {


### PR DESCRIPTION
## Summary
- Add `(email, emailVerified)` composite index on User table to optimize login/verification lookups
- Add `(scheduleId, date)` and `(userId, date)` composite indexes on Availability table to optimize date range queries
- Migration uses `CREATE INDEX CONCURRENTLY` for zero-downtime deployment
- Intentionally conservative: only targets tables with low existing index count (User: 4→5, Availability: 3→5) to avoid write amplification on index-heavy tables like Booking (12 indexes)

## Test plan
- [ ] Verify migration runs cleanly with `yarn workspace @calcom/prisma db-migrate`
- [ ] Verify `yarn prisma generate` succeeds after schema change
- [ ] Run `yarn type-check:ci --force` to confirm no type regressions