### PR TITLE
fix: require uid for booking cancellation on web cancel route

### DIFF
--- a/apps/web/app/api/cancel/route.ts
+++ b/apps/web/app/api/cancel/route.ts
@@ -22,6 +22,14 @@ async function handler(req: NextRequest) {
   }
   const bookingData = bookingCancelWithCsrfSchema.parse(appDirRequestBody);
 
+  // Integer IDs are sequential/guessable — only accept high-entropy UIDs on this route
+  if (!bookingData.uid) {
+    return NextResponse.json(
+      { success: false, message: "uid is required for booking cancellation" },
+      { status: 400 }
+    );
+  }
+
   const csrfError = await validateCsrfToken(bookingData.csrfToken);
   if (csrfError) {
     return csrfError;
@@ -38,8 +46,11 @@ async function handler(req: NextRequest) {
     identifier,
   });
 
+  // Strip integer id to ensure lookup is always by uid
+  const { id: _id, ...safeBookingData } = bookingData;
+
   const result = await handleCancelBooking({
-    bookingData,
+    bookingData: safeBookingData,
     userId: session?.user?.id || -1,
     userUuid: session?.user?.uuid,
     actionSource: "WEBAPP",


### PR DESCRIPTION
## What does this PR do?

The web cancel route now requires a `uid` for booking lookup, rejecting requests that only provide a numeric `id`. When both are provided, the numeric `id` is stripped before processing.                                 

### Changes     

- Reject requests without `uid` with 400                                                                      
- Strip integer `id` from booking data before passing to `handleCancelBooking`

### Context     

Existing consumers already use `uid` exclusively. This aligns the route validation with that expectation.

## How should this be tested?                                                                                 

1. Cancel a booking via the UI → should work normally (uses `uid`)                                            
2. Send cancellation request with only `id` (no `uid`) → should return 400
3. Send with both `id` and `uid` → should succeed, `id` is ignored                                            

## Mandatory Tasks                                                     

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.