### PR TITLE
fix: preserve array query parameters in dynamic group redirects

### DIFF
--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -107,7 +107,7 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
 
     // EXAMPLE - context.params: { orgSlug: 'acme', user: 'member0+owner1' }
     // EXAMPLE - context.query: { redirect: 'undefined', orgRedirection: 'undefined', user: 'member0+owner1' }
-    const originalQueryString = new URLSearchParams(context.query as Record<string, string>).toString();
+    const originalQueryString = encode(context.query);
     const destinationWithQuery = `${destinationUrl}?${originalQueryString}`;
     log.debug(`Dynamic group detected, redirecting to ${destinationUrl}`);
     return {


### PR DESCRIPTION
## Summary

- Fixes incorrect serialization of array query parameters during dynamic group redirects
- Replaces `new URLSearchParams(context.query as Record<string, string>)` with `encode(context.query)` from `node:querystring` (already imported in the file)

## What was wrong

`context.query` in Next.js is typed as `Record<string, string | string[] | undefined>`. Casting it to `Record<string, string>` and passing to `URLSearchParams` causes array values like `?user=john&user=doe` to be serialized as `user=john,doe` — a single comma-joined value instead of repeated keys.

## Fix

`node:querystring.encode()` natively handles `string | string[]` values, producing `user=john&user=doe` for arrays. It was already imported at line 1 but unused for this code path.

## Test plan

- [ ] URL with repeated query params (`/john?user=john&user=doe`) preserves both values in redirect
- [ ] URL with single query params continues to work unchanged
- [ ] Dynamic group redirect includes all original query parameters

Fixes #28687