### PR TITLE
fix: use strict equality in webhook delete handler role check

### DIFF
--- a/packages/trpc/server/routers/viewer/webhook/delete.handler.ts
+++ b/packages/trpc/server/routers/viewer/webhook/delete.handler.ts
@@ -20,7 +20,7 @@ export const deleteHandler = async ({ ctx, input }: DeleteOptions) => {
   if (Array.isArray(where.AND)) {
     if (input.eventTypeId) {
       where.AND.push({ eventTypeId: input.eventTypeId });
-    } else if (ctx.user.role == "ADMIN") {
+    } else if (ctx.user.role === "ADMIN") {
       where.AND.push({ OR: [{ platform: true }, { userId: ctx.user.id }] });
     } else {
       where.AND.push({ userId: ctx.user.id });


### PR DESCRIPTION
## Summary
- Replaced `==` with `===` for the `ADMIN` role comparison in the webhook delete handler
- Using loose equality can lead to unexpected type coercion behavior (e.g., `0 == "0"` is true)

## Test plan
- [ ] Verify webhook deletion still works for ADMIN users
- [ ] Verify non-ADMIN users are still restricted to their own webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)