### PR TITLE
fix: vertically center scroll arrows in All Apps category tab

### DIFF
--- a/apps/web/modules/apps/components/AllApps.tsx
+++ b/apps/web/modules/apps/components/AllApps.tsx
@@ -89,10 +89,10 @@ function CategoryTab({ selectedCategory, categories, searchText, onCategoryChang
       </h2>
       {leftVisible && (
         <button onClick={handleLeft} className="absolute bottom-0 flex  lg:left-1/2">
-          <div className="bg-default flex h-12 w-5 items-center justify-end">
+          <div className="bg-default flex h-10 w-5 items-center justify-end">
             <ChevronLeftIcon className="text-subtle h-4 w-4" />
           </div>
-          <div className="to-default flex h-12 w-5 bg-linear-to-l from-transparent" />
+          <div className="to-default flex h-10 w-5 bg-linear-to-l from-transparent" />
         </button>
       )}
       <ul
@@ -129,8 +129,8 @@ function CategoryTab({ selectedCategory, categories, searchText, onCategoryChang
       </ul>
       {rightVisible && (
         <button onClick={handleRight} className="absolute bottom-0 right-0 flex ">
-          <div className="to-default flex h-12 w-5 bg-linear-to-r from-transparent" />
-          <div className="bg-default flex h-12 w-5 items-center justify-end">
+          <div className="to-default flex h-10 w-5 bg-linear-to-r from-transparent" />
+          <div className="bg-default flex h-10 w-5 items-center justify-end">
             <ChevronRightIcon className="text-subtle h-4 w-4" />
           </div>
         </button>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Note: Cal.diy is a community-maintained open-source project. Contributions here do NOT flow to Cal.com's production service. -->

- Vertically centers scroll arrows in All Apps category tab

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Image Demo (if applicable):

**Before:**
<img width="1512" height="625" alt="Screenshot 2026-04-20 at 9 53 41 AM" src="https://github.com/user-attachments/assets/9f94ae5d-f76d-41e9-ad4d-9606fc9bce8c" />


**After:**
<img width="1512" height="625" alt="Screenshot 2026-04-20 at 9 53 15 AM" src="https://github.com/user-attachments/assets/938724df-d1c7-4caa-99bb-7a5542f94c46" />



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Navigate to `App Store` page accessible at `/apps`.
- Find the `All Apps` section
- On the top-right side of this section, it displays categories with scroll arrows.
- Ensure that they are vertically centered.
