### PR TITLE
fix: narrow AssignmentReasonTooltip prop to used fields

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -1151,7 +1151,7 @@ const AssignmentReasonTooltip = ({
   assignmentReason,
   onClick,
 }: {
-  assignmentReason: AssignmentReason;
+  assignmentReason: Pick<AssignmentReason, "reasonEnum" | "reasonString">;
   onClick?: () => void;
 }) => {
   const { t } = useLocale();


### PR DESCRIPTION
## What does this PR do?                                                                                       

Narrows the `assignmentReason` prop type on `AssignmentReasonTooltip` to only the fields the component actually reads (`reasonEnum`, `reasonString`). Fixes a type-check error where the booking list handler returns `assignmentReasonSortedByCreatedAt` from a Kysely query with `createdAt: string`, but the component expected the full Prisma `AssignmentReason` type with `createdAt: Date`.

### Changes

- `apps/web/components/booking/BookingListItem.tsx`: changed the prop type from `AssignmentReason` to `Pick<AssignmentReason, "reasonEnum" | "reasonString">`

### Context                                                                                                    

`AssignmentReasonTooltip` is a local component used once in `BookingListItem.tsx`. It reads only `assignmentReason.reasonEnum` and `assignmentReason.reasonString`. The prop was typed as the full Prisma `AssignmentReason`, which includes `createdAt: Date`, `id`, `bookingId`.                                       

The booking list handler in `packages/trpc/server/routers/viewer/bookings/get.handler.ts` uses Kysely's `jsonArrayFrom` to fetch `assignmentReasonSortedByCreatedAt`. Postgres JSON aggregation serializes timestamps as strings, so the resulting type is `{ createdAt: string; ... }` — incompatible with the Prisma type.         

Narrowing the prop to what the component actually uses fixes the mismatch without touching the handler, schema, or any other consumer. This is the minimum change that aligns the type with the component's real contract.

## How should this be tested?

1. `yarn type-check:ci` passes on `apps/web`                                                                   
2. Visit the bookings list page with a booking that has an assignment reason → tooltip badge still renders and shows the reason string on hover                                                                               

## Mandatory Tasks                                                                                             

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).                  
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs).                                                                  
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.