### PR TITLE
fix(auth): reject partial API auth credentials instead of treating as anonymous

### DIFF
--- a/apps/api/v2/src/modules/auth/guards/optional-api-auth/optional-api-auth.guard.ts
+++ b/apps/api/v2/src/modules/auth/guards/optional-api-auth/optional-api-auth.guard.ts
@@ -12,12 +12,8 @@ export class OptionalApiAuthGuard extends ApiAuthGuard {
     const onlyClientIdProvided = error && error.message.includes(ONLY_CLIENT_ID_PROVIDED_MESSAGE);
     const onlyClientSecretProvided = error && error.message.includes(ONLY_CLIENT_SECRET_PROVIDED_MESSAGE);
 
-    if (onlyClientIdProvided) {
-      return null;
-    }
-
-    if (onlyClientSecretProvided) {
-      return null;
+    if (onlyClientIdProvided || onlyClientSecretProvided) {
+      throw error;
     }
 
     if (user || noAuthProvided || !error) {

--- a/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.e2e-spec.ts
+++ b/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.e2e-spec.ts
@@ -359,6 +359,36 @@ describe("ApiAuthStrategy", () => {
     });
   });
 
+  describe("OptionalApiAuthGuard behavior (partial auth)", () => {
+    it("should reject request when only client ID is provided (guard level)", async () => {
+      const request = createRequest() as any;
+
+      const error = new HttpException(
+        `ApiAuthStrategy - ${ONLY_CLIENT_ID_PROVIDED_MESSAGE}`,
+        401
+      );
+
+      const guard = new (require("@/modules/auth/guards/optional-api-auth/optional-api-auth.guard")
+        .OptionalApiAuthGuard)();
+
+      expect(() => guard.handleRequest(error, null)).toThrow();
+    });
+
+    it("should reject request when only client secret is provided (guard level)", async () => {
+      const request = createRequest() as any;
+
+      const error = new HttpException(
+        `ApiAuthStrategy - ${ONLY_CLIENT_SECRET_PROVIDED_MESSAGE}`,
+        401
+      );
+
+      const guard = new (require("@/modules/auth/guards/optional-api-auth/optional-api-auth.guard")
+        .OptionalApiAuthGuard)();
+
+      expect(() => guard.handleRequest(error, null)).toThrow();
+    });
+  });
+
   afterAll(async () => {
     await oAuthClientRepositoryFixture.delete(oAuthClient.id);
     await userRepositoryFixture.delete(validApiKeyUser.id);


### PR DESCRIPTION
## What does this PR do?

Fixes an issue in OptionalApiAuthGuard where partially provided API auth credentials (only client ID or only client secret) were incorrectly treated as unauthenticated requests instead of invalid ones.

Previously:
- Sending only client ID OR only client secret ---> request was allowed as anonymous

Now:
- Partial credentials ---> request is rejected (401)
- No credentials ---> still allowed (as intended for optional auth)

This aligns the behavior with the existing comment and expected auth semantics: "optional means no auth is fine, but invalid auth must fail"

---

## Why this change?

The current logic creates a subtle auth downgrade issue: Invalid or incomplete credentials are silently ignored and treated as if no auth was provided.

This can lead to unintended access in endpoints that assume: "If auth is present, it must be valid"

This PR ensures:
- Clear separation between "no auth" vs "invalid auth"
- Consistent and predictable authentication behavior

---

### Behavior Change

Before:
<img width="1743" height="525" alt="image" src="https://github.com/user-attachments/assets/fc47936f-a64c-4266-be8f-d46647e5bc13" />

After:
<img width="1826" height="328" alt="image" src="https://github.com/user-attachments/assets/f84dedb1-2a85-43c2-9888-ef869658608b" />
---

## Changes

- Updated OptionalApiAuthGuard to throw error when only client ID or only client secret is provided
- Added tests to verify correct guard behavior for partial credentials

---

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective

---

## How should this be tested?

1. Send request with only `X_CAL_CLIENT_ID` ---> should return 401

2. Send request with only `X_CAL_SECRET_KEY` ---> should return 401

3. Send request with no auth ---> should be allowed (if endpoint uses OptionalApiAuthGuard)

4. Send valid credentials ---> should authenticate normally

No special env variables required beyond standard setup.

---

## Checklist

- My code follows project style guidelines
- No new warnings introduced
- PR is small and focused