### PR TITLE
fix: enable case-insensitive array comparison in jsonLogic operators

### DIFF
--- a/packages/lib/raqb/jsonLogic.test.ts
+++ b/packages/lib/raqb/jsonLogic.test.ts
@@ -9,7 +9,7 @@ describe("jsonLogic", () => {
       expect(jsonLogic.apply({ "==": ["hello", "world"] })).toBe(false);
     });
 
-    it.skip("should compare arrays case-insensitively", () => {
+    it("should compare arrays case-insensitively", () => {
       expect(
         jsonLogic.apply({
           "==": [
@@ -34,6 +34,25 @@ describe("jsonLogic", () => {
       expect(jsonLogic.apply({ "===": ["hello", "HELLO"] })).toBe(true);
       expect(jsonLogic.apply({ "===": ["hello", "world"] })).toBe(false);
     });
+
+    it("should compare arrays case-insensitively", () => {
+      expect(
+        jsonLogic.apply({
+          "===": [
+            ["hello", "WORLD"],
+            ["HELLO", "world"],
+          ],
+        })
+      ).toBe(true);
+      expect(
+        jsonLogic.apply({
+          "===": [
+            ["hello"],
+            ["hello", "world"],
+          ],
+        })
+      ).toBe(false);
+    });
   });
 
   describe("!== operation", () => {
@@ -41,12 +60,50 @@ describe("jsonLogic", () => {
       expect(jsonLogic.apply({ "!==": ["hello", "HELLO"] })).toBe(false);
       expect(jsonLogic.apply({ "!==": ["hello", "world"] })).toBe(true);
     });
+
+    it("should compare arrays case-insensitively", () => {
+      expect(
+        jsonLogic.apply({
+          "!==": [
+            ["hello", "WORLD"],
+            ["HELLO", "world"],
+          ],
+        })
+      ).toBe(false);
+      expect(
+        jsonLogic.apply({
+          "!==": [
+            ["hello"],
+            ["hi"],
+          ],
+        })
+      ).toBe(true);
+    });
   });
 
   describe("!= operation", () => {
     it("should compare strings case-insensitively", () => {
       expect(jsonLogic.apply({ "!=": ["hello", "HELLO"] })).toBe(false);
       expect(jsonLogic.apply({ "!=": ["hello", "world"] })).toBe(true);
+    });
+
+    it("should compare arrays case-insensitively", () => {
+      expect(
+        jsonLogic.apply({
+          "!=": [
+            ["hello", "WORLD"],
+            ["HELLO", "world"],
+          ],
+        })
+      ).toBe(false);
+      expect(
+        jsonLogic.apply({
+          "!=": [
+            ["a", "b"],
+            ["c", "d"],
+          ],
+        })
+      ).toBe(true);
     });
   });
 

--- a/packages/lib/raqb/jsonLogic.ts
+++ b/packages/lib/raqb/jsonLogic.ts
@@ -18,24 +18,36 @@ function normalize<T extends string | string[]>(input: T): T {
   return input;
 }
 
+// JS == and === compare array references, not values.
+// This compares normalized arrays element-by-element.
+function areEqual(a: any, b: any): boolean {
+  const na = normalize(a);
+  const nb = normalize(b);
+  if (Array.isArray(na) && Array.isArray(nb)) {
+    if (na.length !== nb.length) return false;
+    return na.every((val: any, i: number) => val === nb[i]);
+  }
+  return na === nb;
+}
+
 /**
  * Single Select equals and not equals uses it
  * Short Text equals and not equals uses it
  */
 jsonLogic.add_operation("==", function (a: any, b: any) {
-  return normalize(a) == normalize(b);
+  return areEqual(a, b);
 });
 
 jsonLogic.add_operation("===", function (a: any, b: any) {
-  return normalize(a) === normalize(b);
+  return areEqual(a, b);
 });
 
 jsonLogic.add_operation("!==", function (a: any, b: any) {
-  return normalize(a) !== normalize(b);
+  return !areEqual(a, b);
 });
 
 jsonLogic.add_operation("!=", function (a: any, b: any) {
-  return normalize(a) != normalize(b);
+  return !areEqual(a, b);
 });
 
 /**


### PR DESCRIPTION
## What does this PR do?

Fixes the `==`, `===`, `!=`, and `!==` operators in `packages/lib/raqb/jsonLogic.ts` to correctly compare arrays element-by-element instead of by JS reference equality.

### Problem

JavaScript's `==` and `===` compare arrays by reference, so `["hello", "world"] === ["hello", "world"]` is always `false`. This meant that multiselect "equals" comparisons in routing forms would never match, even when the selected values were identical.

A skipped test (`should compare arrays case-insensitively`) confirmed this bug.

### Fix

Added an `areEqual` helper that:
1. Normalizes both operands (lowercases strings)
2. If both are arrays, compares length then each element
3. Falls back to strict equality for non-arrays

### Tests

- Unskipped the existing `it.skip` test for array comparison on `==`
- Added new array comparison tests for `===`, `!==`, and `!=`
- All 23 tests pass (was 19 pass + 1 skip)

```bash
TZ=UTC yarn vitest run packages/lib/raqb/jsonLogic.test.ts
```

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

```bash
TZ=UTC yarn vitest run packages/lib/raqb/jsonLogic.test.ts
```

All 23 tests should pass, including the previously-skipped array comparison test.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] My PR is small and focused (2 files)

Generated by Ora Studio
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
