### PR TITLE
fix: clamp long profile bio with read more toggle (#27742)

### DIFF
--- a/apps/web/modules/users/views/users-public-view.test.tsx
+++ b/apps/web/modules/users/views/users-public-view.test.tsx
@@ -1,5 +1,5 @@
-import { render } from "@testing-library/react";
-import { describe, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, vi, expect } from "vitest";
 
 import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
 import { useRouterQuery } from "@calcom/lib/hooks/useRouterQuery";
@@ -85,5 +85,60 @@ describe("UserPage Component", () => {
     });
 
     expect(() => render(<UserPage {...mockData.props} />)).not.toThrow();
+  });
+
+  it("should clamp long bio text and show toggle button", () => {
+    const longBio = "<p>" + "This is a very long bio text. ".repeat(20) + "</p>";
+    const mockData = {
+      props: mockedUserPageComponentProps({
+        entity: {
+          considerUnpublished: false,
+          orgSlug: "org1",
+        },
+      }),
+    };
+    mockData.props.safeBio = longBio;
+    mockData.props.users[0].bio = longBio;
+
+    vi.mocked(getOrgFullOrigin).mockImplementation((orgSlug: string | null) => {
+      return `${orgSlug}.cal.local`;
+    });
+
+    vi.mocked(useRouterQuery).mockReturnValue({
+      uid: "uid",
+    });
+
+    render(<UserPage {...mockData.props} />);
+
+    const bioText = screen.getByText(/This is a very long bio text/);
+    expect(bioText).toBeInTheDocument();
+    // The line-clamp-3 is on the container div wrapping the bio text
+    expect(bioText.closest("div")).toHaveClass("line-clamp-3");
+  });
+
+  it("should not render bio section when bio is empty", () => {
+    const mockData = {
+      props: mockedUserPageComponentProps({
+        entity: {
+          considerUnpublished: false,
+          orgSlug: "org1",
+        },
+      }),
+    };
+    mockData.props.safeBio = "";
+    mockData.props.users[0].bio = "";
+
+    vi.mocked(getOrgFullOrigin).mockImplementation((orgSlug: string | null) => {
+      return `${orgSlug}.cal.local`;
+    });
+
+    vi.mocked(useRouterQuery).mockReturnValue({
+      uid: "uid",
+    });
+
+    render(<UserPage {...mockData.props} />);
+
+    const bioText = screen.queryByText("My Bio");
+    expect(bioText).not.toBeInTheDocument();
   });
 });

--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -6,6 +6,7 @@ import {
   useEmbedStyles,
   useIsEmbed,
 } from "@calcom/embed-core/embed-iframe";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useRouterQuery } from "@calcom/lib/hooks/useRouterQuery";
 import useTheme from "@calcom/lib/hooks/useTheme";
 import { UserAvatar } from "@calcom/ui/components/avatar";
@@ -18,6 +19,7 @@ import type { getServerSideProps } from "@server/lib/[user]/getServerSideProps";
 import classNames from "classnames";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Toaster } from "sonner";
 
 export type PageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
@@ -100,15 +102,7 @@ export function UserPage(props: PageProps) {
                   />
                 )}
               </h1>
-              {!isBioEmpty && (
-                <>
-                  {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Content is sanitized via safeBio */}
-                  <div
-                    className="text-default wrap-break-word text-sm [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600"
-                    dangerouslySetInnerHTML={{ __html: props.safeBio }}
-                  />
-                </>
-              )}
+              {!isBioEmpty && <ProfileBio safeBio={props.safeBio} />}
             </div>
           </div>
 
@@ -152,6 +146,40 @@ export function UserPage(props: PageProps) {
         <Toaster position="bottom-right" />
       </div>
     </>
+  );
+}
+
+function ProfileBio({ safeBio }: { safeBio: string }) {
+  const { t } = useLocale();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+
+  const checkClamped = useCallback((node: HTMLDivElement | null) => {
+    if (node) {
+      setIsClamped(node.scrollHeight > node.clientHeight);
+    }
+  }, []);
+
+  return (
+    <div>
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Content is sanitized via safeBio */}
+      <div
+        ref={checkClamped}
+        className={classNames(
+          "text-default break-words text-sm [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600",
+          !isExpanded && "line-clamp-3"
+        )}
+        dangerouslySetInnerHTML={{ __html: safeBio }}
+      />
+      {(isClamped || isExpanded) && (
+        <button
+          type="button"
+          className="text-emphasis mt-1 text-sm font-medium hover:underline"
+          onClick={() => setIsExpanded((prev) => !prev)}>
+          {isExpanded ? t("show_less") : t("show_more")}
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -3144,6 +3144,7 @@
   "redirect_to": "Redirect to",
   "having_trouble_finding_time": "Having trouble finding a time?",
   "show_more": "Show more",
+  "show_less": "Show less",
   "signup_with_google": "Sign up with Google",
   "signup_with_microsoft": "Sign up with Microsoft",
   "signin_with_microsoft": "Sign in with Microsoft",


### PR DESCRIPTION
## What does this PR do?

- Fixes #27742

## Summary

Long profile bios expanded without restriction, breaking layout consistency and reducing readability on user profile pages.

### Changes:
- Added CSS `line-clamp-3` to initially limit bio display to 3 lines
- Added a "Show more" / "Show less" toggle button that appears when bio text is clamped
- Replaced `wrap-break-word` with `break-words` for proper word breaking
- Added `show_less` translation key to `en/common.json`
- Extracted bio rendering into a `ProfileBio` component for cleaner separation

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

```bash
TZ=UTC yarn vitest run apps/web/modules/users/views/users-public-view.test.tsx
```

- Navigate to a user profile page with a long bio (multi-line, many paragraphs)
- Verify bio is clamped to 3 lines initially
- Click "Show more" — full bio should expand
- Click "Show less" — bio should collapse back to 3 lines
- Short bios (< 3 lines) should not show the toggle button

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have self-reviewed my code
- [x] My changes generate no new warnings

Generated by Ora Studio
Vibe coded by ousamabenyounes