### PR TITLE
docs: update Docker image registry references

### DIFF
--- a/apps/docs/content/docker.mdx
+++ b/apps/docs/content/docker.mdx
@@ -2,7 +2,19 @@
 
 ### Introduction
 
-This image can be found on DockerHub at [https://hub.docker.com/r/calcom/cal.diy](https://hub.docker.com/r/calcom/cal.diy). Note for ARM Users: Use the `-arm` suffix for pulling images. Example: `docker pull calcom/cal.diy:v5.6.19-arm`.
+Pre-built images are published to the following registries:
+
+- **GHCR (GitHub Container Registry):** `ghcr.io/calcom/cal.diy`
+- **Docker Hub:** `docker.io/calcom/cal.diy` (may not always be up to date)
+- **Scarf proxy:** `calcom.docker.scarf.sh/calcom/cal.diy` (used by default in `docker-compose.yml`)
+
+For ARM users, use the `-arm` suffix. Example: `docker pull ghcr.io/calcom/cal.diy:v5.6.19-arm`.
+
+If pre-built images are unavailable, you can build from source:
+
+```bash
+docker build -t cal.diy .
+```
 
 ### Contributing
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #28995

Updates the Docker documentation to list all available image registries instead of only referencing Docker Hub, which may not always have the latest image published.

## Changes

- Added GHCR (`ghcr.io/calcom/cal.diy`) and Scarf proxy as alternative registries
- Added build-from-source fallback instructions
- Kept ARM suffix documentation

## How should this be tested?

- Review the rendered docs at `/docker` page
- Verify registry URLs are correct against `.github/actions/docker-build-and-test/action.yml` and `docker-compose.yml`

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (N/A - docs only)