### PR TITLE
fix: use updateTag for teams list cache invalidation

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 
 export async function revalidateTeamsList() {
-  revalidateTag("viewer.teams.list", "max");
+  updateTag("viewer.teams.list");
 }


### PR DESCRIPTION
## What does this PR do?                                                                                       

Switches the teams list cache invalidation from `revalidateTag` to `updateTag` to restore read-your-own-writes semantics across all team mutation flows.                                                                      

### Changes                                                                                                    

- `apps/web/app/(use-page-wrapper)/(main-nav)/teams/actions.ts`: replaced `revalidateTag("viewer.teams.list", "max")` with `updateTag("viewer.teams.list")` and updated the import.                                          

### Context                                                                                                    

`revalidateTeamsList()` is called by 14 call sites across the app whenever a team or team membership is mutated: the wizard team creation flow, the alternative `CreateANewTeamForm`, dsync team creation, disband/delete team, accept/reject team invite, member invite and removal, invite link settings, and org sub-team member management.                                                                                    

The `/teams` page wraps its data in `unstable_cache` tagged with `viewer.teams.list` and a 1-hour revalidate. All the mutation flows above call `revalidateTeamsList()` before redirecting to (or expecting fresh data on) `/teams`.

In Next.js 16.2.x, `revalidateTag` behavior changed when called with a profile argument ("max"): it now performs stale-while-revalidate and does **not** purge the client-side Router Cache. As a result, the next navigation still shows stale data — visible as missing newly-created teams, stale member lists after invites, and disbanded teams still appearing.                                                                           

`updateTag` expires the data immediately and purges the Router Cache, producing the read-your-own-writes semantics these flows need.             

### Verification                                                                                               

The team-management e2e test (which exercises the wizard creation → invite → list roundtrip) was the most visible failure. Verified locally:      

```bash                                                                                                        
PLAYWRIGHT_HEADLESS=1 yarn e2e apps/web/playwright/organization/team-management.e2e.ts
```

Other affected flows (disband, accept invite, invite members, etc.) were not individually re-tested locally but share the same single code path through revalidateTeamsList().                                                

## How should this be tested?                                                                                     

1. Run the e2e test above — should pass                                                                        
2. Manual smoke tests for the breadth of affected flows:                                                       
- Create team via wizard → /teams shows new team immediately
- Disband team → /teams no longer shows it                                                                   
- Accept team invite → /teams shows it
- Invite member → team member count updates                                                                  

## Mandatory Tasks                                          

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). 
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

