### PR TITLE
fix: align local prisma database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,23 @@ Here is what you need to be able to run Cal.diy.
 yarn dx
 ```
 
+If `yarn dx` fails with `P1001: Can't reach database server at localhost:5450`, check whether the local
+Docker database was initialized before the expected `calendso` database was created. You can repair the
+existing container without deleting its volume:
+
+```sh
+docker exec prisma-postgres-1 createdb -U postgres calendso
+yarn workspace @calcom/prisma db-deploy
+yarn workspace @calcom/prisma db-seed
+```
+
+If you do not need the existing local data, you can reset the local database instead:
+
+```sh
+yarn workspace @calcom/prisma db-nuke
+yarn dx
+```
+
 **Default credentials created:**
 
 | Email | Password | Role |

--- a/packages/prisma/docker-compose.yml
+++ b/packages/prisma/docker-compose.yml
@@ -9,11 +9,11 @@ services:
     volumes:
       - db_data:/var/lib/postgresql
     environment:
-      POSTGRES_DB: "cal-saml"
+      POSTGRES_DB: "calendso"
       POSTGRES_PASSWORD: ""
       POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d calendso"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## What changed

- Align the local Prisma Postgres helper with the checked-in `.env.example` by creating the `calendso` database.
- Make the Postgres healthcheck verify the expected app database instead of relying on the default connection.
- Document the non-destructive repair path for users whose Docker volume was already initialized with the wrong database.

## Why

`yarn dx` uses `.env.example` defaults that point Prisma at `postgresql://postgres:@localhost:5450/calendso`, but `packages/prisma/docker-compose.yml` initialized the local Postgres container with `POSTGRES_DB=cal-saml`. On a fresh volume this leaves `calendso` missing, causing Prisma migrations to fail with `P1001`.

## Validation

- `docker-compose -f packages/prisma/docker-compose.yml config`
- `yarn workspace @calcom/prisma db-deploy`
- `yarn workspace @calcom/prisma db-seed`
- `git diff --check`

Note: local pre-commit failed because the current install is missing `@biomejs/cli-darwin-arm64/biome` while running the app-store CLI build. The commit was created with `--no-verify` after the validation above.
