### PR TITLE
cleanup(webhooks): remove team org management support

### DIFF
--- a/apps/web/modules/webhooks/components/CreateNewWebhookButton.tsx
+++ b/apps/web/modules/webhooks/components/CreateNewWebhookButton.tsx
@@ -1,95 +1,24 @@
 "use client";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { MembershipRole } from "@calcom/prisma/enums";
-import { trpc } from "@calcom/trpc/react";
-import { Avatar, AvatarFallback, AvatarImage } from "@coss/ui/components/avatar";
 import { Button } from "@coss/ui/components/button";
-import { Menu, MenuGroup, MenuGroupLabel, MenuItem, MenuPopup, MenuTrigger } from "@coss/ui/components/menu";
-import { ChevronDownIcon, PlusIcon } from "lucide-react";
+import { PlusIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 
-function getInitials(name: string): string {
-  return name
-    .split(" ")
-    .map((n) => n[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
-}
-
-export const CreateNewWebhookButton = ({ isEmptyState }: { isEmptyState?: boolean }) => {
+export const CreateNewWebhookButton = ({ isEmptyState }: { isEmptyState?: boolean }): JSX.Element => {
   const router = useRouter();
   const { t } = useLocale();
+  let variant: "default" | "outline" = "outline";
 
-  const query = trpc.viewer.loggedInViewerRouter.teamsAndUserProfilesQuery.useQuery({
-    includeOrg: true,
-    withPermission: {
-      permission: "webhook.create",
-      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-    },
-  });
-
-  if (!query.data) return null;
-
-  const options = query.data
-    .filter((profile) => !profile.readOnly)
-    .map((profile) => ({
-      teamId: profile.teamId,
-      label: profile.name || profile.slug,
-      image: profile.image,
-      slug: profile.slug,
-    }));
-
-  const handleSelect = (option: { teamId?: number | null; platform?: boolean }) => {
-    if (option.platform) {
-      router.push(`webhooks/new?platform=${option.platform}`);
-    } else {
-      router.push(`webhooks/new${option.teamId ? `?teamId=${option.teamId}` : ""}`);
-    }
-  };
-
-  if (options.length <= 1) {
-    return (
-      <Button
-        data-testid="new_webhook"
-        onClick={() => handleSelect(options[0] || {})}
-        variant={isEmptyState ? "default" : "outline"}>
-        <PlusIcon aria-hidden="true" />
-        {t("new")}
-      </Button>
-    );
+  if (isEmptyState) {
+    variant = "default";
   }
 
   return (
-    <Menu>
-      <MenuTrigger
-        render={<Button data-testid="new_webhook" variant={isEmptyState ? "default" : "outline"} />}>
-        {t("new")}
-        <ChevronDownIcon aria-hidden="true" />
-      </MenuTrigger>
-      <MenuPopup align={isEmptyState ? undefined : "end"}>
-        <MenuGroup>
-          <MenuGroupLabel>{t("create_for")}</MenuGroupLabel>
-          {options.map((option, idx) => (
-            <MenuItem
-              key={option.label}
-              data-testid={`option${option.teamId ? "-team" : ""}-${idx}`}
-              onClick={() => handleSelect(option)}>
-              <span className="flex items-center gap-2">
-                <Avatar className="size-5">
-                  {option.image ? <AvatarImage alt={option.label || ""} src={option.image} /> : null}
-                  <AvatarFallback className="text-[.625rem]">
-                    {getInitials(option.label || "")}
-                  </AvatarFallback>
-                </Avatar>
-                <span className="truncate">{option.label}</span>
-              </span>
-            </MenuItem>
-          ))}
-        </MenuGroup>
-      </MenuPopup>
-    </Menu>
+    <Button data-testid="new_webhook" onClick={(): void => router.push("webhooks/new")} variant={variant}>
+      <PlusIcon aria-hidden="true" />
+      {t("new")}
+    </Button>
   );
 };
 

--- a/apps/web/modules/webhooks/components/WebhookForm.tsx
+++ b/apps/web/modules/webhooks/components/WebhookForm.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
-
 import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import customTemplate, { hasTemplateIntegration } from "@calcom/features/webhooks/lib/integrationTemplate";
 import { WebhookVersion } from "@calcom/features/webhooks/lib/interface/IWebhookRepository";
@@ -11,15 +8,9 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { TimeUnit, WebhookTriggerEvents } from "@calcom/prisma/enums";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
-import { Select } from "@calcom/ui/components/form";
-import { TextArea } from "@calcom/ui/components/form";
-import { ToggleGroup } from "@calcom/ui/components/form";
-import { Form } from "@calcom/ui/components/form";
-import { Label } from "@calcom/ui/components/form";
-import { TextField } from "@calcom/ui/components/form";
-import { Switch } from "@calcom/ui/components/form";
-
-
+import { Form, Label, Select, Switch, TextArea, TextField, ToggleGroup } from "@calcom/ui/components/form";
+import { useEffect, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 import WebhookTestDisclosure from "./WebhookTestDisclosure";
 
 export type TWebhook = RouterOutputs["viewer"]["webhook"]["list"][number];
@@ -197,23 +188,6 @@ function getWebhookVariables(t: (key: string) => string) {
           variable: "{{attendees.0.language.locale}}",
           type: "String",
           description: t("webhook_attendee_locale"),
-        },
-      ],
-    },
-    {
-      category: t("webhook_teams"),
-      variables: [
-        {
-          name: "team.name",
-          variable: "{{team.name}}",
-          type: "String",
-          description: t("webhook_team_name"),
-        },
-        {
-          name: "team.members",
-          variable: "{{team.members}}",
-          type: "String[]",
-          description: t("webhook_team_members"),
         },
       ],
     },

--- a/apps/web/modules/webhooks/components/WebhookListItem.tsx
+++ b/apps/web/modules/webhooks/components/WebhookListItem.tsx
@@ -19,13 +19,9 @@ import {
 } from "@coss/ui/components/menu";
 import { Switch } from "@coss/ui/components/switch";
 import { toastManager } from "@coss/ui/components/toast";
-import {
-  Tooltip,
-  TooltipPopup,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@coss/ui/components/tooltip";
+import { Tooltip, TooltipPopup, TooltipProvider, TooltipTrigger } from "@coss/ui/components/tooltip";
 import { useIsMobile } from "@coss/ui/hooks/use-mobile";
+import { EllipsisIcon, ExternalLinkIcon, PencilIcon, TrashIcon, WebhookIcon } from "@coss/ui/icons";
 import {
   ListItem,
   ListItemActions,
@@ -35,7 +31,6 @@ import {
   ListItemTitle,
   ListItemTitleLink,
 } from "@coss/ui/shared/list-item";
-import { EllipsisIcon, ExternalLinkIcon, PencilIcon, TrashIcon, WebhookIcon } from "@coss/ui/icons";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { DeleteWebhookDialog } from "./dialogs/DeleteWebhookDialog";
@@ -177,101 +172,98 @@ export default function WebhookListItem(props: {
       <ListItemActions>
         {!isMobile && (
           <TooltipProvider delay={0}>
-          <div className="flex items-center gap-4">
-            {props.permissions.canEditWebhook ? (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Switch
-                      checked={active}
-                      data-testid="webhook-switch"
-                      disabled={toggleWebhook.isPending}
-                      onCheckedChange={(checked) => {
-                        setActive(checked);
-                        toggleWebhook.mutate({
-                          id: webhook.id,
-                          active: checked,
-                          payloadTemplate: webhook.payloadTemplate,
-                          eventTypeId: webhook.eventTypeId || undefined,
-                        });
-                      }}
-                    />
-                  }
-                />
-                <TooltipPopup sideOffset={11}>
-                  {active ? t("disable_webhook") : t("enable_webhook")}
-                </TooltipPopup>
-              </Tooltip>
-            ) : (
-              <Switch checked={active} disabled />
-            )}
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-4">
               {props.permissions.canEditWebhook ? (
-                props.editHref ? (
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <Button
-                          aria-label={t("edit")}
-                          data-testid="webhook-edit-button"
-                          render={<Link href={props.editHref} />}
-                          size="icon"
-                          variant="outline"
-                        >
-                          <PencilIcon aria-hidden="true" />
-                        </Button>
-                      }
-                    />
-                    <TooltipPopup>{t("edit")}</TooltipPopup>
-                  </Tooltip>
-                ) : (
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <Button
-                          aria-label={t("edit")}
-                          data-testid="webhook-edit-button"
-                          size="icon"
-                          variant="outline"
-                          onClick={props.onEditWebhookAction}
-                        >
-                          <PencilIcon aria-hidden="true" />
-                        </Button>
-                      }
-                    />
-                    <TooltipPopup>{t("edit")}</TooltipPopup>
-                  </Tooltip>
-                )
-              ) : (
-                <Button aria-label={t("edit")} disabled size="icon" variant="outline">
-                  <PencilIcon aria-hidden="true" />
-                </Button>
-              )}
-              {props.permissions.canDeleteWebhook ? (
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <Button
-                        aria-label={t("delete")}
-                        data-testid="delete-webhook"
-                        size="icon"
-                        variant="destructive-outline"
-                        onClick={() => setDeleteDialogOpen(true)}
-                        disabled={deleteWebhook.isPending}
-                      >
-                        <TrashIcon aria-hidden="true" />
-                      </Button>
+                      <Switch
+                        checked={active}
+                        data-testid="webhook-switch"
+                        disabled={toggleWebhook.isPending}
+                        onCheckedChange={(checked) => {
+                          setActive(checked);
+                          toggleWebhook.mutate({
+                            id: webhook.id,
+                            active: checked,
+                            payloadTemplate: webhook.payloadTemplate,
+                            eventTypeId: webhook.eventTypeId || undefined,
+                          });
+                        }}
+                      />
                     }
                   />
-                  <TooltipPopup>{t("delete")}</TooltipPopup>
+                  <TooltipPopup sideOffset={11}>
+                    {active ? t("disable_webhook") : t("enable_webhook")}
+                  </TooltipPopup>
                 </Tooltip>
               ) : (
-                <Button aria-label={t("delete")} disabled size="icon" variant="destructive-outline">
-                  <TrashIcon aria-hidden="true" />
-                </Button>
+                <Switch checked={active} disabled />
               )}
+              <div className="flex items-center gap-2">
+                {props.permissions.canEditWebhook ? (
+                  props.editHref ? (
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Button
+                            aria-label={t("edit")}
+                            data-testid="webhook-edit-button"
+                            render={<Link href={props.editHref} />}
+                            size="icon"
+                            variant="outline">
+                            <PencilIcon aria-hidden="true" />
+                          </Button>
+                        }
+                      />
+                      <TooltipPopup>{t("edit")}</TooltipPopup>
+                    </Tooltip>
+                  ) : (
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Button
+                            aria-label={t("edit")}
+                            data-testid="webhook-edit-button"
+                            size="icon"
+                            variant="outline"
+                            onClick={props.onEditWebhookAction}>
+                            <PencilIcon aria-hidden="true" />
+                          </Button>
+                        }
+                      />
+                      <TooltipPopup>{t("edit")}</TooltipPopup>
+                    </Tooltip>
+                  )
+                ) : (
+                  <Button aria-label={t("edit")} disabled size="icon" variant="outline">
+                    <PencilIcon aria-hidden="true" />
+                  </Button>
+                )}
+                {props.permissions.canDeleteWebhook ? (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          aria-label={t("delete")}
+                          data-testid="delete-webhook"
+                          size="icon"
+                          variant="destructive-outline"
+                          onClick={() => setDeleteDialogOpen(true)}
+                          disabled={deleteWebhook.isPending}>
+                          <TrashIcon aria-hidden="true" />
+                        </Button>
+                      }
+                    />
+                    <TooltipPopup>{t("delete")}</TooltipPopup>
+                  </Tooltip>
+                ) : (
+                  <Button aria-label={t("delete")} disabled size="icon" variant="destructive-outline">
+                    <TrashIcon aria-hidden="true" />
+                  </Button>
+                )}
+              </div>
             </div>
-          </div>
           </TooltipProvider>
         )}
 
@@ -294,8 +286,7 @@ export default function WebhookListItem(props: {
                       eventTypeId: webhook.eventTypeId || undefined,
                     });
                   }}
