### PR TITLE
fix: set event type description correctly

### DIFF
--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1703,6 +1703,7 @@ export class BookingRepository implements IBookingRepository {
             teamId: true,
             bookingFields: true,
             title: true,
+            description: true,
             hideOrganizerEmail: true,
             recurringEvent: true,
             seatsPerTimeSlot: true,

--- a/packages/lib/buildCalEventFromBooking.ts
+++ b/packages/lib/buildCalEventFromBooking.ts
@@ -35,6 +35,7 @@ type Organizer = {
 
 type EventType = {
   title: string;
+  description?: string | null;
   recurringEvent: Prisma.JsonValue | null;
   seatsPerTimeSlot: number | null;
   seatsShowAttendees: boolean | null;
@@ -91,7 +92,7 @@ export const buildCalEventFromBooking = async ({
   return {
     title: booking.title || "",
     type: (booking.eventType?.title as string) || booking.title || "",
-    description: booking.description || "",
+    description: booking.eventType?.description || "",
     startTime: booking.startTime ? dayjs(booking.startTime).format() : "",
     endTime: booking.endTime ? dayjs(booking.endTime).format() : "",
     organizer: {

--- a/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
@@ -327,7 +327,7 @@ export async function buildCalendarEvent(
   const evt: CalendarEvent = {
     title: booking.title || "",
     type: (booking.eventType?.title as string) || booking?.title || "",
-    description: booking.description || "",
+    description: booking.eventType?.description || "",
     startTime: booking.startTime ? dayjs(booking.startTime).format() : "",
     endTime: booking.endTime ? dayjs(booking.endTime).format() : "",
     organizer: {

--- a/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
@@ -317,7 +317,7 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
   const evt: CalendarEvent = {
     type: booking?.eventType?.slug as string,
     title: booking.title,
-    description: booking.description,
+    description: booking.eventType?.description,
     bookerUrl,
     // TODO: Remove the usage of `bookingFields` in computing responses. We can do that by storing `label` with the response. Also, this would allow us to correctly show the label for a field even after the Event Type has been deleted.
     ...getCalEventResponses({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #28818 (GitHub issue number)
- Fixes CAL-28818 (Linear issue number - should be visible at the bottom of the GitHub issue description)
- Resolves an issue where the wrong description (the booker's additional notes) was being used as the event description in instant meetings and booking confirmations/guests flow.
- Modifies the calendar event generation logic (`buildCalEventFromBooking`, `addGuests.handler`, `confirm.handler`) to properly map the actual event type description (`booking.eventType?.description`) to the event instead of the user's booking notes.
- Included `description: true` in the DB queries fetching the eventType (e.g. `findByIdIncludeDestinationCalendar` in `BookingRepository`) to ensure the field is selected and strongly typed.

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

N/A

#### Image Demo (if applicable):

N/A

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Set up an Event Type that has a specific "Description / Instructions" configured in its advanced settings.
- Make a booking on this event and provide some additional notes in the booking form.
- Verify that the resulting calendar event (and email notifications for add guests / confirmation) correctly displays the Event Type's description as the event's description, rather than mapping the user's additional notes into the description field.

## Checklist

<!-- Remove bullet points below that don't apply to you -->