### PR TITLE
feat: add email domain typo detection for common domains

### DIFF
--- a/apps/web/modules/form-builder/components/Components.tsx
+++ b/apps/web/modules/form-builder/components/Components.tsx
@@ -12,7 +12,7 @@ import type { fieldSchema, variantsConfigSchema, FieldType } from "@calcom/prism
 import { AddressInput } from "@calcom/ui/components/address";
 import { InfoBadge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
-import { Label, CheckboxField, EmailField, InputField, Checkbox } from "@calcom/ui/components/form";
+import { Label, CheckboxField, EmailField, EmailInputWithTypoHint, InputField, Checkbox } from "@calcom/ui/components/form";
 import { RadioGroup, RadioField } from "@calcom/ui/components/radio";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import { XIcon } from "@coss/ui/icons";
@@ -215,7 +215,7 @@ export const Components: Record<FieldType, Component> = {
       }
 
       return (
-        <InputField
+        <EmailInputWithTypoHint
           type="email"
           id={props.name}
           noLabel={true}

--- a/apps/web/modules/form-builder/components/Components.tsx
+++ b/apps/web/modules/form-builder/components/Components.tsx
@@ -12,7 +12,8 @@ import type { fieldSchema, variantsConfigSchema, FieldType } from "@calcom/prism
 import { AddressInput } from "@calcom/ui/components/address";
 import { InfoBadge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
-import { Label, CheckboxField, EmailField, EmailInputWithTypoHint, InputField, Checkbox } from "@calcom/ui/components/form";
+import { Label, CheckboxField, EmailField, InputField, Checkbox } from "@calcom/ui/components/form";
+import { EmailInputWithTypoHint } from "@calcom/ui/components/form/inputs/Input";
 import { RadioGroup, RadioField } from "@calcom/ui/components/radio";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import { XIcon } from "@coss/ui/icons";

--- a/packages/lib/emailDomainTypoDetection.ts
+++ b/packages/lib/emailDomainTypoDetection.ts
@@ -1,88 +1,47 @@
 /**
  * Email domain typo detection for common email providers.
- * Suggests correct domain when a likely typo is detected.
  */
 
-// Common email domains and their known misspellings
 const COMMON_DOMAINS: Record<string, { typoDomains: string[]; hint: string }> = {
   "gmail.com": {
     typoDomains: [
-      "gamil.com",
-      "gmal.com",
-      "gmial.com",
-      "gmaill.com",
-      "gmail.co",
-      "gmail.cm",
-      "gmail.om",
-      "gail.com",
-      "gnail.com",
-      "gmailcom.com",
+      "gamil.com", "gmal.com", "gmial.com", "gmaill.com", "gmail.co",
+      "gmail.cm", "gmail.om", "gail.com", "gnail.com", "gmailcom.com",
     ],
     hint: "Did you mean gmail.com?",
   },
   "yahoo.com": {
     typoDomains: [
-      "yaho.com",
-      "yhaoo.com",
-      "yahoocom.com",
-      "yahoo.co",
-      "yahho.com",
-      "ayhoo.com",
-      "yahooo.com",
-      "yhaoo.com",
-      "yahu.com",
+      "yaho.com", "yhaoo.com", "yahoocom.com", "yahoo.co", "yahho.com",
+      "ayhoo.com", "yahooo.com", "yahu.com",
     ],
     hint: "Did you mean yahoo.com?",
   },
   "hotmail.com": {
     typoDomains: [
-      "htomail.com",
-      "hotmal.com",
-      "hotmail.co",
-      "hotmial.com",
-      "hotmil.com",
-      "hotmial.com",
-      "hotmai.com",
-      "hotmial.com",
-      "hormail.com",
+      "htomail.com", "hotmal.com", "hotmail.co", "hotmial.com",
+      "hotmil.com", "hotmai.com", "hormail.com",
     ],
     hint: "Did you mean hotmail.com?",
   },
   "outlook.com": {
     typoDomains: [
-      "outllok.com",
-      "outlok.com",
-      "outloo.com",
-      "outlookcom.com",
-      "outlook.co",
-      "outlok.com",
-      "outlook.cm",
-      "outllook.com",
+      "outllok.com", "outlok.com", "outloo.com", "outlookcom.com",
+      "outlook.co", "outlook.cm", "outllook.com",
     ],
     hint: "Did you mean outlook.com?",
   },
   "icloud.com": {
-    typoDomains: [
-      "iclod.com",
-      "icloud.com",
-      "icload.com",
-      "iclod.com",
-      "iclude.com",
-      "icloudcom.com",
-    ],
+    typoDomains: ["iclod.com", "icload.com", "iclude.com", "icloudcom.com"],
     hint: "Did you mean icloud.com?",
   },
   "aol.com": {
-    typoDomains: ["aol.cm", "ao.com", "al.com", "aol.com", "aol.co"],
+    typoDomains: ["aol.cm", "ao.com", "al.com", "aol.co"],
     hint: "Did you mean aol.com?",
   },
   "protonmail.com": {
     typoDomains: [
-      "protonmil.com",
-      "protonmall.com",
-      "protonmail.cm",
-      "proton.me",
-      "prontonmail.com",
+      "protonmil.com", "protonmall.com", "protonmail.cm", "prontonmail.com",
     ],
     hint: "Did you mean protonmail.com?",
   },
@@ -95,113 +54,70 @@ const COMMON_DOMAINS: Record<string, { typoDomains: string[]; hint: string }> = 
     hint: "Did you mean zoho.com?",
   },
   "yandex.com": {
-    typoDomains: ["yandex.ru", "yandex.co", "yandex.com", "yndex.com"],
+    typoDomains: ["yndex.com"],
     hint: "Did you mean yandex.com?",
   },
   "gmx.com": {
-    typoDomains: ["gmx.de", "gmx.co", "gmxcom.com", "gmxx.com"],
+    typoDomains: ["gmx.co", "gmxcom.com", "gmxx.com"],
     hint: "Did you mean gmx.com?",
   },
 };
 
-/**
- * Builds a lookup map from typo domain -> correct domain
- */
 const typoToCorrectMap: Map<string, { correctDomain: string; hint: string }> = new Map();
 for (const [correctDomain, config] of Object.entries(COMMON_DOMAINS)) {
   for (const typo of config.typoDomains) {
-    typoToCorrectMap.set(typo.toLowerCase(), {
-      correctDomain,
-      hint: config.hint,
-    });
+    typoToCorrectMap.set(typo.toLowerCase(), { correctDomain, hint: config.hint });
   }
 }
 
-/**
- * Calculates Levenshtein distance between two strings.
- * Used as a fallback for typo detection.
- */
 function levenshteinDistance(a: string, b: string): number {
   const matrix: number[][] = [];
-
-  for (let i = 0; i <= b.length; i++) {
-    matrix[i] = [i];
-  }
-  for (let j = 0; j <= a.length; j++) {
-    matrix[0][j] = j;
-  }
-
+  for (let i = 0; i <= b.length; i++) matrix[i] = [i];
+  for (let j = 0; j <= a.length; j++) matrix[0][j] = j;
   for (let i = 1; i <= b.length; i++) {
     for (let j = 1; j <= a.length; j++) {
       if (b.charAt(i - 1) === a.charAt(j - 1)) {
         matrix[i][j] = matrix[i - 1][j - 1];
       } else {
         matrix[i][j] = Math.min(
-          matrix[i - 1][j - 1] + 1, // substitution
-          matrix[i][j - 1] + 1, // insertion
-          matrix[i - 1][j] + 1 // deletion
+          matrix[i - 1][j - 1] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j] + 1
         );
       }
     }
   }
-
   return matrix[b.length][a.length];
 }
 
 /**
- * Returns a suggestion for the email domain if a likely typo is detected.
- * Returns null if no likely typo is detected.
- *
- * @param email - The email address to check (e.g., "user@gmal.com")
- * @returns An object with the suggested correction and hint, or null if no typo detected
+ * Returns a typo suggestion for an email domain, or null if none detected.
  */
 export function getEmailDomainSuggestion(
   email: string
 ): { suggestedDomain: string; hint: string } | null {
-  if (!email || !email.includes("@")) {
-    return null;
-  }
-
+  if (!email || !email.includes("@")) return null;
   const [, domain] = email.toLowerCase().split("@");
-  if (!domain) {
-    return null;
-  }
+  if (!domain) return null;
 
-  // Check exact match in our lookup table
   const exactMatch = typoToCorrectMap.get(domain);
-  if (exactMatch) {
-    return {
-      suggestedDomain: exactMatch.correctDomain,
-      hint: exactMatch.hint,
-    };
+  if (exactMatch && exactMatch.correctDomain !== domain) {
+    return { suggestedDomain: exactMatch.correctDomain, hint: exactMatch.hint };
   }
 
-  // Check for close Levenshtein distance matches (threshold: 2 for short domains, 3 for longer)
   let bestMatch: { domain: string; distance: number; hint: string } | null = null;
-
   for (const [correctDomain, config] of Object.entries(COMMON_DOMAINS)) {
-    // Only check against the base domain (before any TLD like .co.uk)
     const baseCorrectDomain = correctDomain.split(".")[0];
     const baseDomain = domain.split(".")[0];
+    if (baseDomain === baseCorrectDomain) continue;
 
     const distance = levenshteinDistance(baseDomain, baseCorrectDomain);
     const threshold = baseCorrectDomain.length <= 5 ? 2 : 3;
-
     if (distance <= threshold && (!bestMatch || distance < bestMatch.distance)) {
-      bestMatch = {
-        domain: correctDomain,
-        distance,
-        hint: config.hint,
-      };
+      bestMatch = { domain: correctDomain, distance, hint: config.hint };
     }
   }
 
-  if (bestMatch) {
-    return {
-      suggestedDomain: bestMatch.domain,
-      hint: bestMatch.hint,
-    };
-  }
-
+  if (bestMatch) return { suggestedDomain: bestMatch.domain, hint: bestMatch.hint };
   return null;
 }

--- a/packages/lib/emailDomainTypoDetection.ts
+++ b/packages/lib/emailDomainTypoDetection.ts
@@ -1,0 +1,207 @@
+/**
+ * Email domain typo detection for common email providers.
+ * Suggests correct domain when a likely typo is detected.
+ */
+
+// Common email domains and their known misspellings
+const COMMON_DOMAINS: Record<string, { typoDomains: string[]; hint: string }> = {
+  "gmail.com": {
+    typoDomains: [
+      "gamil.com",
+      "gmal.com",
+      "gmial.com",
+      "gmaill.com",
+      "gmail.co",
+      "gmail.cm",
+      "gmail.om",
+      "gail.com",
+      "gnail.com",
+      "gmailcom.com",
+    ],
+    hint: "Did you mean gmail.com?",
+  },
+  "yahoo.com": {
+    typoDomains: [
+      "yaho.com",
+      "yhaoo.com",
+      "yahoocom.com",
+      "yahoo.co",
+      "yahho.com",
+      "ayhoo.com",
+      "yahooo.com",
+      "yhaoo.com",
+      "yahu.com",
+    ],
+    hint: "Did you mean yahoo.com?",
+  },
+  "hotmail.com": {
+    typoDomains: [
+      "htomail.com",
+      "hotmal.com",
+      "hotmail.co",
+      "hotmial.com",
+      "hotmil.com",
+      "hotmial.com",
+      "hotmai.com",
+      "hotmial.com",
+      "hormail.com",
+    ],
+    hint: "Did you mean hotmail.com?",
+  },
+  "outlook.com": {
+    typoDomains: [
+      "outllok.com",
+      "outlok.com",
+      "outloo.com",
+      "outlookcom.com",
+      "outlook.co",
+      "outlok.com",
+      "outlook.cm",
+      "outllook.com",
+    ],
+    hint: "Did you mean outlook.com?",
+  },
+  "icloud.com": {
+    typoDomains: [
+      "iclod.com",
+      "icloud.com",
+      "icload.com",
+      "iclod.com",
+      "iclude.com",
+      "icloudcom.com",
+    ],
+    hint: "Did you mean icloud.com?",
+  },
+  "aol.com": {
+    typoDomains: ["aol.cm", "ao.com", "al.com", "aol.com", "aol.co"],
+    hint: "Did you mean aol.com?",
+  },
+  "protonmail.com": {
+    typoDomains: [
+      "protonmil.com",
+      "protonmall.com",
+      "protonmail.cm",
+      "proton.me",
+      "prontonmail.com",
+    ],
+    hint: "Did you mean protonmail.com?",
+  },
+  "mail.com": {
+    typoDomains: ["mailcom.com", "mai.com", "mall.com", "mail.co"],
+    hint: "Did you mean mail.com?",
+  },
+  "zoho.com": {
+    typoDomains: ["zoho.cm", "zho.com", "zoho.co"],
+    hint: "Did you mean zoho.com?",
+  },
+  "yandex.com": {
+    typoDomains: ["yandex.ru", "yandex.co", "yandex.com", "yndex.com"],
+    hint: "Did you mean yandex.com?",
+  },
+  "gmx.com": {
+    typoDomains: ["gmx.de", "gmx.co", "gmxcom.com", "gmxx.com"],
+    hint: "Did you mean gmx.com?",
+  },
+};
+
+/**
+ * Builds a lookup map from typo domain -> correct domain
+ */
+const typoToCorrectMap: Map<string, { correctDomain: string; hint: string }> = new Map();
+for (const [correctDomain, config] of Object.entries(COMMON_DOMAINS)) {
+  for (const typo of config.typoDomains) {
+    typoToCorrectMap.set(typo.toLowerCase(), {
+      correctDomain,
+      hint: config.hint,
+    });
+  }
+}
+
+/**
+ * Calculates Levenshtein distance between two strings.
+ * Used as a fallback for typo detection.
+ */
+function levenshteinDistance(a: string, b: string): number {
+  const matrix: number[][] = [];
+
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1, // substitution
+          matrix[i][j - 1] + 1, // insertion
+          matrix[i - 1][j] + 1 // deletion
+        );
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+}
+
+/**
+ * Returns a suggestion for the email domain if a likely typo is detected.
+ * Returns null if no likely typo is detected.
+ *
+ * @param email - The email address to check (e.g., "user@gmal.com")
+ * @returns An object with the suggested correction and hint, or null if no typo detected
+ */
+export function getEmailDomainSuggestion(
+  email: string
+): { suggestedDomain: string; hint: string } | null {
+  if (!email || !email.includes("@")) {
+    return null;
+  }
+
+  const [, domain] = email.toLowerCase().split("@");
+  if (!domain) {
+    return null;
+  }
+
+  // Check exact match in our lookup table
+  const exactMatch = typoToCorrectMap.get(domain);
+  if (exactMatch) {
+    return {
+      suggestedDomain: exactMatch.correctDomain,
+      hint: exactMatch.hint,
+    };
+  }
+
+  // Check for close Levenshtein distance matches (threshold: 2 for short domains, 3 for longer)
+  let bestMatch: { domain: string; distance: number; hint: string } | null = null;
+
+  for (const [correctDomain, config] of Object.entries(COMMON_DOMAINS)) {
+    // Only check against the base domain (before any TLD like .co.uk)
+    const baseCorrectDomain = correctDomain.split(".")[0];
+    const baseDomain = domain.split(".")[0];
+
+    const distance = levenshteinDistance(baseDomain, baseCorrectDomain);
+    const threshold = baseCorrectDomain.length <= 5 ? 2 : 3;
+
+    if (distance <= threshold && (!bestMatch || distance < bestMatch.distance)) {
+      bestMatch = {
+        domain: correctDomain,
+        distance,
+        hint: config.hint,
+      };
+    }
+  }
+
+  if (bestMatch) {
+    return {
+      suggestedDomain: bestMatch.domain,
+      hint: bestMatch.hint,
+    };
+  }
+
+  return null;
+}

--- a/packages/ui/components/form/index.ts
+++ b/packages/ui/components/form/index.ts
@@ -3,6 +3,7 @@ export type { Option as MultiSelectCheckboxesOptionType } from "./checkbox";
 export {
   EmailField,
   EmailInput,
+  EmailInputWithTypoHint,
   PasswordField,
   TextArea,
   TextAreaField,

--- a/packages/ui/components/form/inputs/Input.tsx
+++ b/packages/ui/components/form/inputs/Input.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { getEmailDomainSuggestion } from "@calcom/lib/emailDomainTypoDetection";
 import classNames from "@calcom/ui/classNames";
 import { EyeIcon, EyeOffIcon, SearchIcon } from "@coss/ui/icons";
 import type React from "react";
@@ -81,6 +82,45 @@ export const EmailField = forwardRef<HTMLInputElement, InputFieldProps>(function
     />
   );
 });
