### PR TITLE
cleanup(team-org): remove e2e tests for removed team/org paths

### DIFF
--- a/apps/web/playwright/app-router-not-found.e2e.ts
+++ b/apps/web/playwright/app-router-not-found.e2e.ts
@@ -1,5 +1,4 @@
 import { expectPageToBeNotFound } from "playwright/lib/testUtils";
-
 import { test } from "./lib/fixtures";
 
 test.describe.configure({ mode: "parallel" });
@@ -11,8 +10,6 @@ test.describe("App Router - error handling", () => {
     page,
   }) => {
     await expectPageToBeNotFound({ page, url: "/123491234" });
-    await expectPageToBeNotFound({ page, url: "/team/123491234" });
-    await expectPageToBeNotFound({ page, url: "/org/123491234" });
     await expectPageToBeNotFound({ page, url: "/insights/123491234" });
     await expectPageToBeNotFound({ page, url: "/login/123491234" });
   });

--- a/apps/web/playwright/lib/testUtils.ts
+++ b/apps/web/playwright/lib/testUtils.ts
@@ -586,50 +586,6 @@ export async function confirmBooking(page: Page, url = "/api/book/event") {
   });
 }
 
-export async function bookTeamEvent({
-  page,
-  team,
-  event,
-  teamMatesObj,
-  opts,
-}: {
-  page: Page;
-  team: {
-    slug: string | null;
-    name: string | null;
-  };
-  event: { slug: string; title: string; schedulingType: SchedulingType | null };
-  teamMatesObj?: { name: string }[];
-  opts?: { attendeePhoneNumber?: string };
-}) {
-  // Note that even though the default way to access a team booking in an organization is to not use /team in the URL, but it isn't testable with playwright as the rewrite is taken care of by Next.js config which can't handle on the fly org slug's handling
-  // So, we are using /team in the URL to access the team booking
-  // There are separate tests to verify that the next.config.js rewrites are working
-  // Also there are additional checkly tests that verify absolute e2e flow. They are in __checks__/organization.spec.ts
-  await page.goto(`/team/${team.slug}/${event.slug}`);
-
-  await selectFirstAvailableTimeSlotNextMonth(page);
-  await bookTimeSlot(page, opts);
-  await expect(page.getByTestId("success-page")).toBeVisible();
-
-  // The title of the booking
-  if (event.schedulingType === SchedulingType.ROUND_ROBIN && teamMatesObj) {
-    const bookingTitle = await page.getByTestId("booking-title").textContent();
-
-    const isMatch = teamMatesObj?.some((teamMate) => {
-      const expectedTitle = `${event.title} between ${teamMate.name} and ${testName}`;
-      return expectedTitle.trim() === bookingTitle?.trim();
-    });
-
-    expect(isMatch).toBe(true);
-  } else {
-    const BookingTitle = `${event.title} between ${team.name} and ${testName}`;
-    await expect(page.getByTestId("booking-title")).toHaveText(BookingTitle);
-  }
-  // The booker should be in the attendee list
-  await expect(page.getByTestId(`attendee-name-${testName}`)).toHaveText(testName);
-}
-
 export async function expectPageToBeNotFound({ page, url }: { page: Page; url: string }) {
   await page.goto(`${url}`);
   await expect(page.getByTestId(`404-page`)).toBeVisible();


### PR DESCRIPTION
Removes E2E coverage that still hardcoded removed `/team` and `/org` page paths, plus the unused Playwright helper that depended on `/team/...` routes.

Pure cleanup; no behavior change.