### PR TITLE
fix(onboarding): prevent floating footer from overlapping bio textare…

### DIFF
--- a/apps/web/modules/onboarding/components/OnboardingCard.tsx
+++ b/apps/web/modules/onboarding/components/OnboardingCard.tsx
@@ -66,7 +66,7 @@ export const OnboardingCard = ({
           {/* Content */}
           <div
             className={`flex h-full min-h-0 w-full flex-1 flex-col gap-4 [container-type:size] ${
-              floatingFooter ? "pb-10" : ""
+              floatingFooter ? "pb-24" : ""
             }`}>
             {isLoading ? (
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -82,7 +82,7 @@ export const OnboardingCard = ({
 
       {/* Footer */}
       {floatingFooter ? (
-        <div className="absolute bottom-0 left-0 right-[12px] z-10 flex items-center justify-start rounded-[12px] bg-[rgba(255,255,255,0.01)] p-2 shadow-[0px_12px_32px_-6px_rgba(0,0,0,0.12),0px_0px_0px_1px_rgba(111,107,107,0.1),0px_1px_3px_0px_rgba(63,70,75,0.1)] backdrop-blur-[6px] backdrop-filter">
+        <div className="sticky bottom-0 z-10 mt-2 flex w-full items-center justify-start rounded-[12px] bg-[rgba(255,255,255,0.01)] p-2 shadow-[0px_12px_32px_-6px_rgba(0,0,0,0.12),0px_0px_0px_1px_rgba(111,107,107,0.1),0px_1px_3px_0px_rgba(63,70,75,0.1)] backdrop-blur-[6px] backdrop-filter">
           {footer}
         </div>
       ) : (


### PR DESCRIPTION

## Linked Issue
Closes #28931

## Summary
This fixes a responsive layout bug on onboarding "Add your details" where the floating action footer (`Back` / `Continue`) overlaps the Bio textarea on reduced-width windows (split-screen / half width).

## Root Cause
The onboarding footer was rendered as an absolute overlay, while the content area had insufficient bottom padding. On smaller viewports, the last form field (Bio) could scroll underneath the footer.

## Changes
- Updated floating footer in `apps/web/modules/onboarding/components/OnboardingCard.tsx`
- Switched footer container from `absolute` overlay to `sticky bottom-0` in-flow behavior
- Increased reserved content bottom spacing from `pb-10` to `pb-24` when floating footer is enabled

## Expected Result
- `Continue` button no longer overlaps the Bio textarea
- Bio remains fully visible and interactive at smaller viewport widths
