### PR TITLE
cleanup(webhooks): remove team org delivery support

### DIFF
--- a/packages/features/webhooks/lib/__tests__/consumer/WebhookTaskConsumer.test.ts
+++ b/packages/features/webhooks/lib/__tests__/consumer/WebhookTaskConsumer.test.ts
@@ -1,14 +1,13 @@
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
+import type { PayloadBuilderFactory } from "../../factory/versioned/PayloadBuilderFactory";
 import type { IWebhookDataFetcher } from "../../interface/IWebhookDataFetcher";
 import type { IWebhookRepository } from "../../interface/IWebhookRepository";
 import { WebhookVersion } from "../../interface/IWebhookRepository";
 import type { ILogger } from "../../interface/infrastructure";
 import type { IWebhookService } from "../../interface/services";
-import type { PayloadBuilderFactory } from "../../factory/versioned/PayloadBuilderFactory";
-import type { WebhookTaskPayload } from "../../types/webhookTask";
 import { WebhookTaskConsumer } from "../../service/WebhookTaskConsumer";
+import type { WebhookTaskPayload } from "../../types/webhookTask";
 
 /**
  * Unit Tests for WebhookTaskConsumer
@@ -36,7 +35,6 @@ describe("WebhookTaskConsumer", () => {
       getSubscribers: vi.fn().mockResolvedValue([]),
       getWebhookById: vi.fn(),
       findByWebhookId: vi.fn(),
-      findByOrgIdAndTrigger: vi.fn(),
       getFilteredWebhooksForUser: vi.fn(),
     } as unknown as IWebhookRepository;
 
@@ -47,8 +45,6 @@ describe("WebhookTaskConsumer", () => {
         triggerEvent: payload.triggerEvent,
         userId: "userId" in payload ? payload.userId : undefined,
         eventTypeId: "eventTypeId" in payload ? payload.eventTypeId : undefined,
-        teamId: "teamId" in payload ? payload.teamId : undefined,
-        orgId: "orgId" in payload ? payload.orgId : undefined,
         oAuthClientId: "oAuthClientId" in payload ? payload.oAuthClientId : undefined,
       })),
     });
@@ -136,8 +132,6 @@ describe("WebhookTaskConsumer", () => {
         triggerEvent: WebhookTriggerEvents.BOOKING_CREATED,
         userId: 789,
         eventTypeId: 456,
-        teamId: undefined,
-        orgId: undefined,
         oAuthClientId: undefined,
       });
 
@@ -181,8 +175,6 @@ describe("WebhookTaskConsumer", () => {
         triggerEvent: WebhookTriggerEvents.BOOKING_CANCELLED,
         userId: undefined,
         eventTypeId: 789,
-        teamId: 111,
-        orgId: 222,
         oAuthClientId: "oauth-client-123",
       });
 

--- a/packages/features/webhooks/lib/__tests__/consumer/triggers/booking-requested.test.ts
+++ b/packages/features/webhooks/lib/__tests__/consumer/triggers/booking-requested.test.ts
@@ -20,7 +20,6 @@ import type { BookingWebhookTaskPayload } from "../../../types/webhookTask";
  * - Event types that require confirmation
  * - Paid events that require confirmation
  * - Reschedule scenarios with confirmation required
- * - Team/collective scheduling with confirmation required
  */
 describe("BOOKING_REQUESTED Trigger", () => {
   let consumer: WebhookTaskConsumer;
@@ -88,7 +87,6 @@ describe("BOOKING_REQUESTED Trigger", () => {
       getSubscribers: vi.fn().mockResolvedValue([]),
       getWebhookById: vi.fn(),
       findByWebhookId: vi.fn(),
-      findByOrgIdAndTrigger: vi.fn(),
       getFilteredWebhooksForUser: vi.fn(),
     } as unknown as IWebhookRepository;
 
@@ -111,8 +109,6 @@ describe("BOOKING_REQUESTED Trigger", () => {
         triggerEvent: payload.triggerEvent,
         userId: payload.userId,
         eventTypeId: payload.eventTypeId,
-        teamId: payload.teamId,
-        orgId: payload.orgId,
         oAuthClientId: payload.oAuthClientId,
       })),
     };
@@ -228,45 +224,6 @@ describe("BOOKING_REQUESTED Trigger", () => {
           metadata: { customField: "customValue", source: "api" },
         })
       );
