### PR TITLE
fix(weekly-view): correct time slot offset and clipped slots

### DIFF
--- a/packages/features/calendars/weeklyview/components/event/Empty.tsx
+++ b/packages/features/calendars/weeklyview/components/event/Empty.tsx
@@ -164,7 +164,7 @@ function Cell({ isDisabled, topOffsetMinutes, timeSlot }: CellProps) {
         "group flex w-[calc(100%-1px)] items-center justify-center",
         isDisabled && "pointer-events-none",
         !isDisabled && "bg-default dark:bg-cal-muted",
-        topOffsetMinutes && "absolute"
+        topOffsetMinutes !== undefined && "absolute"
       )}
       data-disabled={isDisabled}
       data-slot={timeSlot.toISOString()}
@@ -172,7 +172,7 @@ function Cell({ isDisabled, topOffsetMinutes, timeSlot }: CellProps) {
       style={{
         height: `calc(${hoverEventDuration}*var(--one-minute-height))`,
         overflow: "visible",
-        top: topOffsetMinutes ? `calc(${topOffsetMinutes}*var(--one-minute-height))` : undefined,
+        top: topOffsetMinutes !== undefined ? `calc(${topOffsetMinutes}*var(--one-minute-height))` : undefined,
       }}
       onClick={() => {
         onEmptyCellClick?.(timeSlot.toDate());
@@ -211,7 +211,7 @@ function CustomCell({
       )}
       data-slot={timeSlot.toISOString()}
       style={{
-        top: topOffsetMinutes ? `calc(${topOffsetMinutes}*var(--one-minute-height))` : undefined,
+        top: topOffsetMinutes !== undefined ? `calc(${topOffsetMinutes}*var(--one-minute-height))` : undefined,
         overflow: "visible",
       }}>
       <div

--- a/packages/features/calendars/weeklyview/components/event/Empty.tsx
+++ b/packages/features/calendars/weeklyview/components/event/Empty.tsx
@@ -19,7 +19,7 @@ type EmptyCellProps = GridCellToDateProps & {
   topOffsetMinutes?: number;
 };
 
-export function EmptyCell(props: EmptyCellProps) {
+function EmptyCell(props: EmptyCellProps): JSX.Element {
   const cellToDate = gridCellToDateTime({
     day: props.day,
     gridCellIdx: props.gridCellIdx,
@@ -42,16 +42,16 @@ type AvailableCellProps = {
   renderOutOfOffice?: (props: OutOfOfficeRenderProps) => ReactNode;
 };
 
-export function AvailableCellsForDay({
+function AvailableCellsForDay({
   timezone,
   availableSlots,
   day,
   startHour,
   renderOutOfOffice,
-}: AvailableCellProps) {
+}: AvailableCellProps): JSX.Element | null {
   const date = dayjs(day);
   const dateFormatted = date.format("YYYY-MM-DD");
-  const slotsForToday = availableSlots && availableSlots[dateFormatted];
+  const slotsForToday = availableSlots?.[dateFormatted];
 
   const slots = useMemo(() => {
     const calculatedSlots: {
@@ -107,7 +107,8 @@ export function AvailableCellsForDay({
 
   if (slots.startEndTimeDuration) {
     const { firstSlot, startEndTimeDuration } = slots;
-    const renderOOO = renderOutOfOffice ?? ((p: OutOfOfficeRenderProps) => <DefaultOutOfOfficeSlot {...p} />);
+    const renderOOO =
+      renderOutOfOffice ?? ((p: OutOfOfficeRenderProps): JSX.Element => <DefaultOutOfOfficeSlot {...p} />);
     return (
       <CustomCell
         timeSlot={dayjs(firstSlot?.start).tz(slots.timezone)}
@@ -147,7 +148,7 @@ type CellProps = {
   timeSlot: Dayjs;
 };
 
-function Cell({ isDisabled, topOffsetMinutes, timeSlot }: CellProps) {
+function Cell({ isDisabled, topOffsetMinutes, timeSlot }: CellProps): JSX.Element {
   const { timeFormat } = useTimePreferences();
 
   const { onEmptyCellClick, hoverEventDuration } = useCalendarStore(
@@ -157,6 +158,11 @@ function Cell({ isDisabled, topOffsetMinutes, timeSlot }: CellProps) {
     }),
     shallow
   );
+
+  let topValue: string | undefined;
+  if (topOffsetMinutes !== undefined) {
+    topValue = `calc(${topOffsetMinutes}*var(--one-minute-height))`;
+  }
 
   return (
     <div
@@ -172,7 +178,7 @@ function Cell({ isDisabled, topOffsetMinutes, timeSlot }: CellProps) {
       style={{
         height: `calc(${hoverEventDuration}*var(--one-minute-height))`,
         overflow: "visible",
-        top: topOffsetMinutes !== undefined ? `calc(${topOffsetMinutes}*var(--one-minute-height))` : undefined,
+        top: topValue,
       }}
       onClick={() => {
         onEmptyCellClick?.(timeSlot.toDate());
@@ -180,7 +186,7 @@ function Cell({ isDisabled, topOffsetMinutes, timeSlot }: CellProps) {
       {!isDisabled && hoverEventDuration !== 0 && (
         <div
           className={classNames(
-            "bg-brand-default hover:bg-brand-default text-brand dark:border-emphasis absolute hidden rounded-[4px] p-[6px] text-xs font-semibold leading-5 group-hover:flex group-hover:cursor-pointer",
+            "absolute hidden rounded-[4px] bg-brand-default p-[6px] font-semibold text-brand text-xs leading-5 hover:bg-brand-default group-hover:flex group-hover:cursor-pointer dark:border-emphasis",
             hoverEventDuration && hoverEventDuration > 15 && "items-start pt-3",
             hoverEventDuration && hoverEventDuration < 15 && "items-center"
           )}
@@ -203,20 +209,25 @@ function CustomCell({
   children,
   topOffsetMinutes,
   startEndTimeDuration,
-}: CellProps & { children: React.ReactNode; startEndTimeDuration?: number }) {
+}: CellProps & { children: React.ReactNode; startEndTimeDuration?: number }): JSX.Element {
+  let topValue: string | undefined;
+  if (topOffsetMinutes !== undefined) {
+    topValue = `calc(${topOffsetMinutes}*var(--one-minute-height))`;
+  }
+
   return (
     <div
       className={classNames(
-        "bg-default dark:bg-cal-muted group absolute z-65 flex w-[calc(100%-1px)] items-center justify-center"
+        "group absolute z-65 flex w-[calc(100%-1px)] items-center justify-center bg-default dark:bg-cal-muted"
       )}
       data-slot={timeSlot.toISOString()}
       style={{
-        top: topOffsetMinutes !== undefined ? `calc(${topOffsetMinutes}*var(--one-minute-height))` : undefined,
+        top: topValue,
         overflow: "visible",
       }}>
       <div
         className={classNames(
-          "dark:border-emphasis bg-default dark:bg-cal-muted cursor-pointer rounded-[4px] p-[6px] text-xs font-semibold dark:text-white"
+          "cursor-pointer rounded-[4px] bg-default p-[6px] font-semibold text-xs dark:border-emphasis dark:bg-cal-muted dark:text-white"
         )}
         style={{
           height: `calc(${startEndTimeDuration}*var(--one-minute-height) - 2px)`,
@@ -227,3 +238,5 @@ function CustomCell({
     </div>
   );
 }
+
+export { EmptyCell, AvailableCellsForDay };

--- a/packages/features/calendars/weeklyview/components/grid/index.tsx
+++ b/packages/features/calendars/weeklyview/components/grid/index.tsx
@@ -15,7 +15,7 @@ export const SchedulerColumns = React.forwardRef<HTMLOListElement, Props>(functi
     <ol
       ref={ref}
       className="scheduler-grid-row-template col-start-1 col-end-2 row-start-1 grid auto-cols-auto text-[0px] scheduler-wrapper"
-      style={{ marginTop: offsetHeight || "var(--gridDefaultSize)", zIndex }}
+      style={{ marginTop: offsetHeight || "var(--calendar-offset-top)", zIndex }}
       data-gridstopsperday={gridStopsPerDay}>
       {children}
     </ol>

--- a/packages/features/calendars/weeklyview/components/grid/index.tsx
+++ b/packages/features/calendars/weeklyview/components/grid/index.tsx
@@ -15,7 +15,7 @@ export const SchedulerColumns = React.forwardRef<HTMLOListElement, Props>(functi
     <ol
       ref={ref}
       className="scheduler-grid-row-template scheduler-wrapper col-start-1 col-end-2 row-start-1 grid auto-cols-auto text-[0px]"
-      style={{ marginTop: offsetHeight || "var(--calendar-offset-top)", zIndex }}
+      style={{ marginTop: offsetHeight ?? "var(--calendar-offset-top)", zIndex }}
       data-gridstopsperday={gridStopsPerDay}>
       {children}
     </ol>

--- a/packages/features/calendars/weeklyview/components/grid/index.tsx
+++ b/packages/features/calendars/weeklyview/components/grid/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type React from "react";
 
 type Props = {
   offsetHeight: number | undefined;
@@ -7,17 +7,20 @@ type Props = {
   zIndex?: number;
 };
 
-export const SchedulerColumns = React.forwardRef<HTMLOListElement, Props>(function SchedulerColumns(
-  { offsetHeight, gridStopsPerDay, children, zIndex },
-  ref
-) {
+export const SchedulerColumns = function SchedulerColumns({
+  offsetHeight,
+  gridStopsPerDay,
+  children,
+  zIndex,
+  ref,
+}: Props & { ref?: React.RefObject<HTMLOListElement | null> }): JSX.Element {
   return (
     <ol
       ref={ref}
-      className="scheduler-grid-row-template col-start-1 col-end-2 row-start-1 grid auto-cols-auto text-[0px] scheduler-wrapper"
+      className="scheduler-grid-row-template scheduler-wrapper col-start-1 col-end-2 row-start-1 grid auto-cols-auto text-[0px]"
       style={{ marginTop: offsetHeight || "var(--calendar-offset-top)", zIndex }}
       data-gridstopsperday={gridStopsPerDay}>
       {children}
     </ol>
   );
-});
+};

--- a/packages/features/calendars/weeklyview/components/grid/index.tsx
+++ b/packages/features/calendars/weeklyview/components/grid/index.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import React from "react";
 
 type Props = {
   offsetHeight: number | undefined;
@@ -7,13 +7,10 @@ type Props = {
   zIndex?: number;
 };
 
-export const SchedulerColumns = function SchedulerColumns({
-  offsetHeight,
-  gridStopsPerDay,
-  children,
-  zIndex,
-  ref,
-}: Props & { ref?: React.RefObject<HTMLOListElement | null> }): JSX.Element {
+export const SchedulerColumns = React.forwardRef<HTMLOListElement, Props>(function SchedulerColumns(
+  { offsetHeight, gridStopsPerDay, children, zIndex },
+  ref
+) {
   return (
     <ol
       ref={ref}
@@ -23,4 +20,4 @@ export const SchedulerColumns = function SchedulerColumns({
       {children}
     </ol>
   );
-};
+});


### PR DESCRIPTION
## What does this PR do?

Fixes two layout bugs in the weekly calendar view.

- Fix `SchedulerColumns` `marginTop` fallback from `var(--gridDefaultSize)` (58px) to `var(--calendar-offset-top)` (28px) so the event grid aligns correctly with time labels on first render
- Fix falsy check for `topOffsetMinutes === 0` in `Cell` and `CustomCell` so slots at the start hour are correctly positioned with `absolute` + `top: 0`

Fixes #14208

## Visual Demo

**Before:** Time slots are offset from the time labels on the left, and end-hour slots get clipped (as shown in the issue screenshots).

**After:** Slots align correctly with time labels and no slots are clipped.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. **N/A**
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to any booker page (e.g. `/alan`)
2. Switch to **Weekly view**
3. Verify that time slots align correctly with the hour labels on the left
4. Verify that all slots within an hour are visible (not clipped)
5. Test with a timezone behind UTC (e.g. Pacific TZ -07) where the bug was most reproducible

No environment variables needed. A standard cal.com local setup is sufficient.
