### PR TITLE
fix(orgs): use runtime origin for booker URL fallback

### DIFF
--- a/packages/features/ee/organizations/lib/getBookerUrlServer.test.ts
+++ b/packages/features/ee/organizations/lib/getBookerUrlServer.test.ts
@@ -1,0 +1,36 @@
+import { constantsScenarios } from "@calcom/lib/__mocks__/constants";
+import { getBrand } from "@calcom/features/ee/organizations/lib/getBrand";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@calcom/features/ee/organizations/lib/getBrand", () => ({
+  getBrand: vi.fn(),
+}));
+
+import { getBookerBaseUrl, getTeamBookerUrl } from "./getBookerUrlServer";
+
+describe("getBookerUrlServer", () => {
+  beforeEach(() => {
+    constantsScenarios.set({
+      WEBAPP_URL: "https://app.cal.eu",
+      WEBSITE_URL: "https://cal.com",
+    });
+  });
+
+  it("uses the runtime webapp origin when no organization brand exists", async () => {
+    vi.mocked(getBrand).mockResolvedValueOnce(null);
+
+    await expect(getBookerBaseUrl(null)).resolves.toBe("https://app.cal.eu");
+  });
+
+  it("uses the runtime webapp origin for team URLs when no organization brand exists", async () => {
+    vi.mocked(getBrand).mockResolvedValueOnce(null);
+
+    await expect(getTeamBookerUrl({ organizationId: null })).resolves.toBe("https://app.cal.eu");
+  });
+
+  it("prefers the organization brand full domain when available", async () => {
+    vi.mocked(getBrand).mockResolvedValueOnce({ fullDomain: "https://acme.cal.eu" } as never);
+
+    await expect(getBookerBaseUrl(123)).resolves.toBe("https://acme.cal.eu");
+  });
+});

--- a/packages/features/ee/organizations/lib/getBookerUrlServer.ts
+++ b/packages/features/ee/organizations/lib/getBookerUrlServer.ts
@@ -1,12 +1,12 @@
 import { getBrand } from "@calcom/features/ee/organizations/lib/getBrand";
-import { WEBSITE_URL } from "@calcom/lib/constants";
+import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
 
-export const getBookerBaseUrl = async (organizationId: number | null) => {
+export const getBookerBaseUrl = async (organizationId: number | null): Promise<string> => {
   const orgBrand = await getBrand(organizationId);
-  return orgBrand?.fullDomain ?? WEBSITE_URL;
+  return orgBrand?.fullDomain ?? getOrgFullOrigin(null);
 };
 
-export const getTeamBookerUrl = async (team: { organizationId: number | null }) => {
+export const getTeamBookerUrl = async (team: { organizationId: number | null }): Promise<string> => {
   const orgBrand = await getBrand(team.organizationId);
-  return orgBrand?.fullDomain ?? WEBSITE_URL;
+  return orgBrand?.fullDomain ?? getOrgFullOrigin(null);
 };


### PR DESCRIPTION
Fixes #28829\n\nThe null-org fallback in getBookerBaseUrl/getTeamBookerUrl now uses the runtime webapp origin via getOrgFullOrigin(null) instead of WEBSITE_URL, so EU shard booking emails build reschedule/cancel links with app.cal.eu rather than cal.com.\n\nValidation:\n- corepack yarn vitest run packages/features/ee/organizations/lib/getBookerUrlServer.test.ts packages/features/ee/organizations/lib/orgDomains.test.ts\n- corepack yarn exec biome check packages/features/ee/organizations/lib/getBookerUrlServer.ts packages/features/ee/organizations/lib/getBookerUrlServer.test.ts\n- git diff --check