-    });
-  });
-
-  describe("Team/Collective scheduling", () => {
-    it("should process BOOKING_REQUESTED for team event with confirmation required", async () => {
-      const payload: BookingWebhookTaskPayload = {
-        operationId: "op-team-booking",
-        triggerEvent: WebhookTriggerEvents.BOOKING_REQUESTED,
-        bookingUid: "booking-uid-team",
-        eventTypeId: 456,
-        userId: 789,
-        teamId: 111,
-        orgId: 222,
-        timestamp: new Date().toISOString(),
-      };
-
-      vi.mocked(mockWebhookRepository.getSubscribers).mockResolvedValueOnce([
-        {
-          id: "sub-team",
-          subscriberUrl: "https://example.com/team-webhook",
-          payloadTemplate: null,
-          appId: null,
-          secret: null,
-          time: null,
-          timeUnit: null,
-          eventTriggers: [WebhookTriggerEvents.BOOKING_REQUESTED],
-          version: WebhookVersion.V_2021_10_20,
-        },
-      ]);
-
-      await consumer.processWebhookTask(payload, "task-team-booking");
-
-      expect(mockBookingDataFetcher.getSubscriberContext).toHaveBeenCalledWith(
-        expect.objectContaining({
-          teamId: 111,
-          orgId: 222,
-        })
-      );
-      expect(mockWebhookService.processWebhooks).toHaveBeenCalled();
     });
   });
 

--- a/packages/features/webhooks/lib/interface/IWebhookDataFetcher.ts
+++ b/packages/features/webhooks/lib/interface/IWebhookDataFetcher.ts
@@ -5,8 +5,6 @@ export interface SubscriberContext {
   triggerEvent: WebhookTriggerEvents;
   userId?: number;
   eventTypeId?: number;
-  teamId?: number | null;
-  orgId?: number;
   oAuthClientId?: string | null;
 }
 

--- a/packages/features/webhooks/lib/interface/IWebhookRepository.ts
+++ b/packages/features/webhooks/lib/interface/IWebhookRepository.ts
@@ -41,8 +41,6 @@ export interface GetSubscribersOptions {
   userId?: number | null;
   eventTypeId?: number | null;
   triggerEvent: WebhookTriggerEvents;
-  teamId?: number | number[] | null;
-  orgId?: number | null;
   oAuthClientId?: string | null;
 }
 
@@ -70,10 +68,6 @@ export interface IWebhookRepository {
     timeUnit: string | null;
     version: WebhookVersion;
   }>;
