### PR TITLE
Add Aspire TypeScript AppHost

### DIFF
--- a/apphost.ts
+++ b/apphost.ts
@@ -1,0 +1,105 @@
+// Aspire TypeScript AppHost
+// For more information, see: https://aspire.dev
+
+import { ContainerLifetime, createBuilder, refExpr } from './.modules/aspire.js';
+
+async function main() {
+    const builder = await createBuilder();
+
+    const nextAuthSecret = await builder.addParameterWithGeneratedValue('nextauth-secret', {
+        minLength: 43,
+        lower: true,
+        upper: true,
+        numeric: true,
+        special: true,
+        minLower: 1,
+        minUpper: 1,
+        minNumeric: 1,
+        minSpecial: 1,
+    }, { secret: true, persist: true });
+
+    const cronApiKey = await builder.addParameterWithGeneratedValue('cron-api-key', {
+        minLength: 32,
+        lower: true,
+        upper: true,
+        numeric: true,
+        minLower: 1,
+        minUpper: 1,
+        minNumeric: 1,
+    }, { secret: true, persist: true });
+
+    const calendsoEncryptionKey = await builder.addParameterWithGeneratedValue('calendso-encryption-key', {
+        minLength: 32,
+        lower: true,
+        upper: true,
+        numeric: true,
+        minLower: 1,
+        minUpper: 1,
+        minNumeric: 1,
+    }, { secret: true, persist: true });
+
+    const postgres = await builder
+        .addPostgres('postgres')
+        .withLifetime(ContainerLifetime.Persistent)
+        .withDataVolume({ name: 'calcom-postgres-data' });
+
+    const calcomDb = await postgres.addDatabase('calendso');
+    const calcomDbUrl = await calcomDb.uriExpression.get();
+
+    const dbDeploy = await builder
+        .addExecutable('calcom-db-deploy', 'yarn', '.', ['workspace', '@calcom/prisma', 'db-deploy'])
+        .withEnvironment('DATABASE_URL', calcomDbUrl)
+        .withEnvironment('DATABASE_DIRECT_URL', calcomDbUrl)
+        .waitFor(calcomDb);
+
+    const dbSeed = await builder
+        .addExecutable('calcom-db-seed', 'yarn', '.', ['workspace', '@calcom/prisma', 'db-seed'])
+        .withEnvironment('DATABASE_URL', calcomDbUrl)
+        .withEnvironment('DATABASE_DIRECT_URL', calcomDbUrl)
+        .withEnvironmentParameter('NEXTAUTH_SECRET', nextAuthSecret)
+        .withEnvironmentParameter('CRON_API_KEY', cronApiKey)
+        .withEnvironmentParameter('CALENDSO_ENCRYPTION_KEY', calendsoEncryptionKey)
+        .waitForCompletion(dbDeploy);
+
+    const calcom = await builder
+        .addJavaScriptApp('calcom', '.', { runScriptName: 'dev' })
+        .withYarn({ install: false })
+        .withEnvironment('NODE_OPTIONS', '--max-old-space-size=8192')
+        .withEnvironment('DATABASE_URL', calcomDbUrl)
+        .withEnvironment('DATABASE_DIRECT_URL', calcomDbUrl)
+        .withEnvironmentParameter('NEXTAUTH_SECRET', nextAuthSecret)
+        .withEnvironmentParameter('CRON_API_KEY', cronApiKey)
+        .withEnvironmentParameter('CALENDSO_ENCRYPTION_KEY', calendsoEncryptionKey)
+        .withHttpEndpoint({ env: 'PORT' })
+        .withExternalHttpEndpoints()
+        .waitFor(calcomDb)
+        .waitForCompletion(dbSeed);
+
+    const calcomHttp = await calcom.getEndpoint('http');
+
+    await dbSeed
+        .withEnvironment('NEXT_PUBLIC_WEBAPP_URL', refExpr`${calcomHttp}`)
+        .withEnvironment('NEXTAUTH_URL', refExpr`${calcomHttp}`);
+
+    await calcom
+        .withEnvironment('NEXT_PUBLIC_WEBAPP_URL', refExpr`${calcomHttp}`)
+        .withEnvironment('NEXT_PUBLIC_WEBSITE_URL', refExpr`${calcomHttp}`)
+        .withEnvironment('NEXT_PUBLIC_EMBED_LIB_URL', refExpr`${calcomHttp}/embed/embed.js`)
+        .withEnvironment('NEXTAUTH_URL', refExpr`${calcomHttp}`)
+        .withEnvironmentCallback(async (ctx) => {
+            const host = await calcomHttp.host.get();
+            const port = await calcomHttp.port.get();
+
+            await ctx.environmentVariables.set(
+                'ALLOWED_HOSTNAMES',
+                `"${host}:${port}","localhost:${port}","127.0.0.1:${port}"`,
+            );
+        });
+
+    await builder.build().run();
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/aspire-apphost-status.md
+++ b/aspire-apphost-status.md
@@ -1,0 +1,55 @@
+# Aspire TypeScript AppHost status
+
+This repository now includes a TypeScript Aspire AppHost for running Cal.com from local source instead of a prebuilt app container.
+
+## Files
+
+* `apphost.ts` - Aspire TypeScript AppHost
+* `aspire.config.json` - AppHost language and package configuration
+* `tsconfig.apphost.json` - TypeScript configuration for the AppHost
+
+## Resources created
+
+* `postgres` - Aspire-managed PostgreSQL server with a persistent data volume
+* `calendso` - PostgreSQL database for Cal.com
+* `calcom-db-deploy` - one-shot Prisma migration step
+* `calcom-db-seed` - one-shot seed step
+* `calcom` - source-backed JavaScript app resource running `turbo run dev --filter=@calcom/web`
+
+## What was achieved
+
+* Runs Cal.com from local source with a TypeScript AppHost.
+* Uses Aspire-managed PostgreSQL instead of Cal.com's nested `packages/prisma/docker-compose.yml` database path.
+* Replaces hard-coded runtime secrets with generated Aspire parameters for:
+  * `NEXTAUTH_SECRET`
+  * `CRON_API_KEY`
+  * `CALENDSO_ENCRYPTION_KEY`
+* Replaces hard-coded database and site URLs with Aspire resource expressions and endpoint-derived values.
+* Applies Prisma migrations and runs the seed step successfully.
+* Starts the Next.js development server from source and serves the app on the Aspire endpoint.
+
+## How to run
+
+1. Install the Aspire CLI dev channel on macOS or Linux:
+
+```bash
+curl -sSL https://aspire.dev/install.sh | bash -s -- --quality dev
+```
+
+2. Restore the AppHost dependencies:
+
+```bash
+yarn install
+```
+
+3. Start the AppHost:
+
+```bash
+aspire run
+```
+
+## Remaining limitations
+
+* **Aspire limitation:** the current TypeScript AppHost runtime still preflights with `npm install`, which breaks this Yarn workspace monorepo without a local npm-to-yarn shim.
+* **Cal.com limitation:** Cal.com appears to use Sentry/dev-console telemetry and does not expose native OTLP/OpenTelemetry configuration in this repo, so OTEL export was not wired.
+* **Cal.com warning:** the seed step logs `Error adding google credentials to DB: Unexpected end of JSON input`, but the overall seed still completes.

--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,14 @@
+{
+  "appHost": {
+    "path": "apphost.ts",
+    "language": "typescript/nodejs"
+  },
+  "sdk": {
+    "version": "13.3.0-preview.1.26221.2"
+  },
+  "channel": "daily",
+  "packages": {
+    "Aspire.Hosting.JavaScript": "13.3.0-preview.1.26221.2",
+    "Aspire.Hosting.PostgreSQL": "13.3.0-preview.1.26221.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
     "changesets-add": "yarn changeset add",
     "changesets-version": "yarn changeset version",
     "changesets-release": "NODE_OPTIONS='--max_old_space_size=12288' turbo run build-npm --filter=@calcom/atoms && yarn changeset publish",
-    "lint-staged": "lint-staged"
+    "lint-staged": "lint-staged",
+    "aspire:start": "aspire run",
+    "aspire:build": "tsc -p tsconfig.apphost.json"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.10",
@@ -95,6 +97,7 @@
     "@snaplet/copycat": "4.1.0",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "16.0.1",
+    "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "4.0.16",
     "@vitest/ui": "4.0.16",
     "c8": "7.13.0",
@@ -112,6 +115,7 @@
     "prismock": "1.35.3",
     "resize-observer-polyfill": "1.5.1",
     "tsc-absolute": "1.0.0",
+    "tsx": "^4.21.0",
     "turbo": "2.7.1",
     "typescript": "5.9.3",
     "vitest": "4.0.16",
@@ -228,5 +232,8 @@
   "syncpack": {
     "filter": "^(?!@calcom).*",
     "semverRange": ""
+  },
+  "dependencies": {
+    "vscode-jsonrpc": "^8.2.0"
   }
 }

--- a/tsconfig.apphost.json
+++ b/tsconfig.apphost.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist/apphost",
+    "rootDir": "."
+  },
+  "include": ["apphost.ts", ".modules/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4397,6 +4397,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/aix-ppc64@npm:0.27.7"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/android-arm64@npm:0.23.1"
@@ -4407,6 +4414,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/android-arm64@npm:0.25.12"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm64@npm:0.27.7"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -4425,6 +4439,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm@npm:0.27.7"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/android-x64@npm:0.23.1"
@@ -4435,6 +4456,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/android-x64@npm:0.25.12"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-x64@npm:0.27.7"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -4453,6 +4481,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-arm64@npm:0.27.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/darwin-x64@npm:0.23.1"
@@ -4463,6 +4498,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/darwin-x64@npm:0.25.12"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-x64@npm:0.27.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -4481,6 +4523,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.7"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/freebsd-x64@npm:0.23.1"
@@ -4491,6 +4540,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/freebsd-x64@npm:0.25.12"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-x64@npm:0.27.7"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -4509,6 +4565,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm64@npm:0.27.7"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/linux-arm@npm:0.23.1"
@@ -4519,6 +4582,13 @@ __metadata:
 "@esbuild/linux-arm@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-arm@npm:0.25.12"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm@npm:0.27.7"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -4537,6 +4607,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ia32@npm:0.27.7"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/linux-loong64@npm:0.23.1"
@@ -4547,6 +4624,13 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-loong64@npm:0.25.12"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-loong64@npm:0.27.7"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -4565,6 +4649,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-mips64el@npm:0.27.7"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ppc64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/linux-ppc64@npm:0.23.1"
@@ -4575,6 +4666,13 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-ppc64@npm:0.25.12"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ppc64@npm:0.27.7"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -4593,6 +4691,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-riscv64@npm:0.27.7"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/linux-s390x@npm:0.23.1"
@@ -4603,6 +4708,13 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-s390x@npm:0.25.12"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-s390x@npm:0.27.7"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -4621,9 +4733,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-x64@npm:0.27.7"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -4642,6 +4768,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-x64@npm:0.27.7"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-arm64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/openbsd-arm64@npm:0.23.1"
@@ -4652,6 +4785,13 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -4670,9 +4810,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-x64@npm:0.27.7"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openharmony-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -4691,6 +4845,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/sunos-x64@npm:0.27.7"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/win32-arm64@npm:0.23.1"
@@ -4701,6 +4862,13 @@ __metadata:
 "@esbuild/win32-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/win32-arm64@npm:0.25.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-arm64@npm:0.27.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -4719,6 +4887,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-ia32@npm:0.27.7"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/win32-x64@npm:0.23.1"
@@ -4729,6 +4904,13 @@ __metadata:
 "@esbuild/win32-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/win32-x64@npm:0.25.12"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-x64@npm:0.27.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -19354,6 +19536,7 @@ __metadata:
     "@snaplet/copycat": "npm:4.1.0"
     "@testing-library/jest-dom": "npm:5.17.0"
     "@testing-library/react": "npm:16.0.1"
+    "@types/node": "npm:^22.0.0"
     "@vitest/coverage-v8": "npm:4.0.16"
     "@vitest/ui": "npm:4.0.16"
     c8: "npm:7.13.0"
@@ -19371,11 +19554,13 @@ __metadata:
     prismock: "npm:1.35.3"
     resize-observer-polyfill: "npm:1.5.1"
     tsc-absolute: "npm:1.0.0"
+    tsx: "npm:^4.21.0"
     turbo: "npm:2.7.1"
     typescript: "npm:5.9.3"
     vitest: "npm:4.0.16"
     vitest-fetch-mock: "npm:0.4.5"
     vitest-mock-extended: "npm:3.1.0"
+    vscode-jsonrpc: "npm:^8.2.0"
   languageName: unknown
   linkType: soft
 
@@ -23178,6 +23363,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:~0.27.0":
+  version: 0.27.7
+  resolution: "esbuild@npm:0.27.7"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.27.7"
+    "@esbuild/android-arm": "npm:0.27.7"
+    "@esbuild/android-arm64": "npm:0.27.7"
+    "@esbuild/android-x64": "npm:0.27.7"
+    "@esbuild/darwin-arm64": "npm:0.27.7"
+    "@esbuild/darwin-x64": "npm:0.27.7"
+    "@esbuild/freebsd-arm64": "npm:0.27.7"
+    "@esbuild/freebsd-x64": "npm:0.27.7"
+    "@esbuild/linux-arm": "npm:0.27.7"
+    "@esbuild/linux-arm64": "npm:0.27.7"
+    "@esbuild/linux-ia32": "npm:0.27.7"
+    "@esbuild/linux-loong64": "npm:0.27.7"
+    "@esbuild/linux-mips64el": "npm:0.27.7"
+    "@esbuild/linux-ppc64": "npm:0.27.7"
+    "@esbuild/linux-riscv64": "npm:0.27.7"
+    "@esbuild/linux-s390x": "npm:0.27.7"
+    "@esbuild/linux-x64": "npm:0.27.7"
+    "@esbuild/netbsd-arm64": "npm:0.27.7"
+    "@esbuild/netbsd-x64": "npm:0.27.7"
+    "@esbuild/openbsd-arm64": "npm:0.27.7"
+    "@esbuild/openbsd-x64": "npm:0.27.7"
+    "@esbuild/openharmony-arm64": "npm:0.27.7"
+    "@esbuild/sunos-x64": "npm:0.27.7"
+    "@esbuild/win32-arm64": "npm:0.27.7"
+    "@esbuild/win32-ia32": "npm:0.27.7"
+    "@esbuild/win32-x64": "npm:0.27.7"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10/262b16c4a33cb70e9f054759a7ce420541649315eef7b064172c795021ccce322e56c3f5fd52e8842873f1c23745f3ab62311a24860950bd5406ba77b36b8529
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
@@ -24773,6 +25047,15 @@ __metadata:
     es-errors: "npm:^1.3.0"
     get-intrinsic: "npm:^1.2.6"
   checksum: 10/a353e3a9595a74720b40fb5bae3ba4a4f826e186e83814d93375182384265676f59e49998b9cdfac4a2225ce95a3d32a68f502a2c5619303987f1c183ab80494
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.5":
+  version: 4.14.0
+  resolution: "get-tsconfig@npm:4.14.0"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10/f5626971905ca386c9ddeb302504e8a2301b9c05641803267223ebd50b7c81aaf9324d29cf9f4e4ff3f245632c3392aa83719dc6cb3e98b4e4a1702a27c5cc5d
   languageName: node
   linkType: hard
 
@@ -36191,6 +36474,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10/0763150adf303040c304009231314d1e84c6e5ebfa2d82b7d94e96a6e82bacd1dcc0b58ae257315f3c8adb89a91d8d0f12928241cba2df1680fbe6f60bf99b0e
+  languageName: node
+  linkType: hard
+
 "resolve.exports@npm:^2.0.0":
   version: 2.0.2
   resolution: "resolve.exports@npm:2.0.2"
@@ -39693,6 +39983,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsx@npm:^4.21.0":
+  version: 4.21.0
+  resolution: "tsx@npm:4.21.0"
+  dependencies:
+    esbuild: "npm:~0.27.0"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10/7afedeff855ba98c47dc28b33d7e8e253c4dc1f791938db402d79c174bdf806b897c1a5f91e5b1259c112520c816f826b4c5d98f0bad7e95b02dec66fedb64d2
+  languageName: node
+  linkType: hard
+
 "tunnel-agent@npm:*, tunnel-agent@npm:^0.6.0":
   version: 0.6.0
   resolution: "tunnel-agent@npm:0.6.0"
@@ -41095,6 +41401,13 @@ __metadata:
   version: 8.2.0
   resolution: "vscode-jsonrpc@npm:8.2.0"
   checksum: 10/6d57c3aed591d0bc89d1c226061d265b04de528582bef183f5998cac5de78a736887e5238fe48b9f6a14ec32f05d8fda71599f92862ac5dacc7f26bf7399b532
+  languageName: node
+  linkType: hard
+
+"vscode-jsonrpc@npm:^8.2.0":
+  version: 8.2.1
+  resolution: "vscode-jsonrpc@npm:8.2.1"
+  checksum: 10/5a30c837abc7a1e45aeca69bc95e9679f43808b56b01830c3b1616d7088782babe8d6ae03276640ff2ba704ddf18305cc68926629bfb0fd8bafff195decb3aad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add a TypeScript Aspire AppHost for running Cal.com from local source
- add the supporting AppHost config/package changes needed to build and run it
- document created resources, achievements, and remaining limitations in `aspire-apphost-status.md`

## What works
- Aspire-managed PostgreSQL replaces the nested Cal.com Prisma docker-compose database path
- Prisma migrations and seed complete through one-shot AppHost steps
- Cal.com runs from source and serves through the Aspire endpoint
- runtime secrets and app URLs come from Aspire parameters and endpoint/resource expressions instead of hard-coded literals

## Remaining limitations
- the current Aspire TypeScript AppHost runtime still preflights with `npm install`, so this Yarn workspace monorepo still needs the known local npm-to-yarn workaround
- Cal.com does not appear to expose native OTLP/OpenTelemetry wiring in this repo, so OTEL export was not added

## Included files
- `apphost.ts`
- `aspire.config.json`
- `tsconfig.apphost.json`
- `aspire-apphost-status.md`
- supporting `package.json` and `yarn.lock` updates for the checked-in AppHost
