### PR TITLE
fix(webhooks): verify requestReschedule flag in BOOKING_CANCELLED webhook

### DIFF
--- a/apps/web/test/handlers/requestReschedule.test.ts
+++ b/apps/web/test/handlers/requestReschedule.test.ts
@@ -11,7 +11,10 @@ import {
   getDate,
   mockCalendar,
 } from "@calcom/testing/lib/bookingScenario/bookingScenario";
-import { expectBookingRequestRescheduledEmails } from "@calcom/testing/lib/bookingScenario/expects";
+import {
+  expectBookingRequestRescheduledEmails,
+  expectWebhookToHaveBeenCalledWith,
+} from "@calcom/testing/lib/bookingScenario/expects";
 
 import type { Request, Response } from "express";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -132,6 +135,101 @@ describe("Handler: requestReschedule", () => {
         loggedInUser,
         emails,
         bookNewTimePath: `/${organizer.username}/${eventTypeSlug}`,
+      });
+    });
+
+    test(`should include requestReschedule: true in BOOKING_CANCELLED webhook payload`, async () => {
+      const { requestRescheduleHandler } = await import(
+        "@calcom/trpc/server/routers/viewer/bookings/requestReschedule.handler"
+      );
+
+      const booker = getBooker({
+        email: "booker@example.com",
+        name: "Booker",
+      });
+
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+      });
+
+      const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+      const bookingUid = "MOCKED_BOOKING_UID_WEBHOOK";
+      const subscriberUrl = "http://my-webhook.example.com/cancelled";
+
+      await createBookingScenario(
+        getScenarioData({
+          webhooks: [
+            {
+              userId: organizer.id,
+              eventTriggers: ["BOOKING_CANCELLED"],
+              subscriberUrl,
+              active: true,
+              eventTypeId: 1,
+              appId: null,
+            },
+          ],
+          eventTypes: [
+            {
+              id: 1,
+              slug: "event-type-1",
+              slotInterval: 45,
+              length: 45,
+              users: [{ id: 101 }],
+            },
+          ],
+          bookings: [
+            {
+              uid: bookingUid,
+              eventTypeId: 1,
+              userId: 101,
+              status: BookingStatus.ACCEPTED,
+              startTime: `${plus1DateString}T05:00:00.000Z`,
+              endTime: `${plus1DateString}T05:15:00.000Z`,
+              attendees: [
+                getMockBookingAttendee({
+                  id: 2,
+                  name: booker.name,
+                  email: booker.email,
+                  locale: "en",
+                  timeZone: "America/New_York",
+                  noShow: false,
+                }),
+              ],
+            },
+          ],
+          organizer,
+          apps: [TestData.apps["google-calendar"], TestData.apps["daily-video"]],
+        })
+      );
+
+      mockCalendar("googlecalendar", { create: true, delete: true });
+
+      await requestRescheduleHandler(
+        getTrpcHandlerData({
+          user: {
+            id: organizer.id,
+            username: organizer.username,
+            email: organizer.email,
+          },
+          input: {
+            bookingUid,
+            rescheduleReason: "Host requested reschedule",
+          },
+        })
+      );
+
+      expectWebhookToHaveBeenCalledWith(subscriberUrl, {
+        triggerEvent: "BOOKING_CANCELLED",
+        payload: {
+          uid: bookingUid,
+          status: "CANCELLED",
+          requestReschedule: true,
+        },
       });
     });
   });


### PR DESCRIPTION
## What does this PR do?

Fixes #28543

When a host triggers **"Request Reschedule"**, the `BOOKING_CANCELLED` webhook fires. This PR adds a regression test to verify that the webhook payload includes `requestReschedule: true`, making it distinguishable from a permanent cancellation.

## Why is this needed?

Without this field being `true`, webhook consumers (Zapier, n8n, Make, CRM integrations) cannot distinguish a host-requested reschedule from a genuine cancellation — causing wrong refunds, incorrect CRM status updates, and broken automations.

The `requestReschedule` flag already exists in the webhook payload type (`EventPayloadType`) and is set in `requestReschedule.handler.ts`, but there was no test asserting it was actually included in the outgoing payload.

## Changes

- Added test to `apps/web/test/handlers/requestReschedule.test.ts` that:
  - Sets up a webhook subscriber listening on `BOOKING_CANCELLED`
  - Triggers "Request Reschedule" as the organizer
  - Asserts the webhook payload contains `requestReschedule: true` and `status: "CANCELLED"`