### PR TITLE
fix: use correct `valid` property in license check response (#26610)

### DIFF
--- a/apps/api/v2/src/modules/deployments/deployments.service.spec.ts
+++ b/apps/api/v2/src/modules/deployments/deployments.service.spec.ts
@@ -1,0 +1,126 @@
+import { DeploymentsRepository } from "@/modules/deployments/deployments.repository";
+import { DeploymentsService } from "@/modules/deployments/deployments.service";
+import { RedisService } from "@/modules/redis/redis.service";
+import { createMock } from "@golevelup/ts-jest";
+import { ConfigService } from "@nestjs/config";
+
+describe("DeploymentsService", () => {
+  let service: DeploymentsService;
+  let deploymentsRepository: DeploymentsRepository;
+  let configService: ConfigService;
+  let redisService: RedisService;
+
+  beforeEach(() => {
+    deploymentsRepository = createMock<DeploymentsRepository>();
+    configService = createMock<ConfigService>();
+    jest.spyOn(configService, "get").mockImplementation((key: string) => {
+      if (key === "api.licenseKey") return "cal_live_test_key";
+      if (key === "api.licenseKeyUrl") return "https://console.cal.com/api/license";
+      if (key === "e2e") return false;
+      return undefined;
+    });
+    redisService = createMock<RedisService>({
+      redis: {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn().mockResolvedValue("OK"),
+      },
+    });
+    service = new DeploymentsService(deploymentsRepository, configService, redisService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("checkLicense", () => {
+    it("should return true when license API responds with { valid: true }", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ valid: true }),
+      });
+
+      const result = await service.checkLicense();
+      expect(result).toBe(true);
+    });
+
+    it("should return false when license API responds with { valid: false }", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ valid: false }),
+      });
+
+      const result = await service.checkLicense();
+      expect(result).toBe(false);
+    });
+
+    it("should return true from cached data with { valid: true }", async () => {
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy;
+      (redisService.redis.get as jest.Mock).mockResolvedValue(JSON.stringify({ valid: true }));
+
+      const result = await service.checkLicense();
+      expect(result).toBe(true);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should return false from cached data with { valid: false }", async () => {
+      (redisService.redis.get as jest.Mock).mockResolvedValue(JSON.stringify({ valid: false }));
+
+      const result = await service.checkLicense();
+      expect(result).toBe(false);
+    });
+
+    it("should return true in e2e mode regardless of license", async () => {
+      (configService.get as jest.Mock).mockImplementation((key: string) => {
+        if (key === "e2e") return true;
+        return undefined;
+      });
+
+      const result = await service.checkLicense();
+      expect(result).toBe(true);
+    });
+
+    it("should return false when no license key is configured", async () => {
+      (configService.get as jest.Mock).mockImplementation((key: string) => {
+        if (key === "e2e") return false;
+        return undefined;
+      });
+      (deploymentsRepository.getDeployment as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.checkLicense();
+      expect(result).toBe(false);
+    });
+
+    it("should cache the license API response in Redis", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ valid: true }),
+      });
+
+      await service.checkLicense();
+
+      expect(redisService.redis.set).toHaveBeenCalledWith(
+        "api-v2-license-key-goblin-url-cal_live_test_key",
+        JSON.stringify({ valid: true }),
+        "EX",
+        86400000
+      );
+    });
+
+    it("should fall back to DB deployment record when env var is not set", async () => {
+      (configService.get as jest.Mock).mockImplementation((key: string) => {
+        if (key === "api.licenseKey") return undefined;
+        if (key === "api.licenseKeyUrl") return "https://console.cal.com/api/license";
+        if (key === "e2e") return false;
+        return undefined;
+      });
+      (deploymentsRepository.getDeployment as jest.Mock).mockResolvedValue({
+        licenseKey: "cal_live_db_key",
+      });
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ valid: true }),
+      });
+
+      const result = await service.checkLicense();
+      expect(result).toBe(true);
+      expect(deploymentsRepository.getDeployment).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/v2/src/modules/deployments/deployments.service.ts
+++ b/apps/api/v2/src/modules/deployments/deployments.service.ts
@@ -8,7 +8,7 @@ const CACHING_TIME = 86400000; // 24 hours in milliseconds
 const getLicenseCacheKey = (key: string) => `api-v2-license-key-goblin-url-${key}`;
 
 type LicenseCheckResponse = {
-  status: boolean;
+  valid: boolean;
 };
 @Injectable()
 export class DeploymentsService {
@@ -36,12 +36,12 @@ export class DeploymentsService {
     const licenseKeyUrl = this.configService.get("api.licenseKeyUrl") + `/${licenseKey}`;
     const cachedData = await this.redisService.redis.get(getLicenseCacheKey(licenseKey));
     if (cachedData) {
-      return (JSON.parse(cachedData) as LicenseCheckResponse)?.status;
+      return (JSON.parse(cachedData) as LicenseCheckResponse)?.valid;
     }
     const response = await fetch(licenseKeyUrl, { mode: "cors" });
     const data = (await response.json()) as LicenseCheckResponse;
     const cacheKey = getLicenseCacheKey(licenseKey);
     this.redisService.redis.set(cacheKey, JSON.stringify(data), "EX", CACHING_TIME);
-    return data.status;
+    return data.valid;
   }
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes #26610

The `checkLicense()` method in `DeploymentsService` reads `data.status` from the Cal.com license API response, but the API actually returns `{ valid: boolean }`. This causes the method to always return `undefined` (falsy), breaking API key authentication on **all self-hosted instances** with valid Enterprise licenses.

### Root cause

```typescript
// Before (broken) — reads non-existent property
type LicenseCheckResponse = { status: boolean };
return data.status; // always undefined

// After (fixed) — reads correct property
type LicenseCheckResponse = { valid: boolean };
return data.valid; // true or false as expected
```

The same bug affects both the fresh fetch path and the Redis cache read path.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Deploy API v2 on a self-hosted instance with a valid `CALCOM_LICENSE_KEY`
2. Create an API key from Settings > Security
3. Make a request: `curl -H "Authorization: Bearer cal_xxx" -H "cal-api-version: 2024-08-13" https://your-domain/api/v2/bookings`
4. **Before fix**: returns 401 "Invalid or missing CALCOM_LICENSE_KEY"
5. **After fix**: returns 200 with bookings data

Unit tests added covering:
- License API response with `{ valid: true }` and `{ valid: false }`
- Cached data path (Redis hit)
- e2e mode bypass
- Missing license key fallback to DB
- Redis caching of API response

## Verification

- [x] Baseline tests: 6819 pass, 0 failures
- [x] Post-fix tests: no regressions
- [x] New tests: 9 added (Jest), all pass
- [x] Review agent: issue alignment verified

## Files changed

| File | Change |
|------|--------|
| `apps/api/v2/src/modules/deployments/deployments.service.ts` | Fix `LicenseCheckResponse` type and property access from `status` to `valid` |
| `apps/api/v2/src/modules/deployments/deployments.service.spec.ts` | New: 9 unit tests for `checkLicense()` |

Generated by Ora Studio
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
