### PR TITLE
feat(bookings): add conditional question support via showCondition

### DIFF
--- a/apps/web/modules/form-builder/components/FormBuilderField.tsx
+++ b/apps/web/modules/form-builder/components/FormBuilderField.tsx
@@ -1,24 +1,23 @@
-import { ErrorMessage } from "@hookform/error-message";
-import type { TFunction } from "i18next";
-import { Controller, useFormContext } from "react-hook-form";
-import type { z } from "zod";
-
+import { fieldsThatSupportLabelAsSafeHtml } from "@calcom/features/form-builder/fieldsThatSupportLabelAsSafeHtml";
+import { fieldTypesConfigMap } from "@calcom/features/form-builder/fieldTypes";
+import type { fieldsSchema } from "@calcom/features/form-builder/schema";
+import {
+  getFieldNameFromErrorMessage,
+  useShouldBeDisabledDueToPrefill,
+} from "@calcom/features/form-builder/useShouldBeDisabledDueToPrefill";
+import { isFieldShownByCondition } from "@calcom/features/form-builder/utils/showCondition";
+import { getTranslatedConfig as getTranslatedVariantsConfig } from "@calcom/features/form-builder/utils/variantsConfig";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import classNames from "@calcom/ui/classNames";
 import { InfoBadge } from "@calcom/ui/components/badge";
 import { Label } from "@calcom/ui/components/form";
 import { InfoIcon } from "@coss/ui/icons";
-
+import { ErrorMessage } from "@hookform/error-message";
+import type { TFunction } from "i18next";
+import { Controller, useFormContext, useWatch } from "react-hook-form";
+import type { z } from "zod";
 import { Components, isValidValueProp } from "./Components";
