### PR TITLE
Fix OTP input text invisible in light theme

### DIFF
--- a/apps/web/modules/bookings/components/VerifyCodeDialog.tsx
+++ b/apps/web/modules/bookings/components/VerifyCodeDialog.tsx
@@ -83,7 +83,7 @@ export const VerifyCodeDialog = ({
   useEffect(() => setValue(""), [isOpenDialog]);
 
   const digitClassName =
-    "h-12 w-12 text-center text-xl! text-emphasis caret-emphasis [-webkit-text-fill-color:currentColor]";
+    "h-12 w-12 text-center text-xl! text-default caret-emphasis [-webkit-text-fill-color:currentColor]";
 
   return (
     <Dialog


### PR DESCRIPTION
#Fixes 28947
### Fix: OTP input text invisible in light theme

#### Summary
Fixes an issue where the OTP verification input text is not visible in light theme.

#### Problem
In the `VerifyCodeDialog` component, the input fields used the Tailwind class `text-emphasis` along with `-webkit-text-fill-color: currentColor`. In light theme, this resulted in very light (almost white) text on a light background, making the entered digits effectively invisible to the user.

#### Solution
Replaced `text-emphasis` with `text-default` in the `digitClassName` to ensure proper contrast and readability in light mode, while maintaining theme consistency.

#### Impact
- Restores visibility of OTP input text in light theme
- Improves usability of the email verification flow
- Low-risk change limited to styling only