### PR TITLE
refactor: narrow user fields returned by dynamic event endpoint

### DIFF
--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -345,16 +345,26 @@ export const getPublicEvent = async (
       bookingFields: getBookingFieldsWithSystemFields({ ...defaultEvent, disableBookingTitle }),
       restrictionScheduleId: null,
       useBookerTimezone: false,
-      // Clears meta data since we don't want to send this in the public api.
+      // Only return fields consumed by the booker.
       subsetOfUsers: users.map((user) => ({
-        ...user,
-        metadata: undefined,
+        name: user.name,
+        username: user.username,
+        avatarUrl: user.avatarUrl,
+        weekStart: user.weekStart,
+        brandColor: user.brandColor,
+        darkBrandColor: user.darkBrandColor,
+        profile: user.profile,
         bookerUrl: getBookerBaseUrlSync(user.profile?.organization?.slug ?? null),
       })),
       users: fetchAllUsers
         ? users.map((user) => ({
-            ...user,
-            metadata: undefined,
+            name: user.name,
+            username: user.username,
+            avatarUrl: user.avatarUrl,
+            weekStart: user.weekStart,
+            brandColor: user.brandColor,
+            darkBrandColor: user.darkBrandColor,
+            profile: user.profile,
             bookerUrl: getBookerBaseUrlSync(user.profile?.organization?.slug ?? null),
           }))
         : undefined,


### PR DESCRIPTION
## What does this PR do?                                                                                      

Replaces the `...user` spread in the dynamic group event path with an explicit field list, matching the pattern already used by `mapHostsToUsers` and `getUsersFromEvent` for non-dynamic events.                     

### Changes                                                                                                   

- Replaced `...user` + `metadata: undefined` with explicit field list (`name`, `username`, `avatarUrl`, `weekStart`, `brandColor`, `darkBrandColor`, `profile`, `bookerUrl`) in both `subsetOfUsers` and `users` mappings for dynamic events

### Context

The non-dynamic paths already use explicit field picking. This aligns the dynamic event path with the same pattern. The allowlist matches `BookerEventUser` in `packages/features/bookings/types.ts`.

## How should this be tested?                                                                                 

1. Dynamic group booking page (`cal.com/user1+user2/event`) → member avatars and names render normally        
2. Non-dynamic event types (team, personal) → unaffected                                                      

## Mandatory Tasks 

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.