+
+/**
+ * Email input with built-in typo detection for common email domains.
+ * Shows a suggestion hint when a likely domain typo is detected.
+ */
+export const EmailInputWithTypoHint = forwardRef<HTMLInputElement, InputFieldProps>(
+  function EmailInputWithTypoHint(props, ref) {
+    const [localValue, setLocalValue] = useState("");
+    const suggestion = getEmailDomainSuggestion(localValue);
+
+    // Extract onChange from props so we can wrap it
+    const { onChange: originalOnChange, ...restProps } = props;
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setLocalValue(e.target.value);
+      originalOnChange?.(e);
+    };
+
+    return (
+      <div>
+        <InputField
+          ref={ref}
+          type="email"
+          autoCapitalize="none"
+          autoComplete="email"
+          autoCorrect="off"
+          inputMode="email"
+          onChange={handleChange}
+          {...restProps}
+        />
+        {suggestion && (
+          <div className="mt-1.5 text-sm text-muted">
+            <span className="font-medium text-[--cal-brand]">{suggestion.hint}</span>
+          </div>
+        )}
+      </div>
+    );
+  }
+);
 
 type TextAreaProps = JSX.IntrinsicElements["textarea"];
 

--- a/packages/ui/components/form/inputs/Input.tsx
+++ b/packages/ui/components/form/inputs/Input.tsx
@@ -83,17 +83,13 @@ export const EmailField = forwardRef<HTMLInputElement, InputFieldProps>(function
   );
 });
 