-  findByOrgIdAndTrigger(options: {
-    orgId: number;
-    triggerEvent: WebhookTriggerEvents;
-  }): Promise<WebhookSubscriber[]>;
   getFilteredWebhooksForUser(options: { userId: number; userRole?: UserPermissionRole }): Promise<{
     webhookGroups: WebhookGroup[];
     profiles: {

--- a/packages/features/webhooks/lib/interface/services.ts
+++ b/packages/features/webhooks/lib/interface/services.ts
@@ -19,8 +19,6 @@ export interface GetSubscribersOptions {
   userId?: number | null;
   eventTypeId?: number | null;
   triggerEvent: WebhookTriggerEvents;
-  teamId?: number | number[] | null;
-  orgId?: number | null;
   oAuthClientId?: string | null;
 }
 
@@ -57,7 +55,6 @@ export interface IWebhookScheduler {
     trigger: WebhookTriggerEvents,
     payload: WebhookPayload,
     scheduledAt: Date,
-    options?: { teamId?: number | number[] | null; orgId?: number | null },
     subscribers?: WebhookSubscriber[],
     isDryRun?: boolean
   ): Promise<void>;

--- a/packages/features/webhooks/lib/repository/WebhookRepository.ts
+++ b/packages/features/webhooks/lib/repository/WebhookRepository.ts
@@ -21,9 +21,15 @@ import type { GetSubscribersOptions } from "./types";
 
 class PermissionCheckService {
   constructor(_prisma?: unknown) {}
-  async checkPermission(..._args: unknown[]) { return true; }
-  async hasPermission(..._args: unknown[]) { return true; }
-  async getTeamIdsWithPermission(..._args: unknown[]): Promise<number[]> { return []; }
+  async checkPermission(..._args: unknown[]) {
+    return true;
+  }
+  async hasPermission(..._args: unknown[]) {
+    return true;
+  }
+  async getTeamIdsWithPermission(..._args: unknown[]): Promise<number[]> {
+    return [];
+  }
 }
 
 // Type for raw query results from the database
@@ -80,11 +86,8 @@ export class WebhookRepository implements IWebhookRepository {
   }
 
   async getSubscribers(options: GetSubscribersOptions): Promise<WebhookSubscriber[]> {
-    const teamId = options.teamId;
     const userId = options.userId;
     const eventTypeId = options.eventTypeId;
-    const teamIds = Array.isArray(teamId) ? teamId : teamId ? [teamId] : undefined;
-    const orgId = options.orgId;
     const oAuthClientId = options.oAuthClientId;
 
     let managedParentEventTypeId: number | undefined;
@@ -97,7 +100,6 @@ export class WebhookRepository implements IWebhookRepository {
       userId,
       eventTypeId,
       managedParentEventTypeId,
-      teamIds: teamIds && orgId ? [...teamIds, orgId] : teamIds || (orgId ? [orgId] : undefined),
       oAuthClientId,
       triggerEvent: options.triggerEvent,
     });
@@ -123,11 +125,10 @@ export class WebhookRepository implements IWebhookRepository {
     userId?: number | null;
     eventTypeId?: number | null;
     managedParentEventTypeId?: number | null;
-    teamIds?: number[];
     oAuthClientId?: string | null;
     triggerEvent: WebhookTriggerEvents;
   }): Promise<WebhookSubscriber[]> {
-    const { userId, eventTypeId, managedParentEventTypeId, teamIds, oAuthClientId, triggerEvent } = params;
+    const { userId, eventTypeId, managedParentEventTypeId, oAuthClientId, triggerEvent } = params;
 
     // IMPORTANT: Explicit type casts (::int, ::text) are required for nullable params
     // PostgreSQL can't infer types for NULL values without explicit casts
@@ -180,26 +181,10 @@ export class WebhookRepository implements IWebhookRepository {
         AND ${triggerEvent}::"WebhookTriggerEvents" = ANY("eventTriggers")
         AND platform = false
       
-      UNION ALL
-      
-      -- Team webhooks (only if teamIds provided and not empty)
-      SELECT 
-        id, "subscriberUrl", "payloadTemplate", "appId", secret, time, "timeUnit", "eventTriggers", version,
-        5 as priority
-      FROM "Webhook"
-      WHERE active = true 
-        AND ${teamIds}::int[] IS NOT NULL
-        AND cardinality(${teamIds}::int[]) > 0
-        AND "teamId" = ANY(${teamIds}::int[])
-        AND ${triggerEvent}::"WebhookTriggerEvents" = ANY("eventTriggers")
-        AND platform = false
-      
-      UNION ALL
-      
       -- OAuth client webhooks (only if oAuthClientId provided)
       SELECT 
         id, "subscriberUrl", "payloadTemplate", "appId", secret, time, "timeUnit", "eventTriggers", version,
-        6 as priority
+        5 as priority
       FROM "Webhook"
       WHERE active = true 
         AND ${oAuthClientId}::text IS NOT NULL
@@ -277,43 +262,6 @@ export class WebhookRepository implements IWebhookRepository {
       ...webhook,
       version: parseWebhookVersion(webhook.version),
     };
-  }
-
-  async findByOrgIdAndTrigger({
-    orgId,
-    triggerEvent,
-  }: {
-    orgId: number;
-    triggerEvent: WebhookTriggerEvents;
-  }): Promise<WebhookSubscriber[]> {
-    const webhooks = await this.prisma.webhook.findMany({
-      where: {
-        teamId: orgId,
-        platform: false,
-        eventTriggers: { has: triggerEvent },
-        active: true,
-      },
-      select: {
-        id: true,
-        subscriberUrl: true,
-        payloadTemplate: true,
-        active: true,
-        eventTriggers: true,
-        secret: true,
-        teamId: true,
-        userId: true,
-        platform: true,
-        time: true,
-        timeUnit: true,
-        appId: true,
-        version: true,
-      },
-    });
-    return webhooks.map((webhook) => ({
-      ...webhook,
-      eventTriggers: webhook.eventTriggers as WebhookTriggerEvents[],
-      version: parseWebhookVersion(webhook.version),
-    }));
   }
 
   async getFilteredWebhooksForUser({ userId, userRole }: { userId: number; userRole?: UserPermissionRole }) {

--- a/packages/features/webhooks/lib/repository/types.ts
+++ b/packages/features/webhooks/lib/repository/types.ts
@@ -4,7 +4,5 @@ export interface GetSubscribersOptions {
   userId?: number | null;
   eventTypeId?: number | null;
   triggerEvent: WebhookTriggerEvents;
-  teamId?: number | number[] | null;
-  orgId?: number | null;
   oAuthClientId?: string | null;
 }

--- a/packages/features/webhooks/lib/service/BookingWebhookService.ts
+++ b/packages/features/webhooks/lib/service/BookingWebhookService.ts
@@ -1,32 +1,31 @@
 import dayjs from "@calcom/dayjs";
 import type { TimeUnit } from "@calcom/prisma/enums";
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
-
 import type {
-  BookingCreatedDTO,
   BookingCancelledDTO,
-  BookingRequestedDTO,
-  BookingRescheduledDTO,
+  BookingCreatedDTO,
+  BookingNoShowDTO,
   BookingPaidDTO,
   BookingPaymentInitiatedDTO,
-  BookingNoShowDTO,
   BookingRejectedDTO,
+  BookingRequestedDTO,
+  BookingRescheduledDTO,
   WebhookSubscriber,
 } from "../dto/types";
-import type { IWebhookService, IBookingWebhookService } from "../interface/services";
-import type { ITasker, ILogger } from "../interface/infrastructure";
+import type { ILogger, ITasker } from "../interface/infrastructure";
+import type { IBookingWebhookService, IWebhookService } from "../interface/services";
 import type { IWebhookNotifier } from "../interface/webhook";
 import type {
-  BookingCreatedParams,
   BookingCancelledParams,
-  BookingRequestedParams,
-  BookingRescheduledParams,
+  BookingCreatedParams,
+  BookingNoShowParams,
   BookingPaidParams,
   BookingPaymentInitiatedParams,
-  BookingNoShowParams,
   BookingRejectedParams,
-  ScheduleMeetingWebhooksParams,
+  BookingRequestedParams,
+  BookingRescheduledParams,
   CancelScheduledMeetingWebhooksParams,
+  ScheduleMeetingWebhooksParams,
   ScheduleNoShowWebhooksParams,
 } from "../types/params";
 
@@ -243,8 +242,6 @@ export class BookingWebhookService implements IBookingWebhookService {
       userId: params.booking.userId,
       eventTypeId: params.booking.eventTypeId,
       triggerEvent: WebhookTriggerEvents.MEETING_STARTED,
-      teamId: params.teamId,
-      orgId: params.orgId,
       oAuthClientId: params.oAuthClientId,
     });
 
@@ -252,8 +249,6 @@ export class BookingWebhookService implements IBookingWebhookService {
       userId: params.booking.userId,
       eventTypeId: params.booking.eventTypeId,
       triggerEvent: WebhookTriggerEvents.MEETING_ENDED,
-      teamId: params.teamId,
-      orgId: params.orgId,
       oAuthClientId: params.oAuthClientId,
     });
 
@@ -347,8 +342,6 @@ export class BookingWebhookService implements IBookingWebhookService {
         userId: params.triggerForUser ? params.organizerUser.id : null,
         eventTypeId: params.booking.eventTypeId,
         triggerEvent: WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW,
-        teamId: params.teamId,
-        orgId: params.orgId,
         oAuthClientId: params.oAuthClientId,
       });
 
