### PR TITLE
fix: verify checkout session metadata in team upgrade endpoint

### DIFF
--- a/apps/web/app/api/teams/[team]/upgrade/route.ts
+++ b/apps/web/app/api/teams/[team]/upgrade/route.ts
@@ -45,6 +45,12 @@ async function getHandler(req: NextRequest, { params }: { params: Promise<Params
       throw new HttpError({ statusCode: 402, message: "Payment required" });
     }
 
+    // Not all sessions carry "teamId": API v2 uses "pendingPaymentTeamId" and legacy sessions predate it.
+    const sessionTeamId = checkoutSession.metadata?.teamId;
+    if (sessionTeamId && Number(sessionTeamId) !== id) {
+      throw new HttpError({ statusCode: 400, message: "Checkout session does not match team" });
+    }
+
     let team = await prisma.team.findFirst({
       where: { metadata: { path: ["paymentId"], equals: checkoutSession.id } },
     });


### PR DESCRIPTION
## What does this PR do?                                                                                      

Adds a consistency check between the checkout session metadata and the team ID in the URL path for the team upgrade callback. Ensures the processed session was created for the specific team being upgraded.             

### Changes                                                                                                   

- When `checkoutSession.metadata.teamId` is present, verify it matches the team ID in the URL before processing billing mutations            
- Check is conditional to preserve compatibility with flows where `teamId` is not set in session metadata (API v2 uses `pendingPaymentTeamId`; legacy sessions predate the field)                                           

## How should this be tested?                                                                                 

1. Team upgrade via Stripe checkout → complete payment → redirect succeeds normally
2. Verify existing integrations that don't set `teamId` in session metadata continue to work                  

## Mandatory Tasks  

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.