### PR TITLE
fix: improve text visibility on routing form cards (#26579)

### DIFF
--- a/packages/ui/components/list/List.tsx
+++ b/packages/ui/components/list/List.tsx
@@ -101,7 +101,7 @@ export function ListLinkItem(props: ListLinkItemProps) {
         passHref
         href={href}
         className={classNames(
-          "text-default grow truncate text-sm",
+          "text-default min-w-0 grow text-sm",
           disabled ? "pointer-events-none cursor-not-allowed opacity-30" : ""
         )}>
         <div className="flex items-center">
@@ -112,9 +112,8 @@ export function ListLinkItem(props: ListLinkItemProps) {
             </Badge>
           )}
         </div>
-        <h2 className="min-h-4 mt-2 text-sm font-normal leading-none text-neutral-600">
-          {subHeading.substring(0, 100)}
-          {subHeading.length > 100 && "..."}
+        <h2 className="min-h-4 mt-2 text-sm font-normal leading-normal text-neutral-600 line-clamp-2 break-words">
+          {subHeading}
         </h2>
         <div className="mt-2">{children}</div>
       </Link>

--- a/packages/ui/components/list/list.test.tsx
+++ b/packages/ui/components/list/list.test.tsx
@@ -90,6 +90,33 @@ describe("Tests for ListLinkItem component", () => {
     const action = screen.getByText("cta");
     expect(action).toBeInTheDocument();
   });
+
+  test("Should render full subHeading text without JavaScript truncation", () => {
+    const longText = "A".repeat(150);
+    render(
+      <ListLinkItem href="https://custom.link" heading="Go" subHeading={longText}>
+        Alright
+      </ListLinkItem>
+    );
+
+    const subHeading = screen.getByText(longText);
+    expect(subHeading).toBeInTheDocument();
+    expect(subHeading.tagName).toBe("H2");
+    expect(subHeading).toHaveClass("line-clamp-2");
+  });
+
+  test("Should not apply truncate class on the link wrapper", () => {
+    render(
+      <ListLinkItem href="https://custom.link" heading="Go" subHeading="There">
+        Alright
+      </ListLinkItem>
+    );
+
+    const listLinkItemElement = screen.getByTestId("list-link-item");
+    const link = listLinkItemElement.firstChild;
+    expect(link).not.toHaveClass("truncate");
+    expect(link).toHaveClass("min-w-0");
+  });
 });
 
 describe("Tests for ListItemTitle component", () => {


### PR DESCRIPTION
## What does this PR do?

- Fixes #26579

## Summary

The `ListLinkItem` component in `packages/ui/components/list/List.tsx` was hiding text on routing form cards at narrow viewports due to two issues:

1. **CSS `truncate` class on the Link wrapper** forced `white-space: nowrap; overflow: hidden`, preventing text from wrapping at all
2. **JavaScript `substring(0, 100)`** hard-truncated subheading text regardless of available space

### Changes:
- Replaced `truncate` with `min-w-0` on the Link wrapper — allows flex child to shrink properly without forcing single-line text
- Replaced JavaScript substring truncation with CSS `line-clamp-2` — shows up to 2 lines with ellipsis, adapting to viewport width
- Changed `leading-none` to `leading-normal` on the subheading for proper multi-line spacing
- Added `break-words` to handle long unbroken strings

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

```bash
TZ=UTC yarn vitest run packages/ui/components/list/list.test.tsx
```

- Navigate to Apps > Routing Forms
- Verify text is visible and wraps on cards, especially at narrow viewports (~325px)
- Long descriptions should show up to 2 lines with ellipsis instead of being hidden

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have self-reviewed my code
- [x] My changes generate no new warnings

Generated by Ora Studio
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
