### PR TITLE
fix(security): run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,10 @@ ENV NEXT_PUBLIC_WEBAPP_URL=$NEXT_PUBLIC_WEBAPP_URL \
   BUILT_NEXT_PUBLIC_WEBAPP_URL=$NEXT_PUBLIC_WEBAPP_URL
 
 ENV NODE_ENV=production
+
+RUN chown -R node:node /calcom
+USER node
+
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=30s --retries=5 \


### PR DESCRIPTION
## Summary
- The Docker `runner` stage previously ran as root, which is a container security anti-pattern
- Added `chown -R node:node /calcom` to set proper file ownership, then `USER node` to drop privileges before the app starts
- The `node` user is built into the official `node:20` Docker image

## Why this matters
Running containers as root means that if an attacker escapes the container, they have root access on the host. Using a non-root user limits the blast radius of container escape vulnerabilities.

## Test plan
- [ ] Build the Docker image and verify the container starts correctly
- [ ] Verify `docker exec <container> whoami` returns `node` instead of `root`
- [ ] Verify the health check and start script still work with non-root permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)