@@ -378,8 +371,6 @@ export class BookingWebhookService implements IBookingWebhookService {
         userId: params.triggerForUser ? params.organizerUser.id : null,
         eventTypeId: params.booking.eventTypeId,
         triggerEvent: WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW,
-        teamId: params.teamId,
-        orgId: params.orgId,
         oAuthClientId: params.oAuthClientId,
       });
 

--- a/packages/features/webhooks/lib/service/WebhookNotificationHandler.test.ts
+++ b/packages/features/webhooks/lib/service/WebhookNotificationHandler.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
-
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BookingWebhookEventDTO, WebhookEventDTO, WebhookSubscriber } from "../dto/types";
-import { WebhookVersion } from "../interface/IWebhookRepository";
 import type { PayloadBuilderFactory } from "../factory/versioned/PayloadBuilderFactory";
+import { WebhookVersion } from "../interface/IWebhookRepository";
 import type { ILogger } from "../interface/infrastructure";
 import type { IWebhookService } from "../interface/services";
 import { WebhookNotificationHandler } from "./WebhookNotificationHandler";
@@ -145,8 +144,6 @@ describe("WebhookNotificationHandler", () => {
         userId: 1,
         eventTypeId: 1,
         triggerEvent: WebhookTriggerEvents.BOOKING_CREATED,
-        teamId: null,
-        orgId: null,
         oAuthClientId: null,
       });
     });

