### PR TITLE
feat: selected event types as removable badges

### DIFF
--- a/apps/web/modules/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/apps/web/modules/ee/workflows/components/WorkflowStepContainer.tsx
@@ -72,7 +72,7 @@ import { CircleHelpIcon, InfoIcon, PhoneIcon } from "@coss/ui/icons";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { showToast } from "@calcom/ui/components/toast";
 import { useHasActiveTeamPlan, useHasPaidPlan } from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
-import { AgentConfigurationSheet }from "./agent-configuration/AgentConfigurationSheet";
+import { AgentConfigurationSheet } from "./agent-configuration/AgentConfigurationSheet";
 import { TestPhoneCallDialog } from "./TestPhoneCallDialog";
 import { TimeTimeUnitInput } from "./TimeTimeUnitInput";
 import { WebCallDialog } from "./WebCallDialog";
@@ -635,26 +635,34 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 name="activeOn"
                 control={form.control}
                 render={() => {
-                  return (
-                    <MultiSelectCheckbox
-                      options={allOptions}
-                      isDisabled={props.readOnly || form.getValues("selectAll")}
-                      className="w-full"
-                      setSelected={setSelectedOptions}
-                      selected={form.getValues("selectAll") ? allOptions : selectedOptions}
-                      setValue={(s: Option[]) => {
-                        form.setValue("activeOn", s, { shouldDirty: true });
-                      }}
-                      countText={
-                        isOrganization
-                          ? "count_team"
-                          : isFormTrigger(form.getValues("trigger"))
-                            ? "nr_routing_form"
-                            : "nr_event_type"
-                      }
-                    />
-                  );
-                }}
+  const activeOptions = form.getValues("selectAll") ? allOptions : selectedOptions;
+  const count = activeOptions.filter((o) => o.value !== "all").length;
+  const countKey = isOrganization
+    ? "count_team"
+    : isFormTrigger(form.getValues("trigger"))
+    ? "nr_routing_form"
+    : "nr_event_type";
+
+  return (
+    <>
+      <MultiSelectCheckbox
+        options={allOptions}
+        isDisabled={props.readOnly || form.getValues("selectAll")}
+        className="w-full"
+        setSelected={setSelectedOptions}
+        selected={activeOptions}
+        setValue={(s: Option[]) => {
+          form.setValue("activeOn", s, { shouldDirty: true });
+        }}
+      />
+      {count > 0 && (
+        <p className="text-subtle mt-1 text-xs">
+          {t(countKey, { count })}
+        </p>
+      )}
+    </>
+  );
+}}
               />
               {!hasCalAIAction(steps) && (
                 <div className="mt-1">

--- a/packages/ui/components/form/checkbox/MultiSelectCheckboxes.tsx
+++ b/packages/ui/components/form/checkbox/MultiSelectCheckboxes.tsx
@@ -61,15 +61,31 @@ type MultiSelectionCheckboxesProps = {
 const MultiValue = ({
   index,
   getValue,
-  countText,
+  removeProps,
+  data,
+  isDisabled,
 }: {
   index: number;
   getValue: () => readonly Option[];
-  countText: string;
+  removeProps: React.HTMLAttributes<HTMLDivElement>;
+  data: Option;
+  isDisabled: boolean;
 }) => {
-  const { t } = useLocale();
-  const count = getValue().filter((option) => option.value !== "all").length;
-  return <>{!index && count !== 0 && <div>{t(countText, { count })}</div>}</>;
+  if (data.value === "all") return null;
+
+  return (
+    <span className="bg-subtle text-default inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium">
+      {data.label}
+      {!isDisabled && (
+        <div
+          {...removeProps}
+          className="text-muted hover:text-default ml-0.5 cursor-pointer"
+        >
+          ×
+        </div>
+      )}
+    </span>
+  );
 };
 
 export default function MultiSelectCheckboxes({
@@ -83,10 +99,16 @@ export default function MultiSelectCheckboxes({
   countText,
 }: Omit<Props, "options"> & MultiSelectionCheckboxesProps) {
   const additonalComponents = {
-    MultiValue: (props: MultiValueProps<Option, boolean, GroupBase<Option>>) => (
-      <MultiValue {...props} countText={countText || "selected"} />
-    ),
-  };
+  MultiValue: (props: MultiValueProps<Option, boolean, GroupBase<Option>>) => (
+    <MultiValue
+      index={props.index}
+      getValue={props.getValue}
+      removeProps={props.removeProps}
+      data={props.data}
+      isDisabled={props.isDisabled}
+    />
+  ),
+};
 
   const allOptions = [{ label: "Select all", value: "all" }, ...options];
 


### PR DESCRIPTION
[##] What does this PR do?

Display selected event types as badges (chips) inside the input field, each showing the event name (e.g., “type 2”, “type 3”), with an option to remove them individually.

- Fixes #28526  (GitHub issue number)

#### Image Demo (if applicable):

Instead of:
- 2 event types

<img width="1118" height="167" alt="Image" src="https://github.com/user-attachments/assets/14096431-fc5a-497b-b159-78964c669276" />


Show:
- type 2 ✕  
- type 3 ✕

<img width="1112" height="172" alt="Image" src="https://github.com/user-attachments/assets/c889a605-fd12-4f28-b073-233423a785b4" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Go to Workflows then enter into a workflow (create one) and select an event in "Which event type will this apply to?"

## Checklist

<!-- Remove bullet points below that don't apply to you -->
