### PR TITLE
fix: escape file paths in build-icons.mjs to support paths with spaces

### DIFF
--- a/packages/ui/scripts/build-icons.mjs
+++ b/packages/ui/scripts/build-icons.mjs
@@ -135,7 +135,7 @@ async function writeIfChanged(filepath, newContent) {
     .catch(() => "");
   if (currentContent === newContent) return false;
   await fsExtra.writeFile(filepath, newContent, "utf8");
-  await $`node ${biomeBin} format --write ${filepath}`;
+  await $`node "${biomeBin}" format --write "${filepath}"`;
   return true;
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug in the icon generation script where file paths containing spaces caused the build to fail on Windows systems. By wrapping the `${filepath}` and `${biomeBin}` variables in double quotes within the `execa` template literal, we ensure the shell treats the entire path as a single argument rather than splitting it into multiple invalid fragments.

- Fixes #28974  (Insert your issue number here)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

To reproduce and verify the fix:
1. **Setup:** Move the project directory to a path containing spaces (e.g., `C:\Users\User Name\cal.diy`).
2. **Execution:** Run `yarn run dx` or navigate to `packages/ui` and run the icon build script directly.
3. **Requirement:** Ensure you are on a Windows environment where shell argument splitting on spaces is the default behavior.
4. **Expected Result:** The script should successfully call Biome to format the `sprite.svg` and `icon-names.ts` files without throwing an `ExecaError`.

## Checklist