--- a/packages/features/webhooks/lib/service/WebhookNotificationHandler.ts
+++ b/packages/features/webhooks/lib/service/WebhookNotificationHandler.ts
@@ -1,11 +1,11 @@
-import { DEFAULT_WEBHOOK_VERSION } from "../interface/IWebhookRepository";
 import type { WebhookEventDTO } from "../dto/types";
 import type { WebhookPayload } from "../factory/types";
 import type { PayloadBuilderFactory } from "../factory/versioned/PayloadBuilderFactory";
+import type { WebhookVersion } from "../interface/IWebhookRepository";
+import { DEFAULT_WEBHOOK_VERSION } from "../interface/IWebhookRepository";
 import type { ILogger } from "../interface/infrastructure";
 import type { IWebhookService } from "../interface/services";
 import type { IWebhookNotificationHandler } from "../interface/webhook";
-import type { WebhookVersion } from "../interface/IWebhookRepository";
 
 export class WebhookNotificationHandler implements IWebhookNotificationHandler {
   private readonly log: ILogger;
@@ -31,8 +31,6 @@ export class WebhookNotificationHandler implements IWebhookNotificationHandler {
         userId: dto.userId,
         eventTypeId: dto.eventTypeId,
         triggerEvent: trigger,
-        teamId: dto.teamId,
-        orgId: dto.orgId,
         oAuthClientId: dto.platformClientId,
       };
 

--- a/packages/features/webhooks/lib/service/WebhookService.ts
+++ b/packages/features/webhooks/lib/service/WebhookService.ts
@@ -1,10 +1,9 @@
 import { createHmac } from "node:crypto";
-
+import process from "node:process";
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
-
-import type { WebhookSubscriber, WebhookDeliveryResult } from "../dto/types";
+import type { WebhookDeliveryResult, WebhookSubscriber } from "../dto/types";
 import type { WebhookPayload } from "../factory/types";
-import type { ITasker, ILogger } from "../interface/infrastructure";
+import type { ILogger, ITasker } from "../interface/infrastructure";
 import type { IWebhookRepository, IWebhookService } from "../interface/services";
 
 export class WebhookService implements IWebhookService {
@@ -300,7 +299,6 @@ export class WebhookService implements IWebhookService {
     trigger: WebhookTriggerEvents,
     payload: WebhookPayload,
     scheduledAt: Date,
-    options?: { teamId?: number | number[] | null; orgId?: number | null },
     subscribers?: WebhookSubscriber[],
     isDryRun = false
   ): Promise<void> {
@@ -312,8 +310,6 @@ export class WebhookService implements IWebhookService {
         userId: null,
         eventTypeId: null,
         triggerEvent: trigger,
-        teamId: options?.teamId,
-        orgId: options?.orgId,
         oAuthClientId: undefined,
       }));
 

--- a/packages/features/webhooks/lib/service/data-fetchers/BookingWebhookDataFetcher.ts
+++ b/packages/features/webhooks/lib/service/data-fetchers/BookingWebhookDataFetcher.ts
@@ -77,8 +77,6 @@ export class BookingWebhookDataFetcher implements IWebhookDataFetcher {
       triggerEvent: payload.triggerEvent,
       userId: payload.userId,
       eventTypeId: payload.eventTypeId,
-      teamId: payload.teamId,
-      orgId: payload.orgId,
       oAuthClientId: payload.oAuthClientId,
     };
   }

