### PR TITLE
fix: i18n for hardcoded "Please reschedule." prefix in webhook cancellation payload

### DIFF
--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4767,5 +4767,6 @@
   "error_adding_user": "There was an error adding this user.",
   "user_updated_successfully": "User updated successfully.",
   "error_updating_user": "There was an error updating this user.",
+  "please_reschedule": "Please reschedule.",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts
@@ -236,7 +236,9 @@ export const requestRescheduleHandler = async ({ ctx, input, source }: RequestRe
     uid: bookingToReschedule.uid,
     location: bookingToReschedule.location,
     destinationCalendar: bookingToReschedule.destinationCalendar,
-    cancellationReason: `Please reschedule. ${cancellationReason}`, // TODO::Add i18-next for this
+    cancellationReason: [tAttendees("please_reschedule"), cancellationReason]
+    .filter(Boolean)
+    .join(" "),
     iCalUID: bookingToReschedule.iCalUID,
     ...(bookingToReschedule.smsReminderNumber && {
       smsReminderNumber: bookingToReschedule.smsReminderNumber,


### PR DESCRIPTION
## What does this PR do?

This PR replaces the hardcoded English string `"Please reschedule."` in the `requestRescheduleHandler` webhook payload with an i18next translation key.

The cancellation reason is attendee facing. Hardcoding it in english meant non english attendees would always receive a partially untranslated message.

#### Video Demo (if applicable):

[Screencast from 2026-04-21 19-45-38.webm](https://github.com/user-attachments/assets/09bc453b-1fc6-4676-821d-9b5b8dc58221)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
