### PR TITLE
feat: expose host meeting token in Platform API v2 for Cal Video (Dai…

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/repositories/bookings.repository.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/repositories/bookings.repository.ts
@@ -30,6 +30,7 @@ export class BookingsRepository_2024_08_13 {
         attendees: true,
         user: true,
         eventType: true,
+        references: true,
       },
     });
   }
@@ -49,6 +50,7 @@ export class BookingsRepository_2024_08_13 {
         },
         user: true,
         eventType: true,
+        references: true,
       },
     });
   }
@@ -125,6 +127,7 @@ export class BookingsRepository_2024_08_13 {
         attendees: true,
         user: true,
         eventType: true,
+        references: true,
       },
     });
   }
@@ -142,6 +145,7 @@ export class BookingsRepository_2024_08_13 {
         },
         user: true,
         eventType: true,
+        references: true,
       },
     });
   }
@@ -155,6 +159,7 @@ export class BookingsRepository_2024_08_13 {
         attendees: true,
         user: true,
         eventType: true,
+        references: true,
       },
     });
     if (!booking) {
@@ -181,6 +186,7 @@ export class BookingsRepository_2024_08_13 {
         },
         user: true,
         eventType: true,
+        references: true,
       },
     });
   }
@@ -216,6 +222,7 @@ export class BookingsRepository_2024_08_13 {
         attendees: true,
         user: true,
         eventType: true,
+        references: true,
       },
     });
   }

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts
@@ -662,7 +662,7 @@ export class BookingsService_2024_08_13 {
     const userIsEventTypeAdminOrOwner =
       authUser && booking.eventType
         ? await this.eventTypeAccessService.userIsEventTypeAdminOrOwner(
-            authUser as NonNullable<AuthOptionalUser>,
+            { ...authUser, isSystemAdmin: authUser.isSystemAdmin ?? false },
             booking.eventType as EventType
           )
         : false;
@@ -751,7 +751,7 @@ export class BookingsService_2024_08_13 {
 
       const userIsEventTypeAdminOrOwner =
         user && formatted.eventType
-          ? await this.eventTypeAccessService.userIsEventTypeAdminOrOwner(user as NonNullable<AuthOptionalUser>, formatted.eventType)
+          ? await this.eventTypeAccessService.userIsEventTypeAdminOrOwner({ ...user, isSystemAdmin: false } as ApiAuthGuardUser, formatted.eventType)
           : false;
 
       const isRecurring = !!formatted.recurringEventId;

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts
@@ -622,17 +622,17 @@ export class BookingsService_2024_08_13 {
       const isSeated = !!booking.eventType?.seatsPerTimeSlot;
 
       if (isRecurring && !isSeated) {
-        return this.outputService.getOutputRecurringBooking(booking);
+        return this.outputService.getOutputRecurringBooking(booking, userIsEventTypeAdminOrOwner);
       }
       if (isRecurring && isSeated) {
         const showAttendees = userIsEventTypeAdminOrOwner || !!booking.eventType?.seatsShowAttendees;
-        return this.outputService.getOutputRecurringSeatedBooking(booking, showAttendees);
+        return this.outputService.getOutputRecurringSeatedBooking(booking, showAttendees, userIsEventTypeAdminOrOwner);
       }
       if (isSeated) {
         const showAttendees = userIsEventTypeAdminOrOwner || !!booking.eventType?.seatsShowAttendees;
-        return this.outputService.getOutputSeatedBooking(booking, showAttendees);
+        return this.outputService.getOutputSeatedBooking(booking, showAttendees, userIsEventTypeAdminOrOwner);
       }
-      return this.outputService.getOutputBooking(booking);
+      return this.outputService.getOutputBooking(booking, userIsEventTypeAdminOrOwner);
     }
 
     const recurringBooking = await this.bookingsRepository.getRecurringByUidWithAttendeesAndUserAndEvent(uid);
@@ -644,10 +644,10 @@ export class BookingsService_2024_08_13 {
     if (isRecurringSeated) {
       const showAttendees =
         userIsEventTypeAdminOrOwner || !!recurringBooking[0].eventType?.seatsShowAttendees;
-      return this.outputService.getOutputRecurringSeatedBookings(ids, showAttendees);
+      return this.outputService.getOutputRecurringSeatedBookings(ids, showAttendees, userIsEventTypeAdminOrOwner);
     }
 
-    return this.outputService.getOutputRecurringBookings(ids);
+    return this.outputService.getOutputRecurringBookings(ids, userIsEventTypeAdminOrOwner);
   }
 
   async getBookingBySeatUid(seatUid: string, authUser: AuthOptionalUser) {
@@ -662,7 +662,7 @@ export class BookingsService_2024_08_13 {
     const userIsEventTypeAdminOrOwner =
       authUser && booking.eventType
         ? await this.eventTypeAccessService.userIsEventTypeAdminOrOwner(
-            authUser,
+            authUser as NonNullable<AuthOptionalUser>,
             booking.eventType as EventType
           )
         : false;
@@ -682,16 +682,16 @@ export class BookingsService_2024_08_13 {
       };
 
       if (isRecurring) {
-        return this.outputService.getOutputRecurringSeatedBooking(bookingWithFilteredAttendees, true);
+        return this.outputService.getOutputRecurringSeatedBooking(bookingWithFilteredAttendees, true, userIsEventTypeAdminOrOwner);
       }
-      return this.outputService.getOutputSeatedBooking(bookingWithFilteredAttendees, true);
+      return this.outputService.getOutputSeatedBooking(bookingWithFilteredAttendees, true, userIsEventTypeAdminOrOwner);
     }
 
     if (isRecurring) {
-      return this.outputService.getOutputRecurringSeatedBooking(booking, true);
+      return this.outputService.getOutputRecurringSeatedBooking(booking, true, userIsEventTypeAdminOrOwner);
     }
 
-    return this.outputService.getOutputSeatedBooking(booking, true);
+    return this.outputService.getOutputSeatedBooking(booking, true, userIsEventTypeAdminOrOwner);
   }
 
   async getBookings(
@@ -749,16 +749,21 @@ export class BookingsService_2024_08_13 {
         absentHost: !!booking.noShowHost,
       };
 
+      const userIsEventTypeAdminOrOwner =
+        user && formatted.eventType
+          ? await this.eventTypeAccessService.userIsEventTypeAdminOrOwner(user as NonNullable<AuthOptionalUser>, formatted.eventType)
+          : false;
+
       const isRecurring = !!formatted.recurringEventId;
       const isSeated = !!formatted.eventType?.seatsPerTimeSlot;
       if (isRecurring && !isSeated) {
-        formattedBookings.push(this.outputService.getOutputRecurringBooking(formatted));
+        formattedBookings.push(this.outputService.getOutputRecurringBooking(formatted, userIsEventTypeAdminOrOwner));
       } else if (isRecurring && isSeated) {
-        formattedBookings.push(this.outputService.getOutputRecurringSeatedBooking(formatted, true));
+        formattedBookings.push(this.outputService.getOutputRecurringSeatedBooking(formatted, true, userIsEventTypeAdminOrOwner));
       } else if (isSeated) {
-        formattedBookings.push(await this.outputService.getOutputSeatedBooking(formatted, true));
+        formattedBookings.push(await this.outputService.getOutputSeatedBooking(formatted, true, userIsEventTypeAdminOrOwner));
       } else {
-        formattedBookings.push(await this.outputService.getOutputBooking(formatted));
+        formattedBookings.push(await this.outputService.getOutputBooking(formatted, userIsEventTypeAdminOrOwner));
       }
     }
 
@@ -855,7 +860,7 @@ export class BookingsService_2024_08_13 {
       const isPlatformManagedUserBooking = !!(booking.userId && booking.user?.isPlatformManaged);
 
       if (isRecurring && !isSeated) {
-        const outputBooking = await this.outputService.getOutputRecurringBooking(databaseBooking);
+        const outputBooking = await this.outputService.getOutputRecurringBooking(databaseBooking, userIsEventTypeAdminOrOwner);
         return Object.assign(outputBooking, { isPlatformManagedUserBooking });
       }
       if (isRecurring && isSeated) {
@@ -874,7 +879,7 @@ export class BookingsService_2024_08_13 {
         );
         return Object.assign(outputBooking, { isPlatformManagedUserBooking });
       }
-      const outputBooking = await this.outputService.getOutputBooking(databaseBooking);
+      const outputBooking = await this.outputService.getOutputBooking(databaseBooking, userIsEventTypeAdminOrOwner);
       return Object.assign(outputBooking, { isPlatformManagedUserBooking });
     } catch (error) {
       this.errorsBookingsService.handleBookingError(error, false);

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/output.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/output.service.ts
@@ -83,6 +83,7 @@ type DatabaseBooking = Booking & {
   }[];
   user: DatabaseUser | null;
   createdAt: Date;
+  references: { type: string; meetingPassword: string | null }[];
 };
 
 type BookingWithUser = Booking & { user: DatabaseUser | null };
@@ -97,7 +98,7 @@ export class OutputBookingsService_2024_08_13 {
     return email.replace(/\+[a-zA-Z0-9]{25}/, "");
   }
 
-  async getOutputBooking(databaseBooking: DatabaseBooking) {
+  async getOutputBooking(databaseBooking: DatabaseBooking, isHostOrAdmin: boolean = false) {
     const dateStart = DateTime.fromISO(databaseBooking.startTime.toISOString());
     const dateEnd = DateTime.fromISO(databaseBooking.endTime.toISOString());
     const duration = dateEnd.diff(dateStart, "minutes").minutes;
@@ -110,6 +111,8 @@ export class OutputBookingsService_2024_08_13 {
     const location = metadata?.videoCallUrl || databaseBooking.location;
     const rescheduledToUid = await this.getRescheduledToUid(databaseBooking);
     const rescheduledByEmail = await this.getRescheduledByEmail(databaseBooking);
+
+    const hostToken = isHostOrAdmin ? databaseBooking.references?.find(ref => ref.type === "daily_video")?.meetingPassword : undefined;
 
     const booking = {
       id: databaseBooking.id,
@@ -139,6 +142,7 @@ export class OutputBookingsService_2024_08_13 {
       })),
       guests: bookingResponses.guests,
       location,
+      hostToken: hostToken || undefined,
       // note(Lauris): meetingUrl is deprecated
       meetingUrl: location,
       absentHost: !!databaseBooking.noShowHost,
@@ -228,7 +232,7 @@ export class OutputBookingsService_2024_08_13 {
     };
   }
 
-  async getOutputRecurringBookings(bookingsIds: number[]) {
+  async getOutputRecurringBookings(bookingsIds: number[], isHostOrAdmin: boolean = false) {
     const databaseBookings = await this.bookingsRepository.getByIdsWithAttendeesAndUserAndEvent(bookingsIds);
     
     const bookingsMap = new Map(databaseBookings.map(booking => [booking.id, booking]));
@@ -238,12 +242,12 @@ export class OutputBookingsService_2024_08_13 {
       if (!databaseBooking) {
         throw new Error(`Booking with id=${bookingId} was not found in the database`);
       }
-      return this.getOutputRecurringBooking(databaseBooking);
+      return this.getOutputRecurringBooking(databaseBooking, isHostOrAdmin);
     });
     return transformed.sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
   }
 
-  getOutputRecurringBooking(databaseBooking: DatabaseBooking) {
+  getOutputRecurringBooking(databaseBooking: DatabaseBooking, isHostOrAdmin: boolean = false) {
     const dateStart = DateTime.fromISO(databaseBooking.startTime.toISOString());
     const dateEnd = DateTime.fromISO(databaseBooking.endTime.toISOString());
     const duration = dateEnd.diff(dateStart, "minutes").minutes;
@@ -254,6 +258,8 @@ export class OutputBookingsService_2024_08_13 {
     );
     const metadata = safeParse(bookingMetadataSchema, databaseBooking.metadata, defaultBookingMetadata);
     const location = metadata?.videoCallUrl || databaseBooking.location;
+
+    const hostToken = isHostOrAdmin ? databaseBooking.references?.find(ref => ref.type === "daily_video")?.meetingPassword : undefined;
 
     const booking = {
       id: databaseBooking.id,
@@ -282,6 +288,7 @@ export class OutputBookingsService_2024_08_13 {
       })),
       guests: bookingResponses.guests,
       location,
+      hostToken: hostToken || undefined,
       // note(Lauris): meetingUrl is deprecated
       meetingUrl: location,
       recurringBookingUid: databaseBooking.recurringEventId,
@@ -327,11 +334,11 @@ export class OutputBookingsService_2024_08_13 {
     userIsEventTypeAdminOrOwner: boolean
   ): Promise<CreateSeatedBookingOutput_2024_08_13> {
     const showAttendees = userIsEventTypeAdminOrOwner || !!databaseBooking.eventType?.seatsShowAttendees;
-    const getSeatedBookingOutput = await this.getOutputSeatedBooking(databaseBooking, showAttendees);
+    const getSeatedBookingOutput = await this.getOutputSeatedBooking(databaseBooking, showAttendees, userIsEventTypeAdminOrOwner);
     return { ...getSeatedBookingOutput, seatUid };
   }
 
-  async getOutputSeatedBooking(databaseBooking: DatabaseBooking, showAttendees: boolean) {
+  async getOutputSeatedBooking(databaseBooking: DatabaseBooking, showAttendees: boolean, isHostOrAdmin: boolean = false) {
     const dateStart = DateTime.fromISO(databaseBooking.startTime.toISOString());
     const dateEnd = DateTime.fromISO(databaseBooking.endTime.toISOString());
     const duration = dateEnd.diff(dateStart, "minutes").minutes;
@@ -339,6 +346,8 @@ export class OutputBookingsService_2024_08_13 {
     const location = metadata?.videoCallUrl || databaseBooking.location;
     const rescheduledToUid = await this.getRescheduledToUid(databaseBooking);
     const rescheduledByEmail = await this.getRescheduledByEmail(databaseBooking);
+
+    const hostToken = isHostOrAdmin ? databaseBooking.references?.find(ref => ref.type === "daily_video")?.meetingPassword : undefined;
 
     const booking = {
       id: databaseBooking.id,
@@ -357,6 +366,7 @@ export class OutputBookingsService_2024_08_13 {
       eventTypeId: databaseBooking.eventTypeId,
       attendees: [],
       location,
+      hostToken: hostToken || undefined,
       // note(Lauris): meetingUrl is deprecated
       meetingUrl: location,
       absentHost: !!databaseBooking.noShowHost,
@@ -408,7 +418,7 @@ export class OutputBookingsService_2024_08_13 {
     return parsed;
   }
 
-  async getOutputRecurringSeatedBookings(bookingsIds: number[], showAttendees: boolean) {
+  async getOutputRecurringSeatedBookings(bookingsIds: number[], showAttendees: boolean, isHostOrAdmin: boolean = false) {
     const databaseBookings = await this.bookingsRepository.getByIdsWithAttendeesWithBookingSeatAndUserAndEvent(bookingsIds);
     
     const bookingsMap = new Map(databaseBookings.map(booking => [booking.id, booking]));
@@ -418,7 +428,7 @@ export class OutputBookingsService_2024_08_13 {
       if (!databaseBooking) {
         throw new Error(`Booking with id=${bookingId} was not found in the database`);
       }
-      return this.getOutputRecurringSeatedBooking(databaseBooking, showAttendees);
+      return this.getOutputRecurringSeatedBooking(databaseBooking, showAttendees, isHostOrAdmin);
     });
 
     return transformed.sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
@@ -456,17 +466,20 @@ export class OutputBookingsService_2024_08_13 {
     const showAttendees = userIsEventTypeAdminOrOwner || !!databaseBooking.eventType?.seatsShowAttendees;
     const getRecurringSeatedBookingOutput = this.getOutputRecurringSeatedBooking(
       databaseBooking,
-      showAttendees
+      showAttendees,
+      userIsEventTypeAdminOrOwner
     );
     return { ...getRecurringSeatedBookingOutput, seatUid };
   }
 
-  getOutputRecurringSeatedBooking(databaseBooking: DatabaseBooking, showAttendees: boolean) {
+  getOutputRecurringSeatedBooking(databaseBooking: DatabaseBooking, showAttendees: boolean, isHostOrAdmin: boolean = false) {
     const dateStart = DateTime.fromISO(databaseBooking.startTime.toISOString());
     const dateEnd = DateTime.fromISO(databaseBooking.endTime.toISOString());
     const duration = dateEnd.diff(dateStart, "minutes").minutes;
     const metadata = safeParse(bookingMetadataSchema, databaseBooking.metadata, defaultBookingMetadata);
     const location = metadata?.videoCallUrl || databaseBooking.location;
+
+    const hostToken = isHostOrAdmin ? databaseBooking.references?.find(ref => ref.type === "daily_video")?.meetingPassword : undefined;
 
     const booking = {
       id: databaseBooking.id,
@@ -485,6 +498,7 @@ export class OutputBookingsService_2024_08_13 {
       eventTypeId: databaseBooking.eventTypeId,
       attendees: [],
       location,
+      hostToken: hostToken || undefined,
       // note(Lauris): meetingUrl is deprecated
       meetingUrl: location,
       recurringBookingUid: databaseBooking.recurringEventId,

--- a/apps/api/v2/src/modules/booking-seat/booking-seat.repository.ts
+++ b/apps/api/v2/src/modules/booking-seat/booking-seat.repository.ts
@@ -111,6 +111,7 @@ export class BookingSeatRepository {
                 userId: true,
               },
             },
+            references: true,
           },
         },
       },

--- a/apps/web/modules/videos/views/videos-single-view.tsx
+++ b/apps/web/modules/videos/views/videos-single-view.tsx
@@ -22,6 +22,7 @@ import type { DailyCall } from "@daily-co/daily-js";
 import DailyIframe from "@daily-co/daily-js";
 import { DailyProvider, useDailyEvent } from "@daily-co/daily-react";
 import type { getServerSideProps } from "@lib/video/[uid]/getServerSideProps";
+import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { CalVideoPremiumFeatures } from "../cal-video-premium-features";
 
@@ -57,7 +58,10 @@ export default function JoinCall(props: PageProps) {
     !!userNameForCall && (requireEmailForGuests ? !!loggedInUserName && isLoggedInUserPartOfMeeting : true);
   const [isCallFrameReady, setIsCallFrameReady] = useState<boolean>(false);
 
-  const activeMeetingPassword = guestCredentials?.meetingPassword ?? meetingPassword;
+  const searchParams = useSearchParams();
+  const tokenParam = searchParams?.get("token") || undefined;
+
+  const activeMeetingPassword = tokenParam ?? guestCredentials?.meetingPassword ?? meetingPassword;
   const activeMeetingUrl = guestCredentials?.meetingUrl ?? meetingUrl;
   const activeUserName = guestCredentials?.userName ?? userNameForCall;
 

--- a/packages/platform/types/bookings/2024-08-13/outputs/booking.output.ts
+++ b/packages/platform/types/bookings/2024-08-13/outputs/booking.output.ts
@@ -288,6 +288,16 @@ class BaseBookingOutput_2024_08_13 {
   @IsOptional()
   @Expose()
   icsUid?: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+    description: "Daily.co host token to join with administrative privileges.",
+  })
+  @IsString()
+  @IsOptional()
+  @Expose()
+  hostToken?: string;
 }
 
 export class BookingOutput_2024_08_13 extends BaseBookingOutput_2024_08_13 {


### PR DESCRIPTION
…ly.co)

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #28586

**Motivation & Context:**
When using the Platform API v2 with managed users and Cal Video (Daily.co integration), there was no way to retrieve the host meeting token (`meetingPassword`) for a booking. This prevented platform consumers from giving their hosts admin/moderator controls in the video call (e.g., mute all, kick, recording).

**Solution:**
This PR securely exposes the Daily.co `hostToken` in Platform API v2 booking responses strictly for authorized users (EventType Owners & Admins). It also updates the frontend `videos-single-view` to accept `token` as a URL query parameter, enabling URL-based admin access for managed users routing from the Platform API.

**Changes:**
1. **API Types & Schema:** Added `hostToken` property to the [BaseBookingOutput_2024_08_13] schema.

2. **Services**
 ([output.service.ts] & [bookings.service.ts]
   - Propagated `isHostOrAdmin` utilizing `eventTypeAccessService.userIsEventTypeAdminOrOwner`.
   - Extracted `meetingPassword` exclusively when the recipient has host permissions.
3. **Repository layer:**
 Ensured `references` are fetched alongside `attendees` and `user` to populate the `hostToken`.

4. **Web App:** 
Extracted the URL `?token=...` parameter natively using `useSearchParams` within [JoinCall] in videos-single-view.tsx component logic to initialize the `DailyIframe` with Host privileges.

####

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
1. **Create a booking:**
 Use an `eventTypeId` that leverages Cal Video (Daily.co) via API v2.
2. **Fetch Bookings as Host:** 
Issue a `GET /v2/bookings/:uid` using an API Key authorized out to the Event Organizer.
   - **Expected Output:** The JSON payload should include `hostToken: "eyJhbG..."`
3. **Fetch Bookings as Attendee/Unauthorized:**
 Issue the same GET request but without host privileges.
   - **Expected Output:** `hostToken` should be entirely undefined/missing from the payload.
4. **Video Validation:**
 Visit `http://localhost:3000/video/<uid>?token=<hostToken>` in an incognito window. You should observe that host-exclusive controls (like Mute All) are enabled.

## Checklist
- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small/concise (<500 lines or <10 files)
