### PR TITLE
fix: prevent data leak in getConnectedApps by explicitly picking safe fields

### DIFF
--- a/packages/app-store/_utils/getConnectedApps.ts
+++ b/packages/app-store/_utils/getConnectedApps.ts
@@ -146,16 +146,45 @@ export async function getConnectedApps({
     filterOnCredentials: onlyInstalled,
     ...(appId ? { where: { slug: appId } } : {}),
   });
-  //TODO: Refactor this to pick up only needed fields and prevent more leaking
   let apps = await Promise.all(
-    enabledApps.map(async ({ credentials: _, credential, key: _2 /* don't leak to frontend */, ...app }) => {
-      const userCredentialIds = credentials.filter((c) => c.appId === app.slug && !c.teamId).map((c) => c.id);
+    enabledApps.map(async (rawApp) => {
+      const { credentials, credential } = rawApp;
+
+      const safeApp = {
+        name: rawApp.name,
+        slug: rawApp.slug,
+        description: rawApp.description,
+        type: rawApp.type,
+        categories: rawApp.categories,
+        logo: rawApp.logo,
+        publisher: rawApp.publisher,
+        url: rawApp.url,
+        docsUrl: rawApp.docsUrl,
+        variant: rawApp.variant,
+        isGlobal: rawApp.isGlobal,
+        isOAuth: rawApp.isOAuth,
+        appData: rawApp.appData,
+        concurrentMeetings: rawApp.concurrentMeetings,
+        extendsFeature: rawApp.extendsFeature,
+        dependencies: rawApp.dependencies,
+        isTemplate: rawApp.isTemplate,
+        dirName: rawApp.dirName,
+        feeType: rawApp.feeType,
+        price: rawApp.price,
+        paid: rawApp.paid,
+        licenseRequired: rawApp.licenseRequired,
+        email: rawApp.email,
+        enabled: rawApp.enabled,
+        locationOption: rawApp.locationOption,
+      };
+
+      const userCredentialIds = credentials.filter((c) => c.appId === safeApp.slug && !c.teamId).map((c) => c.id);
       const invalidCredentialIds = credentials
-        .filter((c) => c.appId === app.slug && c.invalid)
+        .filter((c) => c.appId === safeApp.slug && c.invalid)
         .map((c) => c.id);
       const teams = await Promise.all(
         credentials
-          .filter((c) => c.appId === app.slug && c.teamId)
+          .filter((c) => c.appId === safeApp.slug && c.teamId)
           .map(async (c) => {
             const team = userTeams.find((team) => team.id === c.teamId);
             if (!team) {
@@ -179,21 +208,21 @@ export async function getConnectedApps({
       // We need to know if app is payment type
       // undefined it means that app don't require app/setup/page
       let isSetupAlready = undefined;
-      if (credential && app.categories.includes("payment")) {
-        const paymentAppImportFn = PaymentServiceMap[app.dirName as keyof typeof PaymentServiceMap];
+      if (credential && safeApp.categories.includes("payment")) {
+        const paymentAppImportFn = PaymentServiceMap[safeApp.dirName as keyof typeof PaymentServiceMap];
         if (paymentAppImportFn) {
           const paymentApp = await paymentAppImportFn;
-                              if (paymentApp && "BuildPaymentService" in paymentApp && paymentApp?.BuildPaymentService) {
-                      const createPaymentService = paymentApp.BuildPaymentService;
-                      const paymentInstance = createPaymentService(credential);
+          if (paymentApp && "BuildPaymentService" in paymentApp && paymentApp?.BuildPaymentService) {
+            const createPaymentService = paymentApp.BuildPaymentService;
+            const paymentInstance = createPaymentService(credential);
             isSetupAlready = paymentInstance.isSetupAlready();
           }
         }
       }
 
       let dependencyData: TDependencyData = [];
-      if (app.dependencies?.length) {
-        dependencyData = app.dependencies.map((dependency) => {
+      if (safeApp.dependencies?.length) {
+        dependencyData = safeApp.dependencies.map((dependency) => {
           const dependencyInstalled = enabledApps.some(
             (dbAppIterator) => dbAppIterator.credentials.length && dbAppIterator.slug === dependency
           );
@@ -204,16 +233,16 @@ export async function getConnectedApps({
       }
 
       return {
-        ...app,
+        ...safeApp,
         ...(teams.length && {
           credentialOwner,
         }),
         userCredentialIds,
         invalidCredentialIds,
         teams,
-        isInstalled: !!userCredentialIds.length || !!teams.length || app.isGlobal,
+        isInstalled: !!userCredentialIds.length || !!teams.length || safeApp.isGlobal,
         isSetupAlready,
-        ...(app.dependencies && { dependencyData }),
+        ...(safeApp.dependencies && { dependencyData }),
       };
     })
   );

--- a/packages/app-store/_utils/getConnectedApps.ts
+++ b/packages/app-store/_utils/getConnectedApps.ts
@@ -9,6 +9,7 @@ import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/crede
 import type { TDependencyData } from "../_appRegistry";
 import { PaymentServiceMap } from "../payment.services.generated";
 import type { CredentialOwner } from "../types";
+import type { AppFrontendPayload } from "@calcom/types/App";
 import { getAppFromSlug } from "../utils";
 import getEnabledAppsFromCredentials from "./getEnabledAppsFromCredentials";
 
@@ -150,7 +151,35 @@ export async function getConnectedApps({
     enabledApps.map(async (rawApp) => {
       const { credentials, credential } = rawApp;
 
-      const safeApp = {
+      const safeApp: Pick<
+        AppFrontendPayload,
+        | "name"
+        | "slug"
+        | "description"
+        | "type"
+        | "categories"
+        | "logo"
+        | "publisher"
+        | "url"
+        | "docsUrl"
+        | "variant"
+        | "isGlobal"
+        | "isOAuth"
+        | "appData"
+        | "concurrentMeetings"
+        | "extendsFeature"
+        | "dependencies"
+        | "isTemplate"
+        | "dirName"
+        | "feeType"
+        | "price"
+        | "paid"
+        | "licenseRequired"
+        | "email"
+      > & {
+        enabled: boolean;
+        locationOption: typeof rawApp.locationOption;
+      } = {
         name: rawApp.name,
         slug: rawApp.slug,
         description: rawApp.description,


### PR DESCRIPTION
Fixes #28923 

### Description

This PR resolves a potential data leak vulnerability in `packages/app-store/_utils/getConnectedApps.ts` identified by an existing developer `TODO`.

**What changed:**
Removed the object spread operator (`...app`) and replaced it with a strict, explicitly-mapped `safeApp` payload dictionary.

**Why it matters:**
Previously, the backend used a "deny-list" approach using object destructuring, which would silently expose any newly developed internal codebase flags or secret `AppMeta` variables straight to the frontend HTTP response payload. By switching to a rigorous "allow-list", we guarantee that only explicitly authorized, public-safe properties are ever returned out of the API.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix / Refactor
- [ ] New feature (non-breaking change which adds functionality)

### How to test

1. Ensure the app builds locally without type errors.
2. Hit the `getConnectedApps` query (e.g. from the App Store or user settings page).
3. Validate that the network payload correctly renders the apps but strictly bounds the payload keys to only expected frontend configuration fields.
