### PR TITLE
fix: broken Northflank deploy button image

### DIFF
--- a/apps/docs/content/deployments/northflank.mdx
+++ b/apps/docs/content/deployments/northflank.mdx
@@ -6,4 +6,4 @@ The team at Northflank also have a [detailed blog post](https://northflank.com/g
 
 ## One Click Deployment
 
-[![Deploy on Northflank](https://northflank.com/button.svg)](https://app.northflank.com/s/account/stack-templates/deploy-calcom)
+[![Deploy on Northflank](https://assets.northflank.com/deploy_to_northflank_smm_36700fb050.svg)](https://app.northflank.com/s/account/stack-templates/deploy-calcom)


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Note: Cal.diy is a community-maintained open-source project. Contributions here do NOT flow to Cal.com's production service. -->

- Fixes a broken Northflank deploy button image in the documentation, ensuring the button renders correctly.

## Visual Demo (For contributors especially)

<img width="942" height="460" alt="image" src="https://github.com/user-attachments/assets/af036cd8-0a64-4590-9b7e-5565cd1d4e48" /> 
<img width="942" height="314" alt="image" src="https://github.com/user-attachments/assets/16d8e340-d18b-4360-9aa2-3ba084dec32a" />


## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Open the Northflank documentation page where the deploy button is used
- Confirm the image loads correctly and is visible
- Verify the button behaves as expected (links correctly, no broken asset)
