### PR TITLE
fix(google-calendar): retry PATCH requests on 403 rate limit errors

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarAuth.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarAuth.ts
@@ -303,6 +303,19 @@ export class CalendarAuth {
 
     return new calendar_v3.Calendar({
       auth: googleAuthClient,
+      // Override gaxios defaults to retry PATCH requests on 403 (rate limit) errors.
+      // gaxios defaults omit PATCH from httpMethodsToRetry and 403 from statusCodesToRetry,
+      // which causes Google Calendar PATCH requests (e.g., to update event details after creation)
+      // to fail silently when Google returns a 403 rateLimitExceeded error.
+      retryConfig: {
+        httpMethodsToRetry: ["GET", "HEAD", "PUT", "OPTIONS", "DELETE", "PATCH", "POST"],
+        statusCodesToRetry: [
+          [100, 199],
+          [429, 429],
+          [500, 599],
+          [403, 403],
+        ],
+      },
     });
   }
 }


### PR DESCRIPTION
## Summary\n\nGoogle Calendar API PATCH requests (used to update event details after creation) fail silently when Google returns a  error.\n\n## Root Cause\n\nThe  HTTP client used by the Google API library has default retry settings that:\n- **Omit  from ** - only GET, HEAD, PUT, OPTIONS, DELETE are retried\n- **Omit  from ** - only 100-199, 429, 500-599 are retried\n\nThis causes PATCH requests (which Cal.com uses to update Google Calendar event details after creating the event) to fail without retry when Google enforces rate limits.\n\n## Fix\n\nExplicitly configure the  on the  client constructor to:\n- Add  and  to \n- Add  to \n\nThis matches Google's documented recommendation for handling rate limits on their Calendar API.\n\n## Impact\n\nBefore this fix, a transient 403 rate limit error on a PATCH request would:\n1. Not be retried (no exponential backoff)\n2. Log \n3. Leave the calendar event in an incomplete state (missing description, no Meet link)\n4. But still queue workflow emails as if the booking succeeded\n\nAfter this fix, the PATCH request will be retried up to 3 times with exponential backoff on 403 errors.\n\n## References\n\nFixes #28834