### PR TITLE
fix(bookings): auto-confirm rescheduled paid bookings when confirmation is not required

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/getRequiresConfirmationFlags.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getRequiresConfirmationFlags.ts
@@ -16,6 +16,7 @@ export async function getRequiresConfirmationFlags({
   userId,
   paymentAppData,
   originalRescheduledBookingOrganizerId,
+  originalRescheduledBookingPaid,
   bookerEmail,
 }: {
   eventType: EventType;
@@ -23,6 +24,7 @@ export async function getRequiresConfirmationFlags({
   userId: number | undefined;
   paymentAppData: PaymentAppData;
   originalRescheduledBookingOrganizerId: number | undefined;
+  originalRescheduledBookingPaid?: boolean;
   bookerEmail: string;
 }) {
   const requiresConfirmation = await determineRequiresConfirmation(eventType, bookingStartTime, bookerEmail);
@@ -30,7 +32,8 @@ export async function getRequiresConfirmationFlags({
   const isConfirmedByDefault = determineIsConfirmedByDefault(
     requiresConfirmation,
     paymentAppData.price,
-    userReschedulingIsOwner
+    userReschedulingIsOwner,
+    originalRescheduledBookingPaid
   );
 
   return {
@@ -87,7 +90,12 @@ function isUserReschedulingOwner(
 function determineIsConfirmedByDefault(
   requiresConfirmation: boolean,
   price: number,
-  userReschedulingIsOwner: boolean
+  userReschedulingIsOwner: boolean,
+  originalRescheduledBookingPaid?: boolean
 ): boolean {
+  // When rescheduling an already-paid booking, auto-confirm since payment was already collected
+  if (originalRescheduledBookingPaid && !requiresConfirmation) {
+    return true;
+  }
   return (!requiresConfirmation && price === 0) || userReschedulingIsOwner;
 }

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -743,6 +743,7 @@ async function handler(
     bookingStartTime: reqBody.start,
     userId,
     originalRescheduledBookingOrganizerId: originalRescheduledBooking?.user?.id,
+    originalRescheduledBookingPaid: !!originalRescheduledBooking?.paid,
     paymentAppData,
     bookerEmail,
   });


### PR DESCRIPTION
## What does this PR do?

Fixes #22857

When an attendee reschedules a **paid booking** on an event type that **does not require confirmation**, the rescheduled booking was incorrectly created with `PENDING` status instead of `ACCEPTED`. This caused:

- Duplicate "unconfirmed" bookings piling up
- Hosts having to manually confirm rescheduled sessions that were already paid
- Broken CRM integrations receiving duplicate booking records

## Root cause

In `getRequiresConfirmationFlags.ts`, the `determineIsConfirmedByDefault` function:

```typescript
return (!requiresConfirmation && price === 0) || userReschedulingIsOwner;
```

When `requiresConfirmation = false` and `price > 0` (paid event), this returns `false` — even when rescheduling an already-paid booking. The price check blocks auto-confirmation because it assumes payment hasn't been collected yet.

## Fix

Added `originalRescheduledBookingPaid` parameter to `determineIsConfirmedByDefault`. When the original booking was already paid and the event type doesn't require confirmation, the rescheduled booking is auto-confirmed:

```typescript
if (originalRescheduledBookingPaid && !requiresConfirmation) {
  return true;
}
```

## Changes

- `packages/features/bookings/lib/handleNewBooking/getRequiresConfirmationFlags.ts` — accept and use `originalRescheduledBookingPaid` flag
- `packages/features/bookings/lib/service/RegularBookingService.ts` — pass `originalRescheduledBooking.paid` to the flags function