### PR TITLE
refactor: use userRepository class methods for signup handlers

### DIFF
--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -55,6 +55,8 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
     })
     .parse(body);
 
+  const userRepository = new UserRepository(prisma);
+
   const billingService = getBillingProviderService();
 
   const shouldLockByDefault = await checkIfEmailIsBlockedInWatchlistController({
@@ -95,10 +97,8 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
     });
 
     if (foundToken?.teamId) {
-      const existingUser = await prisma.user.findUnique({
-        where: { email },
-        select: { invitedTo: true },
-      });
+      const existingUser = await userRepository.findByEmailWithInvitedTo({email})
+
       if (existingUser && existingUser.invitedTo !== foundToken.teamId) {
         return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
       }
@@ -189,14 +189,11 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
       const organizationId = team.isOrganization ? team.id : (team.parent?.id ?? null);
 
       if (username) {
-        const existingUserByUsername = await prisma.user.findFirst({
-          where: {
-            username,
-            organizationId,
-            NOT: { email },
-          },
-          select: { id: true },
-        });
+        const existingUserByUsername = await userRepository.findByUsernameAndOrganizationId({
+          username,
+          organizationId,
+          excludeEmail: email
+        })
         if (existingUserByUsername) {
           return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
         }
@@ -204,30 +201,12 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
 
       let user: { id: number };
       try {
-        user = await prisma.user.upsert({
-          where: { email },
-          update: {
-            username,
-            emailVerified: new Date(Date.now()),
-            identityProvider: IdentityProvider.CAL,
-            password: {
-              upsert: {
-                create: { hash: hashedPassword },
-                update: { hash: hashedPassword },
-              },
-            },
-            organizationId,
-          },
-          create: {
-            username,
-            email,
-            emailVerified: new Date(Date.now()),
-            identityProvider: IdentityProvider.CAL,
-            password: { create: { hash: hashedPassword } },
-            organizationId,
-          },
-          select: { id: true },
-        });
+        user = await userRepository.upsertForSignup({
+          email,
+          username,
+          hashedPassword,
+          organizationId
+        })
       } catch (error) {
         if (isPrismaError(error) && error.code === "P2002") {
           const target = String(error.meta?.target ?? "");
@@ -261,19 +240,19 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
   } else {
     // Create the user
     try {
-      await prisma.user.create({
-        data: {
-          username,
-          email,
-          locked: shouldLockByDefault,
-          password: { create: { hash: hashedPassword } },
-          metadata: {
-            stripeCustomerId: customer.stripeCustomerId,
-            checkoutSessionId,
-          },
-          creationSource: CreationSource.WEBAPP,
-        },
-      });
+      await userRepository.create({
+        username,
+        email,
+        hashedPassword,
+        organizationId: null,
+        creationSource: CreationSource.WEBAPP,
+        locked: shouldLockByDefault,
+        identityProvider: IdentityProvider.CAL,
+        metadata: {
+          stripeCustomerId: customer.stripeCustomerId,
+          checkoutSessionId,
+        }
+      })
     } catch (error) {
       // Fallback for race conditions where user was created between our check and create
       if (isPrismaError(error) && error.code === "P2002") {
@@ -308,7 +287,6 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
       });
     }
 
-    const userRepository = new UserRepository(prisma);
     await userRepository.lockByEmail({ email });
 
     return NextResponse.json(

--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -205,7 +205,9 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
           email,
           username,
           hashedPassword,
-          organizationId
+          organizationId,
+          emailVerified: new Date(),
+          identityProvider: IdentityProvider.CAL
         })
       } catch (error) {
         if (isPrismaError(error) && error.code === "P2002") {

--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -27,7 +27,7 @@ import { isPrismaError } from "@calcom/lib/server/getServerErrorFromUnknown";
 import type { CustomNextApiHandler } from "@calcom/lib/server/username";
 import { usernameHandler } from "@calcom/lib/server/username";
 import { getTrackingFromCookies } from "@calcom/lib/tracking";
-import prisma from "@calcom/prisma";
+import { prisma } from "@calcom/prisma";
 import {
   CreationSource,
   IdentityProvider,

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -23,7 +23,7 @@ import {
   throwIfTokenExpired,
   validateAndGetCorrectedUsernameForTeam,
 } from "@calcom/features/auth/signup/utils/token";
-import { CreationSource } from "@calcom/prisma/client";
+import { CreationSource } from "@calcom/prisma/enums";
 
 export default async function handler(body: Record<string, string>) {
   const { email, password, language, token } = signupSchema.parse(body);

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -122,7 +122,9 @@ export default async function handler(body: Record<string, string>) {
           email: userEmail,
           username: correctedUsername,
           hashedPassword,
-          organizationId
+          organizationId,
+          emailVerified: new Date(),
+          identityProvider: IdentityProvider.CAL
         })
       } catch (error) {
         if (isPrismaError(error) && error.code === "P2002") {

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -10,7 +10,7 @@ import logger from "@calcom/lib/logger";
 import { isPrismaError } from "@calcom/lib/server/getServerErrorFromUnknown";
 import { isUsernameReservedDueToMigration } from "@calcom/lib/server/username";
 import slugify from "@calcom/lib/slugify";
-import prisma from "@calcom/prisma";
+import { prisma } from "@calcom/prisma";
 import { IdentityProvider } from "@calcom/prisma/enums";
 import { signupSchema } from "@calcom/prisma/zod-utils";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -13,6 +13,7 @@ import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 import { IdentityProvider } from "@calcom/prisma/enums";
 import { signupSchema } from "@calcom/prisma/zod-utils";
+import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 
 import { joinAnyChildTeamOnOrgInvite } from "@calcom/features/auth/signup/utils/organization";
 import { prefillAvatar } from "@calcom/features/auth/signup/utils/prefillAvatar";
@@ -22,9 +23,12 @@ import {
   throwIfTokenExpired,
   validateAndGetCorrectedUsernameForTeam,
 } from "@calcom/features/auth/signup/utils/token";
+import { CreationSource } from "@calcom/prisma/client";
 
 export default async function handler(body: Record<string, string>) {
   const { email, password, language, token } = signupSchema.parse(body);
+
+  const userRepository = new UserRepository(prisma)
 
   const username = slugify(body.username);
   const userEmail = email.toLowerCase();
@@ -46,10 +50,10 @@ export default async function handler(body: Record<string, string>) {
     });
 
     if (foundToken?.teamId) {
-      const existingUser = await prisma.user.findUnique({
-        where: { email: userEmail },
-        select: { invitedTo: true },
-      });
+      const existingUser = await userRepository.findByEmailWithInvitedTo({
+        email: userEmail
+      })
+
       if (existingUser && existingUser.invitedTo !== foundToken.teamId) {
         return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
       }
@@ -102,44 +106,24 @@ export default async function handler(body: Record<string, string>) {
 
       const organizationId = team.isOrganization ? team.id : (team.parent?.id ?? null);
 
-      const existingUserByUsername = await prisma.user.findFirst({
-        where: {
-          username: correctedUsername,
-          organizationId,
-          NOT: { email: userEmail },
-        },
-        select: { id: true },
-      });
+      const existingUserByUsername = await userRepository.findByUsernameAndOrganizationId({
+        username: correctedUsername,
+        organizationId,
+        excludeEmail: userEmail
+      })
+
       if (existingUserByUsername) {
         return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
       }
 
       let user: { id: number };
       try {
-        user = await prisma.user.upsert({
-          where: { email: userEmail },
-          update: {
-            username: correctedUsername,
-            emailVerified: new Date(Date.now()),
-            identityProvider: IdentityProvider.CAL,
-            password: {
-              upsert: {
-                create: { hash: hashedPassword },
-                update: { hash: hashedPassword },
-              },
-            },
-            organizationId,
-          },
-          create: {
-            username: correctedUsername,
-            email: userEmail,
-            emailVerified: new Date(Date.now()),
-            identityProvider: IdentityProvider.CAL,
-            password: { create: { hash: hashedPassword } },
-            organizationId,
-          },
-          select: { id: true },
-        });
+        user = await userRepository.upsertForSignup({
+          email: userEmail,
+          username: correctedUsername,
+          hashedPassword,
+          organizationId
+        })
       } catch (error) {
         if (isPrismaError(error) && error.code === "P2002") {
           const target = String(error.meta?.target ?? "");
@@ -186,15 +170,15 @@ export default async function handler(body: Record<string, string>) {
     }
 
     try {
-      await prisma.user.create({
-        data: {
-          username: correctedUsername,
-          email: userEmail,
-          password: { create: { hash: hashedPassword } },
-          identityProvider: IdentityProvider.CAL,
-        },
-        select: { id: true },
-      });
+      await userRepository.create({
+        username: correctedUsername,
+        email: userEmail,
+        hashedPassword,
+        organizationId: null,
+        creationSource: CreationSource.WEBAPP,
+        identityProvider: IdentityProvider.CAL,
+        locked: false
+      })
     } catch (error) {
       // Fallback for race conditions where user was created between our check and create
       if (isPrismaError(error) && error.code === "P2002") {

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1554,35 +1554,39 @@ export class UserRepository {
     username,
     hashedPassword,
     organizationId,
-  }:{
-    email: string,
-    username: string | null,
-    hashedPassword: string,
-    organizationId: number | null
+    emailVerified,
+    identityProvider,
+  }: {
+    email: string;
+    username: string | null;
+    hashedPassword: string;
+    organizationId: number | null;
+    emailVerified: Date;
+    identityProvider: IdentityProvider;
   }) {
     return this.prismaClient.user.upsert({
       where: { email },
       update: {
         username,
-        emailVerified: new Date(Date.now()),
-        identityProvider: IdentityProvider.CAL,
+        emailVerified,
+        identityProvider,
         password: {
           upsert: {
             create: { hash: hashedPassword },
-            update: { hash: hashedPassword }
-          }
+            update: { hash: hashedPassword },
+          },
         },
-        organizationId
+        organizationId,
       },
       create: {
         username,
         email,
-        emailVerified: new Date(Date.now()),
-        identityProvider: IdentityProvider.CAL,
+        emailVerified,
+        identityProvider,
         password: { create: { hash: hashedPassword } },
-        organizationId
+        organizationId,
       },
-      select: { id: true }
-    })
+      select: { id: true },
+    });
   }
 }

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -11,7 +11,7 @@ import type { PrismaClient } from "@calcom/prisma";
 import { availabilityUserSelect } from "@calcom/prisma";
 import type { DestinationCalendar, SelectedCalendar, User as UserType } from "@calcom/prisma/client";
 import { Prisma } from "@calcom/prisma/client";
-import { IdentityProvider } from "@calcom/prisma/enums";
+import type { IdentityProvider } from "@calcom/prisma/enums";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { BookingStatus, MembershipRole } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
@@ -905,13 +905,12 @@ export class UserRepository {
       locked: boolean;
     }
   ) {
-    const organizationIdValue = data.organizationId;
-    const { email, username, creationSource, locked, hashedPassword, ...rest } = data;
+    const { email, username, creationSource, locked, hashedPassword, organizationId, ...rest } = data;
 
     log.info("create user", {
       email,
       username,
-      organizationIdValue,
+      organizationId,
       locked,
     });
     const t = await getTranslation("en", "common");
@@ -941,13 +940,13 @@ export class UserRepository {
         },
         creationSource,
         locked,
-        ...(organizationIdValue && username
+        ...(organizationId && username
           ? {
-              organizationId: organizationIdValue,
+              organizationId,
               profiles: {
                 create: {
                   username,
-                  organizationId: organizationIdValue,
+                  organizationId,
                   uid: ProfileRepository.generateProfileUid(),
                 },
               },

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -10,7 +10,7 @@ import { withSelectedCalendars } from "@calcom/lib/server/withSelectedCalendars"
 import type { PrismaClient } from "@calcom/prisma";
 import { availabilityUserSelect } from "@calcom/prisma";
 import type { DestinationCalendar, SelectedCalendar, User as UserType } from "@calcom/prisma/client";
-import { Prisma } from "@calcom/prisma/client";
+import { IdentityProvider, Prisma } from "@calcom/prisma/client";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { BookingStatus, MembershipRole } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
@@ -897,7 +897,7 @@ export class UserRepository {
 
   async create(
     data: Omit<Prisma.UserCreateInput, "password" | "organization" | "movedToProfile"> & {
-      username: string;
+      username: string | null;
       hashedPassword?: string;
       organizationId: number | null;
       creationSource: CreationSource;
@@ -940,7 +940,7 @@ export class UserRepository {
         },
         creationSource,
         locked,
-        ...(organizationIdValue
+        ...(organizationIdValue && username
           ? {
               organizationId: organizationIdValue,
               profiles: {
@@ -1489,6 +1489,38 @@ export class UserRepository {
     });
   }
 
+  async findByEmailWithInvitedTo({ email }: { email: string } ) {
+    return this.prismaClient.user.findUnique({
+      where: {
+        email
+      },
+      select: {
+        invitedTo: true
+      }
+    })
+  }
+
+  async findByUsernameAndOrganizationId({
+    username,
+    organizationId,
+    excludeEmail,
+  }: {
+    username: string,
+    organizationId: number | null,
+    excludeEmail: string
+  }) {
+    return this.prismaClient.user.findFirst({
+      where: {
+        username,
+        organizationId,
+        NOT: { email: excludeEmail }
+      },
+      select: {
+        id: true
+      }
+    })
+  }
+
   async lockByEmail({ email }: { email: string }) {
     await this.prismaClient.user.updateMany({
       where: { email },
@@ -1514,5 +1546,42 @@ export class UserRepository {
     });
 
     return { email: user.email, username: user.username };
+  }
+
+  async upsertForSignup({
+    email,
+    username,
+    hashedPassword,
+    organizationId,
+  }:{
+    email: string,
+    username: string | null,
+    hashedPassword: string,
+    organizationId: number | null
+  }) {
+    return this.prismaClient.user.upsert({
+      where: { email },
+      update: {
+        username,
+        emailVerified: new Date(Date.now()),
+        identityProvider: IdentityProvider.CAL,
+        password: {
+          upsert: {
+            create: { hash: hashedPassword },
+            update: { hash: hashedPassword }
+          }
+        },
+        organizationId
+      },
+      create: {
+        username,
+        email,
+        emailVerified: new Date(Date.now()),
+        identityProvider: IdentityProvider.CAL,
+        password: { create: { hash: hashedPassword } },
+        organizationId
+      },
+      select: { id: true }
+    })
   }
 }

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -10,7 +10,8 @@ import { withSelectedCalendars } from "@calcom/lib/server/withSelectedCalendars"
 import type { PrismaClient } from "@calcom/prisma";
 import { availabilityUserSelect } from "@calcom/prisma";
 import type { DestinationCalendar, SelectedCalendar, User as UserType } from "@calcom/prisma/client";
-import { IdentityProvider, Prisma } from "@calcom/prisma/client";
+import { Prisma } from "@calcom/prisma/client";
+import { IdentityProvider } from "@calcom/prisma/enums";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { BookingStatus, MembershipRole } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
@@ -907,7 +908,7 @@ export class UserRepository {
     const organizationIdValue = data.organizationId;
     const { email, username, creationSource, locked, hashedPassword, ...rest } = data;
 
-    logger.info("create user", {
+    log.info("create user", {
       email,
       username,
       organizationIdValue,


### PR DESCRIPTION
## What does this PR do?

This PR refactors the signup handlers to use the methods of userRepository class in place of prisma calls.

For the sake of abstraction, i have introduced three new methods to the UserRepository class
1. findByEmailWithInvitedTo
2. findByUsernameAndOrganizationId
3. upsertForSignup


- Fixes #14869  (GitHub issue number)
- Fixes CAL-3632 (Linear issue number - should be visible at the bottom of the GitHub issue description)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
