### PR TITLE
fix(event-types): align URL prefix with input text baseline

### DIFF
--- a/apps/web/modules/event-types/components/tabs/setup/EventSetupTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/setup/EventSetupTab.tsx
@@ -178,7 +178,7 @@ export const EventSetupTab = (
             className={classNames("pl-0", customClassNames?.titleSection?.urlInput?.input)}
             addOnLeading={
               isPlatform ? undefined : (
-                <span className="inline-block min-w-0 max-w-24 overflow-hidden text-ellipsis whitespace-nowrap md:max-w-56">
+                <span className="flex items-center h-full min-w-0 max-w-24 overflow-hidden text-ellipsis whitespace-nowrap md:max-w-56 text-sm leading-[1.5] relative top-[1px]">
                   {urlPrefix}/
                   {!isManagedEventType
                     ? team


### PR DESCRIPTION
## What does this PR do?

Fixes a minor visual misalignment in the Event Type Setup tab URL input.

The URL prefix (e.g. `localhost:3000/username/`) appeared slightly higher than the input text due to baseline differences between the prefix element and the input field.

## Solution

- Updated the prefix container to use flex alignment for proper vertical centering
- Applied a minimal 1px vertical offset to match the input text baseline

This results in consistent and visually balanced alignment between the prefix and the input value.

## Visual Demo

### Before
<div align="center">
  <img width="1726" height="867" alt="Before" src="https://github.com/user-attachments/assets/48801582-ddf3-43b3-aea1-4c894d9e614d" />
</div>

### After
<div align="center">
  <img width="1735" height="870" alt="After" src="https://github.com/user-attachments/assets/32b544b4-5eea-4196-96ad-1fa2889eb936" />
</div>

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs if required (N/A)
- [x] I confirm automated tests are in place (N/A - visual fix)

## How should this be tested?

1. Navigate to `/event-types/:id?tabName=setup`
2. Locate the URL input field in the **Basics** section
3. Compare alignment between:
   - URL prefix (e.g. `localhost:3000/username/`)
   - Input value (e.g. `abc`)

### Expected Result
- Prefix and input text should be vertically aligned with no visual offset

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code where necessary(N/A)
- [x] My changes generate no new warnings
- [x] My PR is small and focused