### PR TITLE
refactor: use named import for authedOrgAdminProcedure in dsync routers

### DIFF
--- a/packages/trpc/server/routers/viewer/dsync/_router.tsx
+++ b/packages/trpc/server/routers/viewer/dsync/_router.tsx
@@ -1,4 +1,4 @@
-import authedOrgAdminProcedure from "../../../procedures/authedProcedure";
+import { authedOrgAdminProcedure } from "../../../procedures/authedProcedure";
 import { router } from "../../../trpc";
 import { ZCreateInputSchema } from "./create.schema";
 import { ZDeleteInputSchema } from "./delete.schema";

--- a/packages/trpc/server/routers/viewer/dsync/teamGroupMapping/_router.tsx
+++ b/packages/trpc/server/routers/viewer/dsync/teamGroupMapping/_router.tsx
@@ -1,4 +1,4 @@
-import authedOrgAdminProcedure from "@calcom/trpc/server/procedures/authedProcedure";
+import { authedOrgAdminProcedure } from "@calcom/trpc/server/procedures/authedProcedure";
 import { router } from "@calcom/trpc/server/trpc";
 
 import { ZCreateInputSchema } from "./create.schema";


### PR DESCRIPTION
## What does this PR do?                                                                                      

Uses the named export `authedOrgAdminProcedure` in both dsync routers. The variable was named `authedOrgAdminProcedure` but was resolving to the default export (`authedProcedure`), because `authedOrgAdminProcedure` is a named export in `authedProcedure.ts`.

### Changes

| File | Change |                           
|------|--------|                       
| `dsync/_router.tsx` | `import authedOrgAdminProcedure from` → `import { authedOrgAdminProcedure } from` |
| `dsync/teamGroupMapping/_router.tsx` | Same |                                                               

### Context                                                                                                   

The named export `authedOrgAdminProcedure` applies `isOrgAdminMiddleware`. The default export `authedProcedure` only applies `isAuthed`. Switching to the named import aligns the behavior with the variable name.                     

## How should this be tested?               

1. As org admin, dsync endpoints work normally
2. Verify the middleware chain resolves to the intended procedure                                             

## Mandatory Tasks                                      

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.