### PR TITLE
feat: Visual Indicator for AM/PM ( with respect to the phases of the day )

### DIFF
--- a/apps/web/modules/bookings/components/AvailableTimes.tsx
+++ b/apps/web/modules/bookings/components/AvailableTimes.tsx
@@ -76,6 +76,7 @@ type SlotItemProps = {
   unavailableTimeSlots?: string[];
   confirmButtonDisabled?: boolean;
   handleSlotClick?: (slot: Slot, isOverlapping: boolean) => void;
+  bottomBarWidthCh?: number;
 };
 
 const SlotItem = ({
@@ -97,6 +98,7 @@ const SlotItem = ({
   unavailableTimeSlots = [],
   confirmButtonDisabled,
   confirmStepClassNames,
+  bottomBarWidthCh,
 }: SlotItemProps) => {
   const { t } = useLocale();
 
@@ -112,10 +114,12 @@ const SlotItem = ({
     getQueryParam("overlayCalendar") === "true" || localStorage.getItem("overlayCalendarSwitchDefault");
 
   const { timeFormat, timezone } = useBookerTime();
+
   const bookingData = useBookerStoreContext((state) => state.bookingData);
   const layout = useBookerStoreContext((state) => state.layout);
   const hasTimeSlots = !!seatsPerTimeSlot;
   const computedDateWithUsersTimezone = dayjs.utc(slot.time).tz(timezone);
+  const formattedTime = computedDateWithUsersTimezone.format(timeFormat);
 
   const bookingFull = !!(hasTimeSlots && slot.attendees && slot.attendees >= seatsPerTimeSlot);
   const isHalfFull = slot.attendees && seatsPerTimeSlot && slot.attendees / seatsPerTimeSlot >= 0.5;
@@ -135,6 +139,22 @@ const SlotItem = ({
     offset,
   });
 
+ // Get the current hour in 24h format (0-23)
+ const slotHour = computedDateWithUsersTimezone.hour();
+ // defaulting to sky color
+ let bottomBarColor = "bg-sky-500";
+
+ if (slotHour >= 6 && slotHour < 12) {
+   // Morning: 6 AM to 11:59 AM
+   // A bright, clean yellow to represent the morning sun
+   bottomBarColor = "bg-yellow-400";
+
+ } else if (slotHour >= 12 && slotHour < 18) {
+   // Afternoon: 12 PM to 5:59 PM
+   // A warm, deeper orange to represent the afternoon/evening sun
+   bottomBarColor = "bg-orange-400";
+ }
+
   const onButtonClick = () => {
     if (handleSlotClick) {
       handleSlotClick(slot, isOverlapping);
@@ -146,12 +166,14 @@ const SlotItem = ({
         seatsPerTimeSlot,
       });
     }
+
   };
 
   const isTimeslotUnavailable = unavailableTimeSlots.includes(slot.time);
   return (
     <AnimatePresence>
       <div className="flex gap-2">
+
         <Button
           key={slot.time}
           disabled={
@@ -169,7 +191,7 @@ const SlotItem = ({
           data-time={slot.time}
           onClick={onButtonClick}
           className={classNames(
-            `hover:border-brand-default min-h-9 mb-2 flex h-auto w-full grow flex-col justify-center py-2`,
+            `hover:border-brand-default relative min-h-9 mb-2 flex h-auto w-full grow flex-col justify-center overflow-hidden py-2`,
             selectedSlots?.includes(slot.time) && "border-brand-default",
             `${customClassNames}`
           )}
@@ -183,7 +205,16 @@ const SlotItem = ({
                 )}
               />
             )}
-            {computedDateWithUsersTimezone.format(timeFormat)}
+
+
+            <span className="tabular-nums">{formattedTime}</span>
+
+          </div>
+          <div className="pointer-events-none absolute right-0 bottom-0 left-0 flex justify-center" aria-hidden="true">
+            <span
+              className={classNames("block h-1 rounded-t-full", bottomBarColor)}
+              style={{ width: `${Math.max(bottomBarWidthCh ?? 0, formattedTime.length)}ch` }}
+            />
           </div>
           {bookingFull && <p className="text-sm">{t("booking_full")}</p>}
           {hasTimeSlots && !bookingFull && (
@@ -199,7 +230,11 @@ const SlotItem = ({
               />
             </p>
           )}
+
+
         </Button>
+
+
         {!!slot.showConfirmButton && (
           <HoverCard.Root>
             <HoverCard.Trigger asChild>
@@ -267,6 +302,15 @@ export const AvailableTimes = ({
   ...props
 }: AvailableTimesProps) => {
   const { t } = useLocale();
+  const { timeFormat, timezone } = useBookerTime();
+
+  const bottomBarWidthCh = useMemo(() => {
+    return slots.reduce((maxWidth, slot) => {
+      if (slot.away) return maxWidth;
+      const width = dayjs.utc(slot.time).tz(timezone).format(timeFormat).length;
+      return Math.max(maxWidth, width);
+    }, 0);
+  }, [slots, timeFormat, timezone]);
 
   const oooAllDay = slots.every((slot) => slot.away);
   if (oooAllDay) {
@@ -293,7 +337,7 @@ export const AvailableTimes = ({
         {oooBeforeSlots && !oooAfterSlots && <OOOSlot {...slots[0]} />}
         {slots.map((slot) => {
           if (slot.away) return null;
-          return <SlotItem key={slot.time} slot={slot} {...props} />;
+          return <SlotItem key={slot.time} slot={slot} bottomBarWidthCh={bottomBarWidthCh} {...props} />;
         })}
         {oooAfterSlots && !oooBeforeSlots && <OOOSlot {...slots[slots.length - 1]} className="pb-0" />}
       </div>

--- a/apps/web/modules/bookings/components/AvailableTimes.tsx
+++ b/apps/web/modules/bookings/components/AvailableTimes.tsx
@@ -139,19 +139,15 @@ const SlotItem = ({
     offset,
   });
 
- // Get the current hour in 24h format (0-23)
  const slotHour = computedDateWithUsersTimezone.hour();
- // defaulting to sky color
  let bottomBarColor = "bg-sky-500";
 
  if (slotHour >= 6 && slotHour < 12) {
    // Morning: 6 AM to 11:59 AM
-   // A bright, clean yellow to represent the morning sun
    bottomBarColor = "bg-yellow-400";
 
  } else if (slotHour >= 12 && slotHour < 18) {
    // Afternoon: 12 PM to 5:59 PM
-   // A warm, deeper orange to represent the afternoon/evening sun
    bottomBarColor = "bg-orange-400";
  }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #28086 (GitHub issue number)
- Fixes CAL-7247 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Here is the detailed walkthrough this PR 
### Note : I checked the open PR and with resepect to that I guess this is most visual indicator and possibly the correct UI enhancement , as I'm not adding any kind of icon , just adding a small color div at the bottom of the button component 
 1.  Rendered the color with respect to these phases of time (No need to convert to 24hr format ) as it’s being handled by the day.js part  `computedDateWithUsersTimezone.format(timeFormat)`
 
## Result 
### Without “Overlay my calender”
<img width="1771" height="924" alt="image" src="https://github.com/user-attachments/assets/1ad0ec29-995a-455b-b373-8798129c278f" />
<img width="1918" height="1173" alt="image" src="https://github.com/user-attachments/assets/76fb1231-0d8e-47b3-b3b1-0b1a83ef47f8" />

### With “Overlay my calender”
<img width="1438" height="787" alt="image" src="https://github.com/user-attachments/assets/95c21e38-4f44-4c26-a2be-93694790118d" />
<img width="1915" height="1183" alt="image" src="https://github.com/user-attachments/assets/4aea28a7-dc96-49be-bcd1-90d63a5b53aa" />


## Other Possibilities 
### 1. Placing the color bar just at the bottom of the button component and has a fixed size of `h-[2px]` this looks even more good but but but 
`<div className="pointer-events-none absolute right-0 bottom-0 left-0 flex justify-center" aria-hidden="true">
            <span
              className={classNames("block h-[2px] rounded-t-full", bottomBarColor)}
              style={{ width: ` `${Math.max(bottomBarWidthCh ?? 0, formattedTime.length)}ch` ` }}
            />
          </div>`

Uneven height of the color component . Pattern : the even sequence button (2,4,6..) height decrease and for odd sequence of button the height is maintained 
<img width="1563" height="1137" alt="image" src="https://github.com/user-attachments/assets/2ba516bd-5c0d-4900-aca4-5a75d5227196" />

Similarly goes with when switched to column view
<img width="1513" height="1126" alt="image" src="https://github.com/user-attachments/assets/4116390e-7aae-4a05-86ad-eb22104b02ce" />

Uneven height of the color component . Pattern : the even sequence button (2,4,6..) height decrease and for odd sequence of button the height is maintained 
For this the height is reduced for odd number of sequence button (if you carefully observe ! )

### 2. Uses more good approach by placing the color bar just above the bottom of the button and increase the bar thickness (height)
- Note :
    - `h-1` is the ideal height of the color bar as if we reduce the height to `h-0.5` it will act same as the Possibility-1
    - Same goes with the `bottom-0` not `bottom-px` as `px` will create a spacing of `1px` which looks somewhat appered (which In my opinion doesn’t align with the UI theme )
<img width="393" height="657" alt="image" src="https://github.com/user-attachments/assets/c543be28-afce-433a-b084-6836ca60fed1" />
<img width="393" height="657" alt="image" src="https://github.com/user-attachments/assets/186c75d3-3abb-4e01-8a5c-33a0c433ca6e" />
<img width="481" height="747" alt="image" src="https://github.com/user-attachments/assets/60e952f0-30b1-44f1-9f1a-4df1f303062d" />
<img width="1360" height="1116" alt="image" src="https://github.com/user-attachments/assets/c7144e07-13be-4cc2-a68f-0fac3653b805" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
## How should this be tested?


---

### Manual
1.  **Open a booking page** that uses the default time-slot list UI (not the redesigned detailed calendar view).
3. In that you can see the visual feedback with respect to the am and pm 
4. Morning: 6 AM to 11:59 AM , yellow color 
5. Afternoon: 12 PM to 5:59 PM,  deeper orange to represent the afternoon/evening sun'
6. defaulting to sky color which is at night when there is moon 

---

### Checklist
- [x] I have read the contributing guide.
- [x] My code follows the style guidelines of this project.
- [x]I have checked that my changes generate no new blocking warnings.
- [x] My PR is scoped and reasonably small.