### PR TITLE
cleanup(routing-forms): remove runtime glue

### DIFF
--- a/apps/web/components/PageWrapper.tsx
+++ b/apps/web/components/PageWrapper.tsx
@@ -1,7 +1,7 @@
 /**
  * PAGES ROUTER ONLY - Used exclusively by Next.js Pages Router
  *
- * Currently only serves the /router endpoint (routing forms redirect page).
+ * Legacy Pages Router support only.
  * DO NOT add new features here - this file will be deprecated once we remove apps/web/pages.
  *
  * For App Router, use PageWrapperAppDir.tsx instead.

--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -1,7 +1,7 @@
 /**
  * PAGES ROUTER ONLY - Used exclusively by Next.js Pages Router (_app.tsx)
  *
- * Currently only serves the /router endpoint (routing forms redirect page).
+ * Legacy Pages Router support only.
  * DO NOT add new features here - this file will be deprecated once we remove apps/web/pages.
  *
  * For App Router, use app-providers-app-dir.tsx instead.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -270,14 +270,6 @@ const nextConfig = (phase: string): NextConfig => {
           destination: "/:path*",
         },
         {
-          source: "/forms/:formQuery*",
-          destination: "/apps/routing-forms/routing-link/:formQuery*",
-        },
-        {
-          source: "/routing-forms",
-          destination: "/apps/routing-forms/forms",
-        },
-        {
           source: "/success/:path*",
           has: [
             {
@@ -331,10 +323,6 @@ const nextConfig = (phase: string): NextConfig => {
       ].filter(isNotNull);
 
       const afterFiles = [
-        {
-          source: "/routing/:path*",
-          destination: "/apps/routing-forms/:path*",
-        },
         {
           source: "/org/:slug",
           destination: "/team/:slug",
@@ -508,11 +496,6 @@ const nextConfig = (phase: string): NextConfig => {
         {
           source: "/settings/organizations",
           destination: "/settings/organizations/profile",
-          permanent: false,
-        },
-        {
-          source: "/apps/routing-forms",
-          destination: "/apps/routing-forms/forms",
           permanent: false,
         },
         {

--- a/apps/web/playwright/lib/testUtils.ts
+++ b/apps/web/playwright/lib/testUtils.ts
@@ -274,34 +274,6 @@ export const createNewSeatedEventType = async (page: Page, args: { eventTitle: s
   await page.locator('[data-testid="update-eventtype"]').click();
 };
 
-export async function gotoRoutingLink({
-  page,
-  formId,
-  queryString = "",
-}: {
-  page: Page;
-  formId?: string;
-  queryString?: string;
-}) {
-  let previewLink = null;
-  if (!formId) {
-    // Instead of clicking on the preview link, we are going to the preview link directly because the earlier opens a new tab which is a bit difficult to manage with Playwright
-    await page.locator('[data-testid="preview-button"]').click();
-    const href = await page.locator('[data-testid="open-form-in-new-tab"]').getAttribute("href");
-    if (!href) {
-      throw new Error("Preview link not found");
-    }
-    previewLink = href;
-  } else {
-    previewLink = `/forms/${formId}`;
-  }
-
-  await page.goto(`${previewLink}${queryString ? `?${queryString}` : ""}`);
-
-  // HACK: There seems to be some issue with the inputs to the form getting reset if we don't wait.
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-}
-
 export async function installAppleCalendar(page: Page) {
   await page.goto("/apps/categories/calendar");
   await page.click('[data-testid="app-store-app-card-apple-calendar"]');

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,8 +22,6 @@
     "experimentalDecorators": true
   },
   "include": [
-    /* Find a way to not require this - App files don't belong here. */
-    "../../packages/app-store/routing-forms/env.d.ts",
     "next-env.d.ts",
     "../../packages/trpc/types/router.d.ts",
     "../../packages/types/*.d.ts",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -9,10 +9,6 @@
       "schedule": "0 3 * * *"
     },
     {
-      "path": "/api/cron/queuedFormResponseCleanup",
-      "schedule": "0 */12 * * *"
-    },
-    {
       "path": "/api/tasks/cron",
       "schedule": "* * * * *"
     },


### PR DESCRIPTION
## What this does
- removes stale routing-form rewrites and redirects from `apps/web/next.config.ts`
- removes the dead queued routing-form cleanup cron from `apps/web/vercel.json`
- drops the missing routing-forms env include from `apps/web/tsconfig.json`
- removes the unused Playwright routing-link helper
- trims stale Pages Router comments that still mentioned routing forms

## Verification
```bash
yarn vitest run apps/web/test/lib/next-config.test.ts
yarn type-check:ci --force
```

## Result
- `apps/web/test/lib/next-config.test.ts` passed
- `yarn type-check:ci --force` passed
