### PR TITLE
feat: allow rescheduling unconfirmed bookings without bypassing confirmation

### DIFF
--- a/apps/web/components/booking/actions/bookingActions.ts
+++ b/apps/web/components/booking/actions/bookingActions.ts
@@ -101,6 +101,7 @@ export function getEditEventActions(context: BookingActionContext): ActionType[]
     isDisabledRescheduling,
     getSeatReferenceUid,
     isAttendee,
+    isPending,
     t,
   } = context;
   const seatReferenceUid = getSeatReferenceUid();
@@ -211,8 +212,8 @@ export function shouldShowPendingActions(context: BookingActionContext): boolean
 }
 
 export function shouldShowEditActions(context: BookingActionContext): boolean {
-  const { isPending, isTabRecurring, isRecurring, isCancelled } = context;
-  return !isPending && !(isTabRecurring && isRecurring) && !isCancelled;
+    const { isTabRecurring, isRecurring, isCancelled } = context;
+    return !(isTabRecurring && isRecurring) && !isCancelled;
 }
 
 export function shouldShowRecurringCancelAction(context: BookingActionContext): boolean {
@@ -235,31 +236,43 @@ export function isActionDisabled(actionId: string, context: BookingActionContext
     isAttendee,
     isCancelled,
     isRejected,
+    isPending,
   } = context;
 
   switch (actionId) {
     case "reschedule":
-    case "reschedule_request":
-      // Only apply minimum reschedule notice restriction if user is NOT the organizer
-      // If user is an attendee (or not authenticated), apply the restriction
       const isUserOrganizer =
-        !isAttendee &&
-        booking.loggedInUser?.userId &&
-        booking.user?.id &&
-        booking.loggedInUser.userId === booking.user.id;
-      const isWithinMinimumNotice =
-        !isUserOrganizer &&
-        isWithinMinimumRescheduleNotice(
-          new Date(booking.startTime),
+     !isAttendee &&
+     booking.loggedInUser?.userId &&
+     booking.user?.id &&
+     booking.loggedInUser.userId === booking.user.id;
+   const isWithinMinimumNotice =
+     !isUserOrganizer &&
+     isWithinMinimumRescheduleNotice(
+      new Date(booking.startTime),
           booking.eventType.minimumRescheduleNotice ?? null
         );
-      return (
-        isCancelled ||
-        isRejected ||
-        (isBookingInPast && !booking.eventType.allowReschedulingPastBookings) ||
-        isDisabledRescheduling ||
-        isWithinMinimumNotice
+    return (
+      isCancelled ||
+      isRejected ||
+      (isBookingInPast && !booking.eventType.allowReschedulingPastBookings) ||
+      isDisabledRescheduling ||
+      isWithinMinimumNotice
+    );
+      case "reschedule_request":
+        const isWithinMinimumNoticeForRequest =
+      isWithinMinimumRescheduleNotice(
+        new Date(booking.startTime),
+        booking.eventType.minimumRescheduleNotice ?? null
       );
+    return (
+      isPending ||
+      isCancelled ||
+      isRejected ||
+      (isBookingInPast && !booking.eventType.allowReschedulingPastBookings) ||
+      isDisabledRescheduling ||
+      isWithinMinimumNoticeForRequest
+    );
     case "cancel":
       return isDisabledCancelling || isBookingInPast || isCancelled || isRejected;
     case "view_recordings":
@@ -271,7 +284,7 @@ export function isActionDisabled(actionId: string, context: BookingActionContext
     case "reassign":
     case "change_location":
     case "add_members":
-      return isBookingInPast || isCancelled || isRejected;
+      return isBookingInPast || isCancelled || isRejected || isPending;
     default:
       return false;
   }

--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -44,6 +44,9 @@ import OrganizerRequestReminderEmail from "./templates/organizer-request-reminde
 import OrganizerRequestedToRescheduleEmail from "./templates/organizer-requested-to-reschedule-email";
 import OrganizerRescheduledEmail from "./templates/organizer-rescheduled-email";
 import OrganizerScheduledEmail from "./templates/organizer-scheduled-email";
+import AttendeePendingRescheduledEmail from "./templates/attendee-pending-rescheduled-email";
+import OrganizerPendingRescheduledEmail from "./templates/organizer-pending-rescheduled-email";
+import { BookingStatus } from "@calcom/prisma/enums";
 
 type EventTypeMetadata = z.infer<typeof EventTypeMetaDataSchema>;
 
@@ -282,11 +285,28 @@ export const sendReassignedEmailsAndSMS = async (args: {
 
 const _sendRescheduledEmailsAndSMS = async (
   calEvent: CalendarEvent,
-  eventTypeMetadata?: EventTypeMetadata
+  eventTypeMetadata?: EventTypeMetadata,
+    originalBookingStatus?: BookingStatus,
 ) => {
   const calendarEvent = formatCalEvent(calEvent);
   const emailsToSend: Promise<unknown>[] = [];
   const organizationSettings = await fetchOrganizationEmailSettings(calEvent.organizationId);
+
+  const wasPending = originalBookingStatus === BookingStatus.PENDING;
+
+  console.log('is Pending ? ', wasPending)
+
+  if(wasPending){
+
+    console.log('sending rescheduling mail ')
+    await Promise.all([
+      new OrganizerPendingRescheduledEmail({ calEvent }).sendEmail(),
+      ...calEvent.attendees.map((attendee) => new AttendeePendingRescheduledEmail(calEvent, attendee).sendEmail())
+    ])
+
+    console.log('sent rescheduling mail ')
+    return
+  }
 
   if (!eventTypeDisableHostEmail(eventTypeMetadata)) {
     emailsToSend.push(sendEmail(() => new OrganizerRescheduledEmail({ calEvent: calendarEvent })));

--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -294,19 +294,35 @@ const _sendRescheduledEmailsAndSMS = async (
 
   const wasPending = originalBookingStatus === BookingStatus.PENDING;
 
-  console.log('is Pending ? ', wasPending)
+  if (wasPending) {
+    const attendeeCalEvent = {
+      ...calendarEvent,
+      ...(calendarEvent.hideCalendarNotes && { additionalNotes: undefined }),
+    };
 
-  if(wasPending){
+    if (!eventTypeDisableHostEmail(eventTypeMetadata)) {
+      emailsToSend.push(sendEmail(() => new OrganizerPendingRescheduledEmail({ calEvent: calendarEvent })));
 
-    console.log('sending rescheduling mail ')
-    await Promise.all([
-      new OrganizerPendingRescheduledEmail({ calEvent }).sendEmail(),
-      ...calEvent.attendees.map((attendee) => new AttendeePendingRescheduledEmail(calEvent, attendee).sendEmail())
-    ])
+      if (calendarEvent.team) {
+        for (const teamMember of calendarEvent.team.members) {
+          emailsToSend.push(
+            sendEmail(() => new OrganizerPendingRescheduledEmail({ calEvent: calendarEvent, teamMember }))
+          );
+        }
+      }
+    }
 
-    console.log('sent rescheduling mail ')
-    return
-  }
+    if (!shouldSkipAttendeeEmailWithSettings(eventTypeMetadata, organizationSettings, EmailType.RESCHEDULED)) {
+      emailsToSend.push(
+        ...calendarEvent.attendees.map((attendee) =>
+          sendEmail(() => new AttendeePendingRescheduledEmail(attendeeCalEvent, attendee))
+        )
+      );
+    }
+
+    await Promise.all(emailsToSend);
+    return;
+   }
 
   if (!eventTypeDisableHostEmail(eventTypeMetadata)) {
     emailsToSend.push(sendEmail(() => new OrganizerRescheduledEmail({ calEvent: calendarEvent })));

--- a/packages/emails/templates/attendee-pending-rescheduled-email.ts
+++ b/packages/emails/templates/attendee-pending-rescheduled-email.ts
@@ -15,17 +15,17 @@ export default class AttendeePendingRescheduledEmail extends AttendeeScheduledEm
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
       subject: this.attendee.language.translate(
-        "event_type_has_been_rescheduled_on_time_date",
-        {
-          title: this.calEvent.title,
-          date: this.getFormattedDate(),
-        }
-      ),
+       "rescheduled_pending_event_type_subject",
+       {
+         title: this.calEvent.title,
+         date: this.getFormattedDate(),
+       }
+     ),
       html: await this.getHtml(this.calEvent, this.attendee),
       text: this.getTextBody(
-        "event_has_been_rescheduled",
-        "emailed_you_and_any_other_attendees"
-      ),
+       "rescheduled_pending_attendee_email_title",
+      "rescheduled_pending_attendee_email_subtitle"
+     ),
     };
   }
 

--- a/packages/emails/templates/attendee-pending-rescheduled-email.ts
+++ b/packages/emails/templates/attendee-pending-rescheduled-email.ts
@@ -1,0 +1,38 @@
+import type { CalendarEvent, Person } from "@calcom/types/Calendar";
+import renderEmail from "../src/renderEmail";
+import AttendeeScheduledEmail from "./attendee-scheduled-email";
+
+export default class AttendeePendingRescheduledEmail extends AttendeeScheduledEmail {
+  constructor(calEvent: CalendarEvent, attendee: Person) {
+    super(calEvent, attendee);
+    this.name = "SEND_PENDING_RESCHEDULE_NOTIFICATION";
+  }
+
+  protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    // No ICS attachment: booking is still PENDING, no calendar event should be
+    // created yet. We deliberately omit the icalEvent field here.
+    return {
+      to: `${this.attendee.name} <${this.attendee.email}>`,
+      from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
+      subject: this.attendee.language.translate(
+        "event_type_has_been_rescheduled_on_time_date",
+        {
+          title: this.calEvent.title,
+          date: this.getFormattedDate(),
+        }
+      ),
+      html: await this.getHtml(this.calEvent, this.attendee),
+      text: this.getTextBody(
+        "event_has_been_rescheduled",
+        "emailed_you_and_any_other_attendees"
+      ),
+    };
+  }
+
+  async getHtml(calEvent: CalendarEvent, attendee: Person) {
+    return await renderEmail("AttendeeRescheduledEmail", {
+      calEvent,
+      attendee,
+    });
+  }
+}

--- a/packages/emails/templates/organizer-pending-rescheduled-email.ts
+++ b/packages/emails/templates/organizer-pending-rescheduled-email.ts
@@ -17,19 +17,22 @@ export default class OrganizerPendingRescheduledEmail extends OrganizerScheduled
         true
       ),
       subject: this.calEvent.organizer.language.translate(
-        "event_type_has_been_rescheduled_on_time_date",
-        {
-          title: this.calEvent.title,
-          date: this.getFormattedDate(),
-        }
-      ),
+       "rescheduled_pending_event_type_subject",
+       {
+         title: this.calEvent.title,
+         date: this.getFormattedDate(),
+       }
+     ),
       html: await this.getHtml(
         { ...this.calEvent, attendeeSeatId: undefined },
         this.calEvent.organizer,
         this.teamMember
       ),
 
-      text: this.getTextBody("event_has_been_rescheduled"),
+      text: this.getTextBody(
+       "rescheduled_pending_organizer_email_title",
+       "rescheduled_pending_organizer_email_subtitle"
+     ),
     };
   }
 

--- a/packages/emails/templates/organizer-pending-rescheduled-email.ts
+++ b/packages/emails/templates/organizer-pending-rescheduled-email.ts
@@ -1,0 +1,43 @@
+import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
+import type { CalendarEvent, Person } from "@calcom/types/Calendar";
+import renderEmail from "../src/renderEmail";
+import OrganizerScheduledEmail from "./organizer-scheduled-email";
+
+export default class OrganizerPendingRescheduledEmail extends OrganizerScheduledEmail {
+  protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const toAddresses = [this.teamMember?.email || this.calEvent.organizer.email];
+
+    return {
+      from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
+      to: toAddresses.join(","),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.map(({ email }) => email),
+        true
+      ),
+      subject: this.calEvent.organizer.language.translate(
+        "event_type_has_been_rescheduled_on_time_date",
+        {
+          title: this.calEvent.title,
+          date: this.getFormattedDate(),
+        }
+      ),
+      html: await this.getHtml(
+        { ...this.calEvent, attendeeSeatId: undefined },
+        this.calEvent.organizer,
+        this.teamMember
+      ),
+
+      text: this.getTextBody("event_has_been_rescheduled"),
+    };
+  }
+
+  async getHtml(calEvent: CalendarEvent, attendee: Person, teamMember?: Person) {
+    return await renderEmail("OrganizerRescheduledEmail", {
+      calEvent,
+      attendee,
+      teamMember,
+    });
+  }
+}

