### PR TITLE
feat: add Proton Calendar integration via read-only ICS feed

### DIFF
--- a/apps/web/components/apps/AppSetupPage.tsx
+++ b/apps/web/components/apps/AppSetupPage.tsx
@@ -9,6 +9,7 @@ export const AppSetupMap = {
   "exchange2016-calendar": dynamic(() => import("@calcom/web/components/apps/exchange2016calendar/Setup")),
   "caldav-calendar": dynamic(() => import("@calcom/web/components/apps/caldavcalendar/Setup")),
   "ics-feed": dynamic(() => import("@calcom/web/components/apps/ics-feedcalendar/Setup")),
+  "proton-calendar": dynamic(() => import("@calcom/web/components/apps/proton-calendarcalendar/Setup")),
   make: dynamic(() => import("@calcom/web/components/apps/make/Setup")),
   sendgrid: dynamic(() => import("@calcom/web/components/apps/sendgrid/Setup")),
   stripe: dynamic(() => import("@calcom/web/components/apps/stripepayment/Setup")),

--- a/apps/web/components/apps/proton-calendarcalendar/Setup.tsx
+++ b/apps/web/components/apps/proton-calendarcalendar/Setup.tsx
@@ -1,0 +1,83 @@
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Alert } from "@calcom/ui/components/alert";
+import { Button } from "@calcom/ui/components/button";
+import { Form, TextField } from "@calcom/ui/components/form";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { Toaster } from "sonner";
+
+export default function ProtonCalendarSetup() {
+  const { t } = useLocale();
+  const router = useRouter();
+  const form = useForm({
+    defaultValues: {},
+  });
+
+  const [url, setUrl] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  return (
+    <div className="bg-emphasis flex h-screen">
+      <div className="bg-default m-auto rounded p-5 md:w-[560px] md:p-10">
+        <div className="flex flex-col stack-y-5 md:flex-row md:space-x-5 md:stack-y-0">
+          <div>
+            {/* eslint-disable @next/next/no-img-element */}
+            <img
+              src="/api/app-store/proton-calendarcalendar/icon.svg"
+              alt="Proton Calendar"
+              className="h-12 w-12 max-w-2xl"
+            />
+          </div>
+          <div className="flex w-10/12 flex-col">
+            <h1 className="text-default">{t("connect_proton_calendar")}</h1>
+            <div className="mt-1 text-sm">{t("credentials_stored_encrypted")}</div>
+            <div className="my-2 mt-3">
+              <Form
+                form={form}
+                handleSubmit={async (_) => {
+                  setErrorMessage("");
+                  const res = await fetch("/api/integrations/proton-calendarcalendar/add", {
+                    method: "POST",
+                    body: JSON.stringify({ urls: [url] }),
+                    headers: {
+                      "Content-Type": "application/json",
+                    },
+                  });
+                  const json = await res.json();
+                  if (!res.ok) {
+                    setErrorMessage(json?.message || t("something_went_wrong"));
+                  } else {
+                    router.push(json.url);
+                  }
+                }}>
+                <fieldset className="stack-y-2" disabled={form.formState.isSubmitting}>
+                  <TextField
+                    required
+                    type="text"
+                    label={t("calendar_url")}
+                    value={url}
+                    containerClassName="w-full"
+                    onChange={(e) => setUrl(e.target.value)}
+                    placeholder="https://calendar.proton.me/api/calendar/v1/url/.../calendar.ics"
+                  />
+                </fieldset>
+
+                {errorMessage && <Alert severity="error" title={errorMessage} className="my-4" />}
+                <div className="mt-5 justify-end space-x-2 rtl:space-x-reverse sm:mt-4 sm:flex">
+                  <Button type="button" color="secondary" onClick={() => router.back()}>
+                    {t("cancel")}
+                  </Button>
+                  <Button type="submit" loading={form.formState.isSubmitting}>
+                    {t("save")}
+                  </Button>
+                </div>
+              </Form>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Toaster position="bottom-right" />
+    </div>
+  );
+}

--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -74,6 +74,7 @@ import pipedream_config_json from "./pipedream/config.json";
 import pipedrive_crm_config_json from "./pipedrive-crm/config.json";
 import plausible_config_json from "./plausible/config.json";
 import posthog_config_json from "./posthog/config.json";
+import proton_calendarcalendar_config_json from "./proton-calendarcalendar/config.json";
 import qr_code_config_json from "./qr_code/config.json";
 import raycast_config_json from "./raycast/config.json";
 import retell_ai_config_json from "./retell-ai/config.json";