-/**
- * Email input with built-in typo detection for common email domains.
- * Shows a suggestion hint when a likely domain typo is detected.
- */
+/** Email input with typo detection for common domains. */
 export const EmailInputWithTypoHint = forwardRef<HTMLInputElement, InputFieldProps>(
   function EmailInputWithTypoHint(props, ref) {
     const [localValue, setLocalValue] = useState("");
-    const suggestion = getEmailDomainSuggestion(localValue);
-
-    // Extract onChange from props so we can wrap it
-    const { onChange: originalOnChange, ...restProps } = props;
+    const { onChange: originalOnChange, value, ...restProps } = props;
+    const currentValue = (value as string) ?? localValue;
+    const suggestion = getEmailDomainSuggestion(currentValue);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       setLocalValue(e.target.value);


### PR DESCRIPTION
## Summary

Adds email domain typo detection to booking and form inputs. When a user enters a misspelled email domain (e.g. `john@gmal.com`), a subtle suggestion appears: `Did you mean gmail.com?`

## Problem

Issue #28750: Users frequently mistype common email domains during booking, leading to failed communications.

## Solution

- New utility: `packages/lib/emailDomainTypoDetection.ts` — uses exact lookup + Levenshtein distance fallback
- Supports: Gmail, Yahoo, Hotmail, Outlook, iCloud, AOL, ProtonMail, Mail.com, Zoho, Yandex, GMX
- Non-intrusive hint below the email input

## Files Changed

- `packages/lib/emailDomainTypoDetection.ts` *(new)*
- `packages/ui/components/form/inputs/Input.tsx` *(modified)*
- `packages/ui/components/form/index.ts` *(modified)*
- `apps/web/modules/form-builder/components/Components.tsx` *(modified)*

Closes #28750