### PR TITLE
cleanup(webhooks): remove delegation webhook trigger support

### DIFF
--- a/packages/features/webhooks/lib/constants.ts
+++ b/packages/features/webhooks/lib/constants.ts
@@ -60,7 +60,6 @@ export const WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP = {
     WebhookTriggerEvents.OOO_CREATED,
     WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW,
     WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW,
-    WebhookTriggerEvents.DELEGATION_CREDENTIAL_ERROR,
     WebhookTriggerEvents.WRONG_ASSIGNMENT_REPORT,
   ] as const,
 };

--- a/packages/features/webhooks/lib/service/WebhookNotificationHandler.test.ts
+++ b/packages/features/webhooks/lib/service/WebhookNotificationHandler.test.ts
@@ -249,34 +249,6 @@ describe("WebhookNotificationHandler", () => {
       );
     });
 
-    it("should handle DELEGATION_CREDENTIAL_ERROR through factory", async () => {
-      const errorDTO: WebhookEventDTO = {
-        triggerEvent: WebhookTriggerEvents.DELEGATION_CREDENTIAL_ERROR,
-        createdAt: "2024-01-15T10:00:00Z",
-        error: "Credential error",
-        credential: { id: 1, type: "test" },
-        user: { id: 1, email: "user@test.com" },
-      };
-
-      mockWebhookService.getSubscribers.mockResolvedValue(mockSubscribers);
-
-      await handler.handleNotification(errorDTO);
-
-      // All events now go through the factory for consistent versioning
-      expect(mockFactory.getBuilder).toHaveBeenCalledWith(
-        WebhookVersion.V_2021_10_20,
-        WebhookTriggerEvents.DELEGATION_CREDENTIAL_ERROR
-      );
-      expect(mockWebhookService.processWebhooks).toHaveBeenCalledWith(
-        WebhookTriggerEvents.DELEGATION_CREDENTIAL_ERROR,
-        {
-          triggerEvent: WebhookTriggerEvents.DELEGATION_CREDENTIAL_ERROR,
-          createdAt: errorDTO.createdAt,
-          payload: errorDTO,
-        },
-        mockSubscribers
-      );
-    });
   });
 
   describe("Version Handling", () => {


### PR DESCRIPTION
## What this does

- removes `DELEGATION_CREDENTIAL_ERROR` from the supported webhook trigger list
- removes the remaining webhook notification test that still treated delegation webhook delivery as active support
- keeps the existing no-op delegation webhook helper in place so unrelated app-store callers keep compiling until broader delegation cleanup lands

## Validation

```bash
yarn vitest run packages/features/webhooks/lib/service/WebhookNotificationHandler.test.ts
```

Result: passed (`11` tests)

```bash
yarn type-check:ci --force
```

Result: passed
