### PR TITLE
fix: replace implicit Prisma error with explicit 404 in getBookingToD…

### DIFF
--- a/packages/features/bookings/lib/getBookingToDelete.ts
+++ b/packages/features/bookings/lib/getBookingToDelete.ts
@@ -1,8 +1,9 @@
+import { HttpError } from "@calcom/lib/http-error";
 import prisma, { bookingMinimalSelect } from "@calcom/prisma";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 
 export async function getBookingToDelete(id: number | undefined, uid: string | undefined) {
-  return await prisma.booking.findUniqueOrThrow({
+  const booking = await prisma.booking.findUnique({
     where: {
       id,
       uid,
@@ -111,6 +112,12 @@ export async function getBookingToDelete(id: number | undefined, uid: string | u
       status: true,
     },
   });
+
+  if (!booking) {
+    throw new HttpError({ statusCode: 404, message: "Booking not found" });
+  }
+
+  return booking;
 }
 
 export type BookingToDelete = Awaited<ReturnType<typeof getBookingToDelete>>;

--- a/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
+++ b/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
@@ -344,6 +344,22 @@ describe("Cancel Booking", () => {
     ).rejects.toThrow("Cannot cancel a booking that has already ended");
   });
 
+  test("Should throw HttpError 404 when booking does not exist", async () => {
+    const handleCancelBooking = (await import("@calcom/features/bookings/lib/handleCancelBooking")).default;
+
+    await expect(
+      handleCancelBooking({
+        bookingData: {
+          uid: "non-existent-booking-uid",
+          cancelledBy: "organizer@example.com",
+        },
+      })
+    ).rejects.toMatchObject({
+      statusCode: 404,
+      message: "Booking not found",
+    });
+  });
+
   test("Should block canceling bookings without a cancellation reason when cancelledBy is set to the host", async () => {
     const handleCancelBooking = (await import("@calcom/features/bookings/lib/handleCancelBooking")).default;
 


### PR DESCRIPTION

findUniqueOrThrow leaks a Prisma-internal error message when a booking is not found. Replace with findUnique + explicit HttpError(404) so the API returns a clean, user-facing "Booking not found" message rather than a redacted Prisma internals string.

