### PR TITLE
  refactor: use userRepository class methods for signup handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ You can use any of these credentials to sign in at [http://localhost:3000](http:
 > **Tip**: To view the full list of seeded users and their details, run `yarn db-studio` and visit [http://localhost:5555](http://localhost:5555)
 
 #### Development tip
-hello
 
 1. Add `export NODE_OPTIONS="--max-old-space-size=16384"` to your shell script to increase the memory limit for the node process. Alternatively, you can run this in your terminal before running the app. Replace 16384 with the amount of RAM you want to allocate to the node process.
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ You can use any of these credentials to sign in at [http://localhost:3000](http:
 > **Tip**: To view the full list of seeded users and their details, run `yarn db-studio` and visit [http://localhost:5555](http://localhost:5555)
 
 #### Development tip
-
+hello
 
 1. Add `export NODE_OPTIONS="--max-old-space-size=16384"` to your shell script to increase the memory limit for the node process. Alternatively, you can run this in your terminal before running the app. Replace 16384 with the amount of RAM you want to allocate to the node process.
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ You can use any of these credentials to sign in at [http://localhost:3000](http:
 
 #### Development tip
 
+
 1. Add `export NODE_OPTIONS="--max-old-space-size=16384"` to your shell script to increase the memory limit for the node process. Alternatively, you can run this in your terminal before running the app. Replace 16384 with the amount of RAM you want to allocate to the node process.
 
 2. Add `NEXT_PUBLIC_LOGGER_LEVEL={level}` to your .env file to control the logging verbosity for all tRPC queries and mutations.\

--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -65,6 +65,10 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
     })
     .parse(body);
 
+  const userRepository = new UserRepository(prisma);
+
+  const billingService = getBillingProviderService();
+
   const shouldLockByDefault = await checkIfEmailIsBlockedInWatchlistController({
     email: _email,
     organizationId: null,
@@ -103,10 +107,8 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
     });
 
     if (foundToken?.teamId) {
-      const existingUser = await prisma.user.findUnique({
-        where: { email },
-        select: { invitedTo: true },
-      });
+      const existingUser = await userRepository.findByEmailWithInvitedTo({email})
+
       if (existingUser && existingUser.invitedTo !== foundToken.teamId) {
         return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
       }
@@ -197,14 +199,11 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
       const organizationId = team.isOrganization ? team.id : (team.parent?.id ?? null);
 
       if (username) {
-        const existingUserByUsername = await prisma.user.findFirst({
-          where: {
-            username,
-            organizationId,
-            NOT: { email },
-          },
-          select: { id: true },
-        });
+        const existingUserByUsername = await userRepository.findByUsernameAndOrganizationId({
+          username,
+          organizationId,
+          excludeEmail: email
+        })
         if (existingUserByUsername) {
           return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
         }
@@ -212,30 +211,12 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
 
       let user: { id: number };
       try {
-        user = await prisma.user.upsert({
-          where: { email },
-          update: {
-            username,
-            emailVerified: new Date(Date.now()),
-            identityProvider: IdentityProvider.CAL,
-            password: {
-              upsert: {
-                create: { hash: hashedPassword },
-                update: { hash: hashedPassword },
-              },
-            },
-            organizationId,
-          },
-          create: {
-            username,
-            email,
-            emailVerified: new Date(Date.now()),
-            identityProvider: IdentityProvider.CAL,
-            password: { create: { hash: hashedPassword } },
-            organizationId,
-          },
-          select: { id: true },
-        });
+        user = await userRepository.upsertForSignup({
+          email,
+          username,
+          hashedPassword,
+          organizationId
+        })
       } catch (error) {
         if (isPrismaError(error) && error.code === "P2002") {
           const target = String(error.meta?.target ?? "");
@@ -269,19 +250,19 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
   } else {
     // Create the user
     try {
-      await prisma.user.create({
-        data: {
-          username,
-          email,
-          locked: shouldLockByDefault,
-          password: { create: { hash: hashedPassword } },
-          metadata: {
-            stripeCustomerId: customer.stripeCustomerId,
-            checkoutSessionId,
-          },
-          creationSource: CreationSource.WEBAPP,
-        },
-      });
+      await userRepository.create({
+        username,
+        email,
+        hashedPassword,
+        organizationId: null,
+        creationSource: CreationSource.WEBAPP,
+        locked: shouldLockByDefault,
+        identityProvider: IdentityProvider.CAL,
+        metadata: {
+          stripeCustomerId: customer.stripeCustomerId,
+          checkoutSessionId,
+        }
+      })
     } catch (error) {
       // Fallback for race conditions where user was created between our check and create
       if (isPrismaError(error) && error.code === "P2002") {
@@ -316,7 +297,6 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
       });
     }
 
-    const userRepository = new UserRepository(prisma);
     await userRepository.lockByEmail({ email });
 
     return NextResponse.json(

--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -26,7 +26,7 @@ import { isPrismaError } from "@calcom/lib/server/getServerErrorFromUnknown";
 import type { CustomNextApiHandler } from "@calcom/lib/server/username";
 import { usernameHandler } from "@calcom/lib/server/username";
 import { getTrackingFromCookies } from "@calcom/lib/tracking";
-import prisma from "@calcom/prisma";
+import { prisma } from "@calcom/prisma";
 import {
   CreationSource,
   IdentityProvider,

--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -13,7 +13,7 @@ import {
 } from "@calcom/features/auth/signup/utils/token";
 import { validateAndGetCorrectedUsernameAndEmail } from "@calcom/features/auth/signup/utils/validateUsername";
 import { getFeatureRepository } from "@calcom/features/di/containers/FeatureRepository";
-import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+import { getUserRepository } from "@calcom/features/users/di/UserRepository.container";
 import { GlobalWatchlistRepository } from "@calcom/features/watchlist/lib/repository/GlobalWatchlistRepository";
 import { sentrySpan } from "@calcom/features/watchlist/lib/telemetry";
 import { normalizeEmail } from "@calcom/features/watchlist/lib/utils/normalization";
@@ -65,7 +65,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
     })
     .parse(body);
 
-  const userRepository = new UserRepository(prisma);
+  const userRepository = getUserRepository();
 
   const shouldLockByDefault = await checkIfEmailIsBlockedInWatchlistController({
     email: _email,

--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -215,7 +215,9 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
           email,
           username,
           hashedPassword,
-          organizationId
+          organizationId,
+          emailVerified: new Date(),
+          identityProvider: IdentityProvider.CAL
         })
       } catch (error) {
         if (isPrismaError(error) && error.code === "P2002") {

--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -67,8 +67,6 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
 
   const userRepository = new UserRepository(prisma);
 
-  const billingService = getBillingProviderService();
-
   const shouldLockByDefault = await checkIfEmailIsBlockedInWatchlistController({
     email: _email,
     organizationId: null,

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -121,7 +121,9 @@ export default async function handler(body: Record<string, string>) {
           email: userEmail,
           username: correctedUsername,
           hashedPassword,
-          organizationId
+          organizationId,
+          emailVerified: new Date(),
+          identityProvider: IdentityProvider.CAL
         })
       } catch (error) {
         if (isPrismaError(error) && error.code === "P2002") {

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -22,7 +22,7 @@ import { signupSchema } from "@calcom/prisma/zod-utils";
 import { NextResponse } from "next/server";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 
-import { CreationSource } from "@calcom/prisma/client";
+import { CreationSource } from "@calcom/prisma/enums";
 
 export default async function handler(body: Record<string, string>) {
   const { email, password, language, token } = signupSchema.parse(body);

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -20,9 +20,14 @@ import prisma from "@calcom/prisma";
 import { IdentityProvider } from "@calcom/prisma/enums";
 import { signupSchema } from "@calcom/prisma/zod-utils";
 import { NextResponse } from "next/server";
+import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+
+import { CreationSource } from "@calcom/prisma/client";
 
 export default async function handler(body: Record<string, string>) {
   const { email, password, language, token } = signupSchema.parse(body);
+
+  const userRepository = new UserRepository(prisma)
 
   const username = slugify(body.username);
   const userEmail = email.toLowerCase();
@@ -44,10 +49,10 @@ export default async function handler(body: Record<string, string>) {
     });
 
     if (foundToken?.teamId) {
-      const existingUser = await prisma.user.findUnique({
-        where: { email: userEmail },
-        select: { invitedTo: true },
-      });
+      const existingUser = await userRepository.findByEmailWithInvitedTo({
+        email: userEmail
+      })
+
       if (existingUser && existingUser.invitedTo !== foundToken.teamId) {
         return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
       }
@@ -100,44 +105,24 @@ export default async function handler(body: Record<string, string>) {
 
       const organizationId = team.isOrganization ? team.id : (team.parent?.id ?? null);
 
-      const existingUserByUsername = await prisma.user.findFirst({
-        where: {
-          username: correctedUsername,
-          organizationId,
-          NOT: { email: userEmail },
-        },
-        select: { id: true },
-      });
+      const existingUserByUsername = await userRepository.findByUsernameAndOrganizationId({
+        username: correctedUsername,
+        organizationId,
+        excludeEmail: userEmail
+      })
+
       if (existingUserByUsername) {
         return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
       }
 
       let user: { id: number };
       try {
-        user = await prisma.user.upsert({
-          where: { email: userEmail },
-          update: {
-            username: correctedUsername,
-            emailVerified: new Date(Date.now()),
-            identityProvider: IdentityProvider.CAL,
-            password: {
-              upsert: {
-                create: { hash: hashedPassword },
-                update: { hash: hashedPassword },
-              },
-            },
-            organizationId,
-          },
-          create: {
-            username: correctedUsername,
-            email: userEmail,
-            emailVerified: new Date(Date.now()),
-            identityProvider: IdentityProvider.CAL,
-            password: { create: { hash: hashedPassword } },
-            organizationId,
-          },
-          select: { id: true },
-        });
+        user = await userRepository.upsertForSignup({
+          email: userEmail,
+          username: correctedUsername,
+          hashedPassword,
+          organizationId
+        })
       } catch (error) {
         if (isPrismaError(error) && error.code === "P2002") {
           const target = String(error.meta?.target ?? "");
@@ -174,15 +159,15 @@ export default async function handler(body: Record<string, string>) {
       return NextResponse.json({ message: "A user exists with that username" }, { status: 409 });
     }
     try {
-      await prisma.user.create({
-        data: {
-          username: correctedUsername,
-          email: userEmail,
-          password: { create: { hash: hashedPassword } },
-          identityProvider: IdentityProvider.CAL,
-        },
-        select: { id: true },
-      });
+      await userRepository.create({
+        username: correctedUsername,
+        email: userEmail,
+        hashedPassword,
+        organizationId: null,
+        creationSource: CreationSource.WEBAPP,
+        identityProvider: IdentityProvider.CAL,
+        locked: false
+      })
     } catch (error) {
       // Fallback for race conditions where user was created between our check and create
       if (isPrismaError(error) && error.code === "P2002") {

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -16,7 +16,7 @@ import logger from "@calcom/lib/logger";
 import { isPrismaError } from "@calcom/lib/server/getServerErrorFromUnknown";
 import { isUsernameReservedDueToMigration } from "@calcom/lib/server/username";
 import slugify from "@calcom/lib/slugify";
-import prisma from "@calcom/prisma";
+import { prisma } from "@calcom/prisma";
 import { IdentityProvider } from "@calcom/prisma/enums";
 import { signupSchema } from "@calcom/prisma/zod-utils";
 import { NextResponse } from "next/server";

--- a/packages/features/users/di/UserRepository.container.ts
+++ b/packages/features/users/di/UserRepository.container.ts
@@ -1,0 +1,9 @@
+import { createContainer } from "@calcom/features/di/di";
+import { type UserRepository, moduleLoader as userRepositoryModuleLoader } from "./UserRepository.module";
+
+const userRepositoryContainer = createContainer();
+
+export function getUserRepository(): UserRepository {
+  userRepositoryModuleLoader.loadModule(userRepositoryContainer);
+  return userRepositoryContainer.get<UserRepository>(userRepositoryModuleLoader.token);
+}

--- a/packages/features/users/di/UserRepository.module.ts
+++ b/packages/features/users/di/UserRepository.module.ts
@@ -1,0 +1,24 @@
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as prismaModuleLoader } from "@calcom/features/di/modules/Prisma";
+
+import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+import { DI_TOKENS } from "@calcom/features/di/tokens";
+
+const thisModule = createModule()
+const token = DI_TOKENS.USER_REPOSITORY
+const moduleToken = DI_TOKENS.USER_REPOSITORY_MODULE
+
+const loadModule  = bindModuleToClassOnToken({
+    module: thisModule,
+    moduleToken,
+    token,
+    classs: UserRepository,
+    dep: prismaModuleLoader
+})
+
+export const moduleLoader: ModuleLoader = {
+    token,
+    loadModule
+}
+
+export type { UserRepository }

--- a/packages/features/users/repositories/UserRepository.integration-test.ts
+++ b/packages/features/users/repositories/UserRepository.integration-test.ts
@@ -15,6 +15,8 @@ async function cleanupTestUsers() {
         id: { in: createdUserIds },
       },
     });
+
+    createdUserIds.length = 0
   }
 }
 

--- a/packages/features/users/repositories/UserRepository.integration-test.ts
+++ b/packages/features/users/repositories/UserRepository.integration-test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "@calcom/prisma";
+import { UserRepository } from "./UserRepository";
+import { getUserRepository } from "@calcom/features/users/di/UserRepository.container";
+import { CreationSource, IdentityProvider } from "@calcom/prisma/enums";
+import bcrypt from "bcryptjs";
+
+const testRunId = `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+const createdUserIds: number[] = [];
+
+async function cleanupTestUsers() {
+  if (createdUserIds.length > 0) {
+    await prisma.user.deleteMany({
+      where: {
+        id: { in: createdUserIds },
+      },
+    });
+  }
+}
+
+describe("UserRepository Integration Tests - Signup Methods", () => {
+  let userRepository: UserRepository;
+
+  beforeAll(async () => {
+    userRepository = getUserRepository();
+  });
+
+  afterEach(async () => {
+    await cleanupTestUsers();
+  });
+
+  describe("upsertForSignup", () => {
+    it("should create a new user when email doesn't exist", async () => {
+      const testEmail = `signup-new-${testRunId}@example.com`;
+      const hashedPassword = await bcrypt.hash("password123", 10);
+
+      const result = await userRepository.upsertForSignup({
+        email: testEmail,
+        username: `signupuser-${testRunId}`,
+        hashedPassword,
+        organizationId: null,
+        emailVerified: new Date(),
+        identityProvider: IdentityProvider.CAL,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result.id).toBeDefined();
+      createdUserIds.push(result.id);
+
+      const createdUser = await prisma.user.findUnique({
+        where: { email: testEmail },
+      });
+      expect(createdUser).not.toBeNull();
+      expect(createdUser?.email).toBe(testEmail);
+      expect(createdUser?.emailVerified).not.toBeNull();
+    });
+
+    it("should update existing user's credentials on upsert", async () => {
+      const testEmail = `signup-update-${testRunId}@example.com`;
+      const hashedPassword1 = await bcrypt.hash("password123", 10);
+      const hashedPassword2 = await bcrypt.hash("newpassword456", 10);
+
+      const user1 = await userRepository.upsertForSignup({
+        email: testEmail,
+        username: `user-${testRunId}`,
+        hashedPassword: hashedPassword1,
+        organizationId: null,
+        emailVerified: new Date(Date.now() - 86400000),
+        identityProvider: IdentityProvider.CAL,
+      });
+      createdUserIds.push(user1.id);
+
+      const user2 = await userRepository.upsertForSignup({
+        email: testEmail,
+        username: `user-${testRunId}-updated`,
+        hashedPassword: hashedPassword2,
+        organizationId: null,
+        emailVerified: new Date(),
+        identityProvider: IdentityProvider.CAL,
+      });
+
+      expect(user2.id).toBe(user1.id);
+
+      const updatedUser = await prisma.user.findUnique({
+        where: { email: testEmail },
+        include: { password: true },
+      });
+      expect(updatedUser?.username).toBe(`user-${testRunId}-updated`);
+      expect(updatedUser?.password?.hash).toBe(hashedPassword2);
+    });
+
+    it("should preserve user ID on upsert", async () => {
+      const testEmail = `signup-preserve-${testRunId}@example.com`;
+      const hashedPassword = await bcrypt.hash("password123", 10);
+
+      const user1 = await userRepository.upsertForSignup({
+        email: testEmail,
+        username: `user-${testRunId}-p1`,
+        hashedPassword,
+        organizationId: null,
+        emailVerified: new Date(),
+        identityProvider: IdentityProvider.CAL,
+      });
+      createdUserIds.push(user1.id);
+      const initialId = user1.id;
+
+      const user2 = await userRepository.upsertForSignup({
+        email: testEmail,
+        username: `user-${testRunId}-p2`,
+        hashedPassword,
+        organizationId: null,
+        emailVerified: new Date(),
+        identityProvider: IdentityProvider.CAL,
+      });
+
+      expect(user2.id).toBe(initialId);
+    });
+
+    it("should set email as verified on signup", async () => {
+      const testEmail = `signup-verified-${testRunId}@example.com`;
+      const hashedPassword = await bcrypt.hash("password123", 10);
+      const verificationDate = new Date();
+
+      const result = await userRepository.upsertForSignup({
+        email: testEmail,
+        username: `user-${testRunId}-v1`,
+        hashedPassword,
+        organizationId: null,
+        emailVerified: verificationDate,
+        identityProvider: IdentityProvider.CAL,
+      });
+      createdUserIds.push(result.id);
+
+      const user = await prisma.user.findUnique({
+        where: { email: testEmail },
+      });
+
+      expect(user?.emailVerified).not.toBeNull();
+      expect(user?.emailVerified?.getTime()).toBeLessThanOrEqual(
+        new Date().getTime()
+      );
+    });
+
+    it("should create password record for new user", async () => {
+      const testEmail = `signup-pwd-${testRunId}@example.com`;
+      const hashedPassword = await bcrypt.hash("password123", 10);
+
+      const result = await userRepository.upsertForSignup({
+        email: testEmail,
+        username: `user-${testRunId}-pwd`,
+        hashedPassword,
+        organizationId: null,
+        emailVerified: new Date(),
+        identityProvider: IdentityProvider.CAL,
+      });
+      createdUserIds.push(result.id);
+
+      const userWithPassword = await prisma.user.findUnique({
+        where: { email: testEmail },
+        include: { password: true },
+      });
+
+      expect(userWithPassword?.password).not.toBeNull();
+      expect(userWithPassword?.password?.hash).toBe(hashedPassword);
+      expect(userWithPassword?.password?.userId).toBe(result.id);
+    });
+
+    it("should throw error on duplicate unique constraint if username exists", async () => {
+      const testEmail1 = `signup-dup1-${testRunId}@example.com`;
+      const testEmail2 = `signup-dup2-${testRunId}@example.com`;
+      const duplicateUsername = `dupuser-${testRunId}`;
+      const hashedPassword = await bcrypt.hash("password123", 10);
+
+      const user1 = await userRepository.upsertForSignup({
+        email: testEmail1,
+        username: duplicateUsername,
+        hashedPassword,
+        organizationId: null,
+        emailVerified: new Date(),
+        identityProvider: IdentityProvider.CAL,
+      });
+      createdUserIds.push(user1.id);
+
+      await expect(
+        userRepository.upsertForSignup({
+          email: testEmail2,
+          username: duplicateUsername,
+          hashedPassword,
+          organizationId: null,
+          emailVerified: new Date(),
+          identityProvider: IdentityProvider.CAL,
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("Integration: Individual Signup flow", () => {  
+  it("should complete full individual signup flow: check email, check username, then upsert", async () => {  
+    const testEmail = `flow-${testRunId}@example.com`;  
+    const testUsername = `flowuser-${testRunId}`;  
+    const hashedPassword = await bcrypt.hash("password123", 10);  
+  
+    const existingUser = await userRepository.findByEmail({  
+      email: testEmail,  
+    });  
+    expect(existingUser).toBeNull();  
+  
+    const usersWithUsername = await userRepository.findUsersByUsername({  
+      orgSlug: null,
+      usernameList: [testUsername],  
+    });  
+    const usernameTaken = usersWithUsername.length > 0 ? usersWithUsername[0] : null;  
+    expect(usernameTaken).toBeNull();  
+  
+    const signupResult = await userRepository.upsertForSignup({  
+      email: testEmail,  
+      username: testUsername,  
+      hashedPassword,  
+      organizationId: null,
+      emailVerified: new Date(),  
+      identityProvider: IdentityProvider.CAL,  
+    });  
+    createdUserIds.push(signupResult.id);  
+  
+    expect(signupResult.id).toBeDefined();  
+  
+    const createdUser = await prisma.user.findUnique({  
+      where: { email: testEmail },  
+      include: { password: true },  
+    });  
+    expect(createdUser?.email).toBe(testEmail);  
+    expect(createdUser?.username).toBe(testUsername);  
+    expect(createdUser?.password).not.toBeNull();  
+    expect(createdUser?.organizationId).toBeNull();
+  });  
+});
+});

--- a/packages/features/users/repositories/UserRepository.integration-test.ts
+++ b/packages/features/users/repositories/UserRepository.integration-test.ts
@@ -85,7 +85,14 @@ describe("UserRepository Integration Tests - Signup Methods", () => {
 
       const updatedUser = await prisma.user.findUnique({
         where: { email: testEmail },
-        include: { password: true },
+        select: {
+          username: true,
+          password: {
+            select: {
+              hash: true
+            }
+          }
+        },
       });
       expect(updatedUser?.username).toBe(`user-${testRunId}-updated`);
       expect(updatedUser?.password?.hash).toBe(hashedPassword2);
@@ -138,9 +145,7 @@ describe("UserRepository Integration Tests - Signup Methods", () => {
       });
 
       expect(user?.emailVerified).not.toBeNull();
-      expect(user?.emailVerified?.getTime()).toBeLessThanOrEqual(
-        new Date().getTime()
-      );
+      expect(user?.emailVerified?.getTime()).toBe(verificationDate.getTime());
     });
 
     it("should create password record for new user", async () => {
@@ -159,7 +164,14 @@ describe("UserRepository Integration Tests - Signup Methods", () => {
 
       const userWithPassword = await prisma.user.findUnique({
         where: { email: testEmail },
-        include: { password: true },
+        select: {
+          password: {
+            select: {
+              hash: true,
+              userId: true
+            }
+          }
+        },
       });
 
       expect(userWithPassword?.password).not.toBeNull();
@@ -228,7 +240,16 @@ describe("UserRepository Integration Tests - Signup Methods", () => {
   
     const createdUser = await prisma.user.findUnique({  
       where: { email: testEmail },  
-      include: { password: true },  
+      select: {
+        email: true,
+        username: true,
+        organizationId: true,
+        password: {
+          select: {
+            userId: true
+          }
+        }
+      },  
     });  
     expect(createdUser?.email).toBe(testEmail);  
     expect(createdUser?.username).toBe(testUsername);  

--- a/packages/features/users/repositories/UserRepository.integration-test.ts
+++ b/packages/features/users/repositories/UserRepository.integration-test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { prisma } from "@calcom/prisma";
 import { UserRepository } from "./UserRepository";
 import { getUserRepository } from "@calcom/features/users/di/UserRepository.container";
-import { CreationSource, IdentityProvider } from "@calcom/prisma/enums";
+import { IdentityProvider } from "@calcom/prisma/enums";
 import bcrypt from "bcryptjs";
 
 const testRunId = `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1483,7 +1483,7 @@ export class UserRepository {
   async findByEmailWithInvitedTo({ email }: { email: string } ) {
     return this.prismaClient.user.findUnique({
       where: {
-        email
+        email: email.toLowerCase()
       },
       select: {
         invitedTo: true

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -9,7 +9,7 @@ import type { PrismaClient } from "@calcom/prisma";
 import { availabilityUserSelect } from "@calcom/prisma";
 import type { DestinationCalendar, SelectedCalendar, User as UserType } from "@calcom/prisma/client";
 import { Prisma } from "@calcom/prisma/client";
-import { IdentityProvider } from "@calcom/prisma/enums";
+import type { IdentityProvider } from "@calcom/prisma/enums";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { BookingStatus, MembershipRole } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
@@ -904,13 +904,12 @@ export class UserRepository {
       locked: boolean;
     }
   ) {
-    const organizationIdValue = data.organizationId;
-    const { email, username, creationSource, locked, hashedPassword, ...rest } = data;
+    const { email, username, creationSource, locked, hashedPassword, organizationId, ...rest } = data;
 
     log.info("create user", {
       email,
       username,
-      organizationIdValue,
+      organizationId,
       locked,
     });
     const t = await getTranslation("en", "common");
@@ -940,13 +939,13 @@ export class UserRepository {
         },
         creationSource,
         locked,
-        ...(organizationIdValue && username
+        ...(organizationId && username
           ? {
-              organizationId: organizationIdValue,
+              organizationId,
               profiles: {
                 create: {
                   username,
-                  organizationId: organizationIdValue,
+                  organizationId,
                   uid: ProfileRepository.generateProfileUid(),
                 },
               },

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -8,7 +8,8 @@ import { withSelectedCalendars } from "@calcom/lib/server/withSelectedCalendars"
 import type { PrismaClient } from "@calcom/prisma";
 import { availabilityUserSelect } from "@calcom/prisma";
 import type { DestinationCalendar, SelectedCalendar, User as UserType } from "@calcom/prisma/client";
-import { IdentityProvider, Prisma } from "@calcom/prisma/client";
+import { Prisma } from "@calcom/prisma/client";
+import { IdentityProvider } from "@calcom/prisma/enums";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { BookingStatus, MembershipRole } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
@@ -906,7 +907,7 @@ export class UserRepository {
     const organizationIdValue = data.organizationId;
     const { email, username, creationSource, locked, hashedPassword, ...rest } = data;
 
-    logger.info("create user", {
+    log.info("create user", {
       email,
       username,
       organizationIdValue,

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -1545,35 +1545,39 @@ export class UserRepository {
     username,
     hashedPassword,
     organizationId,
-  }:{
-    email: string,
-    username: string | null,
-    hashedPassword: string,
-    organizationId: number | null
+    emailVerified,
+    identityProvider,
+  }: {
+    email: string;
+    username: string | null;
+    hashedPassword: string;
+    organizationId: number | null;
+    emailVerified: Date;
+    identityProvider: IdentityProvider;
   }) {
     return this.prismaClient.user.upsert({
       where: { email },
       update: {
         username,
-        emailVerified: new Date(Date.now()),
-        identityProvider: IdentityProvider.CAL,
+        emailVerified,
+        identityProvider,
         password: {
           upsert: {
             create: { hash: hashedPassword },
-            update: { hash: hashedPassword }
-          }
+            update: { hash: hashedPassword },
+          },
         },
-        organizationId
+        organizationId,
       },
       create: {
         username,
         email,
-        emailVerified: new Date(Date.now()),
-        identityProvider: IdentityProvider.CAL,
+        emailVerified,
+        identityProvider,
         password: { create: { hash: hashedPassword } },
-        organizationId
+        organizationId,
       },
-      select: { id: true }
-    })
+      select: { id: true },
+    });
   }
 }

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -8,7 +8,7 @@ import { withSelectedCalendars } from "@calcom/lib/server/withSelectedCalendars"
 import type { PrismaClient } from "@calcom/prisma";
 import { availabilityUserSelect } from "@calcom/prisma";
 import type { DestinationCalendar, SelectedCalendar, User as UserType } from "@calcom/prisma/client";
-import { Prisma } from "@calcom/prisma/client";
+import { IdentityProvider, Prisma } from "@calcom/prisma/client";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { BookingStatus, MembershipRole } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
@@ -896,7 +896,7 @@ export class UserRepository {
 
   async create(
     data: Omit<Prisma.UserCreateInput, "password" | "organization" | "movedToProfile"> & {
-      username: string;
+      username: string | null;
       hashedPassword?: string;
       organizationId: number | null;
       creationSource: CreationSource;
@@ -939,7 +939,7 @@ export class UserRepository {
         },
         creationSource,
         locked,
-        ...(organizationIdValue
+        ...(organizationIdValue && username
           ? {
               organizationId: organizationIdValue,
               profiles: {
@@ -1480,6 +1480,38 @@ export class UserRepository {
     });
   }
 
+  async findByEmailWithInvitedTo({ email }: { email: string } ) {
+    return this.prismaClient.user.findUnique({
+      where: {
+        email
+      },
+      select: {
+        invitedTo: true
+      }
+    })
+  }
+
+  async findByUsernameAndOrganizationId({
+    username,
+    organizationId,
+    excludeEmail,
+  }: {
+    username: string,
+    organizationId: number | null,
+    excludeEmail: string
+  }) {
+    return this.prismaClient.user.findFirst({
+      where: {
+        username,
+        organizationId,
+        NOT: { email: excludeEmail }
+      },
+      select: {
+        id: true
+      }
+    })
+  }
+
   async lockByEmail({ email }: { email: string }) {
     await this.prismaClient.user.updateMany({
       where: { email },
@@ -1505,5 +1537,42 @@ export class UserRepository {
     });
 
     return { email: user.email, username: user.username };
+  }
+
+  async upsertForSignup({
+    email,
+    username,
+    hashedPassword,
+    organizationId,
+  }:{
+    email: string,
+    username: string | null,
+    hashedPassword: string,
+    organizationId: number | null
+  }) {
+    return this.prismaClient.user.upsert({
+      where: { email },
+      update: {
+        username,
+        emailVerified: new Date(Date.now()),
+        identityProvider: IdentityProvider.CAL,
+        password: {
+          upsert: {
+            create: { hash: hashedPassword },
+            update: { hash: hashedPassword }
+          }
+        },
+        organizationId
+      },
+      create: {
+        username,
+        email,
+        emailVerified: new Date(Date.now()),
+        identityProvider: IdentityProvider.CAL,
+        password: { create: { hash: hashedPassword } },
+        organizationId
+      },
+      select: { id: true }
+    })
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR refactors the signup handlers to use the methods of userRepository class in place of prisma calls.

For the sake of abstraction, i have introduced three new methods to the UserRepository class
1. findByEmailWithInvitedTo
2. findByUsernameAndOrganizationId
3. upsertForSignup


- Fixes #14869  (GitHub issue number)
- Fixes CAL-3632 (Linear issue number - should be visible at the bottom of the GitHub issue description)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