--- a/packages/features/bookings/lib/BookingEmailSmsHandler.ts
+++ b/packages/features/bookings/lib/BookingEmailSmsHandler.ts
@@ -11,6 +11,7 @@ import type { EventTypeMetadata } from "@calcom/prisma/zod-utils";
 import type { AdditionalInformation, CalendarEvent, Person } from "@calcom/types/Calendar";
 import { default as cloneDeep } from "lodash/cloneDeep";
 import type { Logger } from "tslog";
+import { BookingStatus } from "@calcom/prisma/enums";
 
 export const BookingActionMap = {
   confirmed: "BOOKING_CONFIRMED",
@@ -54,6 +55,8 @@ type ConfirmedEmailAndSmsPayload = EmailAndSmsPayload & {
 type RequestedEmailAndSmsPayload = EmailAndSmsPayload & {
   attendees?: Person[];
   additionalNotes?: string | null;
+  originalRescheduledBooking?: NonNullable<BookingType>;
+  rescheduleReason?: string;
 };
 
 type AddGuestsEmailAndSmsPayload = EmailAndSmsPayload & {
@@ -115,6 +118,7 @@ export class BookingEmailSmsHandler {
       rescheduleReason,
       additionalNotes,
       additionalInformation,
+      originalRescheduledBooking,
     } = data;
 
     const { sendRescheduledEmailsAndSMS } = await import("@calcom/emails/email-manager");
@@ -125,7 +129,8 @@ export class BookingEmailSmsHandler {
         additionalNotes,
         cancellationReason: `$RCH$${rescheduleReason || ""}`,
       },
-      metadata
+      metadata,
+      originalRescheduledBooking.status,
     );
   }
 
@@ -294,11 +299,38 @@ export class BookingEmailSmsHandler {
       eventType: { metadata },
       attendees,
       additionalNotes,
+      originalRescheduledBooking,
+      rescheduleReason,
     } = data;
     if (!attendees?.length) {
       this.log.error("Requested action called without attendee details.");
       return;
     }
+
+    if (originalRescheduledBooking?.status === BookingStatus.PENDING) {
+    this.log.debug(
+      "Action: BOOKING_REQUESTED via pending reschedule. Sending rescheduled pending emails.",
+      safeStringify({ calEvent: getPiiFreeCalendarEvent(evt) })
+    );
+
+    const { sendRescheduledEmailsAndSMS } = await import("@calcom/emails/email-manager");
+
+    try {
+      await sendRescheduledEmailsAndSMS(
+        {
+          ...evt,
+          additionalNotes,
+          cancellationReason: `$RCH$${rescheduleReason || ""}`,
+        },
+        metadata,
+        originalRescheduledBooking.status,
+      );
+    } catch (err) {
+      this.log.error("Failed to send pending reschedule emails", err);
+    }
+    return;
+  }
+
     this.log.debug(
       "Action: BOOKING_REQUESTED. Sending request emails.",
       safeStringify({ calEvent: getPiiFreeCalendarEvent(evt) })

--- a/packages/features/bookings/lib/handleNewBooking/getRequiresConfirmationFlags.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getRequiresConfirmationFlags.ts
@@ -1,6 +1,8 @@
 import dayjs from "@calcom/dayjs";
 import { checkIfFreeEmailDomain } from "@calcom/features/watchlist/lib/freeEmailDomainCheck/checkIfFreeEmailDomain";
 import { withReporting } from "@calcom/lib/sentryWrapper";
+import { BookingStatus } from "@calcom/prisma/enums";
+import type { OriginalRescheduledBooking } from "./originalRescheduledBookingUtils";
 
 import type { getEventTypeResponse } from "./getEventTypesFromDB";
 
@@ -15,22 +17,26 @@ export async function getRequiresConfirmationFlags({
   bookingStartTime,
   userId,
   paymentAppData,
-  originalRescheduledBookingOrganizerId,
+  originalRescheduledBooking,
   bookerEmail,
 }: {
   eventType: EventType;
   bookingStartTime: string;
   userId: number | undefined;
   paymentAppData: PaymentAppData;
-  originalRescheduledBookingOrganizerId: number | undefined;
+  originalRescheduledBooking: OriginalRescheduledBooking | null,
   bookerEmail: string;
 }) {
   const requiresConfirmation = await determineRequiresConfirmation(eventType, bookingStartTime, bookerEmail);
+  const originalRescheduledBookingOrganizerId = originalRescheduledBooking?.user?.id
   const userReschedulingIsOwner = isUserReschedulingOwner(userId, originalRescheduledBookingOrganizerId);
+  const originalWasPending = originalRescheduledBooking?.status === BookingStatus.PENDING
+
   const isConfirmedByDefault = determineIsConfirmedByDefault(
     requiresConfirmation,
     paymentAppData.price,
-    userReschedulingIsOwner
+    userReschedulingIsOwner,
+    originalWasPending
   );
 
   return {
@@ -87,7 +93,8 @@ function isUserReschedulingOwner(
 function determineIsConfirmedByDefault(
   requiresConfirmation: boolean,
   price: number,
-  userReschedulingIsOwner: boolean
+  userReschedulingIsOwner: boolean,
+  originalWasPending: boolean,
 ): boolean {
-  return (!requiresConfirmation && price === 0) || userReschedulingIsOwner;
+  return (!requiresConfirmation && price === 0) || userReschedulingIsOwner && !originalWasPending;
 }

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -669,8 +669,8 @@ async function handler(
     eventType,
     bookingStartTime: reqBody.start,
     userId,
-    originalRescheduledBookingOrganizerId: originalRescheduledBooking?.user?.id,
     paymentAppData,
+    originalRescheduledBooking,
     bookerEmail,
   });
 
@@ -2187,11 +2187,30 @@ async function handler(
     !!booking;
 
   if (!isConfirmedByDefault && noEmail !== true && !bookingRequiresPayment) {
+
+    if (!!originalRescheduledBooking && originalRescheduledBooking.status === BookingStatus.PENDING) {
+    tracingLogger.debug(
+      `Emails: Pending reschedule by owner, sending rescheduled pending emails`,
+      safeStringify({ calEvent: getPiiFreeCalendarEvent(evt) })
+    );
+
+    if (!isDryRun) {
+      await emailsAndSmsHandler.send({
+        action: BookingActionMap.requested,
+        data: {
+          evt,
+          eventType,
+          attendees: attendeesList,
+          additionalNotes,
+          originalRescheduledBooking,
+        },
+      });
+      bookingEmailsAndSmsTaskerAction = BookingActionMap.requested;
+    }
+  } else {
     tracingLogger.debug(
       `Emails: Booking ${organizerUser.username} requires confirmation, sending request emails`,
-      safeStringify({
-        calEvent: getPiiFreeCalendarEvent(evt),
-      })
+      safeStringify({ calEvent: getPiiFreeCalendarEvent(evt) })
     );
     if (!isDryRun) {
       await emailsAndSmsHandler.send({
@@ -2200,6 +2219,7 @@ async function handler(
       });
       bookingEmailsAndSmsTaskerAction = BookingActionMap.requested;
     }
+  }
   }
 
   if (booking.location?.startsWith("http")) {

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -2203,6 +2203,7 @@ async function handler(
           attendees: attendeesList,
           additionalNotes,
           originalRescheduledBooking,
+          rescheduleReason
         },
       });
       bookingEmailsAndSmsTaskerAction = BookingActionMap.requested;

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4768,5 +4768,10 @@
   "user_updated_successfully": "User updated successfully.",
   "error_updating_user": "There was an error updating this user.",
   "please_reschedule": "Please reschedule.",
+  "rescheduled_pending_event_type_subject": "New time proposed for your pending booking - {{title}} on {{date}}",
+"rescheduled_pending_attendee_email_title": "A new time has been proposed for your booking",
+"rescheduled_pending_attendee_email_subtitle": "This booking still requires confirmation from the organizer. You will receive a separate email once it is confirmed or declined.",
+"rescheduled_pending_organizer_email_title": "You have proposed a new time for a pending booking",
+"rescheduled_pending_organizer_email_subtitle": "This booking still requires your confirmation. The attendee has been notified of the proposed new time.",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }


### PR DESCRIPTION
## What does this PR do?

Organizers of event types that require confirmation are currently blocked from rescheduling a `PENDING` booking. The restriction exists to prevent a naive reschedule from producing an `ACCEPTED` booking silently bypassing the confirmation workflow.

This PR ensures that the organizer can now reschedule a `PENDING` booking but the resulting booking **inherits `PENDING` status**. The confirmation requirement is fully preserved only the proposed time changes. Both the organizer and attendee receive a notification that the time has changed and that the booking still awaits confirmation.


- Fixes #8885  (GitHub issue number)

#### Video Demo (if applicable):

[Screencast from 2026-04-19 02-29-35.webm](https://github.com/user-attachments/assets/166bcfa8-0c5c-4a31-8a84-3eba77894cee)



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
