### PR TITLE
fix: prevent sticky booking bar from overlapping form fields on mobile

### DIFF
--- a/apps/web/modules/bookings/components/BookEventForm/BookFormAsModal.tsx
+++ b/apps/web/modules/bookings/components/BookEventForm/BookFormAsModal.tsx
@@ -100,7 +100,7 @@ export const BookFormAsModal = ({
       <DialogContent
         type={undefined}
         enableOverflow
-        className="[&_.modalsticky]:border-t-subtle [&_.modalsticky]:bg-default max-h-[80vh] pb-0 [&_.modalsticky]:sticky [&_.modalsticky]:bottom-0 [&_.modalsticky]:left-0 [&_.modalsticky]:right-0 [&_.modalsticky]:-mx-8 [&_.modalsticky]:border-t [&_.modalsticky]:px-8 [&_.modalsticky]:py-4">
+        className="[&_.modalsticky]:border-t-subtle [&_.modalsticky]:bg-default max-h-[80vh] pb-20 scroll-pb-20 [&_.modalsticky]:sticky [&_.modalsticky]:bottom-0 [&_.modalsticky]:left-0 [&_.modalsticky]:right-0 [&_.modalsticky]:-mx-8 [&_.modalsticky]:border-t [&_.modalsticky]:px-8 [&_.modalsticky]:py-4">
         {!isPlatform ? (
           <BookEventFormWrapper onCancel={onCancel}>{children}</BookEventFormWrapper>
         ) : (


### PR DESCRIPTION
## What does this PR do?

Fixes #29265

On mobile devices, the sticky "Back / Pay to book" action bar at the bottom of the booking confirmation modal was overlapping form fields (e.g. phone number, additional notes), making the last few fields inaccessible even after scrolling to the bottom.

Root Cause: In BookFormAsModal.tsx, the DialogContent had pb-0 (no bottom padding) combined with a sticky bottom-0 button bar. This meant the scrollable area had no room to scroll content above the sticky bar — so the last fields stayed hidden behind it. On mobile (non-embed), layout = "mobile" and shouldShowFormInDialog = true, so all mobile users hit this consistently.

Fix: Changed pb-0 → pb-20 scroll-pb-20 on the DialogContent:

pb-20 — adds 80px of scroll space so users can scroll form fields fully above the sticky bar (the bar visually covers this padding, so no blank gap appears)
scroll-pb-20 — ensures focus-triggered scrolling (e.g. tapping phone/notes on iOS) also respects the bar height