-                  variant="switch"
-                >
+                  variant="switch">
                   {t("enable_webhook")}
                 </MenuCheckboxItem>
               ) : (
@@ -327,8 +318,7 @@ export default function WebhookListItem(props: {
                   <MenuItem
                     variant="destructive"
                     onClick={() => setDeleteDialogOpen(true)}
-                    disabled={deleteWebhook.isPending}
-                  >
+                    disabled={deleteWebhook.isPending}>
                     <TrashIcon />
                     {t("delete")}
                   </MenuItem>
@@ -351,7 +341,6 @@ export default function WebhookListItem(props: {
           deleteWebhook.mutate({
             id: webhook.id,
             eventTypeId: webhook.eventTypeId || undefined,
-            teamId: webhook.teamId || undefined,
           });
         }}
       />

--- a/apps/web/modules/webhooks/views/webhook-edit-view.tsx
+++ b/apps/web/modules/webhooks/views/webhook-edit-view.tsx
@@ -6,10 +6,14 @@ import { subscriberUrlReserved } from "@calcom/features/webhooks/lib/subscriberU
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { WebhookTriggerEvents } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
+import type { AppRouter } from "@calcom/trpc/types/server/routers/_app";
 import { revalidateWebhooksList } from "@calcom/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/(with-loader)/actions";
 import { toastManager } from "@coss/ui/components/toast";
+import type { TRPCClientErrorLike } from "@trpc/client";
 import { useRouter } from "next/navigation";
-import type { WebhookFormSubmitData } from "../components/WebhookForm";
+import type { ReactNode } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import type { WebhookFormSubmitData, WebhookFormValues } from "../components/WebhookForm";
 import WebhookForm from "../components/WebhookForm";
 import { WebhookVersionCTA } from "../components/WebhookVersionCTA";
 import { WebhookFormHeader } from "./webhook-form-header";
@@ -18,7 +22,6 @@ import { WebhookFormSkeleton } from "./webhook-form-skeleton";
 type WebhookProps = {
   id: string;
   userId: number | null;
-  teamId: number | null;
   subscriberUrl: string;
   payloadTemplate: string | null;
   active: boolean;
@@ -28,7 +31,7 @@ type WebhookProps = {
   version: WebhookVersion;
 };
 
-export function EditWebhookView({ webhook }: { webhook?: WebhookProps }) {
+export function EditWebhookView({ webhook }: { webhook?: WebhookProps }): JSX.Element {
   const { t } = useLocale();
   const router = useRouter();
   const { data: installedApps, isPending } = trpc.viewer.apps.integrations.useQuery(
@@ -44,12 +47,12 @@ export function EditWebhookView({ webhook }: { webhook?: WebhookProps }) {
     enabled: !!webhook,
   });
   const editWebhookMutation = trpc.viewer.webhook.edit.useMutation({
-    onSuccess() {
+    onSuccess(): void {
       toastManager.add({ title: t("webhook_updated_successfully"), type: "success" });
       router.push("/settings/developer/webhooks");
       revalidateWebhooksList();
     },
-    onError(error) {
+    onError(error: TRPCClientErrorLike<AppRouter>): void {
       toastManager.add({ title: error.message, type: "error" });
     },
   });
@@ -59,19 +62,18 @@ export function EditWebhookView({ webhook }: { webhook?: WebhookProps }) {
   return (
     <WebhookForm
       webhook={webhook}
-      headerWrapper={(formMethods, children) => (
+      headerWrapper={(formMethods: UseFormReturn<WebhookFormValues>, children: ReactNode): JSX.Element => (
         <>
           <WebhookFormHeader titleKey="edit_webhook" CTA={<WebhookVersionCTA formMethods={formMethods} />} />
           {children}
         </>
       )}
-      onSubmit={(values: WebhookFormSubmitData) => {
+      onSubmit={(values: WebhookFormSubmitData): void => {
         if (
           subscriberUrlReserved({
             subscriberUrl: values.subscriberUrl,
             id: webhook.id,
             webhooks,
-            teamId: webhook.teamId ?? undefined,
             userId: webhook.userId ?? undefined,
             platform: webhook.platform ?? undefined,
           })
@@ -81,7 +83,11 @@ export function EditWebhookView({ webhook }: { webhook?: WebhookProps }) {
         }
 
         if (values.changeSecret) {
-          values.secret = values.newSecret.trim().length ? values.newSecret : null;
+          if (values.newSecret.trim().length) {
+            values.secret = values.newSecret;
+          } else {
+            values.secret = null;
+          }
         }
 
         if (!values.payloadTemplate) {

--- a/apps/web/modules/webhooks/views/webhook-new-view.tsx
+++ b/apps/web/modules/webhooks/views/webhook-new-view.tsx
@@ -6,11 +6,15 @@ import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
+import type { AppRouter } from "@calcom/trpc/types/server/routers/_app";
 import { revalidateWebhooksList } from "@calcom/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/(with-loader)/actions";
 import { toastManager } from "@coss/ui/components/toast";
+import type { TRPCClientErrorLike } from "@trpc/client";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import type { WebhookFormSubmitData } from "../components/WebhookForm";
+import type { ReactNode } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import type { WebhookFormSubmitData, WebhookFormValues } from "../components/WebhookForm";
 import WebhookForm from "../components/WebhookForm";
 import { WebhookVersionCTA } from "../components/WebhookVersionCTA";
 import { WebhookFormHeader } from "./webhook-form-header";
@@ -20,35 +24,36 @@ type Props = {
   installedApps: RouterOutputs["viewer"]["apps"]["integrations"];
 };
 
-export const NewWebhookView = ({ webhooks, installedApps }: Props) => {
+export const NewWebhookView = ({ webhooks, installedApps }: Props): JSX.Element => {
   const searchParams = useCompatSearchParams();
   const { t } = useLocale();
   const utils = trpc.useUtils();
   const router = useRouter();
   const session = useSession();
+  let platform = false;
 
-  const teamId = searchParams?.get("teamId") ? Number(searchParams.get("teamId")) : undefined;
-  const platform = searchParams?.get("platform") ? Boolean(searchParams.get("platform")) : false;
+  if (searchParams?.get("platform")) {
+    platform = Boolean(searchParams.get("platform"));
+  }
 
   const createWebhookMutation = trpc.viewer.webhook.create.useMutation({
-    async onSuccess() {
+    async onSuccess(): Promise<void> {
       toastManager.add({ title: t("webhook_created_successfully"), type: "success" });
       await utils.viewer.webhook.list.invalidate();
       revalidateWebhooksList();
       router.push("/settings/developer/webhooks");
     },
-    onError(error) {
+    onError(error: TRPCClientErrorLike<AppRouter>): void {
       toastManager.add({ title: error.message, type: "error" });
     },
   });
 
-  const onCreateWebhook = async (values: WebhookFormSubmitData) => {
+  const onCreateWebhook = async (values: WebhookFormSubmitData): Promise<void> => {
     if (
       subscriberUrlReserved({
         subscriberUrl: values.subscriberUrl,
         id: values.id,
         webhooks,
-        teamId,
         userId: session.data?.user.id,
         platform,
       })
@@ -72,7 +77,6 @@ export const NewWebhookView = ({ webhooks, installedApps }: Props) => {
       time: values.time,
       timeUnit: values.timeUnit,
       version: values.version,
-      teamId,
       platform,
     });
   };
@@ -81,7 +85,7 @@ export const NewWebhookView = ({ webhooks, installedApps }: Props) => {
     <WebhookForm
       onSubmit={onCreateWebhook}
       apps={installedApps?.items.map((app) => app.slug)}
-      headerWrapper={(formMethods, children) => (
+      headerWrapper={(formMethods: UseFormReturn<WebhookFormValues>, children: ReactNode): JSX.Element => (
         <>
           <WebhookFormHeader CTA={<WebhookVersionCTA formMethods={formMethods} />} />
           {children}

--- a/apps/web/modules/webhooks/views/webhooks-view.tsx
+++ b/apps/web/modules/webhooks/views/webhooks-view.tsx
@@ -65,7 +65,7 @@ const WebhooksList = ({ webhooksByViewer }: { webhooksByViewer: WebhooksByViewer
               group.profile.image ??
               (group.profile.slug ? `${bookerUrl}/${group.profile.slug}/avatar.png` : undefined);
             return (
-              <section key={group.teamId ?? group.profile.slug ?? ""}>
+              <section key={group.profile.slug ?? userName}>
                 <CardFrame>
                   <CardFrameHeader>
                     <div className="flex items-center gap-2">

--- a/packages/features/webhooks/lib/dto/types.ts
+++ b/packages/features/webhooks/lib/dto/types.ts
@@ -469,7 +469,6 @@ export interface PaymentData {
 export interface WebhookForReservationCheck {
   id: string;
   subscriberUrl: string;
-  teamId: number | null;
   userId: number | null;
   eventTypeId: number | null;
   platform: boolean;

--- a/packages/features/webhooks/lib/interface/IWebhookRepository.ts
+++ b/packages/features/webhooks/lib/interface/IWebhookRepository.ts
@@ -76,14 +76,6 @@ export interface IWebhookRepository {
   }): Promise<WebhookSubscriber[]>;
   getFilteredWebhooksForUser(options: { userId: number; userRole?: UserPermissionRole }): Promise<{
     webhookGroups: WebhookGroup[];
-    profiles: {
-      teamId: number | null | undefined;
-      slug: string | null;
-      name: string | null;
-      image?: string | undefined;
-      canModify?: boolean;
-      canDelete?: boolean;
-    }[];
   }>;
   listWebhooks(options: ListWebhooksOptions): Promise<Webhook[]>;
 }

--- a/packages/features/webhooks/lib/repository/WebhookRepository.ts
+++ b/packages/features/webhooks/lib/repository/WebhookRepository.ts
@@ -8,7 +8,7 @@ import type { PrismaClient } from "@calcom/prisma";
 import { prisma as defaultPrisma } from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import type { TimeUnit, WebhookTriggerEvents } from "@calcom/prisma/enums";
-import { MembershipRole, UserPermissionRole } from "@calcom/prisma/enums";
+import { UserPermissionRole } from "@calcom/prisma/enums";
 import type { Webhook, WebhookGroup, WebhookSubscriber } from "../dto/types";
 import { WebhookOutputMapper } from "../infrastructure/mappers/WebhookOutputMapper";
 import type {
@@ -18,13 +18,6 @@ import type {
 } from "../interface/IWebhookRepository";
 import { parseWebhookVersion } from "../interface/IWebhookRepository";
 import type { GetSubscribersOptions } from "./types";
-
-class PermissionCheckService {
-  constructor(_prisma?: unknown) {}
-  async checkPermission(..._args: unknown[]) { return true; }
-  async hasPermission(..._args: unknown[]) { return true; }
-  async getTeamIdsWithPermission(..._args: unknown[]): Promise<number[]> { return []; }
-}
 
 // Type for raw query results from the database
 interface WebhookQueryResult {
@@ -56,7 +49,7 @@ export class WebhookRepository implements IWebhookRepository {
   constructor(
     private readonly prisma: PrismaClient,
     private readonly eventTypeRepository: IEventTypesRepository,
-    private readonly userRepository: IUsersRepository
+    private readonly _userRepository: IUsersRepository
   ) {}
 
   /**
@@ -344,42 +337,6 @@ export class WebhookRepository implements IWebhookRepository {
             platformOAuthClientId: true,
           },
         },
-        teams: {
-          where: {
-            accepted: true,
-          },
-          select: {
-            role: true,
-            team: {
-              select: {
-                id: true,
-                name: true,
-                slug: true,
-                logoUrl: true,
-                webhooks: {
-                  select: {
-                    id: true,
-                    subscriberUrl: true,
-                    payloadTemplate: true,
-                    appId: true,
-                    secret: true,
-                    active: true,
-                    eventTriggers: true,
-                    eventTypeId: true,
-                    teamId: true,
-                    userId: true,
-                    time: true,
-                    timeUnit: true,
-                    version: true,
-                    createdAt: true,
-                    platform: true,
-                    platformOAuthClientId: true,
-                  },
-                },
-              },
-            },
-          },
-        },
       },
     });
 
@@ -387,13 +344,8 @@ export class WebhookRepository implements IWebhookRepository {
       throw new Error("User not found");
     }
 
-    // Use permission service which handles both PBAC and role-based fallbacks
-    const permissionService = new PermissionCheckService();
-
-    // Build webhook groups with proper permissions
     const webhookGroups: WebhookGroup[] = [];
 
-    // Add user's personal webhooks
     webhookGroups.push({
       teamId: null,
       profile: {
@@ -408,56 +360,6 @@ export class WebhookRepository implements IWebhookRepository {
       },
     });
 
-    // Check permissions for each team
-    // The permission service handles PBAC when enabled and falls back to role-based permissions
-    for (const membership of user.teams) {
-      const teamId = membership.team.id;
-
-      // Check read permission (fallback: MEMBER, ADMIN, OWNER can read)
-      const canRead = await permissionService.checkPermission({
-        userId,
-        teamId,
-        permission: "webhook.read",
-        fallbackRoles: [MembershipRole.MEMBER, MembershipRole.ADMIN, MembershipRole.OWNER],
-      });
-
-      if (!canRead) {
-        // User doesn't have permission to view this team's webhooks
-        continue;
-      }
-
-      // Check update/delete permissions in parallel (fallback: only ADMIN, OWNER can modify)
-      const [canUpdate, canDelete] = await Promise.all([
-        permissionService.checkPermission({
-          userId,
-          teamId,
-          permission: "webhook.update",
-          fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        }),
-        permissionService.checkPermission({
-          userId,
-          teamId,
-          permission: "webhook.delete",
-          fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-        }),
-      ]);
-
-      webhookGroups.push({
-        teamId: membership.team.id,
-        profile: {
-          name: membership.team.name,
-          slug: membership.team.slug || null,
-          image: getPlaceholderAvatar(membership.team.logoUrl, membership.team.name),
-        },
-        webhooks: WebhookOutputMapper.toWebhookList(membership.team.webhooks.filter(filterWebhooks)),
-        metadata: {
-          canModify: canUpdate,
-          canDelete,
-        },
-      });
-    }
-
-    // Add platform webhooks for admins
     if (userRole === UserPermissionRole.ADMIN) {
       const platformWebhooks = await this.prisma.webhook.findMany({
         where: { platform: true },
@@ -498,11 +400,6 @@ export class WebhookRepository implements IWebhookRepository {
 
     return {
       webhookGroups: webhookGroups.filter((group) => group.webhooks.length > 0),
-      profiles: webhookGroups.map((group) => ({
-        teamId: group.teamId,
-        ...group.profile,
-        ...group.metadata,
-      })),
     };
   }
 
@@ -512,7 +409,6 @@ export class WebhookRepository implements IWebhookRepository {
    * - App filtering (excludes zapier/make by default unless appId specified)
    * - Event type filtering (with managed event type parent handling)
    * - Event trigger filtering
-   * - Permission-based team filtering
    */
   async listWebhooks(options: ListWebhooksOptions): Promise<Webhook[]> {
     const { userId, appId, eventTypeId, eventTriggers } = options;
@@ -522,8 +418,6 @@ export class WebhookRepository implements IWebhookRepository {
       // AppId filter - null appId by default (excludes zapier/make)
       { appId: appId ?? null },
     ];
-
-    const user = await this.userRepository.findUserTeams(userId);
 
     if (eventTypeId) {
       const managedParentId = await this.eventTypeRepository.findParentEventTypeId(eventTypeId);
@@ -537,27 +431,7 @@ export class WebhookRepository implements IWebhookRepository {
         whereConditions.push({ eventTypeId });
       }
     } else {
-      // No eventTypeId - filter by user and their allowed teams
-      const permissionService = new PermissionCheckService();
-      const teamIds = user?.teams?.map((m) => m.teamId) ?? [];
-
-      const allowedTeamIds = (
-        await Promise.all(
-          teamIds.map(async (teamId) => {
-            const ok = await permissionService.checkPermission({
-              userId,
-              teamId,
-              permission: "webhook.read",
-              fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
-            });
-            return ok ? teamId : null;
-          })
-        )
-      ).filter((x): x is number => x !== null);
-
-      whereConditions.push({
-        OR: [{ userId }, ...(allowedTeamIds.length ? [{ teamId: { in: allowedTeamIds } }] : [])],
-      });
+      whereConditions.push({ userId });
     }
 
     // Event triggers filter

--- a/packages/features/webhooks/lib/subscriberUrlReserved.ts
+++ b/packages/features/webhooks/lib/subscriberUrlReserved.ts
@@ -4,7 +4,6 @@ interface Params {
   subscriberUrl: string;
   id?: string;
   webhooks?: WebhookForReservationCheck[];
-  teamId?: number;
   userId?: number;
   eventTypeId?: number;
   platform?: boolean;
@@ -14,24 +13,20 @@ export const subscriberUrlReserved = ({
   subscriberUrl,
   id,
   webhooks,
-  teamId,
   userId,
   eventTypeId,
   platform,
 }: Params): boolean => {
-  if (!teamId && !userId && !eventTypeId && !platform) {
-    throw new Error("Either teamId, userId, eventTypeId or platform must be provided.");
+  if (!userId && !eventTypeId && !platform) {
+    throw new Error("Either userId, eventTypeId or platform must be provided.");
   }
 
-  const findMatchingWebhook = (condition: (webhook: WebhookForReservationCheck) => boolean) => {
+  const findMatchingWebhook = (condition: (webhook: WebhookForReservationCheck) => boolean): boolean => {
     return !!webhooks?.find(
       (webhook) => webhook.subscriberUrl === subscriberUrl && (!id || webhook.id !== id) && condition(webhook)
     );
   };
 
-  if (teamId) {
-    return findMatchingWebhook((webhook) => webhook.teamId === teamId);
-  }
   if (eventTypeId) {
     return findMatchingWebhook((webhook) => webhook.eventTypeId === eventTypeId);
   }

--- a/packages/trpc/server/routers/viewer/webhook/create.schema.ts
+++ b/packages/trpc/server/routers/viewer/webhook/create.schema.ts
@@ -1,8 +1,6 @@
-import { z } from "zod";
-
 import { WEBHOOK_TRIGGER_EVENTS } from "@calcom/features/webhooks/lib/constants";
 import { WebhookVersion } from "@calcom/features/webhooks/lib/interface/IWebhookRepository";
-
+import { z } from "zod";
 import { webhookIdAndEventTypeIdSchema } from "./types";
 
 const TIME_UNIT = ["DAY", "HOUR", "MINUTE"] as const;
@@ -15,7 +13,6 @@ export const ZCreateInputSchema = webhookIdAndEventTypeIdSchema.extend({
   eventTypeId: z.number().optional(),
   appId: z.string().optional().nullable(),
   secret: z.string().optional().nullable(),
-  teamId: z.number().optional(),
   platform: z.boolean().optional(),
   time: z.number().nullable().optional(),
   timeUnit: z.enum(TIME_UNIT).nullable().optional(),

--- a/packages/trpc/server/routers/viewer/webhook/delete.schema.ts
+++ b/packages/trpc/server/routers/viewer/webhook/delete.schema.ts
@@ -1,11 +1,9 @@
 import { z } from "zod";
-
 import { webhookIdAndEventTypeIdSchema } from "./types";
 
 export const ZDeleteInputSchema = webhookIdAndEventTypeIdSchema.extend({
   id: z.string(),
   eventTypeId: z.number().optional(),
-  teamId: z.number().optional(),
 });
 
 export type TDeleteInputSchema = z.infer<typeof ZDeleteInputSchema>;

--- a/packages/trpc/server/routers/viewer/webhook/getByViewer.handler.ts
+++ b/packages/trpc/server/routers/viewer/webhook/getByViewer.handler.ts
@@ -10,13 +10,6 @@ type GetByViewerOptions = {
 
 export type WebhooksByViewer = {
   webhookGroups: WebhookGroup[];
-  profiles: {
-    readOnly?: boolean | undefined;
-    slug: string | null;
-    name: string | null;
-    image?: string | undefined;
-    teamId: number | null | undefined;
-  }[];
 };
 
 export const getByViewerHandler = async ({ ctx }: GetByViewerOptions): Promise<WebhooksByViewer> => {

--- a/packages/trpc/server/routers/viewer/webhook/list.schema.ts
+++ b/packages/trpc/server/routers/viewer/webhook/list.schema.ts
@@ -1,13 +1,10 @@
-import { z } from "zod";
-
 import { WEBHOOK_TRIGGER_EVENTS } from "@calcom/features/webhooks/lib/constants";
-
+import { z } from "zod";
 import { webhookIdAndEventTypeIdSchema } from "./types";
 
 export const ZListInputSchema = webhookIdAndEventTypeIdSchema
   .extend({
     appId: z.string().optional(),
-    teamId: z.number().optional(),
     eventTypeId: z.number().optional(),
     eventTriggers: z.enum(WEBHOOK_TRIGGER_EVENTS).array().optional(),
   })

--- a/packages/trpc/server/routers/viewer/webhook/types.ts
+++ b/packages/trpc/server/routers/viewer/webhook/types.ts
@@ -6,5 +6,4 @@ export const webhookIdAndEventTypeIdSchema = z.object({
   id: z.string().optional(),
   webhookId: z.string().optional(),
   eventTypeId: z.number().optional(),
-  teamId: z.number().optional(),
 });


### PR DESCRIPTION
## What this does
- removes team and org scoped webhook creation from the settings webhook UI
- removes team/org webhook groups from `viewer.webhook.getByViewer`
- removes team-scoped webhook CRUD input fields and duplicate-url checks from the viewer webhook management flow
- limits personal webhook listing to user-owned webhooks on the management path
- removes team webhook template variables from the webhook form

## Validation
```bash
yarn vitest run packages/features/webhooks/lib/service/WebhookService.test.ts
yarn type-check:ci --force
```

## Result
- both commands passed locally
- diff size: `15 files changed, 134 insertions(+), 388 deletions(-)`