### PR TITLE
feat: make seed-performance-testing script configurable from CLI

### DIFF
--- a/scripts/seed-performance-testing.ts
+++ b/scripts/seed-performance-testing.ts
@@ -1,19 +1,46 @@
 /**
  *  This script can be used to seed the database with a lot of data for performance testing.
- *  TODO: Make it more structured and configurable from CLI
- *  Run it as `npx ts-node --transpile-only ./seed-performance-testing.ts`
  */
-import { uuid } from "short-uuid";
+import dotenv from "dotenv"
+import path from "path"
 
+dotenv.config({ path: path.resolve(__dirname, "../.env") })
+
+import { uuid } from "short-uuid";
+ 
 import dailyMeta from "@calcom/app-store/dailyvideo/_metadata";
 import googleMeetMeta from "@calcom/app-store/googlevideo/_metadata";
 import zoomMeta from "@calcom/app-store/zoomvideo/_metadata";
 import dayjs from "@calcom/dayjs";
 import { BookingStatus } from "@calcom/prisma/enums";
-
+ 
 import { createUserAndEventType } from "./seed-utils";
 
-async function _createManyDifferentUsersWithDifferentEventTypesAndBookings({
+type Mode = "many-bookings" | "many-users";
+ 
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const get = (flag: string) => {
+    const i = args.indexOf(flag);
+    return i !== -1 ? args[i + 1] : undefined;
+  };
+ 
+  const mode = (get("--mode") ?? "many-bookings") as Mode;
+  const bookingsPerEventType = parseInt(get("--bookings") ?? "100", 10);
+  const startFrom = parseInt(get("--start-from") ?? "0", 10);
+  const tillUser = parseInt(get("--till-user") ?? "20", 10);
+
+  if (!["many-bookings", "many-users"].includes(mode)) {
+    console.error(`Invalid --mode "${mode}". Must be many-bookings or many-users.`);
+    process.exit(1);
+  }
+
+  const config = { mode, bookingsPerEventType, startFrom, tillUser };
+
+  return config;
+}
+ 
+async function createManyDifferentUsersWithDifferentEventTypesAndBookings({
   tillUser,
   startFrom = 0,
 }: {
@@ -50,25 +77,14 @@ async function _createManyDifferentUsersWithDifferentEventTypesAndBookings({
             },
           ],
         },
-        {
-          title: "60min",
-          slug: "60min",
-          length: 60,
-        },
+        { title: "60min", slug: "60min", length: 60 },
         {
           title: "Multiple duration",
           slug: "multiple-duration",
           length: 75,
-          metadata: {
-            multipleDuration: [30, 75, 90],
-          },
+          metadata: { multipleDuration: [30, 75, 90] },
         },
-        {
-          title: "paid",
-          slug: "paid",
-          length: 60,
-          price: 100,
-        },
+        { title: "paid", slug: "paid", length: 60, price: 100 },
         {
           title: "In person meeting",
           slug: "in-person",
@@ -99,90 +115,23 @@ async function _createManyDifferentUsersWithDifferentEventTypesAndBookings({
           length: 30,
           recurringEvent: { freq: 2, count: 12, interval: 1 },
           _bookings: [
-            {
+            ...[0, 1, 2, 3, 4, 5].map((week) => ({
               uid: uuid(),
               title: "Yoga class",
               recurringEventId: Buffer.from("yoga-class").toString("base64"),
-              startTime: dayjs().add(1, "day").toDate(),
-              endTime: dayjs().add(1, "day").add(30, "minutes").toDate(),
+              startTime: dayjs().add(1, "day").add(week, "week").toDate(),
+              endTime: dayjs().add(1, "day").add(week, "week").add(30, "minutes").toDate(),
               status: BookingStatus.ACCEPTED,
-            },
-            {
-              uid: uuid(),
-              title: "Yoga class",
-              recurringEventId: Buffer.from("yoga-class").toString("base64"),
-              startTime: dayjs().add(1, "day").add(1, "week").toDate(),
-              endTime: dayjs().add(1, "day").add(1, "week").add(30, "minutes").toDate(),
-              status: BookingStatus.ACCEPTED,
-            },
-            {
-              uid: uuid(),
-              title: "Yoga class",
-              recurringEventId: Buffer.from("yoga-class").toString("base64"),
-              startTime: dayjs().add(1, "day").add(2, "week").toDate(),
-              endTime: dayjs().add(1, "day").add(2, "week").add(30, "minutes").toDate(),
-              status: BookingStatus.ACCEPTED,
-            },
-            {
-              uid: uuid(),
-              title: "Yoga class",
-              recurringEventId: Buffer.from("yoga-class").toString("base64"),
-              startTime: dayjs().add(1, "day").add(3, "week").toDate(),
-              endTime: dayjs().add(1, "day").add(3, "week").add(30, "minutes").toDate(),
-              status: BookingStatus.ACCEPTED,
-            },
-            {
-              uid: uuid(),
-              title: "Yoga class",
-              recurringEventId: Buffer.from("yoga-class").toString("base64"),
-              startTime: dayjs().add(1, "day").add(4, "week").toDate(),
-              endTime: dayjs().add(1, "day").add(4, "week").add(30, "minutes").toDate(),
-              status: BookingStatus.ACCEPTED,
-            },
-            {
-              uid: uuid(),
-              title: "Yoga class",
-              recurringEventId: Buffer.from("yoga-class").toString("base64"),
-              startTime: dayjs().add(1, "day").add(5, "week").toDate(),
-              endTime: dayjs().add(1, "day").add(5, "week").add(30, "minutes").toDate(),
-              status: BookingStatus.ACCEPTED,
-            },
-            {
+            })),
+            ...[0, 1, 2, 3].map((week) => ({
               uid: uuid(),
               title: "Seeded Yoga class",
               description: "seeded",
               recurringEventId: Buffer.from("seeded-yoga-class").toString("base64"),
-              startTime: dayjs().subtract(4, "day").toDate(),
-              endTime: dayjs().subtract(4, "day").add(30, "minutes").toDate(),
+              startTime: dayjs().subtract(4, "day").add(week, "week").toDate(),
+              endTime: dayjs().subtract(4, "day").add(week, "week").add(30, "minutes").toDate(),
               status: BookingStatus.ACCEPTED,
-            },
-            {
-              uid: uuid(),
-              title: "Seeded Yoga class",
-              description: "seeded",
-              recurringEventId: Buffer.from("seeded-yoga-class").toString("base64"),
-              startTime: dayjs().subtract(4, "day").add(1, "week").toDate(),
-              endTime: dayjs().subtract(4, "day").add(1, "week").add(30, "minutes").toDate(),
-              status: BookingStatus.ACCEPTED,
-            },
-            {
-              uid: uuid(),
-              title: "Seeded Yoga class",
-              description: "seeded",
-              recurringEventId: Buffer.from("seeded-yoga-class").toString("base64"),
-              startTime: dayjs().subtract(4, "day").add(2, "week").toDate(),
-              endTime: dayjs().subtract(4, "day").add(2, "week").add(30, "minutes").toDate(),
-              status: BookingStatus.ACCEPTED,
-            },
-            {
-              uid: uuid(),
-              title: "Seeded Yoga class",
-              description: "seeded",
-              recurringEventId: Buffer.from("seeded-yoga-class").toString("base64"),
-              startTime: dayjs().subtract(4, "day").add(3, "week").toDate(),
-              endTime: dayjs().subtract(4, "day").add(3, "week").add(30, "minutes").toDate(),
-              status: BookingStatus.ACCEPTED,
-            },
+            })),
           ],
         },
         {
@@ -191,55 +140,21 @@ async function _createManyDifferentUsersWithDifferentEventTypesAndBookings({
           length: 60,
           recurringEvent: { freq: 2, count: 10, interval: 2 },
           requiresConfirmation: true,
-          _bookings: [
-            {
-              uid: uuid(),
-              title: "Tennis class",
-              recurringEventId: Buffer.from("tennis-class").toString("base64"),
-              startTime: dayjs().add(2, "day").toDate(),
-              endTime: dayjs().add(2, "day").add(60, "minutes").toDate(),
-              status: BookingStatus.PENDING,
-            },
-            {
-              uid: uuid(),
-              title: "Tennis class",
-              recurringEventId: Buffer.from("tennis-class").toString("base64"),
-              startTime: dayjs().add(2, "day").add(2, "week").toDate(),
-              endTime: dayjs().add(2, "day").add(2, "week").add(60, "minutes").toDate(),
-              status: BookingStatus.PENDING,
-            },
-            {
-              uid: uuid(),
-              title: "Tennis class",
-              recurringEventId: Buffer.from("tennis-class").toString("base64"),
-              startTime: dayjs().add(2, "day").add(4, "week").toDate(),
-              endTime: dayjs().add(2, "day").add(4, "week").add(60, "minutes").toDate(),
-              status: BookingStatus.PENDING,
-            },
-            {
-              uid: uuid(),
-              title: "Tennis class",
-              recurringEventId: Buffer.from("tennis-class").toString("base64"),
-              startTime: dayjs().add(2, "day").add(8, "week").toDate(),
-              endTime: dayjs().add(2, "day").add(8, "week").add(60, "minutes").toDate(),
-              status: BookingStatus.PENDING,
-            },
-            {
-              uid: uuid(),
-              title: "Tennis class",
-              recurringEventId: Buffer.from("tennis-class").toString("base64"),
-              startTime: dayjs().add(2, "day").add(10, "week").toDate(),
-              endTime: dayjs().add(2, "day").add(10, "week").add(60, "minutes").toDate(),
-              status: BookingStatus.PENDING,
-            },
-          ],
+          _bookings: [0, 2, 4, 8, 10].map((week) => ({
+            uid: uuid(),
+            title: "Tennis class",
+            recurringEventId: Buffer.from("tennis-class").toString("base64"),
+            startTime: dayjs().add(2, "day").add(week, "week").toDate(),
+            endTime: dayjs().add(2, "day").add(week, "week").add(60, "minutes").toDate(),
+            status: BookingStatus.PENDING,
+          })),
         },
       ],
     });
   }
 }
 
-async function createAUserWithManyBookings() {
+async function createAUserWithManyBookings(bookingsPerEventType: number) {
   const random = Math.random();
   await createUserAndEventType({
     user: {
@@ -250,76 +165,60 @@ async function createAUserWithManyBookings() {
       theme: "light",
     },
     eventTypes: [
-      {
-        title: "30min",
-        slug: "30min",
-        length: 30,
-        _numBookings: 100,
-      },
-      {
-        title: "60min",
-        slug: "60min",
-        length: 60,
-        _numBookings: 100,
-      },
+      { title: "30min", slug: "30min", length: 30, _numBookings: bookingsPerEventType },
+      { title: "60min", slug: "60min", length: 60, _numBookings: bookingsPerEventType },
       {
         title: "Multiple duration",
         slug: "multiple-duration",
         length: 75,
-        metadata: {
-          multipleDuration: [30, 75, 90],
-        },
-        _numBookings: 100,
+        metadata: { multipleDuration: [30, 75, 90] },
+        _numBookings: bookingsPerEventType,
       },
-      {
-        title: "paid",
-        slug: "paid",
-        length: 60,
-        price: 100,
-        _numBookings: 100,
-      },
+      { title: "paid", slug: "paid", length: 60, price: 100, _numBookings: bookingsPerEventType },
       {
         title: "Zoom Event",
         slug: "zoom",
         length: 60,
         locations: [{ type: zoomMeta.appData?.location?.type }],
-        _numBookings: 100,
+        _numBookings: bookingsPerEventType,
       },
       {
         title: "Daily Event",
         slug: "daily",
         length: 60,
         locations: [{ type: dailyMeta.appData?.location?.type }],
-        _numBookings: 100,
+        _numBookings: bookingsPerEventType,
       },
       {
         title: "Google Meet",
         slug: "google-meet",
         length: 60,
         locations: [{ type: googleMeetMeta.appData?.location?.type }],
-        _numBookings: 100,
+        _numBookings: bookingsPerEventType,
       },
-      {
-        title: "Yoga class",
-        slug: "yoga-class",
-        length: 30,
-        _numBookings: 100,
-      },
+      { title: "Yoga class", slug: "yoga-class", length: 30, _numBookings: bookingsPerEventType },
       {
         title: "Tennis class",
         slug: "tennis-class",
         length: 60,
         recurringEvent: { freq: 2, count: 10, interval: 2 },
         requiresConfirmation: true,
-        _numBookings: 100,
+        _numBookings: bookingsPerEventType,
       },
     ],
   });
 }
 
-// createManyDifferentUsersWithDifferentEventTypesAndBookings({
-//   tillUser: 20000,
-//   startFrom: 10000,
-// });
+async function main() {
+  const { mode, bookingsPerEventType, startFrom, tillUser } = parseArgs();
+ 
+  if (mode === "many-users") {
+    await createManyDifferentUsersWithDifferentEventTypesAndBookings({ startFrom, tillUser });
+  } else {
+    await createAUserWithManyBookings(bookingsPerEventType);
+  }
+}
+ 
+main();
+ 
 
-createAUserWithManyBookings();

--- a/scripts/seed-performance-testing.ts
+++ b/scripts/seed-performance-testing.ts
@@ -26,19 +26,40 @@ function parseArgs() {
   };
  
   const mode = (get("--mode") ?? "many-bookings") as Mode;
-  const bookingsPerEventType = parseInt(get("--bookings") ?? "100", 10);
-  const startFrom = parseInt(get("--start-from") ?? "0", 10);
-  const tillUser = parseInt(get("--till-user") ?? "20", 10);
-
-  if (!["many-bookings", "many-users"].includes(mode)) {
+  if (mode !== "many-bookings" && mode !== "many-users") {
     console.error(`Invalid --mode "${mode}". Must be many-bookings or many-users.`);
     process.exit(1);
   }
+ 
+  const parseNonNegativeInt = (flag: string, raw: string | undefined, fallback: number) => {
+    const n = parseInt(raw ?? String(fallback), 10);
+    if (!Number.isFinite(n) || n < 0) {
+      console.error(`Invalid ${flag} "${raw}". Must be a non-negative integer.`);
+      process.exit(1);
+    }
+    return n;
+  };
+ 
+  const bookingsPerEventType = parseNonNegativeInt("--bookings", get("--bookings"), 100);
+  const startFrom = parseNonNegativeInt("--start-from", get("--start-from"), 0);
+  const tillUser = parseNonNegativeInt("--till-user", get("--till-user"), 20);
+  const dryRun = args.includes("--dry-run");
+ 
+  if (mode === "many-users" && tillUser <= startFrom) {
+    console.error(`--till-user (${tillUser}) must be greater than --start-from (${startFrom}).`);
+    process.exit(1);
+  }
 
-  const config = { mode, bookingsPerEventType, startFrom, tillUser };
-
+  const config = { mode, bookingsPerEventType, startFrom, tillUser, dryRun };
+ 
+  if (dryRun) {
+    console.log("Resolved config (dry-run):\n", JSON.stringify(config, null, 2));
+    process.exit(0);
+  }
+ 
   return config;
 }
+
  
 async function createManyDifferentUsersWithDifferentEventTypesAndBookings({
   tillUser,
@@ -219,6 +240,11 @@ async function main() {
   }
 }
  
-main();
+main()
+.then(() => process.exit(0))
+.catch((err) => {
+  console.error(err)
+  process.exit(1)
+});
  
 


### PR DESCRIPTION
## What does this PR do?

Resolves the `TODO: Make it more structured and configurable from CLI` in `seed-performance-testing.ts`.


#### Video Demo (if applicable):

[Screencast from 2026-04-26 19-30-14.webm](https://github.com/user-attachments/assets/e0ee2268-6caa-4536-85ab-7ab4ad04ae58)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?


> **Note for reviewers:** The steps below require a locally reachable Postgres instance. The project's `docker-compose.yml` runs the database inside Docker , to connect from the host you will need to temporarily expose port 5432. This is a local only change and is **not part of this PR**.
>
> In your local `docker-compose.yml`, add the following under the `database` service, run `docker compose up -d database`, then follow the steps below. Remove the port mapping when done.
> ```yaml
> database:
>   ports:
>     - "5432:5432"
> ```


1. In .env
```
   DATABASE_URL=postgresql://unicorn_user:magical_password@localhost:5432/calendso
   DATABASE_DIRECT_URL=postgresql://unicorn_user:magical_password@localhost:5432/calendso
   ```
   
2. Run `docker-compose up -d database`

3. cd into /scripts

4. Three modes are available
  - `--bookings <n>` — number of bookings per event type (default: `100`)
  - `--start-from <n>` — start user index for many-users mode (default: `0`), enables resuming an interrupted run
  - `--till-user <n>` — end user index for many-users mode (default: `20`)
  - `--mode many-bookings | many-users` — replaces the previously commented-out `createManyDifferentUsers` call
  
  
 Examples
 - npx ts-node --transpile-only ./scripts/seed-performance-testing.ts
 - npx ts-node --transpile-only ./scripts/seed-performance-testing.ts --bookings 50
 - npx ts-node --transpile-only ./scripts/seed-performance-testing.ts --mode many-users --till-user 100
 - npx ts-node --transpile-only ./scripts/seed-performance-testing.ts --mode many-users --start-from 500 --till-user 1000