### PR TITLE
fix: remove Turbopack no-op package import optimization

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -233,9 +233,6 @@ const nextConfig = (phase: string): NextConfig => {
       "@boxyhq/saml-jackson",
       "jose",
     ],
-    experimental: {
-      optimizePackageImports: ["@calcom/ui"],
-    },
     productionBrowserSourceMaps: true,
     transpilePackages: [
       "@calcom/app-store",


### PR DESCRIPTION
## What changed
- Removed the `experimental.optimizePackageImports` entry for `@calcom/ui` from the web app Next.js config.

## Why
- The app runs development with Turbopack, where this optimization is not applied consistently for this workspace package.
- The repository already enforces direct `@calcom/ui/...` subpath imports, so the config entry was misleading and did not rewrite any app imports.

Closes #28902

## Validation
- Confirmed there are no production root imports from `@calcom/ui` outside documentation examples.
- Ran `git diff --check`.