### PR TITLE
fix: race condition in CalendarService update using shared mutable variable

### DIFF
--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -541,45 +541,41 @@ export default abstract class BaseCalendarService implements Calendar {
         ? injectVTimezone(iCalString, updateTimezone, event.startTime, event.endTime)
         : "";
 
-      let calendarEvent: CalendarEventType;
       const eventsToUpdate = events.filter((e) => e.uid === uid);
       return Promise.all(
-        eventsToUpdate.map((eventItem) => {
-          calendarEvent = eventItem;
-          return updateCalendarObject({
+        eventsToUpdate.map((eventItem) =>
+          updateCalendarObject({
             calendarObject: {
-              url: calendarEvent.url,
+              url: eventItem.url,
               data: injectScheduleAgent(iCalStringWithTimezone ?? ""),
-              etag: calendarEvent?.etag,
+              etag: eventItem?.etag,
             },
             headers: this.headers,
-          });
-        })
-      ).then((responses) =>
-        responses.map((response) => {
-          if (response.status >= 200 && response.status < 300) {
-            return {
-              uid,
-              type: this.credentials.type,
-              id: typeof calendarEvent.uid === "string" ? calendarEvent.uid : "-1",
-              password: "",
-              url: calendarEvent.url,
-              additionalInfo:
-                typeof event.additionalInformation === "string" ? event.additionalInformation : {},
-            };
-          } else {
-            this.log.error("Error: Status Code", response.status);
-            return {
-              uid,
-              type: event.type,
-              id: typeof event.uid === "string" ? event.uid : "-1",
-              password: "",
-              url: typeof event.location === "string" ? event.location : "-1",
-              additionalInfo:
-                typeof event.additionalInformation === "string" ? event.additionalInformation : {},
-            };
-          }
-        })
+          }).then((response) => {
+            if (response.status >= 200 && response.status < 300) {
+              return {
+                uid,
+                type: this.credentials.type,
+                id: typeof eventItem.uid === "string" ? eventItem.uid : "-1",
+                password: "",
+                url: eventItem.url,
+                additionalInfo:
+                  typeof event.additionalInformation === "string" ? event.additionalInformation : {},
+              };
+            } else {
+              this.log.error("Error: Status Code", response.status);
+              return {
+                uid,
+                type: event.type,
+                id: typeof event.uid === "string" ? event.uid : "-1",
+                password: "",
+                url: typeof event.location === "string" ? event.location : "-1",
+                additionalInfo:
+                  typeof event.additionalInformation === "string" ? event.additionalInformation : {},
+              };
+            }
+          })
+        )
       );
     } catch (reason) {
       this.log.error(reason);


### PR DESCRIPTION
## Summary
- Fixed a race condition in `packages/lib/CalendarService.ts` where a shared mutable `calendarEvent` variable was used across `Promise.all` iterations
- When multiple events share the same UID, all resolved promises would reference the **last** event's data instead of their own, causing incorrect `uid`, `url`, and `etag` values in the response
- Removed the shared variable and restructured the code so each promise correctly pairs its event with its response via closure

## Bug Details

**Before (buggy):**
```typescript
let calendarEvent: CalendarEventType;  // shared mutable variable
return Promise.all(
  eventsToUpdate.map((eventItem) => {
    calendarEvent = eventItem;  // overwritten on each iteration
    return updateCalendarObject({...});
  })
).then((responses) =>
  responses.map((response) => {
    // BUG: calendarEvent always points to LAST item
    url: calendarEvent.url,
    id: calendarEvent.uid,
  })
);
```

**After (fixed):**
Each promise now resolves with its own correctly-scoped `eventItem` data.

## Test plan
- [ ] Verify calendar event updates work correctly when multiple events share the same UID
- [ ] Verify that each response reflects the correct event's URL and UID, not just the last one

🤖 Generated with [Claude Code](https://claude.com/claude-code)