### PR TITLE
fix: push Docker images to calcom/cal.com instead of calcom/cal.diy

### DIFF
--- a/.github/actions/docker-build-and-test/action.yml
+++ b/.github/actions/docker-build-and-test/action.yml
@@ -62,7 +62,7 @@ runs:
       with:
         images: |
           docker.io/calendso/calendso
-          docker.io/calcom/cal.diy
+          docker.io/calcom/cal.com
           ghcr.io/calcom/cal.diy
         flavor: |
           latest=${{ !github.event.release.prerelease && inputs.use-as-latest == 'true' }}


### PR DESCRIPTION
## Summary

- Changes the DockerHub target repository in the release Docker workflow from `calcom/cal.diy` to `calcom/cal.com`
- The `calcom/cal.com` repository has millions of downloads and is the preferred destination per @PeerRichelsen
- GHCR target (`ghcr.io/calcom/cal.diy`) is unchanged

## Test plan

- [ ] Verify next Docker release pushes to `calcom/cal.com` on DockerHub