### PR TITLE
fix(app-store): normalize search to handle spacing and casing issues

### DIFF
--- a/apps/web/modules/apps/components/AllApps.tsx
+++ b/apps/web/modules/apps/components/AllApps.tsx
@@ -158,7 +158,14 @@ export function AllApps({ apps, searchText, categories, userAdminTeams }: AllApp
           : app.category === selectedCategory
         : true
     )
-    .filter((app) => (searchText ? app.name.toLowerCase().includes(searchText.toLowerCase()) : true))
+   .filter((app) =>
+  searchText
+    ? app.name
+        .toLowerCase()
+        .replace(/[\s\-_]/g, "")
+        .includes(searchText.toLowerCase().replace(/[\s\-_]/g, ""))
+    : true
+)
     .sort(function (a, b) {
       if (a.name < b.name) return -1;
       else if (a.name > b.name) return 1;

--- a/packages/app-store/zohocrm/config.json
+++ b/packages/app-store/zohocrm/config.json
@@ -1,6 +1,6 @@
 {
   "/*": "Don't modify slug - If required, do it using cli edit command",
-  "name": "ZohoCRM",
+  "name": "Zoho CRM",
   "slug": "zohocrm",
   "type": "zohocrm_crm",
   "logo": "icon.svg",


### PR DESCRIPTION
Fixes #29233  

## What does this PR do?

Fixes incorrect search matching in the App Store caused by lack of normalization in search logic.

Previously:
- Queries like "zoho crm" did not match "ZohoCRM"
- Search depended on exact spacing/casing

Now:
- Search input is normalized by removing spaces, dashes, and underscores
- Matching works consistently for:
  - zoho crm
  - zohocrm
  - zoho-crm

Also updates the display name from "ZohoCRM" to "Zoho CRM" for consistency.

---

## Visual Demo

### Before (production behavior)
Searching "zoho crm" → No results  

https://github.com/user-attachments/assets/0d0062bb-73b9-4270-9769-fac5d0ed7bb1

### After (local with fix)
Searching "zoho crm" → Zoho CRM appears  

https://github.com/user-attachments/assets/dd1227ac-c037-457e-af1a-030acdc83938

> Note: Zoho CRM is not available in the local dev dataset, so a temporary mock entry was used only for demonstration. The actual fix is limited to search normalization logic.

---

## How should this be tested?

1. Go to App Store page
2. Search for:
   - "zoho crm"
   - "zohocrm"
   - "zoho-crm"

### Expected Result:
All variations should return the same app consistently.

---

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works (N/A – no existing tests for this module)

---

## Checklist

- My code follows the style guidelines of this project
- I have checked that my changes generate no new warnings