### PR TITLE
fix(api-v2-bookings): prevent loss of user provided emails when email  is hidden but still passed

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/getBookingData.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getBookingData.test.ts
@@ -217,4 +217,120 @@ describe("getBookingData", () => {
       expect(result.location).toBe(OrganizerDefaultConferencingAppType);
     });
   });
+
+  describe("email fallback when hidden", () => {
+    it("should use email from reqBody.responses when email field is hidden (not in schema responses)", async () => {
+      const schema = z.object({
+        eventTypeId: z.number(),
+        start: z.string(),
+        end: z.string().optional(),
+        timeZone: z.string(),
+        language: z.string(),
+        metadata: z.record(z.string()),
+        responses: z.object({
+          name: z.string(),
+          location: z
+            .object({
+              value: z.string(),
+              optionValue: z.string().optional(),
+            })
+            .optional(),
+          attendeePhoneNumber: z.string().optional(),
+          guests: z.array(z.string()).optional(),
+          smsReminderNumber: z.string().optional(),
+          notes: z.string().optional(),
+          rescheduleReason: z.string().optional(),
+        }),
+      });
+
+      const mockEventType = createMockEventType({
+        bookingFields: [
+          { name: "name", type: "name" as const, required: true },
+          { name: "location", type: "radioInput" as const, required: false },
+        ],
+      } as Partial<getEventTypeResponse>);
+
+      const reqBody = {
+        eventTypeId: 1,
+        start: "2026-07-21T10:00:00Z",
+        end: "2026-07-21T10:30:00Z",
+        timeZone: "Asia/Kolkata",
+        language: "en",
+        metadata: {},
+        responses: {
+          name: "Pro Example",
+          location: {
+            value: "cal-video",
+            optionValue: "",
+          },
+          email: "pro23@example.com",
+        },
+      };
+
+      const result = await getBookingData({
+        reqBody,
+        eventType: mockEventType,
+        schema,
+      });
+
+      expect(result.email).toBe("pro23@example.com");
+    });
+
+    it("should return undefined email when email is hidden and not provided in reqBody.responses", async () => {
+      const schema = z.object({
+        eventTypeId: z.number(),
+        start: z.string(),
+        end: z.string().optional(),
+        timeZone: z.string(),
+        language: z.string(),
+        metadata: z.record(z.string()),
+        responses: z.object({
+          name: z.string(),
+          location: z
+            .object({
+              value: z.string(),
+              optionValue: z.string().optional(),
+            })
+            .optional(),
+          attendeePhoneNumber: z.string().optional(),
+          guests: z.array(z.string()).optional(),
+          smsReminderNumber: z.string().optional(),
+          notes: z.string().optional(),
+          rescheduleReason: z.string().optional(),
+        }),
+      });
+
+      const mockEventType = createMockEventType({
+        bookingFields: [
+          { name: "name", type: "name" as const, required: true },
+          { name: "location", type: "radioInput" as const, required: false },
+        ],
+      } as Partial<getEventTypeResponse>);
+
+      const reqBody = {
+        eventTypeId: 1157,
+        start: "2026-07-21T10:00:00Z",
+        end: "2026-07-21T10:30:00Z",
+        timeZone: "Asia/Kolkata",
+        language: "en",
+        metadata: {},
+        responses: {
+          name: "Pro Example",
+          attendeePhoneNumber: "+919200000000",
+          location: {
+            value: "cal-video",
+            optionValue: "",
+          },
+        },
+      };
+
+      const result = await getBookingData({
+        reqBody,
+        eventType: mockEventType,
+        schema,
+      });
+
+      expect(result.email).toBeUndefined();
+    });
+  });
 });

--- a/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
@@ -23,6 +23,12 @@ const _getBookingData = async <T extends z.ZodType>({
   schema: T;
 }) => {
   const parsedBody = await schema.parseAsync(reqBody);
+
+  // When the email is hidden in event type but user still passes in the request body object
+  if (reqBody.responses.email && !parsedBody.responses.email) {
+    parsedBody.responses.email = reqBody.responses.email;
+  }
+  
   const parsedBodyWithEnd = (body: TgetBookingDataSchema): body is ReqBodyWithEnd => {
     // Use the event length to auto-set the event end time.
     if (!Object.prototype.hasOwnProperty.call(body, "end")) {

--- a/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
@@ -25,8 +25,9 @@ const _getBookingData = async <T extends z.ZodType>({
   const parsedBody = await schema.parseAsync(reqBody);
 
   // When the email is hidden in event type but user still passes in the request body object
-  if (reqBody.responses.email && !parsedBody.responses.email) {
-    parsedBody.responses.email = reqBody.responses.email;
+  const requestEmail = reqBody.responses?.email;
+  if (requestEmail && parsedBody.responses && !parsedBody.responses.email) {
+    parsedBody.responses.email = requestEmail;
   }
   
   const parsedBodyWithEnd = (body: TgetBookingDataSchema): body is ReqBodyWithEnd => {


### PR DESCRIPTION
## What does this PR do?

Adds user provided email in in the parsed data when event type has email hdden but user still passes email in the request body object

- Fixes #25432 (GitHub issue number)
- Fixes CAL-6824 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

Before:

https://github.com/user-attachments/assets/8f252715-c8b6-4e50-8beb-d603a949d9f0

After:

https://github.com/user-attachments/assets/2b1388d4-dcc3-4431-a761-edd0d69cbb78

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. create an event with hiding email and enabling phone number in the advanced tab
2. create an api key
3. Use api client and 
send this type of data :

```
{
  "start": "2026-07-21T10:00:00Z",
  "eventTypeId": 1157,
  "eventTypeSlug": "test-api-v2",
  "attendee": {
    "name": "Pro Example",
    "email": "pro23@example.com",
    "phoneNumber": "+919200000000",
    "timeZone": "Asia/Kolkata",
    "language": "en"
  },
  "guests": [],
  "location": {
    "type": "integration",
    "integration": "cal-video"
  },
  "metadata": {},
  "bookingFieldsResponses": {
    "customField": "customValue"
  }
}
```

with headers: 

Authorization: <API_TOKEN>
cal-api-version: 2024-08-13
Content-Type: application/json


4. look at the response

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs
