### PR TITLE
feat: show originally scheduled time in rescheduled meeting emails

### DIFF
--- a/packages/emails/src/components/WhenInfo.tsx
+++ b/packages/emails/src/components/WhenInfo.tsx
@@ -6,8 +6,7 @@ import dayjs from "@calcom/dayjs";
 import "@calcom/dayjs/locales";
 import { getEveryFreqFor } from "@calcom/lib/recurringStrings";
 import type { TimeFormat } from "@calcom/lib/timeFormat";
-import type { CalendarEvent, Person } from "@calcom/types/Calendar";
-import type { RecurringEvent } from "@calcom/types/Calendar";
+import type { CalendarEvent, Person, RecurringEvent } from "@calcom/types/Calendar";
 
 import { Info } from "./Info";
 
@@ -40,9 +39,21 @@ export function WhenInfo(props: {
 }) {
   const { timeZone, t, calEvent: { recurringEvent } = {}, locale, timeFormat } = props;
 
+  function getPreviousRecipientStart(format: string): string | null {
+    if(!props.calEvent.previousStartTime) return null
+    return dayjs(props.calEvent.previousStartTime).tz(timeZone).locale(locale).format(format)
+  }
+
+  function getPreviousRecipientEnd(format: string): string | null  {
+    if(!props.calEvent.previousEndTime) return null
+    return dayjs(props.calEvent.previousEndTime).tz(timeZone).locale(locale).format(format)
+  }
+
   function getRecipientStart(format: string) {
     return dayjs(props.calEvent.startTime).tz(timeZone).locale(locale).format(format);
   }
+
+  const hasPreviousTime = !!(props.calEvent.previousStartTime && props.calEvent.previousEndTime);
 
   function getRecipientEnd(format: string) {
     return dayjs(props.calEvent.endTime).tz(timeZone).locale(locale).format(format);
@@ -56,16 +67,30 @@ export function WhenInfo(props: {
   return (
     <div>
       <Info
-        label={`${t("when")} ${recurringInfo !== "" ? ` - ${recurringInfo}` : ""}`}
+        label={`${t("when")}${recurringInfo ? ` - ${recurringInfo}` : ""}`}
         lineThrough={
-          !!props.calEvent.cancellationReason && !props.calEvent.cancellationReason.includes("$RCH$")
+          !!props.calEvent.cancellationReason &&
+          !props.calEvent.cancellationReason.includes("$RCH$")
         }
         description={
-          <span data-testid="when">
-            {recurringEvent?.count ? `${t("starting")} ` : ""}
-            {getRecipientStart(`dddd, LL | ${timeFormat}`)} - {getRecipientEnd(timeFormat)}{" "}
-            <span style={{ color: "#4B5563" }}>({timeZone})</span>
-          </span>
+          <div data-testid="when">
+            {hasPreviousTime && (
+              <div
+                style={{ textDecoration: "line-through", opacity: 0.6 }}
+                data-testid="previous-when">
+                {recurringEvent?.count ? `${t("starting")} ` : ""}
+                {getPreviousRecipientStart(`dddd, LL | ${timeFormat}`)} -{" "}
+                {getPreviousRecipientEnd(timeFormat)}{" "}
+                ({timeZone})
+              </div>
+            )}
+            <div>
+              {recurringEvent?.count ? `${t("starting")} ` : ""}
+              {getRecipientStart(`dddd, LL | ${timeFormat}`)} -{" "}
+              {getRecipientEnd(timeFormat)}{" "}
+              ({timeZone})
+            </div>
+          </div>
         }
         withSpacer
       />

--- a/packages/features/bookings/lib/BookingEmailSmsHandler.ts
+++ b/packages/features/bookings/lib/BookingEmailSmsHandler.ts
@@ -111,6 +111,7 @@ export class BookingEmailSmsHandler {
   private async _handleRescheduled(data: RescheduleEmailAndSmsPayload) {
     const {
       evt,
+      originalRescheduledBooking,
       eventType: { metadata },
       rescheduleReason,
       additionalNotes,
@@ -121,6 +122,12 @@ export class BookingEmailSmsHandler {
     await sendRescheduledEmailsAndSMS(
       {
         ...evt,
+        previousStartTime: originalRescheduledBooking?.startTime
+        ? dayjs(originalRescheduledBooking.startTime).utc().format()
+        : undefined,
+        previousEndTime: originalRescheduledBooking?.endTime
+        ? dayjs(originalRescheduledBooking.endTime).utc().format()
+        : undefined,
         additionalInformation,
         additionalNotes,
         cancellationReason: `$RCH$${rescheduleReason || ""}`,
@@ -151,6 +158,12 @@ export class BookingEmailSmsHandler {
       additionalInformation,
       additionalNotes,
       cancellationReason: `$RCH$${rescheduleReason || ""}`,
+      previousStartTime: originalRescheduledBooking?.startTime
+          ? dayjs(originalRescheduledBooking.startTime).utc().format()
+          : undefined,
+        previousEndTime: originalRescheduledBooking?.endTime
+          ? dayjs(originalRescheduledBooking.endTime).utc().format()
+          : undefined,
     };
     const cancelledRRHostEvt = cloneDeep(copyEventAdditionalInfo);
     this.log.debug("Emails: Sending rescheduled emails for booking confirmation");

--- a/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
@@ -2289,6 +2289,78 @@ describe("handleNewBooking", () => {
         },
         timeout
       );
+
+      test(  
+  `should show original scheduled time with strikethrough in rescheduled emails`,  
+  async ({ emails }) => {  
+    const handleNewBooking = getNewBookingHandler();  
+    const booker = getBooker({  
+      email: "booker@example.com",  
+      name: "Booker",  
+    });  
+  
+    const organizer = getOrganizer({  
+      name: "Organizer",  
+      email: "organizer@example.com",  
+      id: 101,  
+      schedules: [TestData.schedules.IstWorkHours],  
+      credentials: [getGoogleCalendarCredential()],  
+      selectedCalendars: [TestData.selectedCalendars.google],  
+    });  
+  
+    const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });  
+    const uidOfBookingToBeRescheduled = "n5Wv3eHgconAED2j4gcVhP";  
+    const iCalUID = `${uidOfBookingToBeRescheduled}@Cal.diy`;  
+      
+    // Original booking time: 05:00-05:15  
+    await createBookingScenario(  
+      getScenarioData({  
+        eventTypes: [{ id: 1, slotInterval: 15, length: 15, users: [{ id: 101 }] }],  
+        bookings: [{  
+          uid: uidOfBookingToBeRescheduled,  
+          eventTypeId: 1,  
+          status: BookingStatus.ACCEPTED,  
+          startTime: `${plus1DateString}T05:00:00.000Z`,  
+          endTime: `${plus1DateString}T05:15:00.000Z`,  
+          iCalUID,  
+        }],  
+        organizer,  
+        apps: [TestData.apps["google-calendar"]],  
+      })  
+    );  
+  
+    await mockCalendarToHaveNoBusySlots("googlecalendar", {  
+      create: { uid: "MOCK_ID" },  
+      update: { uid: "UPDATED_MOCK_ID", iCalUID },  
+    });  
+  
+    // Reschedule to 04:00-04:15  
+    const mockBookingData = getMockRequestDataForBooking({  
+      data: {  
+        eventTypeId: 1,  
+        rescheduleUid: uidOfBookingToBeRescheduled,  
+        start: `${plus1DateString}T04:00:00.000Z`,  
+        end: `${plus1DateString}T04:15:00.000Z`,  
+        responses: { email: booker.email, name: booker.name },  
+        rescheduledBy: organizer.email,  
+      },  
+    });  
+  
+    const createdBooking = await handleNewBooking({ bookingData: mockBookingData });  
+    const newICalUID = `${createdBooking.uid}`;
+  
+    expectSuccessfulBookingRescheduledEmails({  
+      booker,  
+      organizer,  
+      emails,  
+      iCalUID: newICalUID,  
+      expectPreviousTime: {  
+        startTime: `${plus1DateString}T05:00:00.000Z`,  
+        endTime: `${plus1DateString}T05:15:00.000Z`,  
+      },  
+    });  
+  },  
+);
     });
     describe("Team event-type", () => {
       test(

--- a/packages/testing/src/lib/bookingScenario/expects.ts
+++ b/packages/testing/src/lib/bookingScenario/expects.ts
@@ -773,12 +773,14 @@ export function expectSuccessfulBookingRescheduledEmails({
   booker,
   iCalUID,
   appsStatus,
+  expectPreviousTime,
 }: {
   emails: Fixtures["emails"];
   organizer: { email: string; name: string };
   booker: { email: string; name: string };
   iCalUID: string;
   appsStatus?: AppsStatus[];
+  expectPreviousTime?: { startTime: string; endTime: string };
 }) {
   expect(emails).toHaveEmail(
     {
@@ -806,6 +808,40 @@ export function expectSuccessfulBookingRescheduledEmails({
     },
     `${booker.name} <${booker.email}>`
   );
+
+  if (expectPreviousTime) {    
+  const allEmails = emails.get();    
+  const bookerEmail = allEmails.find(e => e.to === booker.email || e.to === `${booker.name} <${booker.email}>`);    
+  const organizerEmail = allEmails.find(e => e.to === organizer.email || e.to === `${organizer.name} <${organizer.email}>`);    
+    
+  // Booker  
+  const expectedBookerPreviousStart = dayjs(expectPreviousTime.startTime)    
+    .tz(booker.timeZone || "Asia/Kolkata")    
+    .locale(booker.locale || "en")    
+    .format(`dddd, LL | h:mma`);    
+      
+  const expectedBookerPreviousEnd = dayjs(expectPreviousTime.endTime)    
+    .tz(booker.timeZone || "Asia/Kolkata")    
+    .format(`h:mma`);    
+      
+  const expectedBookerTime = `${expectedBookerPreviousStart} - ${expectedBookerPreviousEnd} (${booker.timeZone || "Asia/Kolkata"})`;    
+      
+  expect(bookerEmail?.html).toContain(expectedBookerTime);      
+    
+  // Organizer  
+  const expectedOrganizerPreviousStart = dayjs(expectPreviousTime.startTime)    
+    .tz(organizer.timeZone || "Europe/London")    
+    .locale(organizer.locale || "en")    
+    .format(`dddd, LL | h:mma`);    
+      
+  const expectedOrganizerPreviousEnd = dayjs(expectPreviousTime.endTime)    
+    .tz(organizer.timeZone || "Europe/London")    
+    .format(`h:mma`);    
+      
+  const expectedOrganizerTime = `${expectedOrganizerPreviousStart} - ${expectedOrganizerPreviousEnd} (${organizer.timeZone || "Europe/London"})`;    
+      
+  expect(organizerEmail?.html).toContain(expectedOrganizerTime);      
+}
 }
 
 export function expectSuccesfulLocationChangeEmails({

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -219,6 +219,8 @@ export interface CalendarEvent {
   platformRescheduleUrl?: string | null;
   platformCancelUrl?: string | null;
   platformBookingUrl?: string | null;
+  previousStartTime?: string;
+  previousEndTime?: string;
   hideBranding?: boolean;
   oneTimePassword?: string | null;
   delegationCredentialId?: string | null;


### PR DESCRIPTION
## What does this PR do?

This PR ensures that when a booking is rescheduled email notifications  show the original booking time (with line through) above the new time so recipients can immediately see when free time opened up and how far the meeting was moved.

- Fixes #22406 
- Fixes CAL-6080

#### Video Demo (if applicable):


[Screencast from 2026-04-13 13-32-55.webm](https://github.com/user-attachments/assets/c9874f20-5783-4bcf-b429-770116a29a05)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.