### PR TITLE
fix: add deterministic tiebreaker to RR host selection algorithm

### DIFF
--- a/packages/features/bookings/lib/getLuckyUser.integration-test.ts
+++ b/packages/features/bookings/lib/getLuckyUser.integration-test.ts
@@ -446,7 +446,7 @@ describe("getOrderedListOfLuckyUsers Integration tests", () => {
     vi.setSystemTime("2024-11-14T00:00:13Z");
   });
 
-  it("should sort as per availableUsers if no other criteria like weight/priority/calibration (TODO: make it independent of availableUsers order)", async () => {
+  it("should sort as per availableUsers if no other criteria like weight/priority/calibration", async () => {
     const [host1, host2, host3] = await Promise.all([
       createHostWithBookings({
         user: { email: "test-user1@example.com" },
@@ -480,7 +480,9 @@ describe("getOrderedListOfLuckyUsers Integration tests", () => {
       routingFormResponse: null,
     });
 
-    expectLuckyUsers(luckyUsers, [user2, user1, user3]);
+    const expectedOrder = [user1, user2, user3].sort((a, b) => a.id - b.id)
+
+    expectLuckyUsers(luckyUsers, expectedOrder);
 
     const { users: luckyUsers2 } = await luckyUserService.getOrderedListOfLuckyUsers({
       availableUsers: [user3, user1, user2],
@@ -492,7 +494,7 @@ describe("getOrderedListOfLuckyUsers Integration tests", () => {
       allRRHosts: [],
       routingFormResponse: null,
     });
-    expectLuckyUsers(luckyUsers2, [user3, user1, user2]);
+    expectLuckyUsers(luckyUsers2, expectedOrder);
   });
 
   describe("should sort as per weights", () => {
@@ -534,6 +536,9 @@ describe("getOrderedListOfLuckyUsers Integration tests", () => {
         allRRHosts,
         routingFormResponse: null,
       });
+
+      // const [firstTiedUser, secondTiedUser] = [user1WithWeight100, user2WithWeight100].sort((a, b) => a.id - b.id);
+      // // const expectedOrder = [userWithHighestWeight, firstTiedUser, secondTiedUser];
 
       expectLuckyUsers(luckyUsers, [
         // It has the highest weight

--- a/packages/features/bookings/lib/getLuckyUser.integration-test.ts
+++ b/packages/features/bookings/lib/getLuckyUser.integration-test.ts
@@ -446,7 +446,7 @@ describe("getOrderedListOfLuckyUsers Integration tests", () => {
     vi.setSystemTime("2024-11-14T00:00:13Z");
   });
 
-  it("should sort as per availableUsers if no other criteria like weight/priority/calibration", async () => {
+  it("should sort by user id if no other criteria like weight/priority/calibration", async () => {
     const [host1, host2, host3] = await Promise.all([
       createHostWithBookings({
         user: { email: "test-user1@example.com" },

--- a/packages/features/bookings/lib/getLuckyUser.integration-test.ts
+++ b/packages/features/bookings/lib/getLuckyUser.integration-test.ts
@@ -537,9 +537,6 @@ describe("getOrderedListOfLuckyUsers Integration tests", () => {
         routingFormResponse: null,
       });
 
-      // const [firstTiedUser, secondTiedUser] = [user1WithWeight100, user2WithWeight100].sort((a, b) => a.id - b.id);
-      // // const expectedOrder = [userWithHighestWeight, firstTiedUser, secondTiedUser];
-
       expectLuckyUsers(luckyUsers, [
         // It has the highest weight
         userWithHighestWeight,

--- a/packages/features/bookings/lib/getLuckyUser.ts
+++ b/packages/features/bookings/lib/getLuckyUser.ts
@@ -208,6 +208,7 @@ export class LuckyUserService implements ILuckyUserService {
     availableUsers,
     bookingsOfAvailableUsers,
     organizersWithLastCreated,
+    eventType,
   }: GetLuckyUserParams<T> & {
     bookingsOfAvailableUsers: PartialBooking[];
     organizersWithLastCreated: { id: number; bookings: { createdAt: Date }[] }[];
@@ -254,7 +255,7 @@ export class LuckyUserService implements ILuckyUserService {
     const leastRecentlyBookedUser = availableUsers.sort((a, b) => {
       if (userIdAndAtCreatedPair[a.id] > userIdAndAtCreatedPair[b.id]) return 1;
       else if (userIdAndAtCreatedPair[a.id] < userIdAndAtCreatedPair[b.id]) return -1;
-      else return 0;
+      else return eventType.isRRWeightsEnabled ? 0 : a.id - b.id;
     })[0];
 
     return leastRecentlyBookedUser;


### PR DESCRIPTION
## What does this PR do?

This PR addresses the TODO item in the RR host selection system by implementing deterministic ordering

<img width="1414" height="126" alt="image" src="https://github.com/user-attachments/assets/fc762dae-e6be-4544-b58c-92c8d0e6b19b" />

When isRRWeightsEnabled: false and all hosts have the same priority and no bookings, the system was preserving the input order from availableUsers array instead of providing deterministic ordering.This led to non deterministic behavior where the same inputs could produce different outputs depending on array order.


#### Image Demo (if applicable):

<img width="1252" height="196" alt="image" src="https://github.com/user-attachments/assets/313d1452-1140-48d8-ad9f-77fd00259419" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/28783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
