### PR TITLE
fix(ui): replace text-muted opacity-50 on disabled calendar days for …

### DIFF
--- a/packages/ui/components/form/date-range-picker/Calendar.tsx
+++ b/packages/ui/components/form/date-range-picker/Calendar.tsx
@@ -45,7 +45,7 @@ function Calendar({
         day_selected: "bg-inverted text-inverted",
         day_today: "",
         day_outside: "",
-        day_disabled: "text-muted opacity-50",
+        day_disabled: "text-[#4A4E59] dark:text-[#A3A3A3]",
         day_range_middle: "aria-selected:bg-emphasis aria-selected:text-emphasis",
         day_hidden: "invisible",
         ...classNames,

--- a/packages/ui/components/form/datepicker/datepicker.test.tsx
+++ b/packages/ui/components/form/datepicker/datepicker.test.tsx
@@ -48,7 +48,7 @@ describe("Tests for DatePicker Component", () => {
     const dateButton = getByTestId("pick-date");
     fireEvent.click(dateButton);
 
-    const disabledDates = getAllByRole("gridcell").filter((cell) => cell.classList.contains("opacity-50"));
+    const disabledDates = getAllByRole("gridcell").filter((cell) => cell.getAttribute("aria-disabled") === "true");
     expect(disabledDates.length).toBeGreaterThan(0);
     await expect(disabledDates[0]).toHaveAttribute("disabled");
   });


### PR DESCRIPTION
## What does this PR do?

Replaces `text-muted opacity-50` with `text-[#4A4E59] dark:text-[#A3A3A3]` on disabled calendar day cells (Calendar.tsx line 48) to fix a WCAG 2.1 AA color contrast failure in light mode.

Also updates the test at `datepicker.test.tsx:51` to find disabled dates via `aria-disabled="true"` instead of the removed `opacity-50` class.

The previous styling produced text color `#6B7280` on background `#EEEFF2`, resulting in a 4.2:1 contrast ratio — below the 4.5:1 minimum required by WCAG 2.1 AA for normal text. The new color `#4A4E59` achieves 7.23:1, passing both AA and AAA. Dark mode was already passing at 7.59:1 and is preserved explicitly.

This affects users with low vision and is relevant for compliance with the European Accessibility Act (EAA), which began enforcement in June 2025.

- Fixes #28771

## Visual Demo (For contributors especially)

### Measured Values
| State | Before | After |
|-------|--------|-------|
| Disabled day (light mode) | `#6B7280` on `#EEEFF2` = **4.2:1 ❌ FAIL** | `#4A4E59` on `#EEEFF2` = **7.23:1 ✅ PASS (AA + AAA)** |
| Disabled day (dark mode) | `#A3A3A3` on `#0F0F0F` = **7.59:1 ✅** | Preserved explicitly with `dark:text-[#A3A3A3]` ✅ |

**Before — FAILS (4.2:1):**

<img width="720" height="701" alt="colors_now_cal com_720" src="https://github.com/user-attachments/assets/c835b6b1-5975-4a16-ae2a-b9276314012e" />


**After — PASSES (7.23:1):**

<img width="641" height="691" alt="Screenshot 2026-04-07 at 9 46 31 PM" src="https://github.com/user-attachments/assets/a2c5b857-e3d2-464c-aa06-932827e36721" />


## How I tested
1. Inspected disabled date cells on a live Cal.com booking page using Chrome DevTools
2. Extracted computed text color via `getComputedStyle(document.querySelector('[aria-disabled="true"]')).color`
3. Verified contrast ratios using the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
4. Confirmed the fix passes in both light mode (7.23:1) and dark mode (7.59:1)
5. Verified `Calendar.tsx` is imported only by `DatePicker.tsx` and `DateRangePicker.tsx` — neither passes a `classNames` prop with a `day_disabled` override, so the fix propagates cleanly