### PR TITLE
fix: add @calcom/api-v2 to dev:api turbo script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "deploy": "turbo run deploy",
     "dev:all": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/website\" --filter=\"@calcom/console\"",
     "dev:ai": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/api-proxy\" --filter=\"@calcom/ai\"",
-    "dev:api": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/api-proxy\"",
+    "dev:api": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/api-proxy\" --filter=\"@calcom/api-v2\"",
     "dev:api:console": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/api-proxy\" --filter=\"@calcom/console\"",
     "dev:console": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/console\"",
     "dev:swagger": "turbo run dev --filter=\"@calcom/api-proxy\" --filter=\"@calcom/swagger\"",


### PR DESCRIPTION
The dev:api script is meant to start the full API stack for local development but was missing the @calcom/api-v2 filter. Developers running yarn dev:api would start the web app and api-proxy but never the v2 API server, requiring manual workarounds.


- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
