### PR TITLE
fix: wait for team visibility before click in team-management e2e

### DIFF
--- a/apps/web/playwright/organization/team-management.e2e.ts
+++ b/apps/web/playwright/organization/team-management.e2e.ts
@@ -53,8 +53,10 @@ test.describe("Teams", () => {
     });
 
     await test.step("Can navigate to team settings", async () => {
-      // Click on the team to go to settings
-      await page.locator(`text=${user.username}'s Team`).click();
+      // Wait for the team name to be visible before clicking
+      const teamLocator = page.locator(`text=${user.username}'s Team`);
+      await expect(teamLocator).toBeVisible({ timeout: 15000 });
+      await teamLocator.click();
       await page.waitForURL(/\/settings\/teams\/(\d+)\/profile$/i);
     });
 


### PR DESCRIPTION
## What does this PR do?                                                                                       

Adds an explicit visibility wait before clicking the team name in the `team-management.e2e.ts` test to prevent flakiness. The test previously relied on the default 10s locator timeout to click the team name immediately after redirect to `/teams`, which can fail when the team list takes longer to render.                          

### Changes

- `apps/web/playwright/organization/team-management.e2e.ts`: in the "Can navigate to team settings" step, replaced direct `.click()` with `await expect(teamLocator).toBeVisible({ timeout: 15000 })` followed by `.click()`.

### Context

The test creates a team via the wizard, gets redirected to `/teams`, then tries to click on the team name to navigate to settings. The default Playwright locator timeout (10s) is sometimes insufficient for the team list to render after the wizard's mutation and redirect.

This is a common flakiness pattern — the element is eventually visible, but not within the default timeout. Using `toBeVisible({ timeout: 15000 })` explicitly waits for render completion before interacting, which is     more reliable.  

Previous attempt at stabilizing this test: #28575.

## How should this be tested?

1. `PLAYWRIGHT_HEADLESS=1 yarn e2e apps/web/playwright/organization/team-management.e2e.ts` passes locally
2. CI E2E shard 7 passes                                                                                       

## Mandatory Tasks                                                                                             

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).                  
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs).                                                                  
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.