### PR TITLE
fix(security): use timing-safe comparison for CSRF token validation

### DIFF
--- a/apps/web/lib/validateCsrfToken.ts
+++ b/apps/web/lib/validateCsrfToken.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
@@ -5,9 +6,15 @@ export async function validateCsrfToken(csrfToken: string): Promise<NextResponse
   const cookieStore = await cookies();
   const cookieToken = cookieStore.get("calcom.csrf_token")?.value;
 
-  if (!cookieToken || cookieToken !== csrfToken) {
+  if (!cookieToken || cookieToken.length !== csrfToken.length) {
     return NextResponse.json({ success: false, message: "Invalid CSRF token" }, { status: 403 });
   }
+
+  const isValid = timingSafeEqual(Buffer.from(cookieToken), Buffer.from(csrfToken));
+  if (!isValid) {
+    return NextResponse.json({ success: false, message: "Invalid CSRF token" }, { status: 403 });
+  }
+
   cookieStore.delete("calcom.csrf_token");
   return null;
 }


### PR DESCRIPTION
## Summary
- CSRF token validation in `apps/web/lib/validateCsrfToken.ts` used direct string comparison (`!==`) which is vulnerable to timing side-channel attacks
- Replaced with `crypto.timingSafeEqual` which performs constant-time comparison
- This follows the same pattern already used in the codebase (see `apps/api/v2/src/vercel-webhook.guard.ts`)

## Why this matters
With direct string comparison (`!==`), the comparison short-circuits at the first differing byte. An attacker who can measure response times precisely could gradually determine the CSRF token character by character. `timingSafeEqual` ensures the comparison always takes the same amount of time regardless of where the strings differ.

## Test plan
- [ ] Verify CSRF-protected endpoints still work correctly (login, signup, forms)
- [ ] Verify that invalid CSRF tokens are still rejected with 403
- [ ] Verify that tokens of different lengths are rejected (timingSafeEqual requires equal-length buffers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)