### PR TITLE
fix(zohocrm): repair token expiry, silent error swallowing, and missi…

### DIFF
--- a/packages/app-store/zohocrm/api/callback.ts
+++ b/packages/app-store/zohocrm/api/callback.ts
@@ -72,7 +72,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     },
   });
   // set expiry date as offset from current time.
-  zohoCrmTokenInfo.data.expiryDate = Math.round(Date.now() + 60 * 60);
+  zohoCrmTokenInfo.data.expiryDate = Math.round(Date.now() + 60 * 60 * 1000);
   zohoCrmTokenInfo.data.accountServer = accountsServer;
 
   await createOAuthAppCredential({ appId: appConfig.slug, type: appConfig.type }, zohoCrmTokenInfo.data, req);

--- a/packages/app-store/zohocrm/lib/CrmService.ts
+++ b/packages/app-store/zohocrm/lib/CrmService.ts
@@ -129,6 +129,9 @@ class ZohoCrmCrmService implements CRM {
   };
 
   private createZohoEvent = async (event: CalendarEvent, contacts: Contact[]) => {
+    if (!contacts.length) {
+      return Promise.reject("No contacts provided to link with the Zoho CRM event");
+    }
     const zohoEvent = {
       Event_Title: event.title,
       Start_DateTime: toISO8601String(new Date(event.startTime)),
@@ -140,7 +143,7 @@ class ZohoCrmCrmService implements CRM {
         location: event.location,
         uid: event.uid,
       }),
-      Who_Id: contacts[0].id, // Link the first attendee as the primary Who_Id
+      Who_Id: contacts[0].id,
     };
 
     return axios({
@@ -153,7 +156,10 @@ class ZohoCrmCrmService implements CRM {
       data: JSON.stringify({ data: [zohoEvent] }),
     })
       .then((data) => data.data)
-      .catch((e) => this.log.error(e, e.response?.data));
+      .catch((e) => {
+        this.log.error(e, e.response?.data);
+        throw e;
+      });
   };
 
   private updateMeeting = async (uid: string, event: CalendarEvent) => {
@@ -180,7 +186,10 @@ class ZohoCrmCrmService implements CRM {
       data: JSON.stringify({ data: [zohoEvent] }),
     })
       .then((data) => data.data)
-      .catch((e) => this.log.error(e, e.response?.data));
+      .catch((e) => {
+        this.log.error(e, e.response?.data);
+        throw e;
+      });
   };
 
   private deleteMeeting = async (uid: string) => {
@@ -193,7 +202,10 @@ class ZohoCrmCrmService implements CRM {
       },
     })
       .then((data) => data.data)
-      .catch((e) => this.log.error(e, e.response?.data));
+      .catch((e) => {
+        this.log.error(e, e.response?.data);
+        throw e;
+      });
   };
 
   private zohoCrmAuth = async (credential: CredentialPayload) => {


### PR DESCRIPTION
What does this PR do?
Fixes three bugs in the Zoho CRM integration that caused booked appointments to silently fail to sync into Zoho CRM (no Events, Meetings, or Activities were ever created).

Fixes #29228
Root causes fixed
1. Token expiry set to ~3.6 seconds instead of 1 hour (callback.ts)
Date.now() returns milliseconds, but the initial OAuth callback added only 60 * 60 (seconds) instead of 60 * 60 * 1000 (milliseconds). The stored token expired ~3.6 seconds after the OAuth handshake, making every subsequent API call return 401 Unauthorized. The token refresh path already used the correct * 1000 multiplier — this was an inconsistency left in the original callback.

2. API errors silently swallowed (CrmService.ts)
createZohoEvent, updateMeeting, and deleteMeeting all had .catch((e) => this.log.error(e)) — logging the error but returning undefined. The caller then accessed .data on undefined, threw a TypeError, which EventManager caught as a warning. The Cal.com booking succeeded while Zoho got nothing, with no visible failure to the user.

3. Missing guard on contacts[0] (CrmService.ts)
Who_Id: contacts[0].id was accessed without checking contacts.length, causing a TypeError if contact lookup or creation returned an empty array.