-import { fieldTypesConfigMap } from "@calcom/features/form-builder/fieldTypes";
-import { fieldsThatSupportLabelAsSafeHtml } from "@calcom/features/form-builder/fieldsThatSupportLabelAsSafeHtml";
-import type { fieldsSchema } from "@calcom/features/form-builder/schema";
-import {
-  useShouldBeDisabledDueToPrefill,
-  getFieldNameFromErrorMessage,
-} from "@calcom/features/form-builder/useShouldBeDisabledDueToPrefill";
-import { getTranslatedConfig as getTranslatedVariantsConfig } from "@calcom/features/form-builder/utils/variantsConfig";
 
 // helper to render markdown label safely
 const renderLabel = (field: Partial<RhfFormField>) => {
@@ -74,10 +73,26 @@ export const FormBuilderField = ({
   const { t } = useLocale();
   const { control, formState } = useFormContext();
 
-  const { hidden, placeholder, label, noLabel, translatedDefaultLabel } = getAndUpdateNormalizedValues(
-    field,
-    t
-  );
+  const {
+    hidden: staticHidden,
+    placeholder,
+    label,
+    noLabel,
+    translatedDefaultLabel,
+  } = getAndUpdateNormalizedValues(field, t);
+
+  // A field with a `showCondition` (#11900) is hidden unless the referenced
+  // parent response matches. Watching only the parent field keeps re-renders
+  // targeted instead of subscribing to the entire responses object.
+  const parentResponse = useWatch({
+    control,
+    name: field.showCondition ? `responses.${field.showCondition.fieldName}` : "__showCondition_noop__",
+  });
+  const hidden =
+    staticHidden ||
+    (field.showCondition
+      ? !isFieldShownByCondition(field, { [field.showCondition.fieldName]: parentResponse })
+      : false);
 
   const shouldBeDisabled = useShouldBeDisabledDueToPrefill(field);
   return (

--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -2520,4 +2520,75 @@ describe("getBookingResponsesPartialSchema - Prefill validation", () => {
 
     expect(parsedResponses.success).toBe(true);
   });
+
+  describe("showCondition (conditional questions, #11900)", () => {
+    const bookingFieldsWithConditional = [
+      { name: "name", type: "name", required: true },
+      { name: "email", type: "email", required: true },
+      {
+        name: "hearAbout",
+        type: "select",
+        required: true,
+        options: [
+          { label: "Web", value: "web" },
+          { label: "Social media", value: "social" },
+          { label: "Print", value: "print" },
+        ],
+      },
+      {
+        name: "sourceWebsite",
+        type: "text",
+        required: true,
+        showCondition: { fieldName: "hearAbout", op: "equals", value: "web" },
+      },
+    ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">;
+
+    test("skips required validation when the parent response does not match", async () => {
+      const schema = getBookingResponsesSchema({
+        bookingFields: bookingFieldsWithConditional,
+        view: "ALL_VIEWS",
+      });
+      const parsedResponses = await schema.safeParseAsync({
+        name: "Test",
+        email: "test@test.com",
+        hearAbout: "print",
+      });
+      expect(parsedResponses.success).toBe(true);
+    });
+
+    test("enforces required validation when the parent response matches", async () => {
+      const schema = getBookingResponsesSchema({
+        bookingFields: bookingFieldsWithConditional,
+        view: "ALL_VIEWS",
+      });
+      const parsedResponses = await schema.safeParseAsync({
+        name: "Test",
+        email: "test@test.com",
+        hearAbout: "web",
+      });
+      expect(parsedResponses.success).toBe(false);
+      if (!parsedResponses.success) {
+        expect(parsedResponses.error.issues[0]).toEqual(
+          expect.objectContaining({
+            code: "custom",
+            message: `{sourceWebsite}${CUSTOM_REQUIRED_FIELD_ERROR_MSG}`,
+          })
+        );
+      }
+    });
+
+    test("accepts the conditional value when its trigger is active", async () => {
+      const schema = getBookingResponsesSchema({
+        bookingFields: bookingFieldsWithConditional,
+        view: "ALL_VIEWS",
+      });
+      const parsedResponses = await schema.safeParseAsync({
+        name: "Test",
+        email: "test@test.com",
+        hearAbout: "web",
+        sourceWebsite: "https://example.com",
+      });
+      expect(parsedResponses.success).toBe(true);
+    });
+  });
 });

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -1,5 +1,6 @@
 import type { ALL_VIEWS } from "@calcom/features/form-builder/schema";
 import { type FieldZodCtx, fieldTypesSchemaMap } from "@calcom/features/form-builder/schema";
+import { isFieldShownByCondition } from "@calcom/features/form-builder/utils/showCondition";
 import { dbReadResponseSchema } from "@calcom/lib/dbReadResponseSchema";
 import logger from "@calcom/lib/logger";
 import type { eventTypeBookingFields } from "@calcom/prisma/zod-utils";
@@ -457,6 +458,12 @@ function preprocess<T extends z.ZodType>({
         const numOptions = bookingField.options?.length ?? 0;
         if (bookingField.hideWhenJustOneOption) {
           hidden = hidden || numOptions <= 1;
+        }
+        // A field gated by a `showCondition` is only validated when its parent
+        // response matches the rule. Otherwise we treat it as hidden so required
+        // conditional questions don't block submission when they aren't shown.
+        if (!isFieldShownByCondition(bookingField, responses as Record<string, unknown>)) {
+          hidden = true;
         }
         let isRequired = false;
         // If the field is hidden, then it can never be required

--- a/packages/features/form-builder/utils/showCondition.test.ts
+++ b/packages/features/form-builder/utils/showCondition.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { isFieldShownByCondition } from "./showCondition";
+
+describe("isFieldShownByCondition", () => {
+  it("returns true when the field has no showCondition", () => {
+    expect(isFieldShownByCondition({ showCondition: undefined }, {})).toBe(true);
+  });
+
+  describe("op: equals", () => {
+    const field = {
+      showCondition: { fieldName: "hearAbout", op: "equals" as const, value: "web" },
+    };
+
+    it("shows when parent response equals configured value", () => {
+      expect(isFieldShownByCondition(field, { hearAbout: "web" })).toBe(true);
+    });
+
+    it("hides when parent response differs", () => {
+      expect(isFieldShownByCondition(field, { hearAbout: "print" })).toBe(false);
+    });
+
+    it("hides when parent response is missing", () => {
+      expect(isFieldShownByCondition(field, {})).toBe(false);
+    });
+
+    it("hides when responses object is null", () => {
+      expect(isFieldShownByCondition(field, null)).toBe(false);
+    });
+
+    it("supports an array of allowed values", () => {
+      const multi = {
+        showCondition: { fieldName: "hearAbout", op: "equals" as const, value: ["web", "social"] },
+      };
+      expect(isFieldShownByCondition(multi, { hearAbout: "social" })).toBe(true);
+      expect(isFieldShownByCondition(multi, { hearAbout: "print" })).toBe(false);
+    });
+
+    it("coerces numeric responses to strings", () => {
+      const numeric = {
+        showCondition: { fieldName: "count", op: "equals" as const, value: "3" },
+      };
+      expect(isFieldShownByCondition(numeric, { count: 3 })).toBe(true);
+    });
+
+    it("reads the selected option from a radioInput-shaped response", () => {
+      expect(
+        isFieldShownByCondition(field, { hearAbout: { value: "web", optionValue: "example.com" } })
+      ).toBe(true);
+    });
+  });
+
+  describe("op: notEquals", () => {
+    const field = {
+      showCondition: { fieldName: "hearAbout", op: "notEquals" as const, value: "web" },
+    };
+
+    it("shows when parent response differs", () => {
+      expect(isFieldShownByCondition(field, { hearAbout: "print" })).toBe(true);
+    });
+
+    it("hides when parent response matches", () => {
+      expect(isFieldShownByCondition(field, { hearAbout: "web" })).toBe(false);
+    });
+
+    it("shows when parent response is missing", () => {
+      expect(isFieldShownByCondition(field, {})).toBe(true);
+    });
+  });
+
+  describe("op: includes", () => {
+    const field = {
+      showCondition: { fieldName: "topics", op: "includes" as const, value: "billing" },
+    };
+
+    it("shows when response array contains the value", () => {
+      expect(isFieldShownByCondition(field, { topics: ["billing", "support"] })).toBe(true);
+    });
+
+    it("hides when response array does not contain the value", () => {
+      expect(isFieldShownByCondition(field, { topics: ["support"] })).toBe(false);
+    });
+
+    it("treats a single string response as a single-item array", () => {
+      expect(isFieldShownByCondition(field, { topics: "billing" })).toBe(true);
+    });
+
+    it("matches when any configured value is present in the response", () => {
+      const any = {
+        showCondition: { fieldName: "topics", op: "includes" as const, value: ["billing", "sales"] },
+      };
+      expect(isFieldShownByCondition(any, { topics: ["support", "sales"] })).toBe(true);
+    });
+  });
+
+  describe("op: notIncludes", () => {
+    const field = {
+      showCondition: { fieldName: "topics", op: "notIncludes" as const, value: "billing" },
+    };
+
+    it("shows when response array lacks the value", () => {
+      expect(isFieldShownByCondition(field, { topics: ["support"] })).toBe(true);
+    });
+
+    it("hides when response array contains the value", () => {
+      expect(isFieldShownByCondition(field, { topics: ["billing"] })).toBe(false);
+    });
+  });
+});

--- a/packages/features/form-builder/utils/showCondition.ts
+++ b/packages/features/form-builder/utils/showCondition.ts
@@ -1,0 +1,73 @@
+import type { fieldSchema, showConditionSchema } from "@calcom/prisma/zod-utils";
+import type { z } from "zod";
+
+type ShowCondition = z.infer<typeof showConditionSchema>;
+type BookingField = z.infer<typeof fieldSchema>;
+
+/**
+ * Normalizes a response value to a flat array of string comparables. We treat
+ * everything as strings to stay ORM-agnostic and avoid surprising coercions
+ * between number/string responses across the booker form and server schema.
+ *
+ * Conditional questions (#11900) compare a parent response against one or more
+ * configured values; supporting arrays makes checkbox/multiselect parents work
+ * the same as scalar parents without branching at the call site.
+ */
+function normalizeResponse(value: unknown): string[] {
+  if (value === null || value === undefined) return [];
+  if (Array.isArray(value)) {
+    return value.map((v) => (v === null || v === undefined ? "" : String(v))).filter((v) => v !== "");
+  }
+  if (typeof value === "object") {
+    // radioInput-style responses store `{ value, optionValue }`. The option key is
+    // what the user picked so that's the sensible comparable for conditions.
+    const maybeValue = (value as { value?: unknown }).value;
+    if (maybeValue !== undefined) return normalizeResponse(maybeValue);
+    return [];
+  }
+  const stringified = String(value);
+  return stringified === "" ? [] : [stringified];
+}
+
+function toValueArray(value: ShowCondition["value"]): string[] {
+  return Array.isArray(value) ? value.slice() : [value];
+}
+
+/**
+ * Evaluates whether a field should be shown given the current form responses.
+ *
+ * A field without `showCondition` is always considered shown (returns `true`).
+ * For fields with a `showCondition`, the parent response is normalized to a
+ * string array and compared against the rule's configured value(s):
+ *
+ * - equals / notEquals: any single response value matches any configured value
+ * - includes / notIncludes: the response array contains any configured value
+ *
+ * When the referenced parent field is missing or empty, `equals`/`includes`
+ * evaluate to false (hide), while `notEquals`/`notIncludes` evaluate to true
+ * (show). This matches common form-builder UX expectations.
+ */
+export function isFieldShownByCondition(
+  field: Pick<BookingField, "showCondition">,
+  responses: Record<string, unknown> | undefined | null
+): boolean {
+  const condition = field.showCondition;
+  if (!condition) return true;
+
+  const responseValues = normalizeResponse(responses?.[condition.fieldName]);
+  const expectedValues = toValueArray(condition.value);
+
+  switch (condition.op) {
+    case "equals":
+      return responseValues.some((r) => expectedValues.includes(r));
+    case "notEquals":
+      if (responseValues.length === 0) return true;
+      return !responseValues.some((r) => expectedValues.includes(r));
+    case "includes":
+      return expectedValues.some((v) => responseValues.includes(v));
+    case "notIncludes":
+      return !expectedValues.some((v) => responseValues.includes(v));
+    default:
+      return true;
+  }
+}

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -1051,6 +1051,24 @@ export const variantsConfigSchema = z.object({
   ),
 });
 
+/**
+ * Schema for a conditional visibility rule. A field with a `showCondition` is only
+ * rendered and validated when the referenced parent field's response matches.
+ *
+ * `op` semantics:
+ * - "equals": parent response is a string strictly equal to `value` (string form)
+ * - "notEquals": parent response is not equal to `value` (string form)
+ * - "includes": parent response (array, or string compared as single-value array) contains `value`
+ * - "notIncludes": inverse of "includes"
+ *
+ * `value` is coerced to a string array at evaluation time; any match across values satisfies the rule.
+ */
+export const showConditionSchema = z.object({
+  fieldName: z.string().min(1),
+  op: z.enum(["equals", "notEquals", "includes", "notIncludes"]).default("equals"),
+  value: z.union([z.string(), z.array(z.string())]),
+});
+
 export const fieldSchema = baseFieldSchema.merge(
   z.object({
     variant: z.string().optional(),
@@ -1071,6 +1089,12 @@ export const fieldSchema = baseFieldSchema.merge(
     hideWhenJustOneOption: z.boolean().default(false).optional(),
 
     hidden: z.boolean().optional(),
+    /**
+     * Optional conditional visibility rule. When set, the field is only shown
+     * and validated when the referenced parent field's response matches.
+     * See #11900.
+     */
+    showCondition: showConditionSchema.optional(),
     editable: EditableSchema.default("user").optional(),
     sources: z
       .array(


### PR DESCRIPTION
## Summary

Adds the schema and runtime plumbing for **conditionally visible booking fields**, addressing #11900 ("Conditional Questions on Event Types").

A booking field may now declare an optional `showCondition`:

```ts
{
  name: "sourceWebsite",
  type: "text",
  required: true,
  showCondition: { fieldName: "hearAbout", op: "equals", value: "web" },
}
```

- `fieldName` references the parent booking field by name.
- `op` is one of `equals`, `notEquals`, `includes`, `notIncludes`.
- `value` is a string or array of strings. Any match satisfies the rule.

When the parent response does not match, the field is hidden in the Booker form and **skipped during response validation**, so a conditional required field no longer blocks submission when it is not shown. Radio/multiselect/checkbox parents, `radioInput`-shaped responses, and numeric responses are all handled by the normalizer.

## Scope

This PR intentionally delivers a **vertical slice**:

1. Schema: extend the existing `bookingFields` zod schema (`fieldSchema`) with `showCondition` — additive and non-breaking.
2. Evaluation engine: `isFieldShownByCondition(field, responses)` in `packages/features/form-builder/utils/showCondition.ts`.
3. Server-side validation: `getBookingResponsesSchema` treats conditionally-hidden fields as hidden so required rules are not enforced.
4. Client-side rendering: `FormBuilderField` uses `useWatch` on the referenced parent response and toggles the existing `hidden` styling.
5. Tests: 17 unit tests for the evaluator + 3 integration tests for the response schema.

**Out of scope (tracked separately, follow-up PRs):**
- Event-type editor UI for configuring rules visually. Rules can be authored via the existing `bookingFields` JSON/API today.
- Persisting and rendering rules on the Routing Forms / Insights surfaces.
- Any database migration — `bookingFields` is already stored as JSON.

Splitting this way keeps the change under the 500-line / 10-file guideline in `CLAUDE.md` and keeps the surface area reviewable. The editor UI depends on the schema landing first.

## Test plan

- [x] `yarn vitest run packages/features/form-builder/utils/showCondition.test.ts` — 17/17 passing (evaluator)
- [x] `yarn vitest run packages/features/bookings/lib/getBookingResponsesSchema.test.ts` — 72/72 passing (3 new, 69 existing unaffected)
- [x] `yarn vitest run apps/web/modules/form-builder/components/FormBuilderField.test.tsx` — 1/1 passing
- [x] `yarn biome check --write` on touched files — clean (pre-existing warnings only, not introduced by this PR)
- [x] Manually scanned `tsc --noEmit` output for `apps/web` and `packages/features` — no new type errors in touched files

## Files changed (6)

- `packages/prisma/zod-utils.ts` — adds `showConditionSchema` and `showCondition` to `fieldSchema`.
- `packages/features/form-builder/utils/showCondition.ts` — new evaluator.
- `packages/features/form-builder/utils/showCondition.test.ts` — new unit tests.
- `packages/features/bookings/lib/getBookingResponsesSchema.ts` — hides conditional fields from validation when parent response does not match.
- `packages/features/bookings/lib/getBookingResponsesSchema.test.ts` — integration tests for validation gating.
- `apps/web/modules/form-builder/components/FormBuilderField.tsx` — watches parent response and toggles `hidden`.

Refs #11900