### PR TITLE
fix: align reassignment query handlers with existing access check pattern

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/managedEvents/getManagedEventUsersToReassign.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/managedEvents/getManagedEventUsersToReassign.handler.ts
@@ -4,6 +4,7 @@ import { ensureAvailableUsers } from "@calcom/features/bookings/lib/handleNewBoo
 import { getEventTypesFromDB } from "@calcom/features/bookings/lib/handleNewBooking/getEventTypesFromDB";
 import type { IsFixedAwareUser } from "@calcom/features/bookings/lib/handleNewBooking/types";
 import { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
+import { getBookingAccessService } from "@calcom/features/di/containers/BookingAccessService";
 import { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import { withSelectedCalendars } from "@calcom/features/users/repositories/UserRepository";
 import { ErrorCode } from "@calcom/lib/errorCodes";
@@ -11,6 +12,8 @@ import logger from "@calcom/lib/logger";
 import type { PrismaClient } from "@calcom/prisma";
 
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
+
+import { TRPCError } from "@trpc/server";
 
 import type { TGetManagedEventUsersToReassignInputSchema } from "./getManagedEventUsersToReassign.schema";
 
@@ -73,6 +76,16 @@ export const getManagedEventUsersToReassign = async ({
   const gettingManagedEventUsersToReassignLogger = logger.getSubLogger({
     prefix: ["gettingManagedEventUsersToReassign", `${bookingId}`],
   });
+
+  const bookingAccessService = getBookingAccessService();
+  const isAllowed = await bookingAccessService.doesUserIdHaveAccessToBooking({
+    userId: user.id,
+    bookingId,
+  });
+
+  if (!isAllowed) {
+    throw new TRPCError({ code: "FORBIDDEN", message: "You do not have permission" });
+  }
 
   const bookingRepository = new BookingRepository(prisma);
   const eventTypeRepository = new EventTypeRepository(prisma);

--- a/packages/trpc/server/routers/viewer/teams/roundRobin/getRoundRobinHostsToReasign.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/roundRobin/getRoundRobinHostsToReasign.handler.ts
@@ -2,6 +2,7 @@ import { enrichUsersWithDelegationCredentials } from "@calcom/app-store/delegati
 import dayjs from "@calcom/dayjs";
 import { ensureAvailableUsers } from "@calcom/features/bookings/lib/handleNewBooking/ensureAvailableUsers";
 import type { IsFixedAwareUser } from "@calcom/features/bookings/lib/handleNewBooking/types";
+import { getBookingAccessService } from "@calcom/features/di/containers/BookingAccessService";
 import { withSelectedCalendars } from "@calcom/features/users/repositories/UserRepository";
 import { ErrorCode } from "@calcom/lib/errorCodes";
 import logger from "@calcom/lib/logger";
@@ -9,6 +10,8 @@ import type { PrismaClient } from "@calcom/prisma";
 import { userSelect } from "@calcom/prisma";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
+
+import { TRPCError } from "@trpc/server";
 
 import type { TGetRoundRobinHostsToReassignInputSchema } from "./getRoundRobinHostsToReasign.schema";
 
@@ -110,6 +113,16 @@ export const getRoundRobinHostsToReassign = async ({ ctx, input }: GetRoundRobin
   const gettingRoundRobinHostsToReassignLogger = logger.getSubLogger({
     prefix: ["gettingRoundRobinHostsToReassign", `${bookingId}`],
   });
+
+  const bookingAccessService = getBookingAccessService();
+  const isAllowed = await bookingAccessService.doesUserIdHaveAccessToBooking({
+    userId: user.id,
+    bookingId,
+  });
+
+  if (!isAllowed) {
+    throw new TRPCError({ code: "FORBIDDEN", message: "You do not have permission" });
+  }
 
   const booking = await prisma.booking.findUniqueOrThrow({
     where: { id: bookingId },


### PR DESCRIPTION
## What does this PR do?                                                                                      

Adds `bookingAccessService.doesUserIdHaveAccessToBooking` check to the reassignment query handlers, aligning them with the mutation handlers that already perform this check.                                              

### Changes                                                                                                   

| Handler | Change |                                                                                          
|---------|--------|                                                                                          
| `getRoundRobinHostsToReassign` | Added access check before fetching hosts |
| `getManagedEventUsersToReassign` | Added access check before fetching users |                               

### Context

The mutation handlers (`roundRobinReassign`, `roundRobinManualReassign`, `managedEventManualReassign`) already perform this access check. The query handlers that power the reassignment UI were the exception — this PR brings them in line with the existing pattern.

## How should this be tested?               

1. As the booking host, query reassignment candidates → should succeed
2. As a team admin with access to the booking → should succeed                                                

## Mandatory Tasks   

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.