### PR TITLE
feat: add zapier no-show support

### DIFF
--- a/packages/app-store/zapier/DESCRIPTION.md
+++ b/packages/app-store/zapier/DESCRIPTION.md
@@ -4,6 +4,6 @@ items:
   - 2.jpg
 ---
 
-Connect Cal.diy with 8,000+ apps through Zapier to automate your scheduling workflows. Set up triggers for booking events (created, rescheduled, cancelled, meeting ended) and integrate with popular tools like Slack, Gmail, Google Sheets, and more.
+Connect Cal.diy with 8,000+ apps through Zapier to automate your scheduling workflows. Set up triggers for booking events (created, rescheduled, cancelled, no-show, meeting ended) and integrate with popular tools like Slack, Gmail, Google Sheets, and more.
 
 **Get started:** Click "Visit" to access the Zapier integrations page and create your first automation workflow.

--- a/packages/app-store/zapier/README.md
+++ b/packages/app-store/zapier/README.md
@@ -20,6 +20,7 @@ The following API endpoints are maintained for backward compatibility with exist
 
 - `GET /api/integrations/zapier/listBookings` - List user bookings
 - `GET /api/integrations/zapier/listOOOEntries` - List out-of-office entries
+- `GET /api/integrations/zapier/listNoShowBookings` - List no-show bookings
 - `POST /api/integrations/zapier/addSubscription` - Subscribe to webhooks
 - `DELETE /api/integrations/zapier/deleteSubscription` - Unsubscribe from webhooks
 - `GET /api/integrations/zapier/me` - Get user/team information

--- a/packages/app-store/zapier/_metadata.ts
+++ b/packages/app-store/zapier/_metadata.ts
@@ -3,7 +3,7 @@ import type { AppMeta } from "@calcom/types/App";
 export const metadata = {
   name: "Zapier",
   description:
-    "Workflow automation for everyone. Use the Cal.diy Zapier app to trigger your workflows when a booking is created, rescheduled, or cancelled, or after a meeting ends.",
+    "Workflow automation for everyone. Use the Cal.diy Zapier app to trigger your workflows when a booking is created, rescheduled, cancelled, marked as no-show, or after a meeting ends.",
   installed: true,
   category: "automation",
   categories: ["automation"],

--- a/packages/app-store/zapier/api/index.ts
+++ b/packages/app-store/zapier/api/index.ts
@@ -1,6 +1,7 @@
 export { default as add } from "./add";
 export { default as listBookings } from "./subscriptions/listBookings";
 export { default as listOOOEntries } from "./subscriptions/listOOOEntries";
+export { default as listNoShowBookings } from "./subscriptions/listNoShowBookings";
 export { default as deleteSubscription } from "./subscriptions/deleteSubscription";
 export { default as addSubscription } from "./subscriptions/addSubscription";
 export { default as me } from "./subscriptions/me";

--- a/packages/app-store/zapier/api/subscriptions/listNoShowBookings.ts
+++ b/packages/app-store/zapier/api/subscriptions/listNoShowBookings.ts
@@ -1,0 +1,100 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import prisma from "@calcom/prisma";
+import { WebhookTriggerEvents } from "@calcom/prisma/enums";
+import { defaultHandler } from "@calcom/lib/server/defaultHandler";
+import { defaultResponder } from "@calcom/lib/server/defaultResponder";
+
+import { validateAccountOrApiKey } from "../../lib/validateAccountOrApiKey";
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { account: authorizedAccount, appApiKey: validKey } = await validateAccountOrApiKey(req, [
+    "READ_BOOKING",
+  ]);
+
+  const userId = validKey ? validKey.userId : authorizedAccount && !authorizedAccount.isTeam ? authorizedAccount.id : null;
+  const teamId = validKey ? validKey.teamId : authorizedAccount && authorizedAccount.isTeam ? authorizedAccount.id : null;
+
+  const where = teamId
+    ? {
+        eventType: {
+          OR: [{ teamId }, { parent: { teamId } }],
+        },
+        OR: [{ noShowHost: true }, { attendees: { some: { noShow: true } } }],
+      }
+    : {
+        eventType: { userId },
+        OR: [{ noShowHost: true }, { attendees: { some: { noShow: true } } }],
+      };
+
+  const noShowBookings = await prisma.booking.findMany({
+    take: 3,
+    where,
+    orderBy: {
+      updatedAt: "desc",
+    },
+    select: {
+      uid: true,
+      title: true,
+      description: true,
+      customInputs: true,
+      responses: true,
+      startTime: true,
+      endTime: true,
+      createdAt: true,
+      updatedAt: true,
+      location: true,
+      cancellationReason: true,
+      status: true,
+      metadata: true,
+      noShowHost: true,
+      user: {
+        select: {
+          username: true,
+          name: true,
+          email: true,
+          timeZone: true,
+          locale: true,
+        },
+      },
+      eventType: {
+        select: {
+          title: true,
+          description: true,
+          requiresConfirmation: true,
+          price: true,
+          currency: true,
+          length: true,
+          bookingFields: true,
+          team: true,
+        },
+      },
+      attendees: {
+        select: {
+          name: true,
+          email: true,
+          timeZone: true,
+          noShow: true,
+        },
+      },
+    },
+  });
+
+  if (noShowBookings.length === 0) {
+    return res.status(200).json([]);
+  }
+
+  return res.status(200).json(
+    noShowBookings.map((booking) => ({
+      createdAt: booking.updatedAt ?? booking.createdAt,
+      triggerEvent: WebhookTriggerEvents.BOOKING_NO_SHOW_UPDATED,
+      payload: {
+        booking,
+      },
+    }))
+  );
+}
+
+export default defaultHandler({
+  GET: Promise.resolve({ default: defaultResponder(handler) }),
+});

--- a/packages/app-store/zapier/config.json
+++ b/packages/app-store/zapier/config.json
@@ -9,7 +9,7 @@
   "categories": ["automation"],
   "publisher": "Cal.diy",
   "email": "help@cal.com",
-  "description": "Workflow automation for everyone. Use the Cal.diy Zapier app to automate your workflows when a booking is created, rescheduled, cancelled or when a meeting ends.",
+  "description": "Workflow automation for everyone. Use the Cal.diy Zapier app to automate your workflows when a booking is created, rescheduled, cancelled, marked as no-show, or when a meeting ends.",
   "isTemplate": false,
   "__createdUsingCli": true,
   "__template": "link-as-an-app",


### PR DESCRIPTION
Adds a new listNoShowBookings endpoint and exports it to the Zapier API to support no-show triggers. Updated documentation and app metadata to include no-show event support. Fixes calcom/cal.com#18992.