--- a/packages/features/webhooks/lib/service/data-fetchers/OOOWebhookDataFetcher.ts
+++ b/packages/features/webhooks/lib/service/data-fetchers/OOOWebhookDataFetcher.ts
@@ -28,8 +28,6 @@ export class OOOWebhookDataFetcher implements IWebhookDataFetcher {
       triggerEvent: payload.triggerEvent,
       userId: payload.userId,
       eventTypeId: undefined,
-      teamId: payload.teamId,
-      orgId: undefined,
       oAuthClientId: payload.oAuthClientId,
     };
   }

--- a/packages/features/webhooks/lib/service/data-fetchers/PaymentWebhookDataFetcher.ts
+++ b/packages/features/webhooks/lib/service/data-fetchers/PaymentWebhookDataFetcher.ts
@@ -33,8 +33,6 @@ export class PaymentWebhookDataFetcher implements IWebhookDataFetcher {
       triggerEvent: payload.triggerEvent,
       userId: payload.userId,
       eventTypeId: payload.eventTypeId,
-      teamId: payload.teamId,
-      orgId: payload.orgId,
       oAuthClientId: payload.oAuthClientId,
     };
   }

--- a/packages/features/webhooks/lib/service/data-fetchers/RecordingWebhookDataFetcher.ts
+++ b/packages/features/webhooks/lib/service/data-fetchers/RecordingWebhookDataFetcher.ts
@@ -33,8 +33,6 @@ export class RecordingWebhookDataFetcher implements IWebhookDataFetcher {
       triggerEvent: payload.triggerEvent,
       userId: payload.userId,
       eventTypeId: payload.eventTypeId,
-      teamId: payload.teamId,
-      orgId: undefined,
       oAuthClientId: payload.oAuthClientId,
     };
   }


### PR DESCRIPTION
## What this does
- removes team and organization webhook subscriber resolution from webhook delivery
- stops using `teamId` and `orgId` when selecting subscribers for notification, queued-consumer, meeting, and no-show webhook flows
- removes the org-specific repository lookup and team/org-specific consumer test coverage
- keeps booking metadata fields intact while restricting delivery to personal, event-type, platform, and oauth-client webhook scopes

## Validation
```bash
yarn vitest run packages/features/webhooks/lib/service/WebhookNotificationHandler.test.ts packages/features/webhooks/lib/__tests__/consumer/WebhookTaskConsumer.test.ts packages/features/webhooks/lib/__tests__/consumer/triggers/booking-requested.test.ts
yarn type-check:ci --force
```

## Result
- both commands passed locally
- diff size: `15 files changed, 31 insertions(+), 173 deletions(-)`