### PR TITLE
fix: validate credential ownership in attribute sync update

### DIFF
--- a/packages/features/ee/integration-attribute-sync/repositories/IIntegrationAttributeSyncRepository.ts
+++ b/packages/features/ee/integration-attribute-sync/repositories/IIntegrationAttributeSyncRepository.ts
@@ -63,6 +63,7 @@ export interface ISyncFormData {
   id: string;
   name: string;
   credentialId?: number;
+  integration?: AttributeSyncIntegrations;
   enabled: boolean;
   organizationId: number;
   ruleId: string;
@@ -138,7 +139,7 @@ export interface IIntegrationAttributeSyncUpdateParams {
   integrationAttributeSync: Omit<
     IntegrationAttributeSync,
     "attributeSyncRule" | "syncFieldMappings" | "integration"
-  >;
+  > & { integration?: AttributeSyncIntegrations };
   attributeSyncRule: AttributeSyncRule;
   fieldMappingsToCreate: Omit<AttributeSyncFieldMapping, "id">[];
   fieldMappingsToUpdate: AttributeSyncFieldMapping[];

--- a/packages/features/ee/integration-attribute-sync/services/IntegrationAttributeSyncService.ts
+++ b/packages/features/ee/integration-attribute-sync/services/IntegrationAttributeSyncService.ts
@@ -217,4 +217,11 @@ export class IntegrationAttributeSyncService {
   async getAllByCredentialId(credentialId: number) {
     return this.deps.integrationAttributeSyncRepository.getAllByCredentialId(credentialId);
   }
+
+  async validateCredentialBelongsToOrg(credentialId: number, organizationId: number) {
+    return this.deps.credentialRepository.findByIdAndTeamId({
+      id: credentialId,
+      teamId: organizationId,
+    });
+  }
 }

--- a/packages/trpc/server/routers/viewer/attribute-sync/updateAttributeSync.handler.ts
+++ b/packages/trpc/server/routers/viewer/attribute-sync/updateAttributeSync.handler.ts
@@ -1,5 +1,9 @@
 import { getIntegrationAttributeSyncService } from "@calcom/ee/integration-attribute-sync/di/IntegrationAttributeSyncService.container";
 import {
+  AttributeSyncIntegrations,
+  type ISyncFormData,
+} from "@calcom/ee/integration-attribute-sync/repositories/IIntegrationAttributeSyncRepository";
+import {
   DuplicateAttributeWithinSyncError,
   DuplicateAttributeAcrossSyncsError,
 } from "@calcom/ee/integration-attribute-sync/services/IntegrationAttributeSyncService";
@@ -37,8 +41,29 @@ const updateAttributeSyncHandler = async ({ ctx, input }: UpdateAttributeSyncOpt
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
 
+  // Never trust user-supplied organizationId — override with authenticated user's org
+  const safeInput: ISyncFormData = { ...input, organizationId: org.id };
+
+  // Validate credential belongs to the user's organization and derive integration type
+  if (input.credentialId !== undefined) {
+    const credential = await integrationAttributeSyncService.validateCredentialBelongsToOrg(
+      input.credentialId,
+      org.id
+    );
+    if (!credential) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Credential not found" });
+    }
+
+    const integrationValue = credential.app?.slug || credential.type;
+    if (!Object.values(AttributeSyncIntegrations).includes(integrationValue as AttributeSyncIntegrations)) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: `Unsupported integration type: ${integrationValue}` });
+    }
+
+    safeInput.integration = integrationValue as AttributeSyncIntegrations;
+  }
+
   try {
-    await integrationAttributeSyncService.updateIncludeRulesAndMappings(input);
+    await integrationAttributeSyncService.updateIncludeRulesAndMappings(safeInput);
   } catch (error) {
     if (error instanceof DuplicateAttributeWithinSyncError) {
       throw new TRPCError({


### PR DESCRIPTION
## What does this PR do?                                                                                      

Adds credential ownership validation to the `updateAttributeSync` handler, mirroring the checks already present in the create path. Previously, the update endpoint accepted `credentialId` and `organizationId` from the input without verifying they belong to the authenticated user's organization.                             

### Changes                                                                                                   

- Override `organizationId` in the update input with the authenticated user's org ID
- Validate `credentialId` belongs to the user's organization using the same `findByIdAndTeamId` pattern from the create path                             
- Added `validateCredentialBelongsToOrg` method to `IntegrationAttributeSyncService`                          
- Added `integration?` field to `ISyncFormData` and `IIntegrationAttributeSyncUpdateParams` types

### Context                             

The create path (`createAttributeSync`) already validates credential ownership correctly. This fix aligns the update path with the same pattern.                                                                            

## How should this be tested?                                                                                 

1. Create an attribute sync with a valid credential                                                           
2. Update it with a valid credentialId → should succeed                                                       
3. Update it with a credentialId that doesn't match the org → should return NOT_FOUND

## Mandatory Tasks  

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.