### PR TITLE
fix: pre-commit fail when path contains space

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,5 +1,5 @@
 export default {
   "(apps|packages|companion)/**/*.{js,ts,jsx,tsx}": (files) =>
-    `biome lint --reporter summary --config-path=biome-staged.json ${files.join(" ")}`,
+    `biome lint --reporter summary --config-path=biome-staged.json ${files.map(f => `"${f}"`).join(" ")}`,
   "packages/prisma/schema.prisma": ["prisma format"],
 };

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,5 +1,7 @@
+const quotePath = (file) => `"${file.replace(/"/g, '\\"')}"`;
+
 export default {
   "(apps|packages|companion)/**/*.{js,ts,jsx,tsx}": (files) =>
-    `biome lint --reporter summary --config-path=biome-staged.json ${files.map(f => `"${f}"`).join(" ")}`,
+    `biome lint --reporter summary --config-path=biome-staged.json ${files.map(quotePath).join(" ")}`,
   "packages/prisma/schema.prisma": ["prisma format"],
 };


### PR DESCRIPTION
## What does this PR do?

Fixes 

This PR fixes an issue where pre-commit hooks fail on Windows when the user’s home directory contains spaces (e.g., `C:/Users/First Middle Last/...`).

`lint-staged` was passing staged file paths to `biome lint` without proper quoting, causing the shell to split paths into multiple arguments. As a result, Biome received invalid file paths and failed with `"no files were processed"`.

Fixes #28971 

---

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (N/A – no existing test coverage for this case)

---

## How should this be tested?

1. Use a Windows machine where the user directory contains spaces (e.g., `C:/Users/First Middle Last/`)
2. Clone the repository and install dependencies
3. Modify and stage a file (`git add <file>`)
4. Run `git commit`

### Expected behavior

- Pre-commit hook runs successfully
- `lint-staged` correctly passes file paths
- Biome processes the staged files without errors
- Commit completes successfully

### Previous behavior (before fix)

- Biome receives split file paths
- Outputs `"no files were processed"`
- Pre-commit hook fails and aborts commit

---

## Checklist