### PR TITLE
fix(zohocrm): support multi-DC, correct token expiry, and fix contact…

### DIFF
--- a/packages/app-store/zohocrm/api/callback.ts
+++ b/packages/app-store/zohocrm/api/callback.ts
@@ -71,8 +71,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
     },
   });
-  // set expiry date as offset from current time.
-  zohoCrmTokenInfo.data.expiryDate = Math.round(Date.now() + 60 * 60);
+
+// expires_in is in seconds; Date.now() returns ms — convert before adding.
+// https://www.zoho.com/accounts/protocol/oauth/web-apps/access-token.html
+  zohoCrmTokenInfo.data.expiryDate = Math.round(Date.now() + zohoCrmTokenInfo.data.expires_in * 1000);
   zohoCrmTokenInfo.data.accountServer = accountsServer;
 
   await createOAuthAppCredential({ appId: appConfig.slug, type: appConfig.type }, zohoCrmTokenInfo.data, req);

--- a/packages/app-store/zohocrm/lib/CrmService.ts
+++ b/packages/app-store/zohocrm/lib/CrmService.ts
@@ -52,9 +52,18 @@ class ZohoCrmCrmService implements CRM {
   private client_id = "";
   private client_secret = "";
   private accessToken = "";
+  private apiDomain = "https://www.zohoapis.com"; 
 
   constructor(credential: CredentialPayload) {
     this.integrationName = "zohocrm_crm";
+    const credentialKey = credential.key as unknown as ZohoToken;
+    if (credentialKey?.api_domain) {
+      /**
+       * Zoho is multi-DC — api_domain from the OAuth response is this account's API base URL.
+       * https://www.zoho.com/crm/developer/docs/api/v6/multi-dc.html
+       */
+      this.apiDomain = credentialKey.api_domain;
+    }
     this.auth = this.zohoCrmAuth(credential).then((r) => r);
     this.log = logger.getSubLogger({ prefix: [`[[lib] ${this.integrationName}`] });
   }
@@ -74,7 +83,7 @@ class ZohoCrmCrmService implements CRM {
     });
     const response = await axios({
       method: "post",
-      url: `https://www.zohoapis.com/crm/v3/Contacts`,
+      url: `${this.apiDomain}/crm/v3/Contacts`,
       headers: {
         "content-type": "application/json",
         authorization: `Zoho-oauthtoken ${this.accessToken}`,
@@ -83,10 +92,10 @@ class ZohoCrmCrmService implements CRM {
     });
 
     const { data } = response;
-    return data.data.map((contact: ZohoContact) => {
+    return data.data.map((contact: { details: { id: string } }, index: number) => {
       return {
-        id: contact.id,
-        email: contact.email,
+        id: contact.details.id,
+        email: contactsToCreate[index].email,
       };
     });
   }
@@ -100,7 +109,7 @@ class ZohoCrmCrmService implements CRM {
 
     const response = await axios({
       method: "get",
-      url: `https://www.zohoapis.com/crm/v3/Contacts/search?criteria=${searchCriteria}`,
+      url: `${this.apiDomain}/crm/v3/Contacts/search?criteria=${searchCriteria}`,
       headers: {
         authorization: `Zoho-oauthtoken ${this.accessToken}`,
       },
@@ -110,11 +119,15 @@ class ZohoCrmCrmService implements CRM {
         this.log.error(e, e.response?.data);
       });
 
+   /**
+    * Zoho returns Email (PascalCase) per its field API name convention, not email.
+    * https://www.zoho.com/crm/developer/docs/api/v3/search-records.html
+    */
     return response
-      ? response.data.map((contact: ZohoContact) => {
+      ? response.data.map((contact: { id: string; Email: string }) => {
           return {
             id: contact.id,
-            email: contact.email,
+            email: contact.Email,
           };
         })
       : [];
@@ -145,7 +158,7 @@ class ZohoCrmCrmService implements CRM {
 
     return axios({
       method: "post",
-      url: `https://www.zohoapis.com/crm/v3/Events`,
+      url: `${this.apiDomain}/crm/v3/Events`,
       headers: {
         "content-type": "application/json",
         authorization: `Zoho-oauthtoken ${this.accessToken}`,
@@ -172,7 +185,7 @@ class ZohoCrmCrmService implements CRM {
     };
     return axios({
       method: "put",
-      url: `https://www.zohoapis.com/crm/v3/Events`,
+      url: `${this.apiDomain}/crm/v3/Events`,
       headers: {
         "content-type": "application/json",
         authorization: `Zoho-oauthtoken ${this.accessToken}`,
@@ -186,7 +199,7 @@ class ZohoCrmCrmService implements CRM {
   private deleteMeeting = async (uid: string) => {
     return axios({
       method: "delete",
-      url: `https://www.zohoapis.com/crm/v3/Events?ids=${uid}`,
+      url: `${this.apiDomain}/crm/v3/Events?ids=${uid}`,
       headers: {
         "content-type": "application/json",
         authorization: `Zoho-oauthtoken ${this.accessToken}`,
@@ -238,16 +251,22 @@ class ZohoCrmCrmService implements CRM {
           // set expiry date as offset from current time.
           zohoCrmTokenInfo.data.expiryDate = Math.round(Date.now() + 60 * 60 * 1000);
 
+          const updatedKey = {
+            ...(zohoCrmTokenInfo.data as ZohoToken),
+            refresh_token: credentialKey.refresh_token,
+            accountServer: credentialKey.accountServer,
+            api_domain: zohoCrmTokenInfo.data.api_domain || credentialKey.api_domain,
+          };
+          if (updatedKey.api_domain) {
+            // Sync in-memory domain — the DB write only takes effect on next instantiation
+            this.apiDomain = updatedKey.api_domain;
+          }
           await prisma.credential.update({
             where: {
               id: credential.id,
             },
             data: {
-              key: {
-                ...(zohoCrmTokenInfo.data as ZohoToken),
-                refresh_token: credentialKey.refresh_token,
-                accountServer: credentialKey.accountServer,
-              },
+              key: updatedKey,
             },
           });
           this.accessToken = zohoCrmTokenInfo.data.access_token;


### PR DESCRIPTION
## What does this PR do?

Fixes multiple bugs in the Zoho CRM integration that prevented it from working for non-US accounts and caused incorrect data to be persisted/returned:

- **Multi-data-center support**: Replace the hardcoded `https://www.zohoapis.com` base URL with the `api_domain` returned by Zoho's OAuth response, persisted in the credential and kept in sync on token refresh. Without this, accounts in EU/IN/AU/JP/CN/CA data centers fail with `INVALID_TOKEN` / `INVALID_URL_PATTERN`.

- **OAuth token expiry**: The expiry was computed as `Date.now() + 60 * 60` (3.6 seconds, since `Date.now()` returns ms but `60 * 60` is seconds). Now uses `Date.now() + expires_in * 1000` from Zoho's actual response.

- **`createContacts` response parsing**: Zoho's Insert Records API returns the new record id at `data[i].details.id`, not `data[i].id`, and does not echo the email back. Now reads the id from the correct path and pulls the email from the input array by index (Zoho preserves request order). 

- **`getContacts` response parsing**: Zoho's Search Records API returns the field as `Email` (PascalCase, matching its standard field API name), not `email`. The previous code returned `email: undefined` for every searched contact.

- **Persist `api_domain` on refresh**: The refresh handler now preserves and updates `api_domain` in both the DB and the in-memory service instance, so subsequent API calls in the same request hit the correct DC.


- Fixes #29228 

## Visual Demo

#### Video Demo 

- Before Changes (main branch)
https://github.com/user-attachments/assets/64157338-6107-47d7-80ed-91e68e649454

- After Changes  (current branch)
https://github.com/user-attachments/assets/f0f9843b-7d8d-4b3d-bc14-406b477d2db2


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code 
- [x] N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Setup:**

**Repro on `main` (before this PR):**
1. Connect a non-US Zoho account via Cal.diy → OAuth completes.
2. Create a booking with a Zoho-linked event type → meeting/contact create silently fails with `INVALID_URL_PATTERN` in logs (calls hit `zohoapis.com` regardless of DC).
3. On any account: search existing contacts → returned objects have `email: undefined`.
4. On any account: create a contact via the integration → returned object has `id: undefined`.

**Expected on this branch (after the fix):**
1. Same connect flow works for all DCs; the persisted `credential.key` JSON now contains `api_domain` matching the account's DC (e.g. `https://www.zohoapis.in`).
2. Booking creation triggers a successful `POST /crm/v3/Events` against the correct DC URL → meeting visible in Zoho UI.
3. `getContacts` returns objects with populated `email` fields.
4. `createContacts` returns objects with populated `id` (Zoho's record id).
5. After the access token expires (≈1 hour), the next request triggers a refresh, the `api_domain` is preserved/updated in DB, and subsequent calls in the same request still hit the correct DC.

