### PR TITLE
fix: load team attributes for org admins without team membership

### DIFF
--- a/packages/trpc/server/routers/apps/routing-forms/getAttributesForTeam.handler.test.ts
+++ b/packages/trpc/server/routers/apps/routing-forms/getAttributesForTeam.handler.test.ts
@@ -1,0 +1,93 @@
+import { MembershipRole } from "@calcom/prisma/enums";
+import type { TrpcSessionUser } from "@calcom/trpc/server/types";
+import type { Mock } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCheckPermission }: { mockCheckPermission: Mock } = vi.hoisted(() => ({
+  mockCheckPermission: vi.fn(),
+}));
+
+vi.mock("@calcom/features/pbac/services/permission-check.service", () => ({
+  PermissionCheckService: vi.fn().mockImplementation(function (this: unknown) {
+    return {
+      checkPermission: mockCheckPermission,
+    };
+  }),
+}));
+
+vi.mock("@calcom/features/attributes/lib/getAttributes", () => ({
+  getAttributesForTeam: vi.fn().mockResolvedValue([{ id: "attr-1" }]),
+}));
+
+import { getAttributesForTeam } from "@calcom/features/attributes/lib/getAttributes";
+import getAttributesForTeamHandler from "./getAttributesForTeam.handler";
+
+describe("getAttributesForTeamHandler", () => {
+  const user = { id: 1 } as unknown as NonNullable<TrpcSessionUser>;
+  const teamId = 42;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws FORBIDDEN and does not load attributes when both permission checks fail", async () => {
+    mockCheckPermission.mockResolvedValue(false);
+
+    await expect(
+      getAttributesForTeamHandler({
+        ctx: { user },
+        input: { teamId },
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(getAttributesForTeam).not.toHaveBeenCalled();
+    expect(mockCheckPermission).toHaveBeenCalledTimes(2);
+  });
+
+  it("invokes checkPermission for routingForm.read and eventType.read with team context and fallback roles", async () => {
+    mockCheckPermission.mockImplementation(async ({ permission }) => {
+      return permission === "routingForm.read";
+    });
+
+    await getAttributesForTeamHandler({
+      ctx: { user },
+      input: { teamId },
+    });
+
+    expect(mockCheckPermission).toHaveBeenCalledWith({
+      userId: user.id,
+      teamId,
+      permission: "routingForm.read",
+      fallbackRoles: [MembershipRole.MEMBER, MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
+    expect(mockCheckPermission).toHaveBeenCalledWith({
+      userId: user.id,
+      teamId,
+      permission: "eventType.read",
+      fallbackRoles: [MembershipRole.MEMBER, MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
+  });
+
+  it("returns getAttributesForTeam when routingForm.read is granted", async () => {
+    mockCheckPermission.mockImplementation(async ({ permission }) => permission === "routingForm.read");
+
+    const result = await getAttributesForTeamHandler({
+      ctx: { user },
+      input: { teamId },
+    });
+
+    expect(result).toEqual([{ id: "attr-1" }]);
+    expect(getAttributesForTeam).toHaveBeenCalledWith({ teamId });
+  });
+
+  it("returns getAttributesForTeam when only eventType.read is granted", async () => {
+    mockCheckPermission.mockImplementation(async ({ permission }) => permission === "eventType.read");
+
+    await getAttributesForTeamHandler({
+      ctx: { user },
+      input: { teamId },
+    });
+
+    expect(getAttributesForTeam).toHaveBeenCalledWith({ teamId });
+  });
+});

--- a/packages/trpc/server/routers/apps/routing-forms/getAttributesForTeam.handler.ts
+++ b/packages/trpc/server/routers/apps/routing-forms/getAttributesForTeam.handler.ts
@@ -1,5 +1,6 @@
 import { getAttributesForTeam } from "@calcom/features/attributes/lib/getAttributes";
-import { MembershipRepository } from "@calcom/features/membership/repositories/MembershipRepository";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
+import { MembershipRole } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
 import { TRPCError } from "@trpc/server";
@@ -13,19 +14,39 @@ type GetAttributesForTeamHandlerOptions = {
   input: TGetAttributesForTeamInputSchema;
 };
 
+const fallbackRoles = [MembershipRole.MEMBER, MembershipRole.ADMIN, MembershipRole.OWNER];
+
+/**
+ * Team attribute options for building routing-form rules and event-type segments (e.g. round-robin
+ * filters). Access is allowed if the user has `routingForm.read` or `eventType.read` for this team
+ */
 export default async function getAttributesForTeamHandler({
   ctx,
   input,
 }: GetAttributesForTeamHandlerOptions) {
   const { teamId } = input;
   const { user } = ctx;
-  const membershipRepository = new MembershipRepository();
-  const isMemberOfTeam = await membershipRepository.findUniqueByUserIdAndTeamId({ userId: user.id, teamId });
 
-  if (!isMemberOfTeam) {
+  const permissionService = new PermissionCheckService();
+  const [canReadRoutingForms, canReadEventTypes] = await Promise.all([
+    permissionService.checkPermission({
+      userId: user.id,
+      teamId,
+      permission: "routingForm.read",
+      fallbackRoles,
+    }),
+    permissionService.checkPermission({
+      userId: user.id,
+      teamId,
+      permission: "eventType.read",
+      fallbackRoles,
+    }),
+  ]);
+
+  if (!canReadRoutingForms && !canReadEventTypes) {
     throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "You are not a member of this team",
+      code: "FORBIDDEN",
+      message: "You don't have permission to load attributes for this team",
     });
   }
 


### PR DESCRIPTION
## What does this PR do?                              
                                                                                                           
Aligns the permission check in `getAttributesForTeamHandler` with the rest of the routing-forms surface. Previously the handler required a direct team membership, so org admins who can see routing forms from teams they aren't members of (a supported path in `/routing`) would hit `You are not a member of this team` when the  UI tried to load attribute options.                                                                            

Now the handler uses `PermissionCheckService` and grants access when the caller has either `routingForm.read`  or `eventType.read` on the team, matching the permissions model used elsewhere for team-scoped routing-forms endpoints. 

### Changes                            

- `getAttributesForTeam.handler.ts`: replace the direct membership lookup with `PermissionCheckService.checkPermission` for `routingForm.read` and `eventType.read` (either grants access; fallback roles `MEMBER/ADMIN/OWNER`)                                                                           
- Error code changes from `NOT_FOUND` → `FORBIDDEN` with a clearer message
- New unit tests covering: both permissions denied → `FORBIDDEN`, only `routingForm.read` granted → returns attributes, only `eventType.read` granted → returns attributes, and correct call arguments

### Context                             

Repro: as an org admin, open `/routing` and inspect a team's routing form you aren't a member of. Previously the attributes panel would fail; with this change it loads as expected.

## How should this be tested?

```bash
TZ=UTC yarn vitest run packages/trpc/server/routers/apps/routing-forms/getAttributesForTeam.handler.test.ts
```

### Manual

1. As org admin (not a member of target team), open the team's routing form → attributes load
2. As member with routingForm.read only → attributes load                                                      
3. As user with neither permission → FORBIDDEN (previously NOT_FOUND)

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). 
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.