### PR TITLE
cleanup(workflows): remove dead workflow runtime config

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -29,18 +29,5 @@
       "schedule": "*/5 * * * *"
     }
   ],
-  "functions": {
-    "app/api/cron/workflows/scheduleEmailReminders/route.ts": {
-      "maxDuration": 800
-    },
-    "app/api/cron/workflows/scheduleSMSReminders/route.ts": {
-      "maxDuration": 800
-    },
-    "app/api/cron/workflows/scheduleWhatsappReminders/route.ts": {
-      "maxDuration": 800
-    },
-    "pages/api/trpc/workflows/[trpc].ts": {
-      "maxDuration": 800
-    }
-  }
+  "functions": {}
 }


### PR DESCRIPTION
## Summary
- remove dead workflow function entries from `apps/web/vercel.json`
- stop advertising non-existent workflow cron/trpc handlers in the Vercel runtime config

## Verification
- `node -e 'JSON.parse(require("fs").readFileSync("apps/web/vercel.json","utf8")); console.log("vercel.json valid")'`\n- verified these routes are absent:\n  - `apps/web/app/api/cron/workflows/scheduleEmailReminders/route.ts`\n  - `apps/web/app/api/cron/workflows/scheduleSMSReminders/route.ts`\n  - `apps/web/app/api/cron/workflows/scheduleWhatsappReminders/route.ts`\n  - `apps/web/pages/api/trpc/workflows/[trpc].ts`\n- `yarn type-check:ci --force`