### PR TITLE
refactor: app category metadata to use Record<AppCategories, AppCategoryEntry> for exhaustive type safety

### DIFF
--- a/apps/web/modules/apps/installed/[category]/installed-category-view.tsx
+++ b/apps/web/modules/apps/installed/[category]/installed-category-view.tsx
@@ -21,7 +21,7 @@ import { CalendarListContainer } from "@components/apps/CalendarListContainer";
 import InstalledAppsLayout from "@components/apps/layouts/InstalledAppsLayout";
 import { QueryCell } from "@lib/QueryCell";
 import { useReducer } from "react";
-import { APP_CATEGORY_ENTRIES } from "@calcom/app-store/_utils/getAppCategories";
+import { APP_CATEGORY_ENTRIES, ActiveAppCategoryKeys } from "@calcom/app-store/_utils/getAppCategories";
 
 interface IntegrationsContainerProps {
   variant?: AppCategories;
@@ -48,6 +48,8 @@ const IntegrationsContainer = ({
   const updateDefaultAppMutation = trpc.viewer.apps.updateUserDefaultConferencingApp.useMutation();
 
   const updateLocationsMutation = trpc.viewer.eventTypes.bulkUpdateToDefaultLocation.useMutation();
+
+  const isActiveCategory = (v: AppCategories): v is ActiveAppCategoryKeys => v in APP_CATEGORY_ENTRIES
 
   const { data: eventTypesQueryData, isFetching: isEventTypesFetching } =
     trpc.viewer.eventTypes.bulkEventFetch.useQuery();
@@ -102,21 +104,22 @@ const IntegrationsContainer = ({
       customLoader={<SkeletonLoader />}
       success={({ data }) => {
         if (!data.items.length) {
-          const emptyHeaderCategory = getAppCategoryTitle(variant || "other", true);
+          const resolvedVariant = variant && isActiveCategory(variant) ? variant : "other";
+          const emptyHeaderCategory = getAppCategoryTitle(resolvedVariant, true);
 
           return (
             <EmptyScreen
-              Icon={APP_CATEGORY_ENTRIES[variant || "other"].icon}
+              Icon={APP_CATEGORY_ENTRIES[resolvedVariant].icon}
               headline={t("no_category_apps", {
                 category: emptyHeaderCategory,
               })}
-              description={t(`no_category_apps_description_${variant || "other"}`)}
+              description={t(`no_category_apps_description_${resolvedVariant}`)}
               buttonRaw={
                 <Button
                   color="secondary"
-                  data-testid={`connect-${variant || "other"}-apps`}
-                  href={variant ? `/apps/categories/${variant}` : "/apps/categories/other"}>
-                  {t(`connect_${variant || "other"}_apps`)}
+                  data-testid={`connect-${resolvedVariant}-apps`}
+                  href={`/apps/categories/${resolvedVariant}`}>
+                  {t(`connect_${resolvedVariant}_apps`)}
                 </Button>
               }
             />

--- a/apps/web/modules/apps/installed/[category]/installed-category-view.tsx
+++ b/apps/web/modules/apps/installed/[category]/installed-category-view.tsx
@@ -21,6 +21,7 @@ import { CalendarListContainer } from "@components/apps/CalendarListContainer";
 import InstalledAppsLayout from "@components/apps/layouts/InstalledAppsLayout";
 import { QueryCell } from "@lib/QueryCell";
 import { useReducer } from "react";
+import { APP_CATEGORY_ENTRIES } from "@calcom/app-store/_utils/getAppCategories";
 
 interface IntegrationsContainerProps {
   variant?: AppCategories;
@@ -95,20 +96,6 @@ const IntegrationsContainer = ({
     utils.viewer.apps.getUsersDefaultConferencingApp.invalidate();
   };
 
-  // TODO: Refactor and reuse getAppCategories?
-  const emptyIcon: Record<AppCategories, React.ComponentProps<typeof Icon>["name"]> = {
-    calendar: "calendar",
-    conferencing: "video",
-    automation: "share-2",
-    analytics: "chart-bar",
-    payment: "credit-card",
-    other: "grid-3x3",
-    web3: "credit-card", // deprecated
-    video: "video", // deprecated
-    messaging: "mail",
-    crm: "contact",
-  };
-
   return (
     <QueryCell
       query={query}
@@ -119,7 +106,7 @@ const IntegrationsContainer = ({
 
           return (
             <EmptyScreen
-              Icon={emptyIcon[variant || "other"]}
+              Icon={APP_CATEGORY_ENTRIES[variant || "other"].icon}
               headline={t("no_category_apps", {
                 category: emptyHeaderCategory,
               })}

--- a/apps/web/modules/apps/installed/[category]/installed-category-view.tsx
+++ b/apps/web/modules/apps/installed/[category]/installed-category-view.tsx
@@ -12,7 +12,6 @@ import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
-import type { Icon } from "@calcom/ui/components/icon";
 import { ShellSubHeading } from "@calcom/ui/components/layout";
 import { showToast } from "@calcom/ui/components/toast";
 import AppListCardWebWrapper from "@calcom/web/modules/apps/components/AppListCardWebWrapper";
@@ -28,6 +27,10 @@ interface IntegrationsContainerProps {
   exclude?: AppCategories[];
   handleDisconnect: HandleDisconnect;
 }
+
+const LEGACY_CATEGORY_MAP: Partial<Record<AppCategories, ActiveAppCategoryKeys>> = {
+  video: "conferencing",
+};
 
 const IntegrationsContainer = ({
   variant,
@@ -49,7 +52,13 @@ const IntegrationsContainer = ({
 
   const updateLocationsMutation = trpc.viewer.eventTypes.bulkUpdateToDefaultLocation.useMutation();
 
-  const isActiveCategory = (v: AppCategories): v is ActiveAppCategoryKeys => v in APP_CATEGORY_ENTRIES
+  const isActiveCategory = (v: AppCategories): v is ActiveAppCategoryKeys => v in APP_CATEGORY_ENTRIES;
+
+  const resolveEmptyStateVariant = (v?: AppCategories): ActiveAppCategoryKeys => {
+    if (!v) return "other";
+    if (isActiveCategory(v)) return v;
+    return LEGACY_CATEGORY_MAP[v] || "other";
+  };
 
   const { data: eventTypesQueryData, isFetching: isEventTypesFetching } =
     trpc.viewer.eventTypes.bulkEventFetch.useQuery();
@@ -104,7 +113,7 @@ const IntegrationsContainer = ({
       customLoader={<SkeletonLoader />}
       success={({ data }) => {
         if (!data.items.length) {
-          const resolvedVariant = variant && isActiveCategory(variant) ? variant : "other";
+          const resolvedVariant = resolveEmptyStateVariant(variant);
           const emptyHeaderCategory = getAppCategoryTitle(resolvedVariant, true);
 
           return (

--- a/packages/app-store/_utils/getAppCategories.ts
+++ b/packages/app-store/_utils/getAppCategories.ts
@@ -8,6 +8,8 @@ function getHref(baseURL: string, category: string, useQueryParam: boolean) {
   return useQueryParam ? `${baseUrlParsed.toString()}` : `${baseURL}/${category}`;
 }
 
+type ActiveAppCategoryKeys = Exclude<AppCategories, "video" | "web3">;
+
 type AppCategoryEntry = {
   name: AppCategories;
   href: string;
@@ -15,59 +17,62 @@ type AppCategoryEntry = {
   "data-testid": string;
 };
 
+export const APP_CATEGORY_ENTRIES: Record<ActiveAppCategoryKeys, Omit<AppCategoryEntry, "name">> = {
+  analytics: {
+    href: "",
+    icon: "chart-bar",
+    "data-testid": "analytics"
+  },
+  automation: {
+    href: "",
+    icon: "share-2",
+    "data-testid": "automation"
+  },
+  calendar: {
+    href: "",
+    icon: "calendar",
+    "data-testid": "calendar"
+  },
+  conferencing: {
+    href: "",
+    icon: "video",
+    "data-testid": "conferencing"
+  },
+  crm: {
+    href: "",
+    icon: "contact",
+    "data-testid": "crm"
+  },
+  messaging: {
+    href: "",
+    icon: "mail",
+    "data-testid": "messaging"
+  },
+  payment: {
+    href: "",
+    icon: "credit-card",
+    "data-testid": "payment"
+  },
+  other: {
+    href: "",
+    icon: "grid-3x3",
+    "data-testid": "other"
+  }
+}
+
 const getAppCategories = (baseURL: string, useQueryParam: boolean): AppCategoryEntry[] => {
-  // Manually sorted alphabetically, but leaving "Other" at the end
-  // TODO: Refactor and type with Record<AppCategories, AppCategoryEntry> to enforce consistency
-  return [
-    {
-      name: "analytics",
-      href: getHref(baseURL, "analytics", useQueryParam),
-      icon: "chart-bar",
-      "data-testid": "analytics",
-    },
-    {
-      name: "automation",
-      href: getHref(baseURL, "automation", useQueryParam),
-      icon: "share-2",
-      "data-testid": "automation",
-    },
-    {
-      name: "calendar",
-      href: getHref(baseURL, "calendar", useQueryParam),
-      icon: "calendar",
-      "data-testid": "calendar",
-    },
-    {
-      name: "conferencing",
-      href: getHref(baseURL, "conferencing", useQueryParam),
-      icon: "video",
-      "data-testid": "conferencing",
-    },
-    {
-      name: "crm",
-      href: getHref(baseURL, "crm", useQueryParam),
-      icon: "contact",
-      "data-testid": "crm",
-    },
-    {
-      name: "messaging",
-      href: getHref(baseURL, "messaging", useQueryParam),
-      icon: "mail",
-      "data-testid": "messaging",
-    },
-    {
-      name: "payment",
-      href: getHref(baseURL, "payment", useQueryParam),
-      icon: "credit-card",
-      "data-testid": "payment",
-    },
-    {
-      name: "other",
-      href: getHref(baseURL, "other", useQueryParam),
-      icon: "grid-3x3",
-      "data-testid": "other",
-    },
+  const CATEGORY_ORDER: AppCategories[] = [
+    "analytics", "automation", "calendar", "conferencing",
+    "crm", "messaging", "payment", "other",
   ];
+
+  return CATEGORY_ORDER.map((name) => (
+      {
+        name,
+        ...APP_CATEGORY_ENTRIES[name],
+        href: getHref(baseURL, name, useQueryParam)
+      }
+  ))
 };
 
 export default getAppCategories;

--- a/packages/app-store/_utils/getAppCategories.ts
+++ b/packages/app-store/_utils/getAppCategories.ts
@@ -8,7 +8,7 @@ function getHref(baseURL: string, category: string, useQueryParam: boolean) {
   return useQueryParam ? `${baseUrlParsed.toString()}` : `${baseURL}/${category}`;
 }
 
-type ActiveAppCategoryKeys = Exclude<AppCategories, "video" | "web3">;
+export type ActiveAppCategoryKeys = Exclude<AppCategories, "video" | "web3">;
 
 type AppCategoryEntry = {
   name: AppCategories;
@@ -61,12 +61,12 @@ export const APP_CATEGORY_ENTRIES: Record<ActiveAppCategoryKeys, Omit<AppCategor
 }
 
 const getAppCategories = (baseURL: string, useQueryParam: boolean): AppCategoryEntry[] => {
-  const CATEGORY_ORDER: AppCategories[] = [
+  const CATEGORY_ORDER = [
     "analytics", "automation", "calendar", "conferencing",
     "crm", "messaging", "payment", "other",
-  ];
+  ] as const satisfies readonly ActiveAppCategoryKeys[];
 
-  return CATEGORY_ORDER.map((name) => (
+  return CATEGORY_ORDER.map((name): AppCategoryEntry => (
       {
         name,
         ...APP_CATEGORY_ENTRIES[name],

--- a/packages/app-store/_utils/getAppCategories.ts
+++ b/packages/app-store/_utils/getAppCategories.ts
@@ -62,9 +62,19 @@ export const APP_CATEGORY_ENTRIES: Record<ActiveAppCategoryKeys, Omit<AppCategor
 
 const getAppCategories = (baseURL: string, useQueryParam: boolean): AppCategoryEntry[] => {
   const CATEGORY_ORDER = [
-    "analytics", "automation", "calendar", "conferencing",
-    "crm", "messaging", "payment", "other",
-  ] as const satisfies readonly ActiveAppCategoryKeys[];
+  "analytics",
+  "automation",
+  "calendar",
+  "conferencing",
+  "crm",
+  "messaging",
+  "payment",
+  "other",
+] as const satisfies readonly ActiveAppCategoryKeys[];
+
+  type OrderedCategory = (typeof CATEGORY_ORDER)[number];
+  type MissingInOrder = Exclude<ActiveAppCategoryKeys, OrderedCategory>;
+  type _AssertOrderIsExhaustive = MissingInOrder extends never ? true : never;
 
   return CATEGORY_ORDER.map((name): AppCategoryEntry => (
       {

--- a/packages/app-store/_utils/getAppCategories.ts
+++ b/packages/app-store/_utils/getAppCategories.ts
@@ -18,50 +18,17 @@ type AppCategoryEntry = {
 };
 
 export const APP_CATEGORY_ENTRIES: Record<ActiveAppCategoryKeys, Omit<AppCategoryEntry, "name">> = {
-  analytics: {
-    href: "",
-    icon: "chart-bar",
-    "data-testid": "analytics"
-  },
-  automation: {
-    href: "",
-    icon: "share-2",
-    "data-testid": "automation"
-  },
-  calendar: {
-    href: "",
-    icon: "calendar",
-    "data-testid": "calendar"
-  },
-  conferencing: {
-    href: "",
-    icon: "video",
-    "data-testid": "conferencing"
-  },
-  crm: {
-    href: "",
-    icon: "contact",
-    "data-testid": "crm"
-  },
-  messaging: {
-    href: "",
-    icon: "mail",
-    "data-testid": "messaging"
-  },
-  payment: {
-    href: "",
-    icon: "credit-card",
-    "data-testid": "payment"
-  },
-  other: {
-    href: "",
-    icon: "grid-3x3",
-    "data-testid": "other"
-  }
-}
+  analytics:    { href: "", icon: "chart-bar",   "data-testid": "analytics"    },
+  automation:   { href: "", icon: "share-2",     "data-testid": "automation"   },
+  calendar:     { href: "", icon: "calendar",    "data-testid": "calendar"     },
+  conferencing: { href: "", icon: "video",       "data-testid": "conferencing" },
+  crm:          { href: "", icon: "contact",     "data-testid": "crm"          },
+  messaging:    { href: "", icon: "mail",        "data-testid": "messaging"    },
+  payment:      { href: "", icon: "credit-card", "data-testid": "payment"      },
+  other:        { href: "", icon: "grid-3x3",    "data-testid": "other"        },
+};
 
-const getAppCategories = (baseURL: string, useQueryParam: boolean): AppCategoryEntry[] => {
-  const CATEGORY_ORDER = [
+const CATEGORY_ORDER = [
   "analytics",
   "automation",
   "calendar",
@@ -72,17 +39,18 @@ const getAppCategories = (baseURL: string, useQueryParam: boolean): AppCategoryE
   "other",
 ] as const satisfies readonly ActiveAppCategoryKeys[];
 
-  type OrderedCategory = (typeof CATEGORY_ORDER)[number];
-  type MissingInOrder = Exclude<ActiveAppCategoryKeys, OrderedCategory>;
-  type _AssertOrderIsExhaustive = MissingInOrder extends never ? true : never;
+const _assertCategoryOrderIsExhaustive: Exclude<
+  ActiveAppCategoryKeys,
+  (typeof CATEGORY_ORDER)[number]
+> extends never
+  ? true
+  : never = true;
 
-  return CATEGORY_ORDER.map((name): AppCategoryEntry => (
-      {
-        name,
-        ...APP_CATEGORY_ENTRIES[name],
-        href: getHref(baseURL, name, useQueryParam)
-      }
-  ))
-};
+const getAppCategories = (baseURL: string, useQueryParam: boolean): AppCategoryEntry[] =>
+  CATEGORY_ORDER.map((name): AppCategoryEntry => ({
+    name,
+    ...APP_CATEGORY_ENTRIES[name],
+    href: getHref(baseURL, name, useQueryParam),
+  }));
 
 export default getAppCategories;


### PR DESCRIPTION
## What does this PR do?

This PR replaces the `AppCategoryEntry[]` array in `getAppCategories` with a
`Record<AppCategories, AppCategoryEntry>` as the canonical source of category metadata

and secondly removes the redundant icon mapping in `installed-category-view.tsx`

#### Video Demo (if applicable):

[Screencast from 2026-04-11 20-32-09.webm](https://github.com/user-attachments/assets/866a702e-7507-42ef-92cc-5ca0a24c126c)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.