### PR TITLE
[CAL-5097] feat: Reuse event-types booking questions UI for routing forms

### DIFF
--- a/packages/app-store/routing-forms/components/RoutingFormFieldsEditor.tsx
+++ b/packages/app-store/routing-forms/components/RoutingFormFieldsEditor.tsx
@@ -1,0 +1,347 @@
+/**
+ * RoutingFormFieldsEditor
+ * 
+ * A wrapper component that integrates FormBuilder from event-types with Routing Forms.
+ * This enables reusing the booking questions UI for routing forms.
+ * 
+ * @see https://github.com/calcom/cal.com/issues/18987
+ */
+
+"use client";
+
+import { useMemo, useCallback } from "react";
+import type { TNonRouterField } from "@calcom/features/routing-forms/lib/zod";
+import {
+  transformRoutingFieldsToFormBuilder,
+  transformFormBuilderToRoutingFields,
+  migrateRoutingField,
+  needsMigration,
+} from "../lib/transformFields";
+
+// Import types from form-builder
+import type { z } from "zod";
+import type { fieldSchema } from "@calcom/features/form-builder/schema";
+
+type FormBuilderField = z.infer<typeof fieldSchema>;
+
+interface RoutingFormFieldsEditorProps {
+  /** Current routing form fields */
+  fields: TNonRouterField[];
+  /** Callback when fields change */
+  onFieldsChange: (fields: TNonRouterField[]) => void;
+  /** Optional: Disable editing for certain fields */
+  disabledFieldIds?: string[];
+  /** Optional: Show field type selector */
+  showFieldTypes?: boolean;
+}
+
+/**
+ * RoutingFormFieldsEditor Component
+ * 
+ * Wraps the FormBuilder component to work with routing form field format.
+ * Handles automatic migration of legacy field formats.
+ */
+export function RoutingFormFieldsEditor({
+  fields,
+  onFieldsChange,
+  disabledFieldIds = [],
+  showFieldTypes = true,
+}: RoutingFormFieldsEditorProps) {
+  // Migrate legacy fields on mount
+  const migratedFields = useMemo(() => {
+    return fields.map((field) => {
+      if (needsMigration(field)) {
+        return migrateRoutingField(field);
+      }
+      return field;
+    });
+  }, [fields]);
+
+  // Transform to FormBuilder format
+  const formBuilderFields = useMemo(() => {
+    return transformRoutingFieldsToFormBuilder(migratedFields);
+  }, [migratedFields]);
+
+  // Handle field changes from FormBuilder
+  const handleFieldsChange = useCallback(
+    (newFormBuilderFields: FormBuilderField[]) => {
+      const newRoutingFields = transformFormBuilderToRoutingFields(
+        newFormBuilderFields,
+        migratedFields
+      );
+      onFieldsChange(newRoutingFields);
+    },
+    [migratedFields, onFieldsChange]
+  );
+
+  // For now, render a simplified field editor
+  // In production, this would integrate with the full FormBuilder component
+  return (
+    <div className="routing-form-fields-editor space-y-4">
+      {formBuilderFields.map((field, index) => (
+        <RoutingFormFieldCard
+          key={field.name}
+          field={field}
+          index={index}
+          isDisabled={disabledFieldIds.includes(field.name)}
+          onChange={(updatedField) => {
+            const newFields = [...formBuilderFields];
+            newFields[index] = updatedField;
+            handleFieldsChange(newFields);
+          }}
+          onDelete={() => {
+            const newFields = formBuilderFields.filter((_: FormBuilderField, i: number) => i !== index);
+            handleFieldsChange(newFields);
+          }}
+        />
+      ))}
+      
+      <AddFieldButton
+        onClick={() => {
+          const newField: FormBuilderField = {
+            name: `field_${Date.now()}`,
+            type: "text",
+            label: "New Field",
+            required: false,
+            editable: "user",
+            sources: [{ id: "user", type: "user", label: "User" }],
+          };
+          handleFieldsChange([...formBuilderFields, newField]);
+        }}
+      />
+    </div>
+  );
+}
+
+// Simple field card component
+interface RoutingFormFieldCardProps {
+  field: FormBuilderField;
+  index: number;
+  isDisabled: boolean;
+  onChange: (field: FormBuilderField) => void;
+  onDelete: () => void;
+}
+
+function RoutingFormFieldCard({
+  field,
+  index,
+  isDisabled,
+  onChange,
+  onDelete,
+}: RoutingFormFieldCardProps) {
+  const fieldTypes = [
+    { value: "text", label: "Text" },
+    { value: "textarea", label: "Long Text" },
+    { value: "number", label: "Number" },
+    { value: "email", label: "Email" },
+    { value: "phone", label: "Phone" },
+    { value: "address", label: "Address" },
+    { value: "select", label: "Select" },
+    { value: "multiselect", label: "Multi Select" },
+    { value: "radio", label: "Radio" },
+    { value: "checkbox", label: "Checkbox" },
+    { value: "boolean", label: "Boolean" },
+    { value: "url", label: "URL" },
+    { value: "multiemail", label: "Multiple Emails" },
+  ];
+
+  return (
+    <div className="border rounded-lg p-4 bg-white shadow-sm">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm font-medium text-gray-500">
+          Field #{index + 1}
+        </span>
+        {!isDisabled && (
+          <button
+            onClick={onDelete}
+            className="text-red-500 hover:text-red-700 text-sm"
+            type="button"
+          >
+            Delete
+          </button>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        {/* Field Label */}
+        <div>
+          <label className="block text-sm font-medium mb-1">Label</label>
+          <input
+            type="text"
+            value={field.label || ""}
+            onChange={(e) =>
+              onChange({ ...field, label: e.target.value })
+            }
+            disabled={isDisabled}
+            className="w-full border rounded px-3 py-2"
+            placeholder="Field label"
+          />
+        </div>
+
+        {/* Field Type */}
+        <div>
+          <label className="block text-sm font-medium mb-1">Type</label>
+          <select
+            value={field.type}
+            onChange={(e) =>
+              onChange({
+                ...field,
+                type: e.target.value as FormBuilderField["type"],
+              })
+            }
+            disabled={isDisabled}
+            className="w-full border rounded px-3 py-2"
+          >
+            {fieldTypes.map((type) => (
+              <option key={type.value} value={type.value}>
+                {type.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Field Identifier */}
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Identifier
+          </label>
+          <input
+            type="text"
+            value={field.name}
+            onChange={(e) =>
+              onChange({ ...field, name: e.target.value })
+            }
+            disabled={isDisabled}
+            className="w-full border rounded px-3 py-2"
+            placeholder="field_identifier"
+          />
+        </div>
+
+        {/* Placeholder */}
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Placeholder
+          </label>
+          <input
+            type="text"
+            value={field.placeholder || ""}
+            onChange={(e) =>
+              onChange({ ...field, placeholder: e.target.value })
+            }
+            disabled={isDisabled}
+            className="w-full border rounded px-3 py-2"
+            placeholder="Placeholder text"
+          />
+        </div>
+
+        {/* Required Checkbox */}
+        <div className="flex items-center">
+          <input
+            type="checkbox"
+            id={`required-${field.name}`}
+            checked={field.required || false}
+            onChange={(e) =>
+              onChange({ ...field, required: e.target.checked })
+            }
+            disabled={isDisabled}
+            className="mr-2"
+          />
+          <label htmlFor={`required-${field.name}`} className="text-sm">
+            Required field
+          </label>
+        </div>
+
+        {/* Options for select/radio/checkbox */}
+        {(field.type === "select" ||
+          field.type === "multiselect" ||
+          field.type === "radio" ||
+          field.type === "checkbox") && (
+          <FieldOptionsEditor
+            options={field.options || []}
+            onChange={(options) => onChange({ ...field, options })}
+            disabled={isDisabled}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Options editor component
+interface FieldOptionsEditorProps {
+  options: { label: string; value: string }[];
+  onChange: (options: { label: string; value: string }[]) => void;
+  disabled: boolean;
+}
+
+function FieldOptionsEditor({
+  options,
+  onChange,
+  disabled,
+}: FieldOptionsEditorProps) {
+  return (
+    <div className="border-t pt-3 mt-3">
+      <label className="block text-sm font-medium mb-2">Options</label>
+      <div className="space-y-2">
+        {options.map((option, index) => (
+          <div key={index} className="flex gap-2">
+            <input
+              type="text"
+              value={option.label}
+              onChange={(e) => {
+                const newOptions = [...options];
+                newOptions[index] = {
+                  ...option,
+                  label: e.target.value,
+                  value: e.target.value.toLowerCase().replace(/\s+/g, "_"),
+                };
+                onChange(newOptions);
+              }}
+              disabled={disabled}
+              className="flex-1 border rounded px-3 py-1 text-sm"
+              placeholder="Option label"
+            />
+            {!disabled && (
+              <button
+                onClick={() => {
+                  const newOptions = options.filter((_, i) => i !== index);
+                  onChange(newOptions);
+                }}
+                className="text-red-500 hover:text-red-700 px-2"
+                type="button"
+              >
+                ×
+              </button>
+            )}
+          </div>
+        ))}
+        {!disabled && (
+          <button
+            onClick={() => {
+              onChange([...options, { label: "", value: "" }]);
+            }}
+            className="text-sm text-blue-600 hover:text-blue-800"
+            type="button"
+          >
+            + Add Option
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Add field button
+function AddFieldButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full border-2 border-dashed border-gray-300 rounded-lg p-4 text-gray-600 hover:border-blue-500 hover:text-blue-600 transition-colors"
+      type="button"
+    >
+      + Add New Field
+    </button>
+  );
+}
+
+export default RoutingFormFieldsEditor;

--- a/packages/app-store/routing-forms/index.ts
+++ b/packages/app-store/routing-forms/index.ts
@@ -1,1 +1,17 @@
 export * as api from "./api";
+
+// Field transformation utilities for booking questions integration
+export {
+  transformRoutingFieldToFormBuilder,
+  transformFormBuilderToRoutingField,
+  transformRoutingFieldsToFormBuilder,
+  transformFormBuilderToRoutingFields,
+  transformOptionToFormBuilder,
+  transformOptionToRoutingForm,
+  migrateRoutingField,
+  needsMigration,
+} from "./lib/transformFields";
+
+// New FormBuilder component for routing forms
+export { RoutingFormFieldsEditor } from "./components/RoutingFormFieldsEditor";
+export type { RoutingFormFieldsEditorProps } from "./components/RoutingFormFieldsEditor";

--- a/packages/app-store/routing-forms/lib/transformFields.ts
+++ b/packages/app-store/routing-forms/lib/transformFields.ts
@@ -1,0 +1,177 @@
+/**
+ * Field Transformation Utilities for Routing Forms
+ * 
+ * This module provides conversion functions between Routing Form fields and Booking Fields,
+ * enabling the reuse of FormBuilder components from event-types in routing forms.
+ * 
+ * @see https://github.com/calcom/cal.com/issues/18987
+ */
+
+import type { TNonRouterField, FieldOption, FieldOptionWithValue } from "@calcom/features/routing-forms/lib/zod";
+import type { FieldType } from "@calcom/prisma/zod-utils";
+import type { z } from "zod";
+import type { fieldsSchema } from "@calcom/features/form-builder/schema";
+
+// Type for FormBuilder field (from event-types/booking fields)
+type FormBuilderField = z.infer<typeof fieldsSchema>[number];
+
+// Type for FormBuilder field (from event-types/booking fields)
+type FormBuilderField = z.infer<typeof fieldSchema>;
+
+/**
+ * Detects if an option is in the legacy format {label, id}
+ */
+function isLegacyOption(option: FieldOption | FieldOptionWithValue): option is FieldOption {
+  return "id" in option && !("value" in option);
+}
+
+/**
+ * Converts a routing form field option to FormBuilder format
+ * Legacy format: {label, id} → New format: {label, value}
+ */
+export function transformOptionToFormBuilder(
+  option: FieldOption | FieldOptionWithValue
+): { label: string; value: string } {
+  if (isLegacyOption(option)) {
+    // Legacy format: use id as value (fall back to label if id is null)
+    return {
+      label: option.label,
+      value: option.id || option.label,
+    };
+  }
+  // Already in new format
+  return {
+    label: option.label,
+    value: option.value,
+  };
+}
+
+/**
+ * Converts a FormBuilder option back to routing form format
+ * New format: {label, value} → {label, id, value} (hybrid for compatibility)
+ */
+export function transformOptionToRoutingForm(
+  option: { label: string; value: string }
+): FieldOptionWithValue {
+  return {
+    label: option.label,
+    value: option.value,
+    id: option.value, // Store value as id for backward compatibility
+  };
+}
+
+/**
+ * Transforms a Routing Form field to FormBuilder field format
+ * This enables using the event-types FormBuilder UI with routing forms
+ */
+export function transformRoutingFieldToFormBuilder(
+  field: TNonRouterField
+): FormBuilderField {
+  const baseField = {
+    name: field.identifier || field.id,
+    type: field.type as FieldType,
+    label: field.label,
+    placeholder: field.placeholder,
+    required: field.required ?? false,
+    hidden: field.hidden ?? false,
+    editable: field.editable || "user",
+    sources: field.sources || [
+      {
+        id: "user",
+        type: "user",
+        label: "User",
+      },
+    ],
+    disableOnPrefill: field.disableOnPrefill ?? false,
+  };
+
+  // Handle options transformation
+  if (field.options && field.options.length > 0) {
+    return {
+      ...baseField,
+      options: field.options.map(transformOptionToFormBuilder),
+    } as FormBuilderField;
+  }
+
+  return baseField as FormBuilderField;
+}
+
+/**
+ * Transforms a FormBuilder field back to Routing Form format
+ * Preserves backward compatibility with existing routing form data
+ */
+export function transformFormBuilderToRoutingField(
+  formBuilderField: FormBuilderField,
+  existingField?: Partial<TNonRouterField>
+): TNonRouterField {
+  const field: TNonRouterField = {
+    id: existingField?.id || formBuilderField.name,
+    label: formBuilderField.label || existingField?.label || formBuilderField.name,
+    identifier: formBuilderField.name,
+    type: formBuilderField.type,
+    placeholder: formBuilderField.placeholder,
+    required: formBuilderField.required,
+    hidden: formBuilderField.hidden,
+    editable: formBuilderField.editable,
+    sources: formBuilderField.sources,
+    disableOnPrefill: formBuilderField.disableOnPrefill,
+    // Preserve existing fields if provided
+    ...existingField,
+  };
+
+  // Transform options back to routing form format
+  if (formBuilderField.options && formBuilderField.options.length > 0) {
+    field.options = formBuilderField.options.map(transformOptionToRoutingForm);
+  }
+
+  return field;
+}
+
+/**
+ * Batch transforms an array of routing form fields to FormBuilder format
+ */
+export function transformRoutingFieldsToFormBuilder(
+  fields: TNonRouterField[]
+): FormBuilderField[] {
+  return fields.map(transformRoutingFieldToFormBuilder);
+}
+
+/**
+ * Batch transforms an array of FormBuilder fields back to routing form format
+ */
+export function transformFormBuilderToRoutingFields(
+  formBuilderFields: FormBuilderField[],
+  existingFields?: TNonRouterField[]
+): TNonRouterField[] {
+  return formBuilderFields.map((field, index) => {
+    const existingField = existingFields?.find((f) => f.identifier === field.name || f.id === field.name);
+    return transformFormBuilderToRoutingField(field, existingField);
+  });
+}
+
+/**
+ * Migration helper: Converts legacy routing form fields to the new format
+ * This should be called when loading existing routing forms
+ */
+export function migrateRoutingField(field: TNonRouterField): TNonRouterField {
+  // If options are in legacy format, convert them
+  if (field.options && field.options.length > 0 && isLegacyOption(field.options[0])) {
+    return {
+      ...field,
+      options: field.options.map((opt) => ({
+        label: opt.label,
+        value: (opt as FieldOption).id || opt.label,
+        id: (opt as FieldOption).id,
+      })),
+    };
+  }
+  return field;
+}
+
+/**
+ * Type guard to check if a field needs migration
+ */
+export function needsMigration(field: TNonRouterField): boolean {
+  if (!field.options || field.options.length === 0) return false;
+  return isLegacyOption(field.options[0]);
+}

--- a/packages/features/routing-forms/lib/zod.ts
+++ b/packages/features/routing-forms/lib/zod.ts
@@ -1,8 +1,19 @@
 import { z } from "zod";
 
+// Re-export fieldTypeEnum and FieldType from prisma/zod-utils for consistency with booking fields
+export { fieldTypeEnum, type FieldType } from "@calcom/prisma/zod-utils";
+
+// Legacy FieldOption for backward compatibility
 export type FieldOption = {
   label: string;
   id: string | null;
+};
+
+// New FieldOption with value support (aligned with booking fields)
+export type FieldOptionWithValue = {
+  label: string;
+  value: string;
+  id?: string | null;
 };
 
 export type TNonRouterField = {
@@ -10,39 +21,92 @@ export type TNonRouterField = {
   label: string;
   identifier?: string;
   placeholder?: string;
+  // type is kept as string for backward compatibility but should use FieldType enum values
   type: string;
   /** @deprecated in favour of `options` */
   selectText?: string;
   required?: boolean;
   deleted?: boolean;
-  options?: FieldOption[];
+  // Support both old format {label, id} and new format {label, value}
+  options?: FieldOption[] | FieldOptionWithValue[];
+  // Optional fields aligned with booking fields schema for UI consistency
+  defaultLabel?: string;
+  defaultPlaceholder?: string;
+  minLength?: number;
+  maxLength?: number;
+  editable?: "system" | "system-but-optional" | "system-but-hidden" | "user" | "user-readonly";
+  hidden?: boolean;
+  sources?: {
+    id: string;
+    type: string;
+    label: string;
+    editUrl?: string;
+    fieldRequired?: boolean;
+  }[];
+  disableOnPrefill?: boolean;
+  variant?: string;
 };
 
 // Note: zodNonRouterField is NOT annotated with z.ZodType because it uses .extend() below
 // which requires the full ZodObject type to be preserved
+
+// Option schema supporting both legacy format {label, id} and new format {label, value}
+const fieldOptionSchema = z.union([
+  // Legacy format for backward compatibility
+  z.object({
+    label: z.string(),
+    id: z.string().or(z.null()),
+  }),
+  // New format aligned with booking fields
+  z.object({
+    label: z.string(),
+    value: z.string(),
+    id: z.string().or(z.null()).optional(),
+  }),
+]);
+
+// Field source schema (aligned with booking fields)
+const fieldSourceSchema = z.object({
+  id: z.string(),
+  type: z.union([z.literal("user"), z.literal("system"), z.literal("default"), z.string()]),
+  label: z.string(),
+  editUrl: z.string().optional(),
+  fieldRequired: z.boolean().optional(),
+});
+
+// Editable schema (aligned with booking fields)
+const editableSchema = z.enum([
+  "system",
+  "system-but-optional",
+  "system-but-hidden",
+  "user",
+  "user-readonly",
+]);
+
 export const zodNonRouterField = z.object({
   id: z.string(),
   label: z.string(),
   identifier: z.string().optional(),
   placeholder: z.string().optional(),
-  type: z.string(),
+  type: z.string(), // Keeping as string for backward compatibility
   /**
    * @deprecated in favour of `options`
    */
   selectText: z.string().optional(),
   required: z.boolean().optional(),
   deleted: z.boolean().optional(),
-  options: z
-    .array(
-      z.object({
-        label: z.string(),
-        // To keep backwards compatibility with the options generated from legacy selectText, we allow saving null as id
-        // It helps in differentiating whether the routing logic should consider the option.label as value or option.id as value.
-        // This is important for legacy routes which has option.label saved in conditions and it must keep matching with the value of the option
-        id: z.string().or(z.null()),
-      })
-    )
-    .optional(),
+  // Updated options to support both legacy and new format
+  options: z.array(fieldOptionSchema).optional(),
+  // New optional fields aligned with booking fields for UI consistency
+  defaultLabel: z.string().optional(),
+  defaultPlaceholder: z.string().optional(),
+  minLength: z.number().optional(),
+  maxLength: z.number().optional(),
+  editable: editableSchema.default("user").optional(),
+  hidden: z.boolean().optional(),
+  sources: z.array(fieldSourceSchema).optional(),
+  disableOnPrefill: z.boolean().default(false).optional(),
+  variant: z.string().optional(),
 });
 
 // This is different from FormResponse in types.d.ts in that it has label optional. We don't seem to be using label at this point, so we might want to use this only while saving the response when Routing Form is submitted


### PR DESCRIPTION
## What does this PR do?

Fixes #18987

This PR enables reusing the event-types booking questions UI (FormBuilder) for routing forms by:

1. **Extended field types** - Updated `TNonRouterField` to support booking fields format with new properties like `defaultLabel`, `editable`, `sources`, etc.

2. **Field transformation utilities** - Created bidirectional conversion functions between routing form fields and booking fields formats.

3. **New RoutingFormFieldsEditor component** - A wrapper component that integrates FormBuilder with routing forms, supporting all field types (text, select, radio, etc.).

4. **Backward compatibility** - Added migration utilities for legacy field formats.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

1. Go to Routing Forms settings
2. Create or edit a form
3. Add fields using the new editor - should support all booking questions field types
4. Existing routing forms should continue to work (backward compatible)

## Checklist

- [x] Extended field type definitions
- [x] Created field transformation utilities
- [x] Created FormBuilder wrapper component
- [x] Maintained backward compatibility
- [ ] Added tests (will add if approach is approved)
- [ ] Updated documentation

## Screenshots

N/A - UI component reuse

/claim #18987