### PR TITLE
fix: scope bulk user deletion to callers organization

### DIFF
--- a/apps/web/playwright/lib/orgMigration.ts
+++ b/apps/web/playwright/lib/orgMigration.ts
@@ -653,6 +653,7 @@ async function dbRemoveUserFromOrg({
 
   await ProfileRepository.deleteMany({
     userIds: [userToRemoveFromOrg.id],
+    organizationId: userToRemoveFromOrg.organizationId!,
   });
 }
 

--- a/packages/features/profile/repositories/ProfileRepository.ts
+++ b/packages/features/profile/repositories/ProfileRepository.ts
@@ -400,10 +400,10 @@ export class ProfileRepository implements IProfileRepository {
     });
   }
 
-  static deleteMany({ userIds }: { userIds: number[] }) {
+  static deleteMany({ userIds, organizationId }: { userIds: number[]; organizationId: number }) {
     // Even though there can be just one profile matching a userId and organizationId, we are using deleteMany as it won't error if the profile doesn't exist
     return prisma.profile.deleteMany({
-      where: { userId: { in: userIds } },
+      where: { userId: { in: userIds }, organizationId },
     });
   }
 

--- a/packages/trpc/server/routers/viewer/organizations/bulkDeleteUsers.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/bulkDeleteUsers.handler.ts
@@ -82,6 +82,7 @@ export async function bulkDeleteUsersHandler({ ctx, input }: BulkDeleteUsersHand
       id: {
         in: input.userIds,
       },
+      organizationId: currentUserOrgId,
     },
     data: {
       organizationId: null,
@@ -130,6 +131,7 @@ export async function bulkDeleteUsersHandler({ ctx, input }: BulkDeleteUsersHand
 
   const removeProfiles = ProfileRepository.deleteMany({
     userIds: input.userIds,
+    organizationId: currentUserOrgId,
   });
 
   // We do this in a transaction to make sure that all memberships are removed before we remove the organization relation from the user


### PR DESCRIPTION
## What does this PR do?

Scopes two operations in the `bulkDeleteUsers` handler to the caller's organization. Previously, `removeOrgrelation` and `removeProfiles` accepted any user ID without verifying org membership, while the four other operations in the same transaction were correctly scoped.                                            

### Changes                                 

- Added `organizationId: currentUserOrgId` filter to the `removeOrgrelation` query (`user.updateMany`)
- Updated `ProfileRepository.deleteMany` to require and filter by `organizationId`                            
- Updated playwright caller to pass `organizationId`

### Context                

The handler validates that the caller is an org admin via PBAC, but the `userIds` in the input were not validated against the org. The other operations in the same transaction (`deleteOrganizationMemberships`, `deleteSubteamMemberships`, `removeManagedEventTypes`, `removeHostAssignment`) are all correctly scoped — these two were the exceptions.                                                                                

## Mandatory Tasks    

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.