### PR TITLE
cleanup(cal-video-recordings): remove booking actions

### DIFF
--- a/apps/web/components/booking/actions/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/actions/BookingActionsDropdown.tsx
@@ -90,18 +90,6 @@ export function BookingActionsDropdown({
   // Use store for all other dialog states
   const chargeCardDialogIsOpen = useBookingActionsStoreContext((state) => state.chargeCardDialogIsOpen);
   const setChargeCardDialogIsOpen = useBookingActionsStoreContext((state) => state.setChargeCardDialogIsOpen);
-  const viewRecordingsDialogIsOpen = useBookingActionsStoreContext(
-    (state) => state.viewRecordingsDialogIsOpen
-  );
-  const setViewRecordingsDialogIsOpen = useBookingActionsStoreContext(
-    (state) => state.setViewRecordingsDialogIsOpen
-  );
-  const meetingSessionDetailsDialogIsOpen = useBookingActionsStoreContext(
-    (state) => state.meetingSessionDetailsDialogIsOpen
-  );
-  const setMeetingSessionDetailsDialogIsOpen = useBookingActionsStoreContext(
-    (state) => state.setMeetingSessionDetailsDialogIsOpen
-  );
   const isNoShowDialogOpen = useBookingActionsStoreContext((state) => state.isNoShowDialogOpen);
   const setIsNoShowDialogOpen = useBookingActionsStoreContext((state) => state.setIsNoShowDialogOpen);
   const isOpenRescheduleDialog = useBookingActionsStoreContext((state) => state.isOpenRescheduleDialog);
@@ -186,11 +174,6 @@ export function BookingActionsDropdown({
   // Check if the logged-in user is the host/owner of the booking
   const isHost = booking.loggedInUser.userId === booking.user?.id;
 
-  const isCalVideoLocation =
-    !booking.location ||
-    booking.location === "integrations:daily" ||
-    (typeof booking.location === "string" && booking.location.trim() === "");
-
   const isDisabledCancelling = booking.eventType.disableCancelling;
   const isDisabledRescheduling = booking.eventType.disableRescheduling;
 
@@ -235,7 +218,6 @@ export function BookingActionsDropdown({
     isTabUnconfirmed,
     isDisabledCancelling,
     isDisabledRescheduling,
-    isCalVideoLocation,
     showPendingPayment,
     isAttendee,
     cardCharged,
@@ -288,29 +270,23 @@ export function BookingActionsDropdown({
   const afterEventActions: ActionType[] = baseAfterEventActions.map((action) => ({
     ...action,
     onClick:
-      action.id === "view_recordings"
-        ? () => setViewRecordingsDialogIsOpen(true)
-        : action.id === "meeting_session_details"
-          ? () => setMeetingSessionDetailsDialogIsOpen(true)
-          : action.id === "charge_card"
-            ? () => setChargeCardDialogIsOpen(true)
-            : action.id === "no_show"
-              ? () => {
-                  if (attendeeList.length === 1) {
-                    const attendee = attendeeList[0];
-                    noShowMutation.mutate({
-                      bookingUid: booking.uid,
-                      attendees: [{ email: attendee.email, noShow: !attendee.noShow }],
-                    });
-                    return;
-                  }
-                  setIsNoShowDialogOpen(true);
-                }
-              : undefined,
+      action.id === "charge_card"
+        ? () => setChargeCardDialogIsOpen(true)
+        : action.id === "no_show"
+          ? () => {
+              if (attendeeList.length === 1) {
+                const attendee = attendeeList[0];
+                noShowMutation.mutate({
+                  bookingUid: booking.uid,
+                  attendees: [{ email: attendee.email, noShow: !attendee.noShow }],
+                });
+                return;
+              }
+              setIsNoShowDialogOpen(true);
+            }
+          : undefined,
     disabled:
-      action.disabled ||
-      (action.id === "no_show" && !(isBookingInPast || isOngoing)) ||
-      (action.id === "view_recordings" && !booking.isRecorded),
+      action.disabled || (action.id === "no_show" && !(isBookingInPast || isOngoing)),
   })) as ActionType[];
 
   const reportAction = getReportAction(actionContext);

--- a/apps/web/components/booking/actions/bookingActions.test.ts
+++ b/apps/web/components/booking/actions/bookingActions.test.ts
@@ -5,7 +5,6 @@ import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
 import {
   getPendingActions,
   getCancelEventAction,
-  getVideoOptionsActions,
   getEditEventActions,
   getAfterEventActions,
   shouldShowPendingActions,
@@ -109,7 +108,6 @@ function createMockContext(overrides: Partial<BookingActionContext> = {}): Booki
     isTabUnconfirmed: false,
     isDisabledCancelling: false,
     isDisabledRescheduling: false,
-    isCalVideoLocation: true,
     showPendingPayment: false,
     cardCharged: false,
     attendeeList: [
@@ -211,47 +209,6 @@ describe("Booking Actions", () => {
       const action = getCancelEventAction(context);
 
       expect(action.label).toBe("cancel_all_remaining");
-    });
-  });
-
-  describe("getVideoOptionsActions", () => {
-    it("should return video actions for past confirmed bookings", () => {
-      const context = createMockContext({
-        isBookingInPast: true,
-        isConfirmed: true,
-        isCalVideoLocation: true,
-        booking: {
-          ...createMockContext().booking,
-          isRecorded: true,
-        },
-      });
-      const actions = getVideoOptionsActions(context);
-
-      expect(actions).toHaveLength(2);
-      expect(actions[0].id).toBe("view_recordings");
-      expect(actions[1].id).toBe("meeting_session_details");
-      expect(actions[0].disabled).toBe(false);
-      expect(actions[1].disabled).toBe(false);
-    });
-
-    it("should disable video actions for upcoming bookings", () => {
-      const context = createMockContext({ isBookingInPast: false });
-      const actions = getVideoOptionsActions(context);
-
-      expect(actions[0].disabled).toBe(true);
-      expect(actions[1].disabled).toBe(true);
-    });
-
-    it("should disable video actions for non-Cal video locations", () => {
-      const context = createMockContext({
-        isBookingInPast: true,
-        isConfirmed: true,
-        isCalVideoLocation: false,
-      });
-      const actions = getVideoOptionsActions(context);
-
-      expect(actions[0].disabled).toBe(true);
-      expect(actions[1].disabled).toBe(true);
     });
   });
 
@@ -434,13 +391,11 @@ describe("Booking Actions", () => {
   });
 
   describe("getAfterEventActions", () => {
-    it("should include video actions and no-show action", () => {
+    it("should include no-show action", () => {
       const context = createMockContext({ isBookingInPast: true, isConfirmed: true });
       const actions = getAfterEventActions(context);
 
       const actionIds = actions.map((a) => a.id);
-      expect(actionIds).toContain("view_recordings");
-      expect(actionIds).toContain("meeting_session_details");
       expect(actionIds).toContain("no_show");
     });
 
@@ -566,13 +521,6 @@ describe("Booking Actions", () => {
       });
 
       expect(isActionDisabled("cancel", futureContext)).toBe(false);
-    });
-
-    it("should disable video actions for non-past bookings", () => {
-      const context = createMockContext({ isBookingInPast: false });
-
-      expect(isActionDisabled("view_recordings", context)).toBe(true);
-      expect(isActionDisabled("meeting_session_details", context)).toBe(true);
     });
 
     it("should disable charge card action when already charged", () => {

--- a/apps/web/components/booking/actions/bookingActions.ts
+++ b/apps/web/components/booking/actions/bookingActions.ts
@@ -19,7 +19,6 @@ export interface BookingActionContext {
   isTabUnconfirmed: boolean;
   isDisabledCancelling: boolean;
   isDisabledRescheduling: boolean;
-  isCalVideoLocation: boolean;
   showPendingPayment: boolean;
   isAttendee: boolean;
   cardCharged: boolean;
@@ -73,25 +72,6 @@ export function getCancelEventAction(context: BookingActionContext): ActionType 
     disabled: isActionDisabled("cancel", context),
     bookingUid: booking.uid,
   };
-}
-
-export function getVideoOptionsActions(context: BookingActionContext): ActionType[] {
-  const { booking, isBookingInPast, isConfirmed, isCalVideoLocation, t } = context;
-
-  return [
-    {
-      id: "view_recordings",
-      label: t("view_recordings"),
-      icon: "video",
-      disabled: !(isBookingInPast && isConfirmed && isCalVideoLocation && booking.isRecorded),
-    },
-    {
-      id: "meeting_session_details",
-      label: t("view_session_details"),
-      icon: "info",
-      disabled: !(isBookingInPast && isConfirmed && isCalVideoLocation),
-    },
-  ];
 }
 
 export function getEditEventActions(context: BookingActionContext): ActionType[] {
@@ -184,7 +164,6 @@ export function getAfterEventActions(context: BookingActionContext): ActionType[
   const { booking, cardCharged, attendeeList, t } = context;
 
   const actions: (ActionType | null)[] = [
-    ...getVideoOptionsActions(context),
     booking.status === BookingStatus.ACCEPTED && booking.paid && booking.payment[0]?.paymentOption === "HOLD"
       ? {
           id: "charge_card",
@@ -262,10 +241,6 @@ export function isActionDisabled(actionId: string, context: BookingActionContext
       );
     case "cancel":
       return isDisabledCancelling || isBookingInPast || isCancelled || isRejected;
-    case "view_recordings":
-      return !(isBookingInPast && booking.status === BookingStatus.ACCEPTED && context.isCalVideoLocation);
-    case "meeting_session_details":
-      return !(isBookingInPast && booking.status === BookingStatus.ACCEPTED && context.isCalVideoLocation);
     case "charge_card":
       return context.cardCharged;
     case "reassign":

--- a/apps/web/components/booking/actions/store.ts
+++ b/apps/web/components/booking/actions/store.ts
@@ -7,8 +7,6 @@ export type BookingActionsStore = {
   // Dialog states
   rejectionDialogIsOpen: boolean;
   chargeCardDialogIsOpen: boolean;
-  viewRecordingsDialogIsOpen: boolean;
-  meetingSessionDetailsDialogIsOpen: boolean;
   isNoShowDialogOpen: boolean;
   isOpenRescheduleDialog: boolean;
   isOpenReassignDialog: boolean;
@@ -22,8 +20,6 @@ export type BookingActionsStore = {
   // Dialog setters
   setRejectionDialogIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setChargeCardDialogIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  setViewRecordingsDialogIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  setMeetingSessionDetailsDialogIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setIsNoShowDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setIsOpenRescheduleDialog: React.Dispatch<React.SetStateAction<boolean>>;
   setIsOpenReassignDialog: React.Dispatch<React.SetStateAction<boolean>>;
@@ -40,8 +36,6 @@ export const createBookingActionsStore = () => {
     // Initial dialog states
     rejectionDialogIsOpen: false,
     chargeCardDialogIsOpen: false,
-    viewRecordingsDialogIsOpen: false,
-    meetingSessionDetailsDialogIsOpen: false,
     isNoShowDialogOpen: false,
     isOpenRescheduleDialog: false,
     isOpenReassignDialog: false,
@@ -60,16 +54,6 @@ export const createBookingActionsStore = () => {
     setChargeCardDialogIsOpen: (isOpen) =>
       set((state) => ({
         chargeCardDialogIsOpen: typeof isOpen === "function" ? isOpen(state.chargeCardDialogIsOpen) : isOpen,
-      })),
-    setViewRecordingsDialogIsOpen: (isOpen) =>
-      set((state) => ({
-        viewRecordingsDialogIsOpen:
-          typeof isOpen === "function" ? isOpen(state.viewRecordingsDialogIsOpen) : isOpen,
-      })),
-    setMeetingSessionDetailsDialogIsOpen: (isOpen) =>
-      set((state) => ({
-        meetingSessionDetailsDialogIsOpen:
-          typeof isOpen === "function" ? isOpen(state.meetingSessionDetailsDialogIsOpen) : isOpen,
       })),
     setIsNoShowDialogOpen: (isOpen) =>
       set((state) => ({


### PR DESCRIPTION
## What this does
- removes the booking actions UI affordances for Cal Video recordings and session details
- drops the related booking-actions store state
- removes the focused booking-actions unit coverage for those unsupported actions

## Verification
```bash
yarn vitest run apps/web/components/booking/actions/bookingActions.test.ts
yarn type-check:ci --force
```

## Result
- `apps/web/components/booking/actions/bookingActions.test.ts` passed
- `yarn type-check:ci --force` passed
