### PR TITLE
feat: enforce guest availability for host-initiated non-collective reschedules (CAL-4531)

### DIFF
--- a/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
+++ b/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
@@ -1,8 +1,6 @@
 // page can be a server component
-import type { GetServerSidePropsContext } from "next";
-import { URLSearchParams } from "node:url";
-import { z } from "zod";
 
+import { URLSearchParams } from "node:url";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { buildEventUrlFromBooking } from "@calcom/features/bookings/lib/buildEventUrlFromBooking";
 import { determineReschedulePreventionRedirect } from "@calcom/features/bookings/lib/reschedule/determineReschedulePreventionRedirect";
@@ -10,6 +8,8 @@ import { getDefaultEvent } from "@calcom/features/eventtypes/lib/defaultEvents";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { maybeGetBookingUidFromSeat } from "@calcom/lib/server/maybeGetBookingUidFromSeat";
 import prisma, { bookingMinimalSelect } from "@calcom/prisma";
+import type { GetServerSidePropsContext } from "next";
+import { z } from "zod";
 
 const querySchema = z.object({
   uid: z.string(),
@@ -191,7 +191,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     destinationUrlSearchParams.set("flag.coep", coepFlag as string);
   }
 
-  const currentUserEmail = rescheduledBy ?? session?.user?.email;
+  const currentUserEmail = session?.user?.email ?? rescheduledBy;
 
   if (currentUserEmail) {
     destinationUrlSearchParams.set("rescheduledBy", currentUserEmail);

--- a/apps/web/modules/schedules/hooks/useSchedule.ts
+++ b/apps/web/modules/schedules/hooks/useSchedule.ts
@@ -1,5 +1,3 @@
-import { useSearchParams } from "next/navigation";
-
 import { updateEmbedBookerState } from "@calcom/embed-core/src/embed-iframe";
 import { sdkActionManager } from "@calcom/embed-core/src/sdk-event";
 import { useBookerStore } from "@calcom/features/bookings/Booker/store";
@@ -9,7 +7,7 @@ import { useTimesForSchedule } from "@calcom/features/schedules/hooks/useTimesFo
 import { getRoutedTeamMemberIdsFromSearchParams } from "@calcom/lib/bookings/getRoutedTeamMemberIdsFromSearchParams";
 import { PUBLIC_QUERY_AVAILABLE_SLOTS_INTERVAL_SECONDS } from "@calcom/lib/constants";
 import { trpc } from "@calcom/trpc/react";
-
+import { useSearchParams } from "next/navigation";
 import { useApiV2AvailableSlots } from "./useApiV2AvailableSlots";
 
 export type UseScheduleWithCacheArgs = {
@@ -91,6 +89,7 @@ export const useSchedule = ({
     ? parseInt(routingFormResponseIdParam, 10)
     : undefined;
   const embedConnectVersion = searchParams?.get("cal.embed.connectVersion") || "0";
+  const rescheduledBy = searchParams?.get("rescheduledBy");
   const input = {
     isTeamEvent,
     usernameList: getUsernameList(username ?? ""),
@@ -114,6 +113,7 @@ export const useSchedule = ({
     skipContactOwner,
     ...(queuedFormResponseId ? { queuedFormResponseId } : { routingFormResponseId }),
     email,
+    rescheduledBy,
     // Ensures that connectVersion causes a refresh of the data
     ...(embedConnectVersion ? { embedConnectVersion } : {}),
     _isDryRun: searchParams ? isBookingDryRun(searchParams) : false,

--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -1,25 +1,21 @@
 import CalendarManagerMock from "@calcom/features/calendars/lib/__mocks__/CalendarManager";
 import { constantsScenarios } from "@calcom/lib/__mocks__/constants";
-
 import {
+  createBookingScenario,
+  createCredentials,
+  createOrganization,
   getDate,
   getGoogleCalendarCredential,
-  createBookingScenario,
-  createOrganization,
   getOrganizer,
   getScenarioData,
-  Timezones,
-  TestData,
-  createCredentials,
   mockCrmApp,
+  TestData,
+  Timezones,
 } from "@calcom/testing/lib/bookingScenario/bookingScenario";
-
-import { describe, vi, test } from "vitest";
-
 import dayjs from "@calcom/dayjs";
 import { getAvailableSlotsService } from "@calcom/features/di/containers/AvailableSlots";
-import { SchedulingType, type BookingStatus } from "@calcom/prisma/enums";
-
+import { type BookingStatus, SchedulingType } from "@calcom/prisma/enums";
+import { describe, test, vi } from "vitest";
 import { expect, expectedSlotsForSchedule } from "./getSchedule/expects";
 import { setupAndTeardown } from "./getSchedule/setupAndTeardown";
 import { timeTravelToTheBeginningOfToday } from "./getSchedule/utils";
@@ -3542,6 +3538,248 @@ describe("getSchedule", () => {
       });
 
       // expect only slots of IstEveningShift as this is the slots for the original host of the booking
+      expect(schedule).toHaveTimeSlots(
+        [`11:30:00.000Z`, `12:30:00.000Z`, `13:30:00.000Z`, `14:30:00.000Z`, `15:30:00.000Z`],
+        {
+          dateString: plus2DateString,
+        }
+      );
+    });
+
+    test("Reschedule: should not filter by guest availability when attendee initiates reschedule", async () => {
+      vi.setSystemTime("2024-05-21T00:00:13Z");
+
+      const plus1DateString = "2024-05-22";
+      const plus2DateString = "2024-05-23";
+
+      await createBookingScenario({
+        eventTypes: [
+          {
+            id: 1,
+            slotInterval: 60,
+            length: 60,
+            hosts: [
+              {
+                userId: 101,
+                isFixed: false,
+              },
+            ],
+            schedulingType: "ROUND_ROBIN",
+          },
+        ],
+        users: [
+          {
+            ...TestData.users.example,
+            email: "example@example.com",
+            id: 101,
+            schedules: [TestData.schedules.IstEveningShift],
+            defaultScheduleId: 1,
+          },
+          {
+            ...TestData.users.example,
+            email: "example1@example.com",
+            id: 102,
+            schedules: [TestData.schedules.IstMorningShift],
+            defaultScheduleId: 2,
+          },
+        ],
+        bookings: [
+          {
+            uid: "BOOKING_TO_RESCHEDULE_UID",
+            userId: 101,
+            attendees: [
+              {
+                email: "example1@example.com",
+              },
+            ],
+            eventTypeId: 1,
+            status: "ACCEPTED",
+            startTime: `${plus2DateString}T04:00:00.000Z`,
+            endTime: `${plus2DateString}T05:00:00.000Z`,
+          },
+        ],
+      });
+
+      const schedule = await availableSlotsService.getAvailableSlots({
+        input: {
+          eventTypeId: 1,
+          eventTypeSlug: "",
+          startTime: `${plus1DateString}T18:30:00.000Z`,
+          endTime: `${plus2DateString}T18:29:59.999Z`,
+          timeZone: Timezones["+5:30"],
+          isTeamEvent: true,
+          rescheduleUid: "BOOKING_TO_RESCHEDULE_UID",
+          rescheduledBy: "example1@example.com",
+        },
+      });
+
+      // Attendee-initiated reschedule keeps host-only availability.
+      expect(schedule).toHaveTimeSlots(
+        [`11:30:00.000Z`, `12:30:00.000Z`, `13:30:00.000Z`, `14:30:00.000Z`, `15:30:00.000Z`],
+        {
+          dateString: plus2DateString,
+        }
+      );
+    });
+
+    test("Reschedule: should filter by guest availability when attendee matches verified secondary email", async () => {
+      vi.setSystemTime("2024-05-21T00:00:13Z");
+
+      const plus1DateString = "2024-05-22";
+      const plus2DateString = "2024-05-23";
+
+      await createBookingScenario({
+        eventTypes: [
+          {
+            id: 1,
+            slotInterval: 60,
+            length: 60,
+            hosts: [
+              {
+                userId: 101,
+                isFixed: false,
+              },
+            ],
+            schedulingType: "ROUND_ROBIN",
+          },
+        ],
+        users: [
+          {
+            ...TestData.users.example,
+            email: "example@example.com",
+            id: 101,
+            schedules: [TestData.schedules.IstEveningShift],
+            defaultScheduleId: 1,
+          },
+          {
+            ...TestData.users.example,
+            email: "guest-primary@example.com",
+            id: 102,
+            schedules: [TestData.schedules.IstEveningShift],
+            defaultScheduleId: 2,
+            secondaryEmails: [
+              {
+                email: "guestalias@example.com",
+                emailVerified: new Date("2024-01-01T00:00:00.000Z"),
+              },
+            ],
+          },
+        ],
+        bookings: [
+          {
+            uid: "BOOKING_TO_RESCHEDULE_UID",
+            userId: 101,
+            attendees: [
+              {
+                email: "guestalias@example.com",
+              },
+            ],
+            eventTypeId: 1,
+            status: "ACCEPTED",
+            startTime: `${plus2DateString}T04:00:00.000Z`,
+            endTime: `${plus2DateString}T05:00:00.000Z`,
+          },
+          {
+            uid: "GUEST_BUSY_BOOKING_UID",
+            userId: 102,
+            attendees: [
+              {
+                email: "someone@example.com",
+              },
+            ],
+            eventTypeId: 1,
+            status: "ACCEPTED",
+            startTime: `${plus2DateString}T12:30:00.000Z`,
+            endTime: `${plus2DateString}T13:30:00.000Z`,
+          },
+        ],
+      });
+
+      const schedule = await availableSlotsService.getAvailableSlots({
+        input: {
+          eventTypeId: 1,
+          eventTypeSlug: "",
+          startTime: `${plus1DateString}T18:30:00.000Z`,
+          endTime: `${plus2DateString}T18:29:59.999Z`,
+          timeZone: Timezones["+5:30"],
+          isTeamEvent: true,
+          rescheduleUid: "BOOKING_TO_RESCHEDULE_UID",
+          rescheduledBy: "example@example.com",
+        },
+      });
+
+      expect(schedule).toHaveTimeSlots([`11:30:00.000Z`, `13:30:00.000Z`, `14:30:00.000Z`, `15:30:00.000Z`], {
+        dateString: plus2DateString,
+      });
+    });
+
+    test("Reschedule: should keep the current slot available for host-initiated reschedule", async () => {
+      vi.setSystemTime("2024-05-21T00:00:13Z");
+
+      const plus1DateString = "2024-05-22";
+      const plus2DateString = "2024-05-23";
+
+      await createBookingScenario({
+        eventTypes: [
+          {
+            id: 1,
+            slotInterval: 60,
+            length: 60,
+            hosts: [
+              {
+                userId: 101,
+                isFixed: false,
+              },
+            ],
+            schedulingType: "ROUND_ROBIN",
+          },
+        ],
+        users: [
+          {
+            ...TestData.users.example,
+            email: "example@example.com",
+            id: 101,
+            schedules: [TestData.schedules.IstEveningShift],
+            defaultScheduleId: 1,
+          },
+          {
+            ...TestData.users.example,
+            email: "example1@example.com",
+            id: 102,
+            schedules: [TestData.schedules.IstEveningShift],
+            defaultScheduleId: 2,
+          },
+        ],
+        bookings: [
+          {
+            uid: "BOOKING_TO_RESCHEDULE_UID",
+            userId: 101,
+            attendees: [
+              {
+                email: "example1@example.com",
+              },
+            ],
+            eventTypeId: 1,
+            status: "ACCEPTED",
+            startTime: `${plus2DateString}T12:30:00.000Z`,
+            endTime: `${plus2DateString}T13:30:00.000Z`,
+          },
+        ],
+      });
+
+      const schedule = await availableSlotsService.getAvailableSlots({
+        input: {
+          eventTypeId: 1,
+          eventTypeSlug: "",
+          startTime: `${plus1DateString}T18:30:00.000Z`,
+          endTime: `${plus2DateString}T18:29:59.999Z`,
+          timeZone: Timezones["+5:30"],
+          isTeamEvent: true,
+          rescheduleUid: "BOOKING_TO_RESCHEDULE_UID",
+          rescheduledBy: "example@example.com",
+        },
+      });
+
       expect(schedule).toHaveTimeSlots(
         [`11:30:00.000Z`, `12:30:00.000Z`, `13:30:00.000Z`, `14:30:00.000Z`, `15:30:00.000Z`],
         {

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -564,6 +564,60 @@ export class BookingRepository implements IBookingRepository {
     });
   }
 
+  async findBySeatReferenceUidIncludeEventType({ seatReferenceUid }: { seatReferenceUid: string }) {
+    const bookingSeat = await this.prismaClient.bookingSeat.findUnique({
+      where: {
+        referenceUid: seatReferenceUid,
+      },
+      select: {
+        booking: {
+          select: {
+            userId: true,
+            user: {
+              select: {
+                id: true,
+                email: true,
+              },
+            },
+            attendees: {
+              select: {
+                email: true,
+              },
+            },
+            eventType: {
+              select: {
+                teamId: true,
+                parent: {
+                  select: {
+                    teamId: true,
+                  },
+                },
+                hosts: {
+                  select: {
+                    userId: true,
+                    user: {
+                      select: {
+                        email: true,
+                      },
+                    },
+                  },
+                },
+                users: {
+                  select: {
+                    id: true,
+                    email: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return bookingSeat?.booking ?? null;
+  }
+
   async findByIdIncludeEventType({ bookingId }: { bookingId: number }) {
     return await this.prismaClient.booking.findUnique({
       where: {

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -277,6 +277,77 @@ export class UserRepository {
     return user;
   }
 
+  async findAvailabilityUserByEmail({ email }: { email: string }) {
+    const normalizedEmail = email.toLowerCase();
+    const availabilityUserWithCredentialsSelect = {
+      locked: true,
+      ...availabilityUserSelect,
+      selectedCalendars: true,
+      credentials: {
+        select: credentialForCalendarServiceSelect,
+      },
+    } satisfies Prisma.UserSelect;
+
+    // Prefer primary-email matches first, then fall back to verified secondary emails.
+    let user = await this.prismaClient.user.findFirst({
+      where: {
+        email: {
+          equals: normalizedEmail,
+          mode: "insensitive",
+        },
+      },
+      select: availabilityUserWithCredentialsSelect,
+    });
+
+    if (!user) {
+      // Exact secondary-email match (works with test DB adapters that don't support `mode`).
+      user = await this.prismaClient.user.findFirst({
+        where: {
+          secondaryEmails: {
+            some: {
+              email: normalizedEmail,
+              emailVerified: {
+                not: null,
+              },
+            },
+          },
+        },
+        select: availabilityUserWithCredentialsSelect,
+      });
+    }
+
+    if (!user) {
+      // Case-insensitive fallback for mixed-case secondary emails.
+      user = await this.prismaClient.user.findFirst({
+        where: {
+          secondaryEmails: {
+            some: {
+              email: {
+                equals: normalizedEmail,
+                mode: "insensitive",
+              },
+              emailVerified: {
+                not: null,
+              },
+            },
+          },
+        },
+        select: availabilityUserWithCredentialsSelect,
+      });
+    }
+
+    if (!user || user.locked) {
+      return null;
+    }
+
+    const { locked: _locked, credentials, ...userWithSelectedCalendars } = withSelectedCalendars(user);
+
+    return {
+      ...userWithSelectedCalendars,
+      credentials: buildNonDelegationCredentials(credentials),
+    };
+  }
+
   async findManyByEmailsWithEmailVerificationSettings({ emails }: { emails: string[] }) {
     const normalizedEmails = emails.map((e) => e.toLowerCase());
 

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -1,7 +1,6 @@
 import type { IncomingMessage } from "node:http";
-import { z } from "zod";
-
 import { timeZoneSchema } from "@calcom/lib/dayjs/timeZone.schema";
+import { z } from "zod";
 
 const isValidDateString = (val: string) => !isNaN(Date.parse(val));
 
@@ -40,6 +39,7 @@ export const getScheduleSchemaObject = z.object({
   routingFormResponseId: z.number().optional(),
   queuedFormResponseId: z.string().nullish(),
   email: z.string().nullish(),
+  rescheduledBy: z.string().trim().toLowerCase().nullish(),
 });
 
 export const getScheduleSchema = getScheduleSchemaObject

--- a/packages/trpc/server/routers/viewer/slots/util.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from "vitest";
-
 import { BookingDateInPastError, isTimeOutOfBounds } from "@calcom/lib/isOutOfBounds";
-
+import { SchedulingType } from "@calcom/prisma/enums";
 import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AvailableSlotsService } from "./util";
 
 describe("BookingDateInPastError handling", () => {
   it("should convert BookingDateInPastError to TRPCError with BAD_REQUEST code", () => {
@@ -41,5 +41,240 @@ describe("BookingDateInPastError handling", () => {
     // This should throw a TRPCError with BAD_REQUEST code
     expect(() => testFilteringLogic()).toThrow(TRPCError);
     expect(() => testFilteringLogic()).toThrow("Attempting to book a meeting in the past.");
+  });
+});
+
+describe("AvailableSlotsService._getRescheduleGuestUser", () => {
+  const findByUidIncludeEventType = vi.fn();
+  const findAvailabilityUserByEmail = vi.fn();
+
+  const serviceDependencies: ConstructorParameters<typeof AvailableSlotsService>[0] = {
+    bookingRepo: {
+      findByUidIncludeEventType,
+    },
+    userRepo: {
+      findAvailabilityUserByEmail,
+    },
+  };
+
+  const service = new AvailableSlotsService(serviceDependencies);
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns guest availability user for host-initiated reschedule", async () => {
+    findByUidIncludeEventType.mockResolvedValue({
+      user: {
+        email: "host@example.com",
+      },
+      attendees: [
+        {
+          email: "host@example.com",
+        },
+        {
+          email: "guest@example.com",
+        },
+      ],
+    });
+
+    const expectedGuestUser = {
+      id: 102,
+      email: "guest@example.com",
+      username: "guest",
+      timeZone: "UTC",
+      bufferTime: 0,
+      availability: [],
+      timeFormat: null,
+      defaultScheduleId: null,
+      isPlatformManaged: false,
+      schedules: [],
+      credentials: [],
+      allSelectedCalendars: [],
+      userLevelSelectedCalendars: [],
+      travelSchedules: [],
+      groupId: null,
+      isFixed: true,
+    };
+    findAvailabilityUserByEmail.mockResolvedValue(expectedGuestUser);
+
+    const result = await (
+      service as unknown as {
+        _getRescheduleGuestUser: (args: {
+          rescheduleUid?: string | null;
+          organizerEmails: string[];
+          schedulingType: SchedulingType | null;
+          rescheduledBy?: string | null;
+        }) => Promise<unknown>;
+      }
+    )._getRescheduleGuestUser({
+      rescheduleUid: "BOOKING_TO_RESCHEDULE_UID",
+      organizerEmails: ["host@example.com"],
+      schedulingType: SchedulingType.ROUND_ROBIN,
+      rescheduledBy: "host@example.com",
+    });
+
+    expect(findByUidIncludeEventType).toHaveBeenCalledWith({
+      bookingUid: "BOOKING_TO_RESCHEDULE_UID",
+    });
+    expect(findAvailabilityUserByEmail).toHaveBeenCalledWith({
+      email: "guest@example.com",
+    });
+    expect(result).toEqual(expectedGuestUser);
+  });
+
+  it("preserves attendee alias email when resolved user has a different primary email", async () => {
+    findByUidIncludeEventType.mockResolvedValue({
+      user: {
+        email: "host@example.com",
+      },
+      attendees: [
+        {
+          email: "host@example.com",
+        },
+        {
+          email: "guest-alias@example.com",
+        },
+      ],
+    });
+
+    findAvailabilityUserByEmail.mockResolvedValue({
+      id: 102,
+      email: "guest-primary@example.com",
+    });
+
+    const result = await (
+      service as unknown as {
+        _getRescheduleGuestUser: (args: {
+          rescheduleUid?: string | null;
+          organizerEmails: string[];
+          schedulingType: SchedulingType | null;
+          rescheduledBy?: string | null;
+        }) => Promise<unknown>;
+      }
+    )._getRescheduleGuestUser({
+      rescheduleUid: "BOOKING_TO_RESCHEDULE_UID",
+      organizerEmails: ["host@example.com"],
+      schedulingType: SchedulingType.ROUND_ROBIN,
+      rescheduledBy: "host@example.com",
+    });
+
+    expect(findAvailabilityUserByEmail).toHaveBeenCalledWith({
+      email: "guest-alias@example.com",
+    });
+    expect(result).toEqual({
+      id: 102,
+      email: "guest-alias@example.com",
+    });
+  });
+
+  it("returns null when attendee initiates reschedule", async () => {
+    findByUidIncludeEventType.mockResolvedValue({
+      user: {
+        email: "host@example.com",
+      },
+      attendees: [
+        {
+          email: "guest@example.com",
+        },
+      ],
+    });
+
+    const result = await (
+      service as unknown as {
+        _getRescheduleGuestUser: (args: {
+          rescheduleUid?: string | null;
+          organizerEmails: string[];
+          schedulingType: SchedulingType | null;
+          rescheduledBy?: string | null;
+        }) => Promise<unknown>;
+      }
+    )._getRescheduleGuestUser({
+      rescheduleUid: "BOOKING_TO_RESCHEDULE_UID",
+      organizerEmails: ["host@example.com"],
+      schedulingType: SchedulingType.ROUND_ROBIN,
+      rescheduledBy: "guest@example.com",
+    });
+
+    expect(result).toBeNull();
+    expect(findAvailabilityUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns null when guest is not a Cal.com user", async () => {
+    findByUidIncludeEventType.mockResolvedValue({
+      user: {
+        email: "host@example.com",
+      },
+      attendees: [
+        {
+          email: "guest@external.com",
+        },
+      ],
+    });
+    findAvailabilityUserByEmail.mockResolvedValue(null);
+
+    const result = await (
+      service as unknown as {
+        _getRescheduleGuestUser: (args: {
+          rescheduleUid?: string | null;
+          organizerEmails: string[];
+          schedulingType: SchedulingType | null;
+          rescheduledBy?: string | null;
+        }) => Promise<unknown>;
+      }
+    )._getRescheduleGuestUser({
+      rescheduleUid: "BOOKING_TO_RESCHEDULE_UID",
+      organizerEmails: ["host@example.com"],
+      schedulingType: SchedulingType.ROUND_ROBIN,
+      rescheduledBy: "host@example.com",
+    });
+
+    expect(result).toBeNull();
+    expect(findAvailabilityUserByEmail).toHaveBeenCalledWith({
+      email: "guest@external.com",
+    });
+  });
+
+  it("returns null for collective scheduling", async () => {
+    const result = await (
+      service as unknown as {
+        _getRescheduleGuestUser: (args: {
+          rescheduleUid?: string | null;
+          organizerEmails: string[];
+          schedulingType: SchedulingType | null;
+          rescheduledBy?: string | null;
+        }) => Promise<unknown>;
+      }
+    )._getRescheduleGuestUser({
+      rescheduleUid: "BOOKING_TO_RESCHEDULE_UID",
+      organizerEmails: ["host@example.com"],
+      schedulingType: SchedulingType.COLLECTIVE,
+      rescheduledBy: "host@example.com",
+    });
+
+    expect(result).toBeNull();
+    expect(findByUidIncludeEventType).not.toHaveBeenCalled();
+    expect(findAvailabilityUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns null when rescheduledBy is missing", async () => {
+    const result = await (
+      service as unknown as {
+        _getRescheduleGuestUser: (args: {
+          rescheduleUid?: string | null;
+          organizerEmails: string[];
+          schedulingType: SchedulingType | null;
+          rescheduledBy?: string | null;
+        }) => Promise<unknown>;
+      }
+    )._getRescheduleGuestUser({
+      rescheduleUid: "BOOKING_TO_RESCHEDULE_UID",
+      organizerEmails: ["host@example.com"],
+      schedulingType: SchedulingType.ROUND_ROBIN,
+      rescheduledBy: null,
+    });
+
+    expect(result).toBeNull();
+    expect(findByUidIncludeEventType).not.toHaveBeenCalled();
+    expect(findAvailabilityUserByEmail).not.toHaveBeenCalled();
   });
 });

--- a/packages/trpc/server/routers/viewer/slots/util.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.test.ts
@@ -46,11 +46,13 @@ describe("BookingDateInPastError handling", () => {
 
 describe("AvailableSlotsService._getRescheduleGuestUser", () => {
   const findByUidIncludeEventType = vi.fn();
+  const findBySeatReferenceUidIncludeEventType = vi.fn();
   const findAvailabilityUserByEmail = vi.fn();
 
   const serviceDependencies: ConstructorParameters<typeof AvailableSlotsService>[0] = {
     bookingRepo: {
       findByUidIncludeEventType,
+      findBySeatReferenceUidIncludeEventType,
     },
     userRepo: {
       findAvailabilityUserByEmail,
@@ -116,10 +118,62 @@ describe("AvailableSlotsService._getRescheduleGuestUser", () => {
     expect(findByUidIncludeEventType).toHaveBeenCalledWith({
       bookingUid: "BOOKING_TO_RESCHEDULE_UID",
     });
+    expect(findBySeatReferenceUidIncludeEventType).not.toHaveBeenCalled();
     expect(findAvailabilityUserByEmail).toHaveBeenCalledWith({
       email: "guest@example.com",
     });
     expect(result).toEqual(expectedGuestUser);
+  });
+
+  it("resolves seat reference UID to booking for host-initiated reschedule", async () => {
+    findByUidIncludeEventType.mockResolvedValue(null);
+    findBySeatReferenceUidIncludeEventType.mockResolvedValue({
+      user: {
+        email: "host@example.com",
+      },
+      attendees: [
+        {
+          email: "host@example.com",
+        },
+        {
+          email: "guest@example.com",
+        },
+      ],
+    });
+    findAvailabilityUserByEmail.mockResolvedValue({
+      id: 102,
+      email: "guest@example.com",
+    });
+
+    const result = await (
+      service as unknown as {
+        _getRescheduleGuestUser: (args: {
+          rescheduleUid?: string | null;
+          organizerEmails: string[];
+          schedulingType: SchedulingType | null;
+          rescheduledBy?: string | null;
+        }) => Promise<unknown>;
+      }
+    )._getRescheduleGuestUser({
+      rescheduleUid: "SEAT_REFERENCE_UID",
+      organizerEmails: ["host@example.com"],
+      schedulingType: SchedulingType.ROUND_ROBIN,
+      rescheduledBy: "host@example.com",
+    });
+
+    expect(findByUidIncludeEventType).toHaveBeenCalledWith({
+      bookingUid: "SEAT_REFERENCE_UID",
+    });
+    expect(findBySeatReferenceUidIncludeEventType).toHaveBeenCalledWith({
+      seatReferenceUid: "SEAT_REFERENCE_UID",
+    });
+    expect(findAvailabilityUserByEmail).toHaveBeenCalledWith({
+      email: "guest@example.com",
+    });
+    expect(result).toEqual({
+      id: 102,
+      email: "guest@example.com",
+    });
   });
 
   it("preserves attendee alias email when resolved user has a different primary email", async () => {

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -848,7 +848,9 @@ export class AvailableSlotsService {
 
   /**
    * Finds the guest (first non-organizer attendee) and returns their availability.
-   * The rescheduleUid booking is automatically excluded from availability calculations
+   * For seated events, rescheduleUid can be bookingSeat.referenceUid; this method
+   * resolves that to the underlying booking before applying guest enforcement.
+   * The reschedule booking is automatically excluded from availability calculations
    * by the downstream calculateHostsAndAvailabilities method, so the current slot
    * remains available for rescheduling.
    */
@@ -867,9 +869,15 @@ export class AvailableSlotsService {
       return null;
     }
 
-    const booking = await this.dependencies.bookingRepo.findByUidIncludeEventType({
+    const bookingFromUid = await this.dependencies.bookingRepo.findByUidIncludeEventType({
       bookingUid: rescheduleUid,
     });
+
+    const booking =
+      bookingFromUid ??
+      (await this.dependencies.bookingRepo.findBySeatReferenceUidIncludeEventType({
+        seatReferenceUid: rescheduleUid,
+      }));
 
     // `rescheduledBy` is a contextual hint from the reschedule flow, not an auth signal.
     // Only apply guest constraint when the host/owner initiates reschedule so attendee-driven
@@ -1422,10 +1430,16 @@ export class AvailableSlotsService {
       }
     }
 
+    // guest is injected as a host-equivalent participant for conflict enforcement only.
+    // it should not change team-event semantics for OOO/away slot annotations.
+    const effectiveHostAvailabilityCount = rescheduleGuestHost
+      ? allUsersAvailability.length - 1
+      : allUsersAvailability.length;
+
     const isTeamEvent =
       eventType.schedulingType === SchedulingType.COLLECTIVE ||
       eventType.schedulingType === SchedulingType.ROUND_ROBIN ||
-      allUsersAvailability.length > 1;
+      effectiveHostAvailabilityCount > 1;
 
     const timeSlots = getSlots({
       inviteeDate: startTime,

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -9,6 +9,7 @@ import type {
   GetAvailabilityUser,
   UserAvailabilityService,
 } from "@calcom/features/availability/lib/getUserAvailability";
+import type { IGetAvailableSlots } from "@calcom/features/bookings/Booker/hooks/useAvailableTimeSlots";
 import type { CheckBookingLimitsService } from "@calcom/features/bookings/lib/checkBookingLimits";
 import { checkForConflicts } from "@calcom/features/bookings/lib/conflictChecker/checkForConflicts";
 import type { QualifiedHostsService } from "@calcom/features/bookings/lib/host-filtering/findQualifiedHostsWithDelegationCredentials";
@@ -16,12 +17,14 @@ import { isEventTypeLoggingEnabled } from "@calcom/features/bookings/lib/isEvent
 import type { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
 import type { BusyTimesService } from "@calcom/features/busyTimes/services/getBusyTimes";
 import type { getBusyTimesService } from "@calcom/features/di/containers/BusyTimes";
+import type { OrgMembershipLookup } from "@calcom/features/di/modules/OrgMembershipLookup";
 import type { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { getDefaultEvent } from "@calcom/features/eventtypes/lib/defaultEvents";
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import type { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import type { PrismaOOORepository } from "@calcom/features/ooo/repositories/PrismaOOORepository";
 import type { IRedisService } from "@calcom/features/redis/IRedisService";
+import type { RoutingFormResponseRepository } from "@calcom/features/routing-forms/repositories/RoutingFormResponseRepository";
 import { buildDateRanges } from "@calcom/features/schedules/lib/date-ranges";
 import getSlots from "@calcom/features/schedules/lib/slots";
 import type { ScheduleRepository } from "@calcom/features/schedules/repositories/ScheduleRepository";
@@ -48,7 +51,6 @@ import {
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { withReporting } from "@calcom/lib/sentryWrapper";
-import type { RoutingFormResponseRepository } from "@calcom/features/routing-forms/repositories/RoutingFormResponseRepository";
 import { PeriodType, SchedulingType } from "@calcom/prisma/enums";
 import type { CalendarFetchMode, EventBusyDate, EventBusyDetails } from "@calcom/types/Calendar";
 import type { CredentialForCalendarService } from "@calcom/types/Credential";
@@ -57,8 +59,6 @@ import type { Logger } from "tslog";
 import { v4 as uuid } from "uuid";
 import type { TGetScheduleInputSchema } from "./getSchedule.schema";
 import type { GetScheduleOptions } from "./types";
-import type { OrgMembershipLookup } from "@calcom/features/di/modules/OrgMembershipLookup";
-import type { IGetAvailableSlots } from "@calcom/features/bookings/Booker/hooks/useAvailableTimeSlots";
 
 const log = logger.getSubLogger({ prefix: ["[slots/util]"] });
 const DEFAULT_SLOTS_CACHE_TTL = 2000;
@@ -846,6 +846,69 @@ export class AvailableSlotsService {
     "getUsersWithCredentials"
   );
 
+  /**
+   * Finds the guest (first non-organizer attendee) and returns their availability.
+   * The rescheduleUid booking is automatically excluded from availability calculations
+   * by the downstream calculateHostsAndAvailabilities method, so the current slot
+   * remains available for rescheduling.
+   */
+  private async _getRescheduleGuestUser({
+    rescheduleUid,
+    organizerEmails,
+    schedulingType,
+    rescheduledBy,
+  }: {
+    rescheduleUid?: string | null;
+    organizerEmails: string[];
+    schedulingType: SchedulingType | null;
+    rescheduledBy?: string | null;
+  }): Promise<GetAvailabilityUserWithDelegationCredentials | null> {
+    if (!rescheduleUid || schedulingType === SchedulingType.COLLECTIVE || !rescheduledBy) {
+      return null;
+    }
+
+    const booking = await this.dependencies.bookingRepo.findByUidIncludeEventType({
+      bookingUid: rescheduleUid,
+    });
+
+    // `rescheduledBy` is a contextual hint from the reschedule flow, not an auth signal.
+    // Only apply guest constraint when the host/owner initiates reschedule so attendee-driven
+    // reschedules keep previous behavior.
+    if (!booking?.user?.email || booking.user.email.toLowerCase() !== rescheduledBy.toLowerCase()) {
+      return null;
+    }
+
+    const organizerEmailsSet = new Set(organizerEmails.map((email) => email.toLowerCase()));
+
+    const rescheduleGuestAttendee = booking.attendees.find((attendee) => {
+      return !organizerEmailsSet.has(attendee.email.toLowerCase());
+    });
+
+    if (!rescheduleGuestAttendee) {
+      return null;
+    }
+
+    const rescheduleGuestUser = await this.dependencies.userRepo.findAvailabilityUserByEmail({
+      email: rescheduleGuestAttendee.email,
+    });
+
+    if (!rescheduleGuestUser) {
+      return null;
+    }
+
+    // Preserve the attendee email used on the booking (including verified secondary aliases)
+    // so attendee-based busy booking lookups continue to match during slot calculation.
+    return {
+      ...rescheduleGuestUser,
+      email: rescheduleGuestAttendee.email,
+    };
+  }
+
+  private getRescheduleGuestUser = withReporting(
+    this._getRescheduleGuestUser.bind(this),
+    "getRescheduleGuestUser"
+  );
+
   private getStartTime(startTimeInput: string, timeZone?: string, minimumBookingNotice?: number) {
     const startTimeMin = dayjs.utc().add(minimumBookingNotice || 1, "minutes");
     const startTime = timeZone === "Etc/GMT" ? dayjs.utc(startTimeInput) : dayjs(startTimeInput).tz(timeZone);
@@ -1247,6 +1310,22 @@ export class AvailableSlotsService {
       };
     }
 
+    const organizerEmails = allHosts.map((host) => host.user.email);
+    const rescheduledGuestUser = await this.getRescheduleGuestUser({
+      rescheduleUid: input.rescheduleUid,
+      organizerEmails,
+      schedulingType: eventType.schedulingType,
+      rescheduledBy: input.rescheduledBy,
+    });
+
+    const rescheduleGuestHost = rescheduledGuestUser
+      ? {
+          isFixed: true,
+          groupId: null,
+          user: rescheduledGuestUser,
+        }
+      : null;
+
     const twoWeeksFromNow = dayjs().add(2, "week");
 
     const hasFallbackRRHosts =
@@ -1256,7 +1335,7 @@ export class AvailableSlotsService {
       await this.calculateHostsAndAvailabilities({
         input,
         eventType,
-        hosts: allHosts,
+        hosts: rescheduleGuestHost ? [...allHosts, rescheduleGuestHost] : allHosts,
         loggerWithEventDetails,
         // adjust start time so we can check for available slots in the first two weeks
         startTime:
@@ -1291,7 +1370,9 @@ export class AvailableSlotsService {
           const firstTwoWeeksAvailabilities = await this.calculateHostsAndAvailabilities({
             input,
             eventType,
-            hosts: [...eligibleQualifiedRRHosts, ...eligibleFixedHosts],
+            hosts: rescheduleGuestHost
+              ? [...eligibleQualifiedRRHosts, ...eligibleFixedHosts, rescheduleGuestHost]
+              : [...eligibleQualifiedRRHosts, ...eligibleFixedHosts],
             loggerWithEventDetails,
             startTime: dayjs(),
             endTime: twoWeeksFromNow,
@@ -1327,7 +1408,9 @@ export class AvailableSlotsService {
           await this.calculateHostsAndAvailabilities({
             input,
             eventType,
-            hosts: [...eligibleFallbackRRHosts, ...eligibleFixedHosts],
+            hosts: rescheduleGuestHost
+              ? [...eligibleFallbackRRHosts, ...eligibleFixedHosts, rescheduleGuestHost]
+              : [...eligibleFallbackRRHosts, ...eligibleFixedHosts],
             loggerWithEventDetails,
             startTime,
             endTime,


### PR DESCRIPTION
## Summary

This PR fixes CAL-4531 (Fixes #16378) by enforcing guest availability when a host reschedules a booking.

When the host initiates a non-collective reschedule, slots are filtered against guest availability to prevent guest double-booking.

This implementation is intentionally scoped and reuses the existing availability engine instead of introducing a separate guestBusyTimes pipeline.

### Changes Made

- Added end-to-end rescheduledBy propagation through the reschedule flow.
- Added rescheduledBy validation and normalization in schedule input schema.
- Added host-initiated guard in slot calculation where rescheduledBy must match booking owner.
- Kept collective scheduling excluded from this behavior in current scope.
- Added guest resolution from booking attendees using Cal.com user lookup with verified secondary-email support.
- Injected the resolved guest as a host-equivalent participant into the existing availability pipeline.
- Preserved attendee alias email after user resolution to keep attendee-based busy-booking matching accurate.
- Added and updated tests for host-initiated behavior, attendee-initiated regression safety, secondary-email behavior, collective bypass, and current-slot preservation.

### Why this approach

- Lower regression risk by staying inside the existing availability pipeline.
- Preserves behavior boundaries so attendee-initiated flow remains unchanged.
- Automatically respects existing constraints already enforced by the engine: calendars, before and after buffers, booking limits, team limits, OOO, and reschedule-aware busy-time handling.

### Comparison to PR #26811 and PR #27710

- This PR keeps host-initiated gating explicit via rescheduledBy.
- This PR keeps non-collective-only scope explicit.
- This PR avoids introducing a parallel guestBusyTimes ruleset.
- This PR centralizes behavior in the existing slot engine instead of splitting logic across two availability paths.
- This PR is intentionally scoped for safer rollout and easier review.

### Type of Change

- [x] Feature (behavior improvement in existing flow)
- [x] Bug fix (non-breaking change)

### Test Plan

- [x] Host-initiated reschedule applies guest availability filtering.
- [x] Attendee-initiated reschedule keeps previous behavior.
- [x] Verified secondary-email attendee path is handled.
- [x] Current booking slot remains available during reschedule.
- [x] Collective scheduling is explicitly bypassed in this scope.
- [x] Unit coverage for guest resolution guards and alias preservation.
- [x] Integration coverage for host and attendee reschedule scenarios.

### Scope Note

Current scope resolves the first non-organizer attendee for guest enforcement.  
If product wants multi-attendee enforcement, that can be added in a follow-up without changing this PR core design.

### Demo

I will shortly add a video demo showing:
- host-initiated reschedule with guest conflict filtering
- attendee-initiated behavior unchanged
- current-slot preservation during reschedule

Fixes #16378  
Refs CAL-4531  
Related: #26811, #27710


/claim #16378