### PR TITLE
fix: preserve array query parameters during dynamic group redirect

### DIFF
--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -109,7 +109,15 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
 
     // EXAMPLE - context.params: { orgSlug: 'acme', user: 'member0+owner1' }
     // EXAMPLE - context.query: { redirect: 'undefined', orgRedirection: 'undefined', user: 'member0+owner1' }
-    const originalQueryString = new URLSearchParams(context.query as Record<string, string>).toString();
+    const queryParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(context.query)) {
+      if (Array.isArray(value)) {
+        value.forEach((v) => queryParams.append(key, v));
+      } else if (value !== undefined) {
+        queryParams.append(key, value);
+      }
+    }
+    const originalQueryString = queryParams.toString();
     const destinationWithQuery = `${destinationUrl}?${originalQueryString}`;
     log.debug(`Dynamic group detected, redirecting to ${destinationUrl}`);
     return {


### PR DESCRIPTION
## What does this PR do?

Fixes #28687

When a URL contains repeated query parameters (e.g., `/john?user=john&user=doe`), Next.js parses them as `string[]`. Passing `context.query` cast to `Record<string, string>` into `URLSearchParams` serializes arrays as comma-separated strings (`user=john%2Cdoe`), breaking downstream logic.

## Fix

Replace the cast with explicit iteration using `URLSearchParams.append()` per value:

```typescript
// Before — array values collapsed to comma-separated string
new URLSearchParams(context.query as Record<string, string>)

// After — each value appended individually
const queryParams = new URLSearchParams();
for (const [key, value] of Object.entries(context.query)) {
  if (Array.isArray(value)) {
    value.forEach((v) => queryParams.append(key, v));
  } else if (value !== undefined) {
    queryParams.append(key, value);
  }
}
```

## Changes

- `apps/web/server/lib/[user]/getServerSideProps.ts` — fix query string serialization in dynamic group redirect