### PR TITLE
fix: preserve array query parameters in user redirect

### DIFF
--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -107,7 +107,15 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
 
     // EXAMPLE - context.params: { orgSlug: 'acme', user: 'member0+owner1' }
     // EXAMPLE - context.query: { redirect: 'undefined', orgRedirection: 'undefined', user: 'member0+owner1' }
-    const originalQueryString = new URLSearchParams(context.query as Record<string, string>).toString();
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(context.query)) {
+      if (Array.isArray(value)) {
+        value.forEach((v) => params.append(key, v));
+      } else if (value !== undefined) {
+        params.append(key, value);
+      }
+    }
+    const originalQueryString = params.toString();
     const destinationWithQuery = `${destinationUrl}?${originalQueryString}`;
     log.debug(`Dynamic group detected, redirecting to ${destinationUrl}`);
     return {


### PR DESCRIPTION
## Summary

When redirecting dynamic groups to `/.../dynamic`, the query string was built with `URLSearchParams(context.query as Record<string, string>)`. Next.js passes `string | string[] | undefined` per key; array values were not serialized as repeated keys and broke multi-value params.

This change builds `URLSearchParams` by appending each value (and each array element) explicitly.

Fixes #28687.

Made with [Cursor](https://cursor.com)