### PR TITLE
feat(bookings): add overrideAvailability flag to v2 create endpoint

### DIFF
--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -130,6 +130,8 @@ export class BookingsController_2024_08_13 {
       If you are creating a seated booking for an event type with 'show attendees' disabled, then to retrieve attendees in the response either set 'show attendees' to true on event type level or
       you have to provide an authentication method of event type owner, host, team admin or owner or org admin or owner.
 
+      To create a booking that overlaps busy time or existing bookings (organizer override), set \`overrideAvailability\` to \`true\` in the JSON body while authenticated as the event type owner, host, team admin or owner, or org admin or owner.
+
       For event types that have SMS reminders enabled, you need to pass the attendee's phone number in the request body via \`attendee.phoneNumber\` (e.g., "+19876543210" in international format). This is an optional field, but becomes required when SMS reminders are enabled for the event type. For the complete attendee object structure, see the attendee schema in the \`/docs\` Swagger endpoint.
 
       <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>

--- a/apps/api/v2/src/platform/bookings/2024-08-13/services/bookings.service.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/services/bookings.service.ts
@@ -182,7 +182,10 @@ export class BookingsService_2024_08_13 {
     if (!params.overrideAvailabilityRequested) {
       return false;
     }
-    if (!params.authUser || !params.userIsEventTypeAdminOrOwner) {
+    if (!params.authUser) {
+      throw new UnauthorizedException("overrideAvailability requires authentication");
+    }
+    if (!params.userIsEventTypeAdminOrOwner) {
       throw new ForbiddenException(
         "overrideAvailability is only permitted when authenticated as the event type owner or host, or as a team or organization administrator."
       );

--- a/apps/api/v2/src/platform/bookings/2024-08-13/services/bookings.service.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/services/bookings.service.ts
@@ -122,6 +122,11 @@ export class BookingsService_2024_08_13 {
       const userIsEventTypeAdminOrOwner = authUser
         ? await this.eventTypeAccessService.userIsEventTypeAdminOrOwner(authUser, eventType)
         : false;
+      const skipAvailabilityCheck = this.getSkipAvailabilityForOverride({
+        overrideAvailabilityRequested: !!body.overrideAvailability,
+        authUser,
+        userIsEventTypeAdminOrOwner,
+      });
       await this.checkBookingRequiresAuthenticationSetting(eventType, authUser, userIsEventTypeAdminOrOwner);
 
       if (eventType.schedulingType === "MANAGED") {
@@ -142,19 +147,47 @@ export class BookingsService_2024_08_13 {
       await this.hasRequiredBookingFieldsResponses(body, eventType);
 
       if (isRecurring && isSeated) {
-        return await this.createRecurringSeatedBooking(request, body, eventType, userIsEventTypeAdminOrOwner);
+        return await this.createRecurringSeatedBooking(
+          request,
+          body,
+          eventType,
+          userIsEventTypeAdminOrOwner,
+          skipAvailabilityCheck
+        );
       }
       if (isRecurring && !isSeated) {
-        return await this.createRecurringBooking(request, body, eventType);
+        return await this.createRecurringBooking(request, body, eventType, skipAvailabilityCheck);
       }
       if (isSeated) {
-        return await this.createSeatedBooking(request, body, eventType, userIsEventTypeAdminOrOwner);
+        return await this.createSeatedBooking(
+          request,
+          body,
+          eventType,
+          userIsEventTypeAdminOrOwner,
+          skipAvailabilityCheck
+        );
       }
 
-      return await this.createRegularBooking(request, body, eventType);
+      return await this.createRegularBooking(request, body, eventType, skipAvailabilityCheck);
     } catch (error) {
       this.errorsBookingsService.handleBookingError(error, bookingTeamEventType);
     }
+  }
+
+  private getSkipAvailabilityForOverride(params: {
+    overrideAvailabilityRequested: boolean;
+    authUser: AuthOptionalUser;
+    userIsEventTypeAdminOrOwner: boolean;
+  }): boolean {
+    if (!params.overrideAvailabilityRequested) {
+      return false;
+    }
+    if (!params.authUser || !params.userIsEventTypeAdminOrOwner) {
+      throw new ForbiddenException(
+        "overrideAvailability is only permitted when authenticated as the event type owner or host, or as a team or organization administrator."
+      );
+    }
+    return true;
   }
 
   async checkEventTypeHasHosts(eventTypeId: number) {
@@ -399,7 +432,8 @@ export class BookingsService_2024_08_13 {
   async createRecurringBooking(
     request: Request,
     body: CreateRecurringBookingInput_2024_08_13,
-    eventType: EventTypeWithOwnerAndTeam
+    eventType: EventTypeWithOwnerAndTeam,
+    skipAvailabilityCheck: boolean
   ) {
     const bookingRequest = await this.inputService.createRecurringBookingRequest(request, body, eventType);
     const bookings = await this.recurringBookingService.createBooking({
@@ -414,6 +448,7 @@ export class BookingsService_2024_08_13 {
         platformBookingLocation: bookingRequest.platformBookingLocation,
         noEmail: bookingRequest.noEmail,
         areCalendarEventsEnabled: bookingRequest.areCalendarEventsEnabled,
+        skipAvailabilityCheck,
       },
       creationSource: "API_V2",
     });
@@ -429,7 +464,8 @@ export class BookingsService_2024_08_13 {
     request: Request,
     body: CreateRecurringBookingInput_2024_08_13,
     eventType: EventTypeWithOwnerAndTeam,
-    userIsEventTypeAdminOrOwner: boolean
+    userIsEventTypeAdminOrOwner: boolean,
+    skipAvailabilityCheck: boolean
   ) {
     const bookingRequest = await this.inputService.createRecurringBookingRequest(request, body, eventType);
     const bookings = await this.recurringBookingService.createBooking({
@@ -443,6 +479,7 @@ export class BookingsService_2024_08_13 {
         platformBookingUrl: bookingRequest.platformBookingUrl,
         platformBookingLocation: bookingRequest.platformBookingLocation,
         areCalendarEventsEnabled: bookingRequest.areCalendarEventsEnabled,
+        skipAvailabilityCheck,
       },
       creationSource: "API_V2",
     });
@@ -459,7 +496,8 @@ export class BookingsService_2024_08_13 {
   async createRegularBooking(
     request: Request,
     body: CreateBookingInput_2024_08_13,
-    eventType: EventTypeWithOwnerAndTeam
+    eventType: EventTypeWithOwnerAndTeam,
+    skipAvailabilityCheck: boolean
   ) {
     const bookingRequest = await this.inputService.createBookingRequest(request, body, eventType);
     const booking = await this.regularBookingService.createBooking({
@@ -473,6 +511,7 @@ export class BookingsService_2024_08_13 {
         platformBookingUrl: bookingRequest.platformBookingUrl,
         platformBookingLocation: bookingRequest.platformBookingLocation,
         areCalendarEventsEnabled: bookingRequest.areCalendarEventsEnabled,
+        skipAvailabilityCheck,
       },
     });
 
@@ -500,7 +539,8 @@ export class BookingsService_2024_08_13 {
     request: Request,
     body: CreateBookingInput_2024_08_13,
     eventType: EventTypeWithOwnerAndTeam,
-    userIsEventTypeAdminOrOwner: boolean
+    userIsEventTypeAdminOrOwner: boolean,
+    skipAvailabilityCheck: boolean
   ) {
     const bookingRequest = await this.inputService.createBookingRequest(request, body, eventType);
     try {
@@ -515,6 +555,7 @@ export class BookingsService_2024_08_13 {
           platformBookingUrl: bookingRequest.platformBookingUrl,
           platformBookingLocation: bookingRequest.platformBookingLocation,
           areCalendarEventsEnabled: bookingRequest.areCalendarEventsEnabled,
+          skipAvailabilityCheck,
         },
       });
 

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -46,7 +46,7 @@
       "post": {
         "operationId": "BookingsController_2024_08_13_createBooking",
         "summary": "Create a booking",
-        "description": "\n      POST /v2/bookings is used to create regular bookings, recurring bookings and instant bookings. The request bodies for all 3 are almost the same except:\n      If eventTypeId in the request body is id of a regular event, then regular booking is created.\n\n      If it is an id of a recurring event type, then recurring booking is created.\n\n      Meaning that the request bodies are equal but the outcome depends on what kind of event type it is with the goal of making it as seamless for developers as possible.\n\n      The start needs to be in UTC aka if the timezone is GMT+2 in Rome and meeting should start at 11, then UTC time should have hours 09:00 aka without time zone.\n\n      Finally, there are 2 ways to book an event type belonging to an individual user:\n      1. Provide `eventTypeId` in the request body.\n      2. Provide `eventTypeSlug` and `username` and optionally `organizationSlug` if the user with the username is within an organization.\n\n      And 2 ways to book and event type belonging to a team:\n      1. Provide `eventTypeId` in the request body.\n      2. Provide `eventTypeSlug` and `teamSlug` and optionally `organizationSlug` if the team with the teamSlug is within an organization.\n\n      If you are creating a seated booking for an event type with 'show attendees' disabled, then to retrieve attendees in the response either set 'show attendees' to true on event type level or\n      you have to provide an authentication method of event type owner, host, team admin or owner or org admin or owner.\n\n      For event types that have SMS reminders enabled, you need to pass the attendee's phone number in the request body via `attendee.phoneNumber` (e.g., \"+19876543210\" in international format). This is an optional field, but becomes required when SMS reminders are enabled for the event type. For the complete attendee object structure, see the attendee schema in the `/docs` Swagger endpoint.\n\n      <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>\n      ",
+        "description": "\n      POST /v2/bookings is used to create regular bookings, recurring bookings and instant bookings. The request bodies for all 3 are almost the same except:\n      If eventTypeId in the request body is id of a regular event, then regular booking is created.\n\n      If it is an id of a recurring event type, then recurring booking is created.\n\n      Meaning that the request bodies are equal but the outcome depends on what kind of event type it is with the goal of making it as seamless for developers as possible.\n\n      The start needs to be in UTC aka if the timezone is GMT+2 in Rome and meeting should start at 11, then UTC time should have hours 09:00 aka without time zone.\n\n      Finally, there are 2 ways to book an event type belonging to an individual user:\n      1. Provide `eventTypeId` in the request body.\n      2. Provide `eventTypeSlug` and `username` and optionally `organizationSlug` if the user with the username is within an organization.\n\n      And 2 ways to book and event type belonging to a team:\n      1. Provide `eventTypeId` in the request body.\n      2. Provide `eventTypeSlug` and `teamSlug` and optionally `organizationSlug` if the team with the teamSlug is within an organization.\n\n      If you are creating a seated booking for an event type with 'show attendees' disabled, then to retrieve attendees in the response either set 'show attendees' to true on event type level or\n      you have to provide an authentication method of event type owner, host, team admin or owner or org admin or owner.\n\n      To create a booking that overlaps busy time or existing bookings (organizer override), set `overrideAvailability` to `true` in the JSON body while authenticated as the event type owner, host, team admin or owner, or org admin or owner.\n\n      For event types that have SMS reminders enabled, you need to pass the attendee's phone number in the request body via `attendee.phoneNumber` (e.g., \"+19876543210\" in international format). This is an optional field, but becomes required when SMS reminders are enabled for the event type. For the complete attendee object structure, see the attendee schema in the `/docs` Swagger endpoint.\n\n      <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>\n      ",
         "parameters": [
           {
             "name": "cal-api-version",
@@ -1964,7 +1964,7 @@
             "name": "eventUid",
             "required": true,
             "in": "path",
-            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: GET /v2/organizations/{orgId}/teams/{teamId}/bookings/{bookingUid}/references\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
+            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
             "schema": {
               "type": "string"
             }
@@ -2011,7 +2011,7 @@
             "name": "eventUid",
             "required": true,
             "in": "path",
-            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: GET /v2/organizations/{orgId}/teams/{teamId}/bookings/{bookingUid}/references\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
+            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
             "schema": {
               "type": "string"
             }
@@ -2110,7 +2110,7 @@
             "name": "eventUid",
             "required": true,
             "in": "path",
-            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: GET /v2/organizations/{orgId}/teams/{teamId}/bookings/{bookingUid}/references\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
+            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
             "schema": {
               "type": "string"
             }
@@ -2157,7 +2157,7 @@
             "name": "eventUid",
             "required": true,
             "in": "path",
-            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: GET /v2/organizations/{orgId}/teams/{teamId}/bookings/{bookingUid}/references\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
+            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
             "schema": {
               "type": "string"
             }
@@ -12426,6 +12426,12 @@
             "type": "string",
             "description": "Email verification code required when event type has email verification enabled.",
             "example": "123456"
+          },
+          "overrideAvailability": {
+            "type": "boolean",
+            "description": "When true, skips host availability and calendar conflict checks. Only permitted when the request is authenticated as the event type owner, a host, or a team or organization administrator. Use for organizer overrides (double bookings, administrative sessions) or integration tests.",
+            "example": false,
+            "default": false
           }
         },
         "required": ["start", "attendee"]
@@ -12549,6 +12555,12 @@
             "type": "string",
             "description": "Email verification code required when event type has email verification enabled.",
             "example": "123456"
+          },
+          "overrideAvailability": {
+            "type": "boolean",
+            "description": "When true, skips host availability and calendar conflict checks. Only permitted when the request is authenticated as the event type owner, a host, or a team or organization administrator. Use for organizer overrides (double bookings, administrative sessions) or integration tests.",
+            "example": false,
+            "default": false
           },
           "recurrenceCount": {
             "type": "number",
@@ -15194,7 +15206,6 @@
                 "MEETING_ENDED",
                 "MEETING_STARTED",
                 "RECORDING_READY",
-                "INSTANT_MEETING",
                 "RECORDING_TRANSCRIPTION_GENERATED",
                 "OOO_CREATED",
                 "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
@@ -15242,7 +15253,6 @@
                 "MEETING_ENDED",
                 "MEETING_STARTED",
                 "RECORDING_READY",
-                "INSTANT_MEETING",
                 "RECORDING_TRANSCRIPTION_GENERATED",
                 "OOO_CREATED",
                 "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
@@ -15326,7 +15336,6 @@
                 "MEETING_ENDED",
                 "MEETING_STARTED",
                 "RECORDING_READY",
-                "INSTANT_MEETING",
                 "RECORDING_TRANSCRIPTION_GENERATED",
                 "OOO_CREATED",
                 "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
@@ -15390,7 +15399,6 @@
                 "MEETING_ENDED",
                 "MEETING_STARTED",
                 "RECORDING_READY",
-                "INSTANT_MEETING",
                 "RECORDING_TRANSCRIPTION_GENERATED",
                 "OOO_CREATED",
                 "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
@@ -15489,7 +15497,6 @@
                 "MEETING_ENDED",
                 "MEETING_STARTED",
                 "RECORDING_READY",
-                "INSTANT_MEETING",
                 "RECORDING_TRANSCRIPTION_GENERATED",
                 "OOO_CREATED",
                 "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",

--- a/packages/features/bookings/lib/service/RecurringBookingService.ts
+++ b/packages/features/bookings/lib/service/RecurringBookingService.ts
@@ -46,6 +46,7 @@ export const handleNewRecurringBooking = async function (
     platformBookingUrl: input.platformBookingUrl,
     platformBookingLocation: input.platformBookingLocation,
     areCalendarEventsEnabled: input.areCalendarEventsEnabled,
+    skipAvailabilityCheck: input.skipAvailabilityCheck,
   };
 
   if (isRoundRobin) {

--- a/packages/platform/types/bookings/2024-08-13/inputs/create-booking.input.ts
+++ b/packages/platform/types/bookings/2024-08-13/inputs/create-booking.input.ts
@@ -396,6 +396,22 @@ export class CreateBookingInput_2024_08_13 {
   @IsString()
   emailVerificationCode?: string;
 
+  @ApiPropertyOptional({
+    type: Boolean,
+    description:
+      "When true, skips host availability and calendar conflict checks. Only permitted when the request is authenticated as the event type owner, a host, or a team or organization administrator. Use for organizer overrides (double bookings, administrative sessions) or integration tests.",
+    example: false,
+    default: false,
+  })
+  @Transform(({ value }) => {
+    if (value === true || value === "true") return true;
+    if (value === false || value === "false") return false;
+    return value;
+  })
+  @IsOptional()
+  @IsBoolean()
+  overrideAvailability?: boolean;
+
   /* @ApiPropertyOptional({
     type: [Number],
     description:

--- a/packages/platform/types/bookings/2024-08-13/inputs/create-booking.input.ts
+++ b/packages/platform/types/bookings/2024-08-13/inputs/create-booking.input.ts
@@ -404,6 +404,7 @@ export class CreateBookingInput_2024_08_13 {
     default: false,
   })
   @Transform(({ value }) => {
+    if (value === null || value === undefined) return undefined;
     if (value === true || value === "true") return true;
     if (value === false || value === "false") return false;
     return value;


### PR DESCRIPTION
## What does this PR do?

Adds a new optional `overrideAvailability` field to `POST /v2/bookings` that lets event type owners, hosts, and team or organization administrators create bookings on slots that are otherwise busy (calendar conflicts or existing bookings).

When the flag is sent without proper authentication, the request is rejected with `403 Forbidden`. When sent with a valid API key for an event type owner / host / admin, host availability and conflict checks are skipped.

- Fixes #29249

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

**1. Owner with override — succeeds on busy slot (201)**
<img width="1911" height="1076" alt="image" src="https://github.com/user-attachments/assets/16d4944f-60ee-45a5-a0dd-3a8ce9b674a9" />


**2. Same slot without override — rejected (400)**
<img width="1911" height="1076" alt="image" src="https://github.com/user-attachments/assets/a72324a7-54c7-4a12-b7b3-69fa2cf1a48c" />

**3. Override without auth — rejected (403)**
<img width="1911" height="1076" alt="image" src="https://github.com/user-attachments/assets/a4b5fe90-38ad-4bdc-be0a-5723706dff74" />

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. The endpoint description and DTO description are updated; OpenAPI spec is regenerated.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Manual verification with the API v2 server running on port 5555:

**Setup:** authenticate as the event type owner. Pick an event type id where the slot is already busy.

```bash
# (a) Owner with override → expect 201
curl -i -X POST "http://localhost:5555/v2/bookings" \
  -H "Authorization: Bearer <OWNER_API_KEY>" \
  -H "cal-api-version: 2024-08-13" \
  -H "Content-Type: application/json" \
  -d '{"start":"2026-06-10T15:00:00.000Z","eventTypeId":14,"overrideAvailability":true,"attendee":{"name":"Owner Override","email":"override@example.com","timeZone":"Asia/Kolkata"}}'

# (b) Same call without overrideAvailability → expect 400 (slot busy)
# (c) overrideAvailability without auth → expect 403 ForbiddenException
