### PR TITLE
feat(slots): thread rescheduledBy param from URL through to tRPC input

### DIFF
--- a/apps/web/modules/schedules/hooks/useEvent.ts
+++ b/apps/web/modules/schedules/hooks/useEvent.ts
@@ -101,6 +101,7 @@ export const useScheduleForEvent = ({
 
   const searchParams = useCompatSearchParams();
   const rescheduleUid = searchParams?.get("rescheduleUid");
+  const rescheduledBy = searchParams?.get("rescheduledBy");
 
   const schedule = useSchedule({
     username: usernameFromStore ?? username,
@@ -110,6 +111,7 @@ export const useScheduleForEvent = ({
     selectedDate,
     dayCount,
     rescheduleUid,
+    rescheduledBy,
     month: monthFromStore ?? month,
     duration: durationFromStore ?? duration,
     isTeamEvent,

--- a/apps/web/modules/schedules/hooks/useSchedule.ts
+++ b/apps/web/modules/schedules/hooks/useSchedule.ts
@@ -20,6 +20,7 @@ export type UseScheduleWithCacheArgs = {
   duration?: number | null;
   dayCount?: number | null;
   rescheduleUid?: string | null;
+  rescheduledBy?: string | null;
   isTeamEvent?: boolean;
   orgSlug?: string;
   teamMemberEmail?: string | null;
@@ -58,6 +59,7 @@ export const useSchedule = ({
   duration,
   dayCount,
   rescheduleUid,
+  rescheduledBy,
   isTeamEvent,
   orgSlug,
   teamMemberEmail,
@@ -102,6 +104,7 @@ export const useSchedule = ({
     timeZone: timezone ?? "PLACEHOLDER_TIMEZONE",
     duration: duration ? `${duration}` : undefined,
     rescheduleUid,
+    rescheduledBy,
     orgSlug,
     teamMemberEmail,
     routedTeamMemberIds,

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -26,6 +26,7 @@ export const getScheduleSchemaObject = z.object({
     .optional()
     .transform((val) => val && parseInt(val)),
   rescheduleUid: z.string().nullish(),
+  rescheduledBy: z.string().nullish(),
   // whether to do team event or user event
   isTeamEvent: z.boolean().optional().default(false),
   orgSlug: z.string().nullish(),


### PR DESCRIPTION
Second of three PRs splitting #28636.

Threads a new rescheduledBy URL param through useScheduleForEvent, useSchedule, and the tRPC getSchedule input. Nothing consumes it yet; Part C (#28911) reads it to decide whether a reschedule is host-initiated. Small additive change, backwards compatible at both the URL and schema levels (nullish).