### PR TITLE
fix(security): upgrade protobufjs to 7.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "form-data": "4.0.4",
     "axios": "1.15.0",
     "follow-redirects": "1.16.0",
+    "protobufjs": "7.5.5",
     "jws": "4.0.1",
     "jsonwebtoken": "9.0.0",
     "sha.js": "2.4.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34681,9 +34681,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.0":
-  version: 7.4.0
-  resolution: "protobufjs@npm:7.4.0"
+"protobufjs@npm:7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -34697,7 +34697,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10/408423506610f70858d7593632f4a6aa4f05796c90fd632be9b9252457c795acc71aa6d3b54bb7f48a890141728fee4ca3906723ccea6c202ad71f21b3879b8b
+  checksum: 10/048898023a38d22f5fc9a1bcf0dcce5cfbcd37fb00753bd72283720eee7e2cb6055b23957542e5bcdc136379af66203a2ddb8d8c39d11f73169bacf07885fedd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Pins `protobufjs` to `7.5.5` via root `resolutions` to patch [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) (critical — arbitrary code execution, affects `<7.5.5`).
- The vulnerable `7.4.0` was pulled in transitively through `@opentelemetry/otlp-transformer@0.203.0`, causing `Security Audit / audit` (`yarn npm audit --all --recursive --severity critical`) to fail on every open PR and block merges.

## Test plan

- [x] `yarn install --mode=update-lockfile` succeeds and updates the `protobufjs` entry in `yarn.lock` to `7.5.5`.
- [x] `yarn npm audit --all --recursive --severity critical` reports `No audit suggestions`.
- [ ] CI `Security Audit / audit` job passes on this PR.