### PR TITLE
fix: add retry config for Google Calendar PATCH requests

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarAuth.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarAuth.ts
@@ -303,6 +303,21 @@ export class CalendarAuth {
 
     return new calendar_v3.Calendar({
       auth: googleAuthClient,
+      // Override gaxios retry defaults so that transient Google API errors
+      // on PATCH requests (used to update event description, location, and
+      // conference data after creation) are retried instead of silently
+      // dropped. Google returns 403 for rateLimitExceeded in addition to
+      // 429 — both should trigger exponential backoff. See #28834.
+      retryConfig: {
+        retry: 3,
+        httpMethodsToRetry: ["GET", "HEAD", "PUT", "OPTIONS", "DELETE", "PATCH"],
+        statusCodesToRetry: [
+          [100, 199],
+          [403, 403],
+          [429, 429],
+          [500, 599],
+        ],
+      },
     });
   }
 }


### PR DESCRIPTION
Fixes #28834.

The Google Calendar client in `CalendarAuth.getClient()` was created without a `retryConfig`, so it used gaxios defaults which:

1. Don't include `PATCH` in `httpMethodsToRetry` (only GET, HEAD, PUT, OPTIONS, DELETE)
2. Don't include `403` in `statusCodesToRetry` (only 100-199, 429, 500-599)

Google returns `403 rateLimitExceeded` on transient rate limit errors (in addition to `429`), and the PATCH call that updates event description/location/conference data after creation was never retried. The booking looks successful in Cal.com but the calendar event is missing the updated fields.

Added an explicit `retryConfig` to the `calendar_v3.Calendar` constructor that includes PATCH in retryable methods and 403 in retryable status codes, matching [Google's error handling docs](https://developers.google.com/workspace/calendar/api/guides/errors). One file, one config block.