### PR TITLE
feat(filters): add UTM parameter filter support for bookings

### DIFF
--- a/apps/web/modules/bookings/columns/filterColumns.ts
+++ b/apps/web/modules/bookings/columns/filterColumns.ts
@@ -24,6 +24,11 @@ const FILTER_COLUMN_IDS = [
   "attendeeEmail",
   "dateRange",
   "bookingUid",
+  "utmSource",
+  "utmMedium",
+  "utmCampaign",
+  "utmTerm",
+  "utmContent",
 ] as const;
 
 /**
@@ -128,5 +133,64 @@ export function buildFilterColumns({ t, permissions, status }: BuildFilterColumn
         },
       },
     }),
+    columnHelper.accessor((row) => (row.type === "data" ? row.booking.utmSource : null), {
+      id: "utmSource",
+      header: t("utm_source"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.TEXT,
+        },
+      },
+    }),
+    columnHelper.accessor((row) => (row.type === "data" ? row.booking.utmMedium : null), {
+      id: "utmMedium",
+      header: t("utm_medium"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.TEXT,
+        },
+      },
+    }),
+    columnHelper.accessor((row) => (row.type === "data" ? row.booking.utmCampaign : null), {
+      id: "utmCampaign",
+      header: t("utm_campaign"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.TEXT,
+        },
+      },
+    }),
+    columnHelper.accessor((row) => (row.type === "data" ? row.booking.utmTerm : null), {
+      id: "utmTerm",
+      header: t("utm_term"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.TEXT,
+        },
+      },
+    }),
+    columnHelper.accessor((row) => (row.type === "data" ? row.booking.utmContent : null), {
+      id: "utmContent",
+      header: t("utm_content"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.TEXT,
+        },
+      },
+    }),
   ];
-}


### PR DESCRIPTION
Fixes #28717

## Summary
Adds UTM parameter filters to the bookings data table, allowing users to filter bookings by UTM source, medium, campaign, term, and content.

## Changes
- Added 5 UTM filter columns to filterColumns.ts:
  - utmSource
  - utmMedium  
  - utmCampaign
  - utmTerm
  - utmContent
- All filters use TEXT filter type
- Filters are hidden from the UI (filter-only functionality)

## Benefits
- Marketing teams can track which campaigns drive bookings
- Allows filtering bookings by traffic source
- Useful for analytics and attribution

## Testing
- Test filtering by UTM parameters