### PR TITLE
fix(ui): prevent event type slug from overflowing its container

### DIFF
--- a/apps/web/components/apps/installation/EventTypesStepCard.tsx
+++ b/apps/web/components/apps/installation/EventTypesStepCard.tsx
@@ -60,7 +60,7 @@ const EventTypeCard: FC<EventTypeCardProps> = ({
         <li>
           <div>
             <span className="text-default font-semibold ltr:mr-1 rtl:ml-1">{title}</span>{" "}
-            <small className="text-subtle hidden font-normal sm:inline">
+            <small className="text-subtle hidden max-w-xs overflow-hidden text-ellipsis font-normal sm:inline-block">
               /{team ? team.slug : userName}/{slug}
             </small>
           </div>


### PR DESCRIPTION
## What does this PR do?

Fixes #28533

Long event type slugs on the app installation page (e.g. `/apps/installation/event-types?slug=discord`) overflowed their container and broke the layout on smaller screens.

## Root cause

The slug is rendered in a `<small>` element with `sm:inline` display. Inline elements ignore `overflow: hidden`, so long slugs had no truncation.

## Fix

Changed `sm:inline` → `sm:inline-block` and added `max-w-xs overflow-hidden text-ellipsis` so long slugs truncate with an ellipsis instead of overflowing.

## Changes

- `apps/web/components/apps/installation/EventTypesStepCard.tsx` — 1 line change