### PR TITLE
fix(internal-notes): handle unique constraint violation for presets

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/updateInternalNotesPresets.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/teams/updateInternalNotesPresets.handler.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
+import { prisma } from "@calcom/prisma";
+import { Prisma } from "@calcom/prisma/client";
+
+import type { TrpcSessionUser } from "../../../types";
+import { updateInternalNotesPresetsHandler } from "./updateInternalNotesPresets.handler";
+import type { TUpdateInternalNotesPresetsInputSchema } from "./updateInternalNotesPresets.schema";
+
+vi.mock("@calcom/prisma", () => ({
+  prisma: {
+    internalNotePreset: {
+      findMany: vi.fn(),
+      deleteMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+  Prisma: {
+    PrismaClientKnownRequestError: class extends Error {
+      code: string;
+      meta: unknown;
+      constructor(message: string, options: { code: string; clientVersion: string; meta?: unknown }) {
+        super(message);
+        this.name = "PrismaClientKnownRequestError";
+        this.code = options.code;
+        this.meta = options.meta;
+      }
+    },
+  },
+}));
+
+vi.mock("@calcom/features/pbac/services/permission-check.service", () => ({
+  PermissionCheckService: vi.fn().mockImplementation(function () {
+    return {
+      checkPermission: vi.fn(),
+    };
+  }),
+}));
+
+describe("updateInternalNotesPresetsHandler", () => {
+  const mockPermissionCheckService = {
+    checkPermission: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(PermissionCheckService).mockImplementation(function () {
+      return mockPermissionCheckService as unknown as InstanceType<typeof PermissionCheckService>;
+    });
+  });
+
+  describe("Permission Check", () => {
+    const user: NonNullable<TrpcSessionUser> = {
+      id: 1,
+      organization: { isOrgAdmin: false },
+    } as NonNullable<TrpcSessionUser>;
+
+    it("should throw UNAUTHORIZED when permission check fails", async () => {
+      const input: TUpdateInternalNotesPresetsInputSchema = {
+        teamId: 50,
+        presets: [{ id: -1, name: "New Preset" }],
+      };
+
+      mockPermissionCheckService.checkPermission.mockResolvedValue(false);
+
+      await expect(
+        updateInternalNotesPresetsHandler({
+          ctx: { user },
+          input,
+        })
+      ).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+      });
+
+      expect(prisma.internalNotePreset.findMany).not.toHaveBeenCalled();
+    });
+
+    it("should allow access when permission check passes", async () => {
+      const input: TUpdateInternalNotesPresetsInputSchema = {
+        teamId: 50,
+        presets: [{ id: -1, name: "New Preset" }],
+      };
+
+      mockPermissionCheckService.checkPermission.mockResolvedValue(true);
+      vi.mocked(prisma.internalNotePreset.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.internalNotePreset.create).mockResolvedValue({
+        id: 1,
+        name: "New Preset",
+        teamId: 50,
+        createdAt: new Date(),
+        cancellationReason: null,
+      });
+
+      const result = await updateInternalNotesPresetsHandler({
+        ctx: { user },
+        input,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(prisma.internalNotePreset.create).toHaveBeenCalled();
+    });
+  });
+
+  describe("Org Admin Bypass", () => {
+    const orgAdminUser: NonNullable<TrpcSessionUser> = {
+      id: 1,
+      organization: { isOrgAdmin: true },
+    } as NonNullable<TrpcSessionUser>;
+
+    it("should bypass permission check for org admins", async () => {
+      const input: TUpdateInternalNotesPresetsInputSchema = {
+        teamId: 50,
+        presets: [{ id: -1, name: "New Preset" }],
+      };
+
+      vi.mocked(prisma.internalNotePreset.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.internalNotePreset.create).mockResolvedValue({
+        id: 1,
+        name: "New Preset",
+        teamId: 50,
+        createdAt: new Date(),
+        cancellationReason: null,
+      });
+
+      const result = await updateInternalNotesPresetsHandler({
+        ctx: { user: orgAdminUser },
+        input,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(mockPermissionCheckService.checkPermission).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Duplicate Constraint", () => {
+    const user: NonNullable<TrpcSessionUser> = {
+      id: 1,
+      organization: { isOrgAdmin: true },
+    } as NonNullable<TrpcSessionUser>;
+
+    it("should throw CONFLICT when duplicate preset exists", async () => {
+      const input: TUpdateInternalNotesPresetsInputSchema = {
+        teamId: 50,
+        presets: [{ id: -1, name: "Duplicate Preset" }],
+      };
+
+      const duplicateError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "1.0.0",
+      });
+
+      vi.mocked(prisma.internalNotePreset.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.internalNotePreset.create).mockRejectedValue(duplicateError);
+
+      await expect(
+        updateInternalNotesPresetsHandler({
+          ctx: { user },
+          input,
+        })
+      ).rejects.toMatchObject({
+        code: "CONFLICT",
+        message: "A preset with this name already exists. Please try a different name.",
+      });
+    });
+
+    it("should re-throw non-P2002 errors", async () => {
+      const input: TUpdateInternalNotesPresetsInputSchema = {
+        teamId: 50,
+        presets: [{ id: -1, name: "New Preset" }],
+      };
+
+      const genericError = new Prisma.PrismaClientKnownRequestError("Some other error", {
+        code: "P5000",
+        clientVersion: "1.0.0",
+      });
+
+      vi.mocked(prisma.internalNotePreset.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.internalNotePreset.create).mockRejectedValue(genericError);
+
+      await expect(
+        updateInternalNotesPresetsHandler({
+          ctx: { user },
+          input,
+        })
+      ).rejects.toThrow("Some other error");
+    });
+  });
+
+  describe("CRUD Operations", () => {
+    const user: NonNullable<TrpcSessionUser> = {
+      id: 1,
+      organization: { isOrgAdmin: true },
+    } as NonNullable<TrpcSessionUser>;
+
+    it("should update existing presets when id is provided", async () => {
+      const input: TUpdateInternalNotesPresetsInputSchema = {
+        teamId: 50,
+        presets: [{ id: 1, name: "Updated Preset", cancellationReason: "Updated Reason" }],
+      };
+
+      vi.mocked(prisma.internalNotePreset.findMany).mockResolvedValue([{ id: 1, cancellationReason: '', createdAt: new Date(), name: '', teamId: 1 }]);
+      vi.mocked(prisma.internalNotePreset.update).mockResolvedValue({
+        id: 1,
+        name: "Updated Preset",
+        teamId: 50,
+        createdAt: new Date('2025-05-05'),
+        cancellationReason: "Updated Reason",
+      });
+
+      const result = await updateInternalNotesPresetsHandler({
+        ctx: { user },
+        input,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(prisma.internalNotePreset.update).toHaveBeenCalledWith({
+        where: { id: 1, teamId: 50 },
+        data: { name: "Updated Preset", cancellationReason: "Updated Reason" },
+      });
+    });
+
+    it("should delete presets not in the update", async () => {
+      const input: TUpdateInternalNotesPresetsInputSchema = {
+        teamId: 50,
+        presets: [{ id: 1, name: "Keep Preset" }],
+      };
+
+      vi.mocked(prisma.internalNotePreset.findMany).mockResolvedValue([{ id: 1, cancellationReason: '', createdAt: new Date(), name: 'a', teamId: 1 }, { id: 2, cancellationReason: '', createdAt: new Date(), name: 'b', teamId: 1 }, { id: 3, cancellationReason: '', createdAt: new Date(), name: 'c', teamId: 1 }]);
+      vi.mocked(prisma.internalNotePreset.deleteMany).mockResolvedValue({ count: 2 });
+      vi.mocked(prisma.internalNotePreset.update).mockResolvedValue({
+        id: 1,
+        name: "Keep Preset",
+        teamId: 50,
+        createdAt: new Date('2025-05-05'),
+        cancellationReason: null,
+      });
+
+      const result = await updateInternalNotesPresetsHandler({
+        ctx: { user },
+        input,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(prisma.internalNotePreset.deleteMany).toHaveBeenCalledWith({
+        where: { id: { in: [2, 3] }, teamId: 50 },
+      });
+    });
+  });
+});

--- a/packages/trpc/server/routers/viewer/teams/updateInternalNotesPresets.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/updateInternalNotesPresets.handler.ts
@@ -6,6 +6,7 @@ import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 import { TRPCError } from "@trpc/server";
 
 import type { TUpdateInternalNotesPresetsInputSchema } from "./updateInternalNotesPresets.schema";
+import { Prisma } from "@calcom/prisma/client";
 
 type UpdateInternalNotesPresetsOptions = {
   ctx: {
@@ -63,32 +64,41 @@ export const updateInternalNotesPresetsHandler = async ({
   }
 
   // Update or create presets
-  const updatedPresets = await Promise.all(
-    input.presets.map((preset) => {
-      if (preset.id && preset.id !== -1) {
-        // Update existing preset
-        return prisma.internalNotePreset.update({
-          where: {
-            id: preset.id,
-            teamId: input.teamId,
-          },
-          data: {
-            name: preset.name,
-            cancellationReason: preset.cancellationReason,
-          },
-        });
-      } else {
-        // Create new preset
-        return prisma.internalNotePreset.create({
-          data: {
-            name: preset.name,
-            cancellationReason: preset.cancellationReason,
-            teamId: input.teamId,
-          },
-        });
-      }
-    })
-  );
+const updatedPresets = await Promise.all(
+  input.presets.map((preset) => {
+    if (preset.id && preset.id !== -1) {
+      // Update existing preset
+      return prisma.internalNotePreset.update({
+        where: {
+          id: preset.id,
+          teamId: input.teamId,
+        },
+        data: {
+          name: preset.name,
+          cancellationReason: preset.cancellationReason,
+        },
+      });
+    } else {
+      // Create new preset
+      return prisma.internalNotePreset.create({
+        data: {
+          name: preset.name,
+          cancellationReason: preset.cancellationReason,
+          teamId: input.teamId,
+        },
+      });
+    }
+  })
+).catch((error) => {
+  if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: "A preset with this name already exists. Please try a different name.",
+    });
+  }
+
+  throw error;
+});
 
   return updatedPresets;
 };


### PR DESCRIPTION
## What does this PR do?

Handles unique constraint violation  cause by creating internal note preset creation/update with same name.

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

Before:

https://github.com/user-attachments/assets/b34898b5-cf13-4d55-9fb9-6993d7df04cf

After:

https://github.com/user-attachments/assets/3465c82f-4134-4577-94a8-6dde3ae9d53f

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs
