### PR TITLE
fix(embed-react): config prop changes ignored after initial mount

### DIFF
--- a/packages/embeds/embed-react/src/Cal.tsx
+++ b/packages/embeds/embed-react/src/Cal.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-
 import type { PrefillAndIframeAttrsConfig } from "@calcom/embed-core";
-
+import { useEffect, useRef } from "react";
 import useEmbed from "./useEmbed";
 
 type CalProps = {
@@ -32,28 +30,26 @@ const Cal = function Cal(props: CalProps) {
     }
     initializedRef.current = true;
     const element = ref.current;
+
     if (namespace) {
-      Cal("init", namespace, {
-        ...initConfig,
-        origin: calOrigin,
-      });
-      Cal.ns[namespace]("inline", {
-        elementOrSelector: element,
-        calLink,
-        config,
-      });
+      Cal("init", namespace, { ...initConfig, origin: calOrigin });
+      Cal.ns[namespace]("inline", { elementOrSelector: element, calLink, config });
     } else {
-      Cal("init", {
-        ...initConfig,
-        origin: calOrigin,
-      });
-      Cal("inline", {
-        elementOrSelector: element,
-        calLink,
-        config,
-      });
+      Cal("init", { ...initConfig, origin: calOrigin });
+      Cal("inline", { elementOrSelector: element, calLink, config });
     }
-  }, [Cal, calLink, config, namespace, calOrigin, initConfig]);
+  }, [Cal, calLink, namespace, calOrigin]);
+
+  useEffect(() => {
+    if (!Cal || !initializedRef.current || !config) {
+      return;
+    }
+    if (namespace) {
+      Cal.ns[namespace]("ui", config);
+    } else {
+      Cal("ui", config);
+    }
+  }, [Cal, namespace, config]);
 
   if (!Cal) {
     return null;


### PR DESCRIPTION
Split single useEffect into two to fix config/theme updates being silently ignored after initial mount.

The initialization effect used an initializedRef guard to prevent double-init under React Strict Mode. This guard was correct, but config was also listed as a dependency, meaning React would re-run the effect on every config change and then immediately bail out because initializedRef.current was already true.

Fix: split into two effects with clearly separated responsibilities.

Effect 1 (initialization): keeps the initializedRef guard, runs once per mount, config removed from deps since it only needs the value at first mount.

Effect 2 (config updates): Calls Cal("ui", config) whenever config changes to push updates into the live iframe without remounting.

## What does this PR do?

- Fixes #28979

The <Cal> inline embed ignored config changes after first mount. The useRef guard that prevents double-init under React Strict Mode also blocked every re-run when config changed, making it a silent no-op. Fix splits the effect in two: one that initializes once, one that calls ui() on every config change.

## Mandatory Tasks

- [x] I have self-reviewed the code.
- [x] No documentation change required. N/A.
- [x] The fix can be verified manually by mounting a `<Cal config={{ theme: "light" }} />`, toggling the theme, and confirming the embed updates without remounting.

## How should this be tested?

1. Mount a `<Cal>` inline embed with `config={{ theme: "light" }}`
2. Trigger a theme change so `config` becomes `{ theme: "dark" }`
3. **Before this fix:** embed does not update
4. **After this fix:** embed updates its theme instantly with no iframe reload


## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I have commented the code where the intent is non-obvious
- [x] My changes generate no new warnings
- [x] This PR is a single file, minimal change