### PR TITLE
fix: Instead of try catch block implemented the prisma trxn logic and…

### DIFF
--- a/packages/trpc/server/routers/viewer/organizations/adminDelete.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/adminDelete.handler.ts
@@ -1,0 +1,134 @@
+import { deleteDomain } from "@calcom/lib/domainManager/organization";
+import logger from "@calcom/lib/logger";
+import { prisma } from "@calcom/prisma";
+import { RedirectType } from "@calcom/prisma/enums";
+
+import { TRPCError } from "@trpc/server";
+
+import type { TrpcSessionUser } from "../../../types";
+import type { TAdminDeleteInput } from "./adminDelete.schema";
+import { Prisma } from "@calcom/prisma/client";
+
+const log = logger.getSubLogger({ prefix: ["organizations/adminDelete"] });
+type AdminDeleteOption = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+  };
+  input: TAdminDeleteInput;
+};
+
+export const adminDeleteHandler = async ({ input }: AdminDeleteOption) => {
+  const foundOrg = await prisma.team.findUnique({
+    where: {
+      id: input.orgId,
+      isOrganization: true,
+    },
+    include: {
+      members: {
+        select: {
+          user: true,
+        },
+      },
+    },
+  });
+
+  if (!foundOrg)
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Organization not found",
+    });
+
+    return await  prisma.$transaction(async (tx) => {
+
+      if ( foundOrg.slug ) {
+        await deleteDomain(foundOrg.slug );
+      }
+
+      await deleteAllRedirectsForUsers(tx , foundOrg.members.map((member) => member.user));
+
+      await renameUsersToAvoidUsernameConflicts(tx , foundOrg.members.map((member) => member.user));
+
+      await tx.team.delete({
+          where: {
+            id: input.orgId,
+          },
+        });
+
+      return {
+        ok: true,
+          message: `Organization ${foundOrg.name} deleted.`,
+      }
+    })
+  };
+
+  export default adminDeleteHandler;
+
+async function renameUsersToAvoidUsernameConflicts(tx: Prisma.TransactionClient, users: { id: number; username: string | null }[]) {
+  for (const user of users) {
+    let currentUsername = user.username;
+
+    if (!currentUsername) {
+      currentUsername = "no-username";
+      log.warn(`User ${user.id} has no username, defaulting to ${currentUsername}`);
+    }
+
+    const globalConflict = await tx.user.findFirst({
+      where : {
+        username: currentUsername,
+        organizationId: null ,
+        NOT :{
+          id : user.id
+        },
+      },
+      select : {
+        id : true
+      }
+    });
+
+    if ( globalConflict) {
+      // Conflict Detected : Someone else owns the name globally and change the logic back to `username - user.id`
+      await tx.user.update ({
+        where : {
+          id : user.id
+        },
+        data : {
+          username : `${currentUsername}-${user.id}`,
+          organizationId:null,
+        },
+      });
+    } else {
+      // Name is free globally.
+      await tx.user.update ({
+        where: {
+          id : user.id
+        },
+        data : {
+          username : currentUsername,
+          organizationId:null,
+        },
+      });
+    }
+  }
+}
+
+async function deleteAllRedirectsForUsers(tx: Prisma.TransactionClient , users: { username: string | null }[]) {
+  return await Promise.all(
+    users
+      .filter(
+        (
+          user
+        ): user is {
+          username: string;
+        } => !!user.username
+      )
+      .map((user) =>
+        tx.tempOrgRedirect.deleteMany({
+          where: {
+            from: user.username,
+            type: RedirectType.User,
+            fromOrgId: 0,
+          },
+        })
+      )
+  );
+}


### PR DESCRIPTION
# Fix: Preserve usernames and handle conflicts during organization deletion

## What does this PR do?

This PR improves the organization deletion process within the admin handler. Previously, deleting an organization could lead to username conflicts or orphaned redirects when members were transitioned back to global users. 

**Key Changes:**
* **Atomic Transactions:** Wrapped the entire deletion process in a Prisma transaction to ensure data integrity.
* **Domain Cleanup:** Automatically triggers `deleteDomain` if the organization has a slug.
* **Redirect Management:** Introduced `deleteAllRedirectsForUsers` to clean up `tempOrgRedirect` entries for all members of the deleted organization.
* **Smart Username Recovery:** Added `renameUsersToAvoidUsernameConflicts`. When an organization is deleted:
    * If a member's username is **available** globally (where `organizationId` is null), they keep their current username.
    * If a member's username **conflicts** with an existing global user, the system appends their user ID (`username-id`) to prevent database unique constraint errors.
    * All members have their `organizationId` set to `null`.

- this fixes #28584

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).


## How should this be tested?

1.  **Setup:**
    * Create an Organization (Org A).
    * Add two members: `user1` and `user2`.
    * Create a global user (not in any org) with the username `user1`.
2.  **Action:**
    * Trigger the `adminDelete` handler for Org A via the TRPC procedure.
3.  **Expected Outcome:**
    * The organization and its domain should be deleted.
    * `user1` (from Org A) should now have the username `user1-{id}` because of the global conflict.
    * `user2` (from Org A) should still have the username `user2` because there was no global conflict.
    * Both users should have `organizationId: null`.
    * Any `tempOrgRedirect` entries for these users should be removed.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
- [x] My PR is small and focused on fixing the specific issue described.