### PR TITLE
fix(navigation): prevent nested <a> elements in NavigationItem Tooltip

### DIFF
--- a/apps/web/modules/shell/navigation/NavigationItem.tsx
+++ b/apps/web/modules/shell/navigation/NavigationItem.tsx
@@ -203,7 +203,6 @@ export const NavigationItem: React.FC<{
         </Tooltip>
       ) : (
         <Tooltip side="right" content={t(item.name)} className="lg:hidden">
-          {/* Wrap in span so the tooltip trigger is not an <a>, preventing nested <a> elements */}
           <span className="block">
             <Link
               data-test-id={item.name}

--- a/apps/web/modules/shell/navigation/NavigationItem.tsx
+++ b/apps/web/modules/shell/navigation/NavigationItem.tsx
@@ -203,49 +203,52 @@ export const NavigationItem: React.FC<{
         </Tooltip>
       ) : (
         <Tooltip side="right" content={t(item.name)} className="lg:hidden">
-          <Link
-            data-test-id={item.name}
-            onClick={() => trackNavigationClick(item.name)}
-            href={item.href}
-            aria-label={t(item.name)}
-            target={item.target}
-            className={classNames(
-              "todesktop:py-[7px] text-default group flex items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
-              item.child
-                ? `aria-[aria-current='page']:bg-transparent!`
-                : `[&[aria-current='page']]:bg-emphasis`,
-              isChild
-                ? `[&[aria-current='page']]:text-emphasis [&[aria-current='page']]:bg-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 ${
-                    props.index === 0 ? "mt-0" : "mt-1  hover:mt-1 [&[aria-current='page']]:mt-1"
-                  }`
-                : "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm md:justify-center lg:justify-start",
-              isLocaleReady
-                ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
-                : ""
-            )}
-            aria-current={current ? "page" : undefined}>
-            {item.icon && (
-              <Icon
-                name={item.isLoading ? "rotate-cw" : item.icon}
-                className={classNames(
-                  "todesktop:!text-blue-500 h-4 w-4 shrink-0 aria-[aria-current='page']:text-inherit lg:ltr:mr-2 lg:rtl:ml-2",
-                  item.isLoading && "animate-spin"
-                )}
-                aria-hidden="true"
-                aria-current={current ? "page" : undefined}
-              />
-            )}
-            {isLocaleReady ? (
-              <span
-                className="hidden w-full justify-between truncate text-ellipsis lg:flex"
-                data-testid={`${item.name}-test`}>
-                {t(item.name)}
-                {item.badge && item.badge}
-              </span>
-            ) : (
-              <SkeletonText className="h-[20px] w-full" />
-            )}
-          </Link>
+          {/* Wrap in span so the tooltip trigger is not an <a>, preventing nested <a> elements */}
+          <span className="block">
+            <Link
+              data-test-id={item.name}
+              onClick={() => trackNavigationClick(item.name)}
+              href={item.href}
+              aria-label={t(item.name)}
+              target={item.target}
+              className={classNames(
+                "todesktop:py-[7px] text-default group flex items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
+                item.child
+                  ? `aria-[aria-current='page']:bg-transparent!`
+                  : `[&[aria-current='page']]:bg-emphasis`,
+                isChild
+                  ? `[&[aria-current='page']]:text-emphasis [&[aria-current='page']]:bg-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 ${
+                      props.index === 0 ? "mt-0" : "mt-1  hover:mt-1 [&[aria-current='page']]:mt-1"
+                    }`
+                  : "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm md:justify-center lg:justify-start",
+                isLocaleReady
+                  ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
+                  : ""
+              )}
+              aria-current={current ? "page" : undefined}>
+              {item.icon && (
+                <Icon
+                  name={item.isLoading ? "rotate-cw" : item.icon}
+                  className={classNames(
+                    "todesktop:!text-blue-500 h-4 w-4 shrink-0 aria-[aria-current='page']:text-inherit lg:ltr:mr-2 lg:rtl:ml-2",
+                    item.isLoading && "animate-spin"
+                  )}
+                  aria-hidden="true"
+                  aria-current={current ? "page" : undefined}
+                />
+              )}
+              {isLocaleReady ? (
+                <span
+                  className="hidden w-full justify-between truncate text-ellipsis lg:flex"
+                  data-testid={`${item.name}-test`}>
+                  {t(item.name)}
+                  {item.badge && item.badge}
+                </span>
+              ) : (
+                <SkeletonText className="h-[20px] w-full" />
+              )}
+            </Link>
+          </span>
         </Tooltip>
       )}
       {hasChildren && (


### PR DESCRIPTION
## What does this PR do?

Fixes #27984

The `Tooltip` component uses Radix UI's `asChild` on its trigger, which forwards event handlers directly onto the child element. In the non-parent branch of `NavigationItem`, the child is a Next.js `Link` (which renders as `<a>`). This makes the tooltip trigger itself an anchor element. In certain render paths (specifically at tablet viewport widths where `className="lg:hidden"` applies to the Tooltip), this `<a>` ends up nested inside another `<a>` in the shell structure, producing:

```
<a> cannot contain a nested <a>.
  at NavigationItem (NavigationItem.tsx:206:11)
  at Tooltip (Tooltip.tsx:49:7)
  at NavigationItem (NavigationItem.tsx:205:9)
```

## Fix

Wrap the `<Link>` in a `<span className="block">` so the Tooltip trigger is a non-anchor element. This means:

- The `<span>` becomes the tooltip trigger via `asChild` (receives hover/focus handlers)
- The `<Link>` inside retains all its existing CSS classes and handles navigation on click
- No visual or layout change — `block` display matches the previous behaviour
- DOM is now valid HTML with no nested anchors

## How to test

1. Run the project locally (`yarn dx`)
2. Navigate to `http://localhost:3000/event-types`
3. Confirm no `<a> cannot contain a nested <a>` error in the browser console
4. Confirm sidebar navigation renders correctly at all viewport sizes (mobile, tablet, desktop)
5. Confirm tooltip appears on hover of nav items at tablet width
6. Confirm navigation works normally when clicking nav items
7. In DevTools console, run: `document.querySelectorAll("a a")` → should return empty NodeList

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs if needed (N/A — logic/DOM fix only)
- [x] I confirm the fix is focused and under 500 lines / 10 files