### PR TITLE
fix(auth): allow invited placeholder users to complete signup from invite links

### DIFF
--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -102,19 +102,22 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
       isSignup: true,
     });
 
-    if (foundToken?.teamId) {
-      const existingUser = await prisma.user.findUnique({
-        where: { email },
-        select: { invitedTo: true },
-      });
-        if (
-          existingUser &&
-          existingUser.invitedTo !== null &&
-          existingUser.invitedTo !== foundToken.teamId
-        ) {
-          return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
+      if (foundToken?.teamId) {
+        const existingUser = await prisma.user.findUnique({
+          where: { email },
+          select: { invitedTo: true, emailVerified: true, password: { select: { hash: true } } },
+        });
+        if (existingUser) {
+          const isInvitedPlaceholderAccount =
+            existingUser.invitedTo === foundToken.teamId &&
+            !existingUser.password?.hash &&
+            !existingUser.emailVerified;
+
+          if (!isInvitedPlaceholderAccount) {
+            return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
+          }
         }
-    }
+      }
   } else {
     const usernameAndEmailValidation = await validateAndGetCorrectedUsernameAndEmail({
       username,

--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -107,9 +107,13 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
         where: { email },
         select: { invitedTo: true },
       });
-      if (existingUser && existingUser.invitedTo !== foundToken.teamId) {
-        return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
-      }
+        if (
+          existingUser &&
+          existingUser.invitedTo !== null &&
+          existingUser.invitedTo !== foundToken.teamId
+        ) {
+          return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
+        }
     }
   } else {
     const usernameAndEmailValidation = await validateAndGetCorrectedUsernameAndEmail({

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -46,14 +46,17 @@ export default async function handler(body: Record<string, string>) {
     if (foundToken?.teamId) {
       const existingUser = await prisma.user.findUnique({
         where: { email: userEmail },
-        select: { invitedTo: true },
+        select: { invitedTo: true, emailVerified: true, password: { select: { hash: true } } },
       });
-      if (
-        existingUser &&
-        existingUser.invitedTo !== null &&
-        existingUser.invitedTo !== foundToken.teamId
-      ) {
-        return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
+      if (existingUser) {
+        const isInvitedPlaceholderAccount =
+          existingUser.invitedTo === foundToken.teamId &&
+          !existingUser.password?.hash &&
+          !existingUser.emailVerified;
+
+        if (!isInvitedPlaceholderAccount) {
+          return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
+        }
       }
     }
   } else {

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -48,7 +48,11 @@ export default async function handler(body: Record<string, string>) {
         where: { email: userEmail },
         select: { invitedTo: true },
       });
-      if (existingUser && existingUser.invitedTo !== foundToken.teamId) {
+      if (
+        existingUser &&
+        existingUser.invitedTo !== null &&
+        existingUser.invitedTo !== foundToken.teamId
+      ) {
         return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
       }
     }

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -998,10 +998,10 @@ export const getOptions = ({
           }
 
           // check if user was invited
+          // Invited placeholder users may already have a generated username; password/email verification
+          // are the reliable signals that account setup is incomplete and should be completed here.
           if (
-            !existingUserWithEmail.password?.hash &&
-            !existingUserWithEmail.emailVerified &&
-            !existingUserWithEmail.username
+            !existingUserWithEmail.password?.hash && !existingUserWithEmail.emailVerified
           ) {
             await prisma.user.update({
               where: {


### PR DESCRIPTION
## Linked Issues
Closes #28380  
Follow-up to #28351

## Summary
This PR fixes a regression where invited users could receive invite emails but fail account creation from the invite link.

Symptoms:
- Email/password flow returned `invalid_server_response`
- Google flow could land on `Internal Server Error`

## Root Cause
Invite-signup completion logic treated some valid invited placeholder records as conflicts:
1. Invite-token signup rejected users when `invitedTo` was `null`, even for valid invited placeholders.
2. OAuth invited-user merge required `username` to be empty, but placeholder records can already have generated usernames.

This caused signup paths to incorrectly fail instead of completing the invited account.

## Changes
### 1) Invite token signup handlers
Updated conflict guard to reject only when `invitedTo` is explicitly set to a different team.

Files:
- `apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts`
- `apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts`

Change:
- From: reject when `existingUser.invitedTo !== foundToken.teamId`
- To: reject only when `existingUser.invitedTo !== null && existingUser.invitedTo !== foundToken.teamId`

### 2) OAuth invited account completion
Relaxed invited placeholder detection in NextAuth login callback to rely on:
- no password hash
- no email verification

and no longer require missing username.

File:
- `packages/features/auth/lib/next-auth-options.ts`

## Behavior After Fix
- Invitee with placeholder account can complete signup via email/password.
- Invitee can complete signup via Google OAuth even if placeholder username exists.
- Existing safety checks still block users explicitly invited to a different team.