@@ -186,6 +187,7 @@ export const appStoreMetadata = {
   "pipedrive-crm": pipedrive_crm_config_json,
   plausible: plausible_config_json,
   posthog: posthog_config_json,
+  "proton-calendarcalendar": proton_calendarcalendar_config_json,
   qr_code: qr_code_config_json,
   raycast: raycast_config_json,
   "retell-ai": retell_ai_config_json,

--- a/packages/app-store/apps.server.generated.ts
+++ b/packages/app-store/apps.server.generated.ts
@@ -55,6 +55,7 @@ export const apiHandlers = {
   "pipedrive-crm": import("./pipedrive-crm/api"),
   plausible: import("./plausible/api"),
   posthog: import("./posthog/api"),
+  "proton-calendarcalendar": import("./proton-calendarcalendar/api"),
   qr_code: import("./qr_code/api"),
   riverside: import("./riverside/api"),
   roam: import("./roam/api"),

--- a/packages/app-store/calendar.services.generated.ts
+++ b/packages/app-store/calendar.services.generated.ts
@@ -16,5 +16,6 @@ export const CalendarServiceMap =
         "ics-feedcalendar": import("./ics-feedcalendar/lib/CalendarService"),
         larkcalendar: import("./larkcalendar/lib/CalendarService"),
         office365calendar: import("./office365calendar/lib/CalendarService"),
+        "proton-calendarcalendar": import("./proton-calendarcalendar/lib/CalendarService"),
         zohocalendar: import("./zohocalendar/lib/CalendarService"),
       };

--- a/packages/app-store/proton-calendarcalendar/DESCRIPTION.md
+++ b/packages/app-store/proton-calendarcalendar/DESCRIPTION.md
@@ -1,0 +1,5 @@
+Connect your Proton Calendar to check availability when scheduling. Events in your Proton Calendar will block times on your booking page.
+
+**Setup:** Share your Proton Calendar via an ICS link (Settings > Share via link > Full view), then paste the link here. Requires a paid Proton plan.
+
+**Note:** This is a read-only integration. Cal.diy can read your busy times but cannot create events in Proton Calendar.

--- a/packages/app-store/proton-calendarcalendar/api/__tests__/add.test.ts
+++ b/packages/app-store/proton-calendarcalendar/api/__tests__/add.test.ts
@@ -48,8 +48,7 @@ describe("isValidProtonUrl", () => {
     expect(isValidProtonUrl("file:///etc/passwd")).toBe(false);
   });
 
-  it("rejects URLs with credentials in userinfo", () => {
+  it("accepts URLs with credentials in userinfo when hostname is valid", () => {
     expect(isValidProtonUrl("https://user:pass@calendar.proton.me/ics")).toBe(true);
-    // URL parser treats this as valid hostname - the hostname check is what matters
   });
 });

--- a/packages/app-store/proton-calendarcalendar/api/__tests__/add.test.ts
+++ b/packages/app-store/proton-calendarcalendar/api/__tests__/add.test.ts
@@ -48,7 +48,7 @@ describe("isValidProtonUrl", () => {
     expect(isValidProtonUrl("file:///etc/passwd")).toBe(false);
   });
 
-  it("accepts URLs with credentials in userinfo when hostname is valid", () => {
-    expect(isValidProtonUrl("https://user:pass@calendar.proton.me/ics")).toBe(true);
+  it("rejects URLs with credentials in userinfo", () => {
+    expect(isValidProtonUrl("https://user:pass@calendar.proton.me/ics")).toBe(false);
   });
 });

--- a/packages/app-store/proton-calendarcalendar/api/__tests__/add.test.ts
+++ b/packages/app-store/proton-calendarcalendar/api/__tests__/add.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { isValidProtonUrl } from "../add";
+
+describe("isValidProtonUrl", () => {
+  it("accepts valid calendar.proton.me HTTPS URL", () => {
+    expect(
+      isValidProtonUrl("https://calendar.proton.me/api/calendar/v1/url/abc123/calendar.ics?CacheKey=secret")
+    ).toBe(true);
+  });
+
+  it("accepts valid calendar.protonmail.com HTTPS URL", () => {
+    expect(isValidProtonUrl("https://calendar.protonmail.com/api/calendar/v1/url/x/calendar.ics")).toBe(true);
+  });
+
+  it("rejects HTTP (non-HTTPS) URLs", () => {
+    expect(isValidProtonUrl("http://calendar.proton.me/api/calendar/v1/url/x/calendar.ics")).toBe(false);
+  });
+
+  it("rejects non-Proton hostnames", () => {
+    expect(isValidProtonUrl("https://evil.com/api/calendar/v1/url/x/calendar.ics")).toBe(false);
+  });
+
+  it("rejects subdomain spoofing (e.g. fake-calendar.proton.me)", () => {
+    expect(isValidProtonUrl("https://fake-calendar.proton.me/something")).toBe(false);
+  });
+
+  it("rejects endsWith bypass (e.g. notcalendar.proton.me)", () => {
+    expect(isValidProtonUrl("https://notcalendar.proton.me/ics")).toBe(false);
+  });
+
+  it("rejects hostname suffix attacks (e.g. evil.calendar.proton.me)", () => {
+    expect(isValidProtonUrl("https://evil.calendar.proton.me/something")).toBe(false);
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(isValidProtonUrl("not-a-url")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidProtonUrl("")).toBe(false);
+  });
+
+  it("rejects javascript: protocol", () => {
+    expect(isValidProtonUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects file: protocol", () => {
+    expect(isValidProtonUrl("file:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects URLs with credentials in userinfo", () => {
+    expect(isValidProtonUrl("https://user:pass@calendar.proton.me/ics")).toBe(true);
+    // URL parser treats this as valid hostname - the hostname check is what matters
+  });
+});

--- a/packages/app-store/proton-calendarcalendar/api/add.ts
+++ b/packages/app-store/proton-calendarcalendar/api/add.ts
@@ -1,0 +1,93 @@
+import process from "node:process";
+import { symmetricEncrypt } from "@calcom/lib/crypto";
+import logger from "@calcom/lib/logger";
+import prisma from "@calcom/prisma";
+import type { NextApiRequest, NextApiResponse } from "next";
+import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+import appConfig from "../config.json";
+import { BuildCalendarService } from "../lib";
+
+const log = logger.getSubLogger({ prefix: ["app:proton-calendar:add"] });
+
+const ALLOWED_HOSTNAMES = ["calendar.proton.me", "calendar.protonmail.com"];
+
+export function isValidProtonUrl(urlString: string): boolean {
+  try {
+    const url = new URL(urlString);
+    if (url.protocol !== "https:") return false;
+    return ALLOWED_HOSTNAMES.includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "POST") {
+    const { urls } = req.body;
+
+    if (!Array.isArray(urls) || urls.length === 0) {
+      return res.status(400).json({ message: "At least one Proton Calendar ICS URL is required" });
+    }
+
+    for (const url of urls) {
+      if (!isValidProtonUrl(url)) {
+        return res
+          .status(400)
+          .json({ message: "Invalid URL. Only HTTPS links from calendar.proton.me are accepted." });
+      }
+    }
+
+    if (!req.session?.user?.id) {
+      return res.status(401).json({ message: "You must be logged in" });
+    }
+
+    const user = await prisma.user.findFirstOrThrow({
+      where: {
+        id: req.session.user.id,
+      },
+      select: {
+        id: true,
+        email: true,
+      },
+    });
+
+    const data = {
+      type: appConfig.type,
+      key: symmetricEncrypt(JSON.stringify({ urls }), process.env.CALENDSO_ENCRYPTION_KEY || ""),
+      userId: user.id,
+      teamId: null,
+      appId: appConfig.slug,
+      invalid: false,
+      delegationCredentialId: null,
+    };
+
+    try {
+      const dav = BuildCalendarService({
+        id: 0,
+        ...data,
+        user: { email: user.email },
+        encryptedKey: null,
+      });
+      const listedCals = await dav.listCalendars();
+
+      if (listedCals.length !== urls.length) {
+        throw new Error("Could not validate all provided Proton Calendar URLs");
+      }
+
+      await prisma.credential.create({
+        data,
+      });
+    } catch {
+      log.error("Could not add Proton Calendar feeds");
+      return res.status(500).json({ message: "Could not add Proton Calendar feeds" });
+    }
+
+    return res
+      .status(200)
+      .json({ url: getInstalledAppPath({ variant: "calendar", slug: "proton-calendar" }) });
+  }
+
+  if (req.method === "GET") {
+    return res.status(200).json({ url: "/apps/proton-calendar/setup" });
+  }
+}

--- a/packages/app-store/proton-calendarcalendar/api/add.ts
+++ b/packages/app-store/proton-calendarcalendar/api/add.ts
@@ -33,7 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (!isValidProtonUrl(url)) {
         return res
           .status(400)
-          .json({ message: "Invalid URL. Only HTTPS links from calendar.proton.me are accepted." });
+          .json({ message: "Invalid URL. Only HTTPS links from calendar.proton.me or calendar.protonmail.com are accepted." });
       }
     }
 

--- a/packages/app-store/proton-calendarcalendar/api/add.ts
+++ b/packages/app-store/proton-calendarcalendar/api/add.ts
@@ -11,7 +11,8 @@ const log = logger.getSubLogger({ prefix: ["app:proton-calendar:add"] });
 
 const ALLOWED_HOSTNAMES = ["calendar.proton.me", "calendar.protonmail.com"];
 
-export function isValidProtonUrl(urlString: string): boolean {
+export function isValidProtonUrl(urlString: unknown): boolean {
+  if (typeof urlString !== "string") return false;
   try {
     const url = new URL(urlString);
     if (url.protocol !== "https:") return false;

--- a/packages/app-store/proton-calendarcalendar/api/add.ts
+++ b/packages/app-store/proton-calendarcalendar/api/add.ts
@@ -43,9 +43,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     for (const url of urls) {
       if (!isValidProtonUrl(url)) {
-        return res
-          .status(400)
-          .json({ message: "Invalid URL. Only HTTPS links from calendar.proton.me or calendar.protonmail.com are accepted." });
+        return res.status(400).json({
+          message:
+            "Invalid URL. Only HTTPS links from calendar.proton.me or calendar.protonmail.com are accepted.",
+        });
       }
     }
 

--- a/packages/app-store/proton-calendarcalendar/api/add.ts
+++ b/packages/app-store/proton-calendarcalendar/api/add.ts
@@ -15,6 +15,7 @@ export function isValidProtonUrl(urlString: string): boolean {
   try {
     const url = new URL(urlString);
     if (url.protocol !== "https:") return false;
+    if (url.username || url.password) return false;
     return ALLOWED_HOSTNAMES.includes(url.hostname);
   } catch {
     return false;
@@ -23,6 +24,16 @@ export function isValidProtonUrl(urlString: string): boolean {
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "POST") {
+    if (!req.session?.user?.id) {
+      return res.status(401).json({ message: "You must be logged in" });
+    }
+
+    const encryptionKey = process.env.CALENDSO_ENCRYPTION_KEY;
+    if (!encryptionKey) {
+      log.error("CALENDSO_ENCRYPTION_KEY is not set");
+      return res.status(500).json({ message: "Server is not configured to store credentials" });
+    }
+
     const { urls } = req.body;
 
     if (!Array.isArray(urls) || urls.length === 0) {
@@ -37,10 +48,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
     }
 
-    if (!req.session?.user?.id) {
-      return res.status(401).json({ message: "You must be logged in" });
-    }
-
     const user = await prisma.user.findFirstOrThrow({
       where: {
         id: req.session.user.id,
@@ -53,7 +60,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const data = {
       type: appConfig.type,
-      key: symmetricEncrypt(JSON.stringify({ urls }), process.env.CALENDSO_ENCRYPTION_KEY || ""),
+      key: symmetricEncrypt(JSON.stringify({ urls }), encryptionKey),
       userId: user.id,
       teamId: null,
       appId: appConfig.slug,
@@ -90,4 +97,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === "GET") {
     return res.status(200).json({ url: "/apps/proton-calendar/setup" });
   }
+
+  res.setHeader("Allow", "GET, POST");
+  return res.status(405).json({ message: "Method not allowed" });
 }

--- a/packages/app-store/proton-calendarcalendar/api/index.ts
+++ b/packages/app-store/proton-calendarcalendar/api/index.ts
@@ -1,0 +1,1 @@
+export { default as add } from "./add";

--- a/packages/app-store/proton-calendarcalendar/config.json
+++ b/packages/app-store/proton-calendarcalendar/config.json
@@ -1,0 +1,15 @@
+{
+  "name": "Proton Calendar",
+  "title": "Proton Calendar",
+  "slug": "proton-calendar",
+  "dirName": "proton-calendarcalendar",
+  "type": "proton-calendar_calendar",
+  "logo": "icon.svg",
+  "variant": "calendar",
+  "categories": ["calendar"],
+  "publisher": "Cal.com, Inc.",
+  "email": "help@cal.com",
+  "description": "Import your Proton Calendar availability into Cal.diy via ICS share link.",
+  "isTemplate": false,
+  "__createdUsingCli": false
+}

--- a/packages/app-store/proton-calendarcalendar/index.ts
+++ b/packages/app-store/proton-calendarcalendar/index.ts
@@ -1,0 +1,2 @@
+export * as api from "./api";
+export * as lib from "./lib";

--- a/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
@@ -45,6 +45,9 @@ class ProtonCalendarService implements Calendar {
   protected integrationName = "proton-calendar_calendar";
 
   constructor(credential: CredentialPayload) {
+    if (!credential.key) {
+      throw new Error("Missing Proton Calendar credential key");
+    }
     const { urls } = JSON.parse(symmetricDecrypt(credential.key as string, CALENDSO_ENCRYPTION_KEY));
     this.urls = urls;
   }

--- a/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
@@ -166,8 +166,7 @@ class ProtonCalendarService implements Calendar {
         const event = new ICAL.Event(vevent);
         const title = String(vevent.getFirstPropertyValue("summary") || "Busy");
         const dtstartProperty = vevent.getFirstProperty("dtstart");
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const tzidFromDtstart = dtstartProperty ? (dtstartProperty as any).jCal[1].tzid : undefined;
+        const tzidFromDtstart = dtstartProperty ? dtstartProperty.getParameter("tzid") : undefined;
 
         const dtstart: { [key: string]: string } | undefined = vevent?.getFirstPropertyValue("dtstart");
         const timezone = dtstart ? dtstart.timezone : undefined;

--- a/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
@@ -188,19 +188,21 @@ class ProtonCalendarService implements Calendar {
 
         const tzid: string | undefined = tzidFromDtstart || (isUTC ? "UTC" : timezone);
 
-        if (!vcalendar.getFirstSubcomponent("vtimezone")) {
-          const timezoneToUse = tzid || userTimeZone;
-          if (timezoneToUse) {
+        const timezoneToUse = tzid || userTimeZone;
+        if (timezoneToUse) {
+          const allVtimezones = vcalendar.getAllSubcomponents("vtimezone");
+          const hasMatchingTz = allVtimezones.some(
+            (vtz) => vtz.getFirstPropertyValue("tzid") === timezoneToUse
+          );
+          if (!hasMatchingTz) {
             try {
               const timezoneComp = new ICAL.Component("vtimezone");
               timezoneComp.addPropertyWithValue("tzid", timezoneToUse);
               const standard = new ICAL.Component("standard");
 
-              const tzoffsetfrom = dayjs(event.startDate.toJSDate()).tz(timezoneToUse).format("Z");
-              const tzoffsetto = dayjs(event.endDate.toJSDate()).tz(timezoneToUse).format("Z");
-
-              standard.addPropertyWithValue("tzoffsetfrom", tzoffsetfrom);
-              standard.addPropertyWithValue("tzoffsetto", tzoffsetto);
+              const utcOffset = dayjs(event.startDate.toJSDate()).tz(timezoneToUse).format("Z");
+              standard.addPropertyWithValue("tzoffsetfrom", utcOffset);
+              standard.addPropertyWithValue("tzoffsetto", utcOffset);
               standard.addPropertyWithValue("dtstart", "1601-01-01T00:00:00");
               timezoneComp.addSubcomponent(standard);
               vcalendar.addSubcomponent(timezoneComp);
@@ -214,10 +216,6 @@ class ProtonCalendarService implements Calendar {
         if (tzid) {
           const allVtimezones = vcalendar.getAllSubcomponents("vtimezone");
           vtimezone = allVtimezones.find((vtz) => vtz.getFirstPropertyValue("tzid") === tzid);
-        }
-
-        if (!vtimezone) {
-          vtimezone = vcalendar.getFirstSubcomponent("vtimezone");
         }
 
         applyTravelDuration(event, getTravelDurationInSeconds(vevent));

--- a/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
@@ -4,6 +4,8 @@
 import process from "node:process";
 import dayjs from "@calcom/dayjs";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import logger from "@calcom/lib/logger";
 import type {
   Calendar,
@@ -46,10 +48,19 @@ class ProtonCalendarService implements Calendar {
 
   constructor(credential: CredentialPayload) {
     if (!credential.key) {
-      throw new Error("Missing Proton Calendar credential key");
+      throw new ErrorWithCode(ErrorCode.InternalServerError, "Missing Proton Calendar credential key");
     }
-    const { urls } = JSON.parse(symmetricDecrypt(credential.key as string, CALENDSO_ENCRYPTION_KEY));
-    this.urls = urls;
+    try {
+      const parsed = JSON.parse(symmetricDecrypt(credential.key as string, CALENDSO_ENCRYPTION_KEY));
+      const { urls } = parsed;
+      if (!Array.isArray(urls) || !urls.every((u: unknown) => typeof u === "string")) {
+        throw new Error("urls must be a string array");
+      }
+      this.urls = urls;
+    } catch (error) {
+      log.error("Failed to parse Proton Calendar credential key", error);
+      this.urls = [];
+    }
   }
 
   createEvent(_event: CalendarEvent, _credentialId: number): Promise<NewCalendarEventType> {
@@ -171,12 +182,11 @@ class ProtonCalendarService implements Calendar {
         const dtstartProperty = vevent.getFirstProperty("dtstart");
         const tzidFromDtstart = dtstartProperty ? dtstartProperty.getParameter("tzid") : undefined;
 
-        const dtstart: { [key: string]: string } | undefined = vevent?.getFirstPropertyValue("dtstart");
-        const timezone = dtstart ? dtstart.timezone : undefined;
+        const dtstart = vevent.getFirstPropertyValue<ICAL.Time | undefined>("dtstart");
+        const timezone = dtstart?.timezone;
         const isUTC = timezone === "Z";
 
-        const tzid: string | undefined =
-          tzidFromDtstart || vevent?.getFirstPropertyValue("tzid") || (isUTC ? "UTC" : timezone);
+        const tzid: string | undefined = tzidFromDtstart || (isUTC ? "UTC" : timezone);
 
         if (!vcalendar.getFirstSubcomponent("vtimezone")) {
           const timezoneToUse = tzid || userTimeZone;
@@ -281,7 +291,7 @@ class ProtonCalendarService implements Calendar {
       }
     });
 
-    return Promise.resolve(events);
+    return events;
   }
 
   async listCalendars(): Promise<IntegrationCalendar[]> {

--- a/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
@@ -1,0 +1,303 @@
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/// <reference path="../../../types/ical.d.ts"/>
+
+import process from "node:process";
+import dayjs from "@calcom/dayjs";
+import { symmetricDecrypt } from "@calcom/lib/crypto";
+import logger from "@calcom/lib/logger";
+import type {
+  Calendar,
+  CalendarEvent,
+  EventBusyDate,
+  GetAvailabilityParams,
+  IntegrationCalendar,
+  NewCalendarEventType,
+} from "@calcom/types/Calendar";
+import type { CredentialPayload } from "@calcom/types/Credential";
+import ICAL from "ical.js";
+
+const CALENDSO_ENCRYPTION_KEY = process.env.CALENDSO_ENCRYPTION_KEY || "";
+const MAX_RECURRENCE_ITERATIONS = 365;
+const FETCH_TIMEOUT_MS = 10_000;
+
+const log = logger.getSubLogger({ prefix: ["app:proton-calendar"] });
+
+const getTravelDurationInSeconds = (vevent: ICAL.Component) => {
+  const travelDuration: ICAL.Duration = vevent.getFirstPropertyValue("x-apple-travel-duration");
+  if (!travelDuration) return 0;
+  try {
+    const travelSeconds = travelDuration.toSeconds();
+    if (!Number.isInteger(travelSeconds)) return 0;
+    return travelSeconds;
+  } catch {
+    return 0;
+  }
+};
+
+const applyTravelDuration = (event: ICAL.Event, seconds: number) => {
+  if (seconds <= 0) return event;
+  event.startDate.second -= seconds;
+  return event;
+};
+
+class ProtonCalendarService implements Calendar {
+  private urls: string[] = [];
+  protected integrationName = "proton-calendar_calendar";
+
+  constructor(credential: CredentialPayload) {
+    const { urls } = JSON.parse(symmetricDecrypt(credential.key as string, CALENDSO_ENCRYPTION_KEY));
+    this.urls = urls;
+  }
+
+  createEvent(_event: CalendarEvent, _credentialId: number): Promise<NewCalendarEventType> {
+    return Promise.resolve({
+      uid: _event.uid || "",
+      type: this.integrationName,
+      id: "",
+      password: "",
+      url: "",
+      additionalInfo: { calWarnings: ["Proton Calendar is read-only"] },
+    });
+  }
+
+  deleteEvent(_uid: string, _event: CalendarEvent, _externalCalendarId?: string): Promise<unknown> {
+    return Promise.resolve();
+  }
+
+  updateEvent(
+    _uid: string,
+    _event: CalendarEvent,
+    _externalCalendarId?: string
+  ): Promise<NewCalendarEventType | NewCalendarEventType[]> {
+    return Promise.resolve({
+      uid: _event.uid || "",
+      type: this.integrationName,
+      id: "",
+      password: "",
+      url: "",
+      additionalInfo: { calWarnings: ["Proton Calendar is read-only"] },
+    });
+  }
+
+  fetchCalendars = async (): Promise<{ url: string; vcalendar: ICAL.Component }[]> => {
+    const results: { url: string; vcalendar: ICAL.Component }[] = [];
+
+    const settled = await Promise.allSettled(
+      this.urls.map(async (url) => {
+        const response = await fetch(url, {
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+          redirect: "error",
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const text = await response.text();
+        return { url, text };
+      })
+    );
+
+    for (const result of settled) {
+      if (result.status !== "fulfilled") {
+        log.error("Failed to fetch Proton Calendar feed");
+        continue;
+      }
+      try {
+        const jcalData = ICAL.parse(result.value.text);
+        results.push({
+          url: result.value.url,
+          vcalendar: new ICAL.Component(jcalData),
+        });
+      } catch {
+        log.error("Failed to parse Proton Calendar ICS data");
+      }
+    }
+
+    return results;
+  };
+
+  getUserTimezoneFromDB = async (id: number): Promise<string | undefined> => {
+    const prisma = await import("@calcom/prisma").then((mod) => mod.default);
+    const user = await prisma.user.findUnique({
+      where: { id },
+      select: { timeZone: true },
+    });
+    return user?.timeZone;
+  };
+
+  getUserId = (selectedCalendars: IntegrationCalendar[]): number | null => {
+    if (selectedCalendars.length === 0) return null;
+    return selectedCalendars[0].userId || null;
+  };
+
+  async getAvailability(params: GetAvailabilityParams): Promise<EventBusyDate[]> {
+    const { dateFrom, dateTo, selectedCalendars } = params;
+    const startISOString = new Date(dateFrom).toISOString();
+
+    const calendars = await this.fetchCalendars();
+
+    const userId = this.getUserId(selectedCalendars);
+    const userTimeZone = userId ? await this.getUserTimezoneFromDB(userId) : "Europe/London";
+    const events: { start: string; end: string; title: string }[] = [];
+
+    const cancelledInstances = new Set<string>();
+
+    calendars.forEach(({ vcalendar }) => {
+      const vevents = vcalendar.getAllSubcomponents("vevent");
+
+      for (const vevent of vevents) {
+        const status = vevent.getFirstPropertyValue("status");
+        if (typeof status === "string" && status.toUpperCase() === "CANCELLED") {
+          const uid = vevent.getFirstPropertyValue("uid");
+          const recurrenceId = vevent.getFirstPropertyValue("recurrence-id");
+          if (uid && recurrenceId) {
+            cancelledInstances.add(`${uid}:${recurrenceId}`);
+          } else if (uid) {
+            cancelledInstances.add(`${uid}`);
+          }
+        }
+      }
+
+      for (const vevent of vevents) {
+        const status = vevent.getFirstPropertyValue("status");
+        if (typeof status === "string" && status.toUpperCase() === "CANCELLED") continue;
+
+        const uid = vevent.getFirstPropertyValue("uid");
+        if (uid && cancelledInstances.has(`${uid}`)) continue;
+
+        const event = new ICAL.Event(vevent);
+        const title = String(vevent.getFirstPropertyValue("summary") || "Busy");
+        const dtstartProperty = vevent.getFirstProperty("dtstart");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const tzidFromDtstart = dtstartProperty ? (dtstartProperty as any).jCal[1].tzid : undefined;
+
+        const dtstart: { [key: string]: string } | undefined = vevent?.getFirstPropertyValue("dtstart");
+        const timezone = dtstart ? dtstart.timezone : undefined;
+        const isUTC = timezone === "Z";
+
+        const tzid: string | undefined =
+          tzidFromDtstart || vevent?.getFirstPropertyValue("tzid") || (isUTC ? "UTC" : timezone);
+
+        if (!vcalendar.getFirstSubcomponent("vtimezone")) {
+          const timezoneToUse = tzid || userTimeZone;
+          if (timezoneToUse) {
+            try {
+              const timezoneComp = new ICAL.Component("vtimezone");
+              timezoneComp.addPropertyWithValue("tzid", timezoneToUse);
+              const standard = new ICAL.Component("standard");
+
+              const tzoffsetfrom = dayjs(event.startDate.toJSDate()).tz(timezoneToUse).format("Z");
+              const tzoffsetto = dayjs(event.endDate.toJSDate()).tz(timezoneToUse).format("Z");
+
+              standard.addPropertyWithValue("tzoffsetfrom", tzoffsetfrom);
+              standard.addPropertyWithValue("tzoffsetto", tzoffsetto);
+              standard.addPropertyWithValue("dtstart", "1601-01-01T00:00:00");
+              timezoneComp.addSubcomponent(standard);
+              vcalendar.addSubcomponent(timezoneComp);
+            } catch {
+              // Non-standard TZIDs from some providers
+            }
+          }
+        }
+
+        let vtimezone = null;
+        if (tzid) {
+          const allVtimezones = vcalendar.getAllSubcomponents("vtimezone");
+          vtimezone = allVtimezones.find((vtz) => vtz.getFirstPropertyValue("tzid") === tzid);
+        }
+
+        if (!vtimezone) {
+          vtimezone = vcalendar.getFirstSubcomponent("vtimezone");
+        }
+
+        applyTravelDuration(event, getTravelDurationInSeconds(vevent));
+
+        if (event.isRecurring()) {
+          let iterations = MAX_RECURRENCE_ITERATIONS;
+          if (["HOURLY", "SECONDLY", "MINUTELY"].includes(event.getRecurrenceTypes())) {
+            continue;
+          }
+
+          const start = dayjs(dateFrom);
+          const end = dayjs(dateTo);
+          const startDate = ICAL.Time.fromDateTimeString(startISOString);
+          startDate.hour = event.startDate.hour;
+          startDate.minute = event.startDate.minute;
+          startDate.second = event.startDate.second;
+          const iterator = event.iterator(startDate);
+          let current: ICAL.Time;
+          let currentEvent: ReturnType<ICAL.Event["getOccurrenceDetails"]> | undefined;
+          let currentStart: ReturnType<typeof dayjs> | null = null;
+          let currentError: string | undefined;
+
+          while (
+            iterations > 0 &&
+            (currentStart === null || currentStart.isAfter(end) === false) &&
+            (current = iterator.next())
+          ) {
+            iterations -= 1;
+
+            try {
+              currentEvent = event.getOccurrenceDetails(current);
+            } catch (error) {
+              if (error instanceof Error && error.message !== currentError) {
+                currentError = error.message;
+              }
+            }
+            if (!currentEvent) continue;
+
+            const instanceKey = `${uid}:${currentEvent.startDate}`;
+            if (cancelledInstances.has(instanceKey)) continue;
+
+            if (vtimezone) {
+              const zone = new ICAL.Timezone(vtimezone);
+              currentEvent.startDate = currentEvent.startDate.convertToZone(zone);
+              currentEvent.endDate = currentEvent.endDate.convertToZone(zone);
+            }
+            currentStart = dayjs(currentEvent.startDate.toJSDate());
+
+            if (currentStart.isBetween(start, end) === true) {
+              events.push({
+                start: currentStart.toISOString(),
+                end: dayjs(currentEvent.endDate.toJSDate()).toISOString(),
+                title,
+              });
+            }
+          }
+          continue;
+        }
+
+        if (vtimezone) {
+          const zone = new ICAL.Timezone(vtimezone);
+          event.startDate = event.startDate.convertToZone(zone);
+          event.endDate = event.endDate.convertToZone(zone);
+        }
+
+        events.push({
+          start: dayjs(event.startDate.toJSDate()).toISOString(),
+          end: dayjs(event.endDate.toJSDate()).toISOString(),
+          title,
+        });
+      }
+    });
+
+    return Promise.resolve(events);
+  }
+
+  async listCalendars(): Promise<IntegrationCalendar[]> {
+    const vcals = await this.fetchCalendars();
+
+    return vcals.map(({ url, vcalendar }) => {
+      const name: string = vcalendar.getFirstPropertyValue("x-wr-calname") || "Proton Calendar";
+      return {
+        name,
+        readOnly: true,
+        externalId: url,
+        integration: this.integrationName,
+      };
+    });
+  }
+}
+
+export default function BuildCalendarService(credential: CredentialPayload): Calendar {
+  return new ProtonCalendarService(credential);
+}

--- a/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
@@ -36,7 +36,7 @@ const getTravelDurationInSeconds = (vevent: ICAL.Component) => {
 
 const applyTravelDuration = (event: ICAL.Event, seconds: number) => {
   if (seconds <= 0) return event;
-  event.startDate.second -= seconds;
+  event.startDate.adjust(0, 0, 0, -seconds);
   return event;
 };
 
@@ -139,7 +139,7 @@ class ProtonCalendarService implements Calendar {
     const calendars = await this.fetchCalendars();
 
     const userId = this.getUserId(selectedCalendars);
-    const userTimeZone = userId ? await this.getUserTimezoneFromDB(userId) : "Europe/London";
+    const userTimeZone = (userId ? await this.getUserTimezoneFromDB(userId) : undefined) ?? "Europe/London";
     const events: { start: string; end: string; title: string }[] = [];
 
     calendars.forEach(({ vcalendar }) => {
@@ -256,7 +256,7 @@ class ProtonCalendarService implements Calendar {
             }
             currentStart = dayjs(currentEvent.startDate.toJSDate());
 
-            if (currentStart.isBetween(start, end) === true) {
+            if (currentStart.isBetween(start, end, null, "[)") === true) {
               events.push({
                 start: currentStart.toISOString(),
                 end: dayjs(currentEvent.endDate.toJSDate()).toISOString(),

--- a/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
@@ -139,9 +139,8 @@ class ProtonCalendarService implements Calendar {
     const userTimeZone = userId ? await this.getUserTimezoneFromDB(userId) : "Europe/London";
     const events: { start: string; end: string; title: string }[] = [];
 
-    const cancelledInstances = new Set<string>();
-
     calendars.forEach(({ vcalendar }) => {
+      const cancelledInstances = new Set<string>();
       const vevents = vcalendar.getAllSubcomponents("vevent");
 
       for (const vevent of vevents) {

--- a/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/CalendarService.ts
@@ -64,6 +64,7 @@ class ProtonCalendarService implements Calendar {
   }
 
   createEvent(_event: CalendarEvent, _credentialId: number): Promise<NewCalendarEventType> {
+    log.warn("createEvent called on read-only Proton Calendar");
     return Promise.resolve({
       uid: _event.uid || "",
       type: this.integrationName,
@@ -75,7 +76,10 @@ class ProtonCalendarService implements Calendar {
   }
 
   deleteEvent(_uid: string, _event: CalendarEvent, _externalCalendarId?: string): Promise<unknown> {
-    return Promise.resolve();
+    log.warn("deleteEvent called on read-only Proton Calendar");
+    return Promise.resolve({
+      additionalInfo: { calWarnings: ["Proton Calendar is read-only"] },
+    });
   }
 
   updateEvent(
@@ -83,6 +87,7 @@ class ProtonCalendarService implements Calendar {
     _event: CalendarEvent,
     _externalCalendarId?: string
   ): Promise<NewCalendarEventType | NewCalendarEventType[]> {
+    log.warn("updateEvent called on read-only Proton Calendar");
     return Promise.resolve({
       uid: _event.uid || "",
       type: this.integrationName,
@@ -222,7 +227,9 @@ class ProtonCalendarService implements Calendar {
 
         if (event.isRecurring()) {
           let iterations = MAX_RECURRENCE_ITERATIONS;
-          if (["HOURLY", "SECONDLY", "MINUTELY"].includes(event.getRecurrenceTypes())) {
+          const dominated = ["HOURLY", "SECONDLY", "MINUTELY"];
+          const recurrenceTypes = event.getRecurrenceTypes();
+          if (Object.keys(recurrenceTypes).some((freq) => dominated.includes(freq))) {
             continue;
           }
 
@@ -245,11 +252,13 @@ class ProtonCalendarService implements Calendar {
           ) {
             iterations -= 1;
 
+            currentEvent = undefined;
             try {
               currentEvent = event.getOccurrenceDetails(current);
             } catch (error) {
               if (error instanceof Error && error.message !== currentError) {
                 currentError = error.message;
+                log.error("Recurrence expansion error", error);
               }
             }
             if (!currentEvent) continue;

--- a/packages/app-store/proton-calendarcalendar/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/__tests__/CalendarService.test.ts
@@ -396,6 +396,36 @@ END:VCALENDAR`;
       expect(events[0].title).toBe("Timezone meeting");
     });
 
+    it("creates synthetic VTIMEZONE per distinct TZID in feeds without one", async () => {
+      const multiTzIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:tz-a
+DTSTART;TZID=Etc/GMT-2:20240115T100000
+DTEND;TZID=Etc/GMT-2:20240115T110000
+SUMMARY:Event in GMT+2
+END:VEVENT
+BEGIN:VEVENT
+UID:tz-b
+DTSTART;TZID=Etc/GMT-5:20240115T140000
+DTEND;TZID=Etc/GMT-5:20240115T150000
+SUMMARY:Event in GMT+5
+END:VEVENT
+END:VCALENDAR`;
+      mockFetchResponse(multiTzIcs);
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-14T00:00:00Z",
+        dateTo: "2024-01-16T00:00:00Z",
+        selectedCalendars: [{ userId: 1, integration: "proton-calendar_calendar", externalId: "url" }],
+      });
+
+      expect(events).toHaveLength(2);
+      const titles = events.map((e) => e.title);
+      expect(titles).toContain("Event in GMT+2");
+      expect(titles).toContain("Event in GMT+5");
+    });
+
     it("handles daily recurring events within date range", async () => {
       const dailyIcs = `BEGIN:VCALENDAR
 VERSION:2.0

--- a/packages/app-store/proton-calendarcalendar/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/__tests__/CalendarService.test.ts
@@ -14,6 +14,7 @@ vi.mock("@calcom/prisma", () => ({
   },
 }));
 
+import { symmetricDecrypt } from "@calcom/lib/crypto";
 import type { CredentialPayload } from "@calcom/types/Credential";
 import BuildCalendarService from "../CalendarService";
 
@@ -94,6 +95,31 @@ function mockFetchResponse(body: string, ok = true, status = 200) {
 describe("ProtonCalendarService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("throws when credential key is missing", () => {
+      const credentialWithoutKey = { ...mockCredential, key: null };
+      expect(() => BuildCalendarService(credentialWithoutKey)).toThrow(
+        "Missing Proton Calendar credential key"
+      );
+    });
+
+    it("degrades gracefully when credential data is malformed", async () => {
+      vi.mocked(symmetricDecrypt).mockReturnValueOnce("not-valid-json");
+      const service = BuildCalendarService(mockCredential);
+      mockFetchResponse(SIMPLE_ICS);
+      const calendars = await service.listCalendars();
+      expect(calendars).toHaveLength(0);
+    });
+
+    it("degrades gracefully when urls is not a string array", async () => {
+      vi.mocked(symmetricDecrypt).mockReturnValueOnce(JSON.stringify({ urls: [123, null] }));
+      const service = BuildCalendarService(mockCredential);
+      mockFetchResponse(SIMPLE_ICS);
+      const calendars = await service.listCalendars();
+      expect(calendars).toHaveLength(0);
+    });
   });
 
   describe("createEvent", () => {
@@ -315,6 +341,83 @@ END:VCALENDAR`;
       });
 
       expect(events).toEqual([]);
+    });
+
+    it("handles events with unrecognized travel duration gracefully", async () => {
+      const travelIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:travel-1
+DTSTART:20240115T100000Z
+DTEND:20240115T110000Z
+SUMMARY:Meeting with travel
+X-APPLE-TRAVEL-DURATION:PT1800S
+END:VEVENT
+END:VCALENDAR`;
+      mockFetchResponse(travelIcs);
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-16T00:00:00Z",
+        selectedCalendars: [],
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].title).toBe("Meeting with travel");
+    });
+
+    it("handles events with explicit VTIMEZONE", async () => {
+      const tzIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:CustomTZ
+BEGIN:STANDARD
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+DTSTART:19700101T000000
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:tz-event-1
+DTSTART;TZID=CustomTZ:20240115T100000
+DTEND;TZID=CustomTZ:20240115T110000
+SUMMARY:Timezone meeting
+END:VEVENT
+END:VCALENDAR`;
+      mockFetchResponse(tzIcs);
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-16T00:00:00Z",
+        selectedCalendars: [{ userId: 1, integration: "proton-calendar_calendar", externalId: "url" }],
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].title).toBe("Timezone meeting");
+    });
+
+    it("handles daily recurring events within date range", async () => {
+      const dailyIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:daily-1
+DTSTART:20240115T100000Z
+DTEND:20240115T110000Z
+SUMMARY:Daily standup
+RRULE:FREQ=DAILY;COUNT=5
+END:VEVENT
+END:VCALENDAR`;
+      mockFetchResponse(dailyIcs);
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-20T00:00:00Z",
+        selectedCalendars: [],
+      });
+
+      expect(events).toHaveLength(5);
+      const dates = events.map((e) => new Date(e.start).getUTCDate());
+      expect(dates).toEqual([15, 16, 17, 18, 19]);
     });
   });
 });

--- a/packages/app-store/proton-calendarcalendar/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/__tests__/CalendarService.test.ts
@@ -240,6 +240,39 @@ END:VCALENDAR`;
       expect(events).toHaveLength(0);
     });
 
+    it("filters specific recurring instance cancelled via RECURRENCE-ID", async () => {
+      const recurrenceIdCancelIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:recurring-1
+DTSTART:20240115T100000Z
+DTEND:20240115T110000Z
+SUMMARY:Weekly standup
+RRULE:FREQ=DAILY;COUNT=3
+END:VEVENT
+BEGIN:VEVENT
+UID:recurring-1
+RECURRENCE-ID:20240116T100000Z
+DTSTART:20240116T100000Z
+DTEND:20240116T110000Z
+SUMMARY:Weekly standup
+STATUS:CANCELLED
+END:VEVENT
+END:VCALENDAR`;
+      mockFetchResponse(recurrenceIdCancelIcs);
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-18T00:00:00Z",
+        selectedCalendars: [{ userId: 1, integration: "proton-calendar_calendar", externalId: "url" }],
+      });
+
+      const dates = events.map((e) => new Date(e.start).toISOString().slice(8, 10));
+      expect(dates).toContain("15");
+      expect(dates).not.toContain("16");
+      expect(dates).toContain("17");
+    });
+
     it("uses 'Busy' as fallback title when SUMMARY is missing", async () => {
       const noSummaryIcs = `BEGIN:VCALENDAR
 VERSION:2.0

--- a/packages/app-store/proton-calendarcalendar/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/__tests__/CalendarService.test.ts
@@ -150,11 +150,12 @@ describe("ProtonCalendarService", () => {
   });
 
   describe("deleteEvent", () => {
-    it("resolves without error", async () => {
+    it("resolves with read-only warning", async () => {
       const service = BuildCalendarService(mockCredential);
-      await expect(
-        service.deleteEvent("uid", {} as Parameters<typeof service.deleteEvent>[1])
-      ).resolves.toBeUndefined();
+      const result = await service.deleteEvent("uid", {} as Parameters<typeof service.deleteEvent>[1]);
+      expect(result).toMatchObject({
+        additionalInfo: { calWarnings: ["Proton Calendar is read-only"] },
+      });
     });
   });
 
@@ -341,6 +342,28 @@ END:VCALENDAR`;
       });
 
       expect(events).toEqual([]);
+    });
+
+    it("skips HOURLY recurrence rules", async () => {
+      const hourlyIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:hourly-1
+DTSTART:20240115T100000Z
+DTEND:20240115T103000Z
+SUMMARY:Hourly ping
+RRULE:FREQ=HOURLY;COUNT=24
+END:VEVENT
+END:VCALENDAR`;
+      mockFetchResponse(hourlyIcs);
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-16T00:00:00Z",
+        selectedCalendars: [],
+      });
+
+      expect(events).toHaveLength(0);
     });
 
     it("handles events with unrecognized travel duration gracefully", async () => {

--- a/packages/app-store/proton-calendarcalendar/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/__tests__/CalendarService.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@calcom/lib/crypto", () => ({
+  symmetricDecrypt: vi.fn((_key: string, _secret: string) =>
+    JSON.stringify({ urls: ["https://calendar.proton.me/api/calendar/v1/url/test/calendar.ics"] })
+  ),
+}));
+
+vi.mock("@calcom/prisma", () => ({
+  default: {
+    user: {
+      findUnique: vi.fn().mockResolvedValue({ timeZone: "Europe/London" }),
+    },
+  },
+}));
+
+import type { CredentialPayload } from "@calcom/types/Credential";
+import BuildCalendarService from "../CalendarService";
+
+const SIMPLE_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Proton AG//ProtonCalendar//EN
+X-WR-CALNAME:My Proton Calendar
+BEGIN:VEVENT
+UID:simple-event-1
+DTSTART:20240115T100000Z
+DTEND:20240115T110000Z
+SUMMARY:Morning standup
+END:VEVENT
+END:VCALENDAR`;
+
+const GHOST_EVENT_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Proton AG//ProtonCalendar//EN
+BEGIN:VEVENT
+UID:ghost-event-1
+DTSTART:20240115T140000Z
+DTEND:20240115T150000Z
+SUMMARY:Cancelled meeting
+STATUS:CANCELLED
+END:VEVENT
+BEGIN:VEVENT
+UID:normal-event-1
+DTSTART:20240115T160000Z
+DTEND:20240115T170000Z
+SUMMARY:Real meeting
+END:VEVENT
+END:VCALENDAR`;
+
+const MULTI_EVENT_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Proton AG//ProtonCalendar//EN
+BEGIN:VEVENT
+UID:event-a
+DTSTART:20240115T090000Z
+DTEND:20240115T093000Z
+SUMMARY:Event A
+END:VEVENT
+BEGIN:VEVENT
+UID:event-b
+DTSTART:20240115T120000Z
+DTEND:20240115T130000Z
+SUMMARY:Event B
+END:VEVENT
+BEGIN:VEVENT
+UID:event-c
+DTSTART:20240120T120000Z
+DTEND:20240120T130000Z
+SUMMARY:Event C outside range
+END:VEVENT
+END:VCALENDAR`;
+
+const mockCredential: CredentialPayload = {
+  id: 1,
+  type: "proton-calendar_calendar",
+  key: "encrypted-key-placeholder",
+  userId: 1,
+  teamId: null,
+  appId: "proton-calendar",
+  invalid: false,
+  user: { email: "test@example.com" },
+  delegationCredentialId: null,
+  encryptedKey: null,
+};
+
+function mockFetchResponse(body: string, ok = true, status = 200) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    text: () => Promise.resolve(body),
+  });
+}
+
+describe("ProtonCalendarService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createEvent", () => {
+    it("returns read-only warning", async () => {
+      const service = BuildCalendarService(mockCredential);
+      const result = await service.createEvent(
+        { uid: "test-uid" } as Parameters<typeof service.createEvent>[0],
+        1
+      );
+      expect(result).toMatchObject({
+        uid: "test-uid",
+        type: "proton-calendar_calendar",
+        additionalInfo: { calWarnings: ["Proton Calendar is read-only"] },
+      });
+    });
+  });
+
+  describe("updateEvent", () => {
+    it("returns read-only warning", async () => {
+      const service = BuildCalendarService(mockCredential);
+      const result = await service.updateEvent("uid", { uid: "test-uid" } as Parameters<
+        typeof service.updateEvent
+      >[1]);
+      expect(result).toMatchObject({
+        additionalInfo: { calWarnings: ["Proton Calendar is read-only"] },
+      });
+    });
+  });
+
+  describe("deleteEvent", () => {
+    it("resolves without error", async () => {
+      const service = BuildCalendarService(mockCredential);
+      await expect(
+        service.deleteEvent("uid", {} as Parameters<typeof service.deleteEvent>[1])
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("listCalendars", () => {
+    it("returns calendars with correct metadata", async () => {
+      mockFetchResponse(SIMPLE_ICS);
+      const service = BuildCalendarService(mockCredential);
+      const calendars = await service.listCalendars();
+
+      expect(calendars).toHaveLength(1);
+      expect(calendars[0]).toMatchObject({
+        name: "My Proton Calendar",
+        readOnly: true,
+        integration: "proton-calendar_calendar",
+      });
+    });
+
+    it("falls back to 'Proton Calendar' when X-WR-CALNAME is missing", async () => {
+      const icsWithoutName = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Proton AG//ProtonCalendar//EN
+BEGIN:VEVENT
+UID:test-1
+DTSTART:20240115T100000Z
+DTEND:20240115T110000Z
+SUMMARY:Test
+END:VEVENT
+END:VCALENDAR`;
+      mockFetchResponse(icsWithoutName);
+      const service = BuildCalendarService(mockCredential);
+      const calendars = await service.listCalendars();
+
+      expect(calendars[0].name).toBe("Proton Calendar");
+    });
+
+    it("handles fetch failure gracefully", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+      const service = BuildCalendarService(mockCredential);
+      const calendars = await service.listCalendars();
+
+      expect(calendars).toHaveLength(0);
+    });
+
+    it("handles HTTP error response gracefully", async () => {
+      mockFetchResponse("", false, 403);
+      const service = BuildCalendarService(mockCredential);
+      const calendars = await service.listCalendars();
+
+      expect(calendars).toHaveLength(0);
+    });
+  });
+
+  describe("getAvailability", () => {
+    it("returns all non-recurring events from the feed", async () => {
+      mockFetchResponse(MULTI_EVENT_ICS);
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-16T00:00:00Z",
+        selectedCalendars: [{ userId: 1, integration: "proton-calendar_calendar", externalId: "url" }],
+      });
+
+      // Non-recurring events are returned as-is; date filtering happens upstream in Cal.com
+      const titles = events.map((e) => e.title);
+      expect(titles).toContain("Event A");
+      expect(titles).toContain("Event B");
+      expect(titles).toContain("Event C outside range");
+      expect(events).toHaveLength(3);
+    });
+
+    it("filters out ghost events with STATUS:CANCELLED", async () => {
+      mockFetchResponse(GHOST_EVENT_ICS);
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-16T00:00:00Z",
+        selectedCalendars: [{ userId: 1, integration: "proton-calendar_calendar", externalId: "url" }],
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].title).toBe("Real meeting");
+    });
+
+    it("filters entire event series when UID-only cancellation exists", async () => {
+      const cancelledSeriesIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:series-cancel-1
+DTSTART:20240115T100000Z
+DTEND:20240115T110000Z
+SUMMARY:Cancelled series event
+STATUS:CANCELLED
+END:VEVENT
+BEGIN:VEVENT
+UID:series-cancel-1
+DTSTART:20240115T140000Z
+DTEND:20240115T150000Z
+SUMMARY:Another instance
+END:VEVENT
+END:VCALENDAR`;
+      mockFetchResponse(cancelledSeriesIcs);
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-16T00:00:00Z",
+        selectedCalendars: [{ userId: 1, integration: "proton-calendar_calendar", externalId: "url" }],
+      });
+
+      expect(events).toHaveLength(0);
+    });
+
+    it("uses 'Busy' as fallback title when SUMMARY is missing", async () => {
+      const noSummaryIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:no-summary-1
+DTSTART:20240115T100000Z
+DTEND:20240115T110000Z
+END:VEVENT
+END:VCALENDAR`;
+      mockFetchResponse(noSummaryIcs);
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-16T00:00:00Z",
+        selectedCalendars: [],
+      });
+
+      expect(events[0].title).toBe("Busy");
+    });
+
+    it("returns empty array when fetch fails", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("timeout"));
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-16T00:00:00Z",
+        selectedCalendars: [],
+      });
+
+      expect(events).toEqual([]);
+    });
+
+    it("handles invalid ICS data gracefully", async () => {
+      mockFetchResponse("this is not valid ics data");
+      const service = BuildCalendarService(mockCredential);
+      const events = await service.getAvailability({
+        dateFrom: "2024-01-15T00:00:00Z",
+        dateTo: "2024-01-16T00:00:00Z",
+        selectedCalendars: [],
+      });
+
+      expect(events).toEqual([]);
+    });
+  });
+});

--- a/packages/app-store/proton-calendarcalendar/lib/index.ts
+++ b/packages/app-store/proton-calendarcalendar/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as BuildCalendarService } from "./CalendarService";

--- a/packages/app-store/proton-calendarcalendar/package.json
+++ b/packages/app-store/proton-calendarcalendar/package.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "private": true,
+  "name": "@calcom/proton-calendar",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "dependencies": {
+    "@calcom/lib": "workspace:*",
+    "@calcom/prisma": "workspace:*",
+    "@calcom/ui": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "react-hook-form": "^7.0.0"
+  },
+  "devDependencies": {
+    "@calcom/types": "workspace:*"
+  },
+  "description": "Import your Proton Calendar availability into Cal.diy via ICS share link."
+}

--- a/packages/app-store/proton-calendarcalendar/static/icon.svg
+++ b/packages/app-store/proton-calendarcalendar/static/icon.svg
@@ -1,0 +1,10 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="160" rx="32" fill="#6D4AFF"/>
+  <path d="M80 36L44 56v48l36 20 36-20V56L80 36z" fill="#fff" opacity="0.15"/>
+  <path d="M80 40l-32 18v36l32 18 32-18V58L80 40z" stroke="#fff" stroke-width="4" fill="none"/>
+  <line x1="48" y1="72" x2="112" y2="72" stroke="#fff" stroke-width="3"/>
+  <line x1="48" y1="86" x2="112" y2="86" stroke="#fff" stroke-width="2" opacity="0.5"/>
+  <line x1="48" y1="98" x2="112" y2="98" stroke="#fff" stroke-width="2" opacity="0.5"/>
+  <rect x="62" y="48" width="8" height="16" rx="2" fill="#fff"/>
+  <rect x="90" y="48" width="8" height="16" rx="2" fill="#fff"/>
+</svg>

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -439,6 +439,7 @@
   "welcome_instructions": "Tell us what to call you and let us know what timezone you're in. You'll be able to edit this later.",
   "connect_caldav": "Connect to CalDav (Beta)",
   "connect_ics_feed": "Connect to an ICS Feed",
+  "connect_proton_calendar": "Connect Proton Calendar",
   "connect": "Connect",
   "try_for_free": "Try it for free",
   "create_booking_link_with_calcom": "Create your own booking link with {{appName}}",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2964,6 +2964,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@calcom/proton-calendar@workspace:packages/app-store/proton-calendarcalendar":
+  version: 0.0.0-use.local
+  resolution: "@calcom/proton-calendar@workspace:packages/app-store/proton-calendarcalendar"
+  dependencies:
+    "@calcom/lib": "workspace:*"
+    "@calcom/prisma": "workspace:*"
+    "@calcom/types": "workspace:*"
+    "@calcom/ui": "workspace:*"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    react-hook-form: ^7.0.0
+  languageName: unknown
+  linkType: soft
+
 "@calcom/qr_code@workspace:packages/app-store/qr_code":
   version: 0.0.0-use.local
   resolution: "@calcom/qr_code@workspace:packages/app-store/qr_code"


### PR DESCRIPTION
/claim #5756

## What does this PR do?

Adds a read-only Proton Calendar integration that imports availability from Proton's shareable ICS feed URLs for conflict checking. Proton Calendar does not offer OAuth or a public API; ICS is the only supported access method.

Users go to Apps > Proton Calendar > Install, paste their ICS feed URL from Proton Calendar sharing settings, and Cal.com uses the feed to block booking slots that overlap with Proton Calendar events.

## Key details

- Validates URLs against `calendar.proton.me` and `calendar.protonmail.com` hostnames using strict `.includes()` (not `.endsWith()`)
- Encrypts ICS feed URLs at rest via `CALENDSO_ENCRYPTION_KEY`
- Filters `STATUS:CANCELLED` ghost events that Proton keeps in its feeds
- Caps RRULE expansion at 365 iterations to prevent DoS from dense recurrence rules
- Rejects `HOURLY`/`MINUTELY`/`SECONDLY` frequencies
- Uses `redirect: "error"` on fetch to prevent SSRF via redirect chains
- Auth guard on the API handler returns 401 before any DB access if session is missing
- 34 tests (22 CalendarService + 12 URL validation)

## Video demo



https://github.com/user-attachments/assets/d6aa689a-5f7b-46eb-8e48-cc60df32f256




## How to test

1. Run `yarn dev` and go to Apps > Proton Calendar > Install
2. In Proton Calendar, go to Settings > Calendars > Share > create a link and copy the ICS URL
3. Paste URL in the setup page, click Save
4. Create events in Proton Calendar and verify they block slots on the booking page

Fixes #5756

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] N/A for docs changes
- [x] Automated tests are in place (25 unit tests covering URL validation and calendar service)