### PR TITLE
fix(web): preserve repeated query params in redirects

### DIFF
--- a/apps/web/lib/serializeNextQueryParams.ts
+++ b/apps/web/lib/serializeNextQueryParams.ts
@@ -1,0 +1,20 @@
+export function serializeNextQueryParams(query: Record<string, string | string[] | undefined>) {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, item);
+      }
+      continue;
+    }
+
+    searchParams.append(key, value);
+  }
+
+  return searchParams.toString();
+}

--- a/apps/web/lib/serializeNextQueryParams.ts
+++ b/apps/web/lib/serializeNextQueryParams.ts
@@ -1,3 +1,10 @@
+/**
+ * Serializes Next.js query objects while preserving repeated keys.
+ *
+ * Next.js query params can contain `string[]` values for repeated keys, and
+ * `URLSearchParams` built from a record will otherwise collapse those arrays
+ * into comma-joined strings.
+ */
 export function serializeNextQueryParams(query: Record<string, string | string[] | undefined>) {
   const searchParams = new URLSearchParams();
 

--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -1,4 +1,3 @@
-import { encode } from "node:querystring";
 import { getUsernameList } from "@calcom/features/eventtypes/lib/defaultEvents";
 import { getEventTypesPublic } from "@calcom/features/eventtypes/lib/getEventTypesPublic";
 import { getBrandingForUser } from "@calcom/features/profile/lib/getBranding";
@@ -7,6 +6,7 @@ import { DEFAULT_DARK_BRAND_COLOR, DEFAULT_LIGHT_BRAND_COLOR } from "@calcom/lib
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import logger from "@calcom/lib/logger";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
+import { serializeNextQueryParams } from "@calcom/web/lib/serializeNextQueryParams";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { stripMarkdown } from "@calcom/lib/stripMarkdown";
 import { prisma } from "@calcom/prisma";
@@ -107,8 +107,10 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
 
     // EXAMPLE - context.params: { orgSlug: 'acme', user: 'member0+owner1' }
     // EXAMPLE - context.query: { redirect: 'undefined', orgRedirection: 'undefined', user: 'member0+owner1' }
-    const originalQueryString = new URLSearchParams(context.query as Record<string, string>).toString();
-    const destinationWithQuery = `${destinationUrl}?${originalQueryString}`;
+    const originalQueryString = serializeNextQueryParams(context.query);
+    const destinationWithQuery = originalQueryString
+      ? `${destinationUrl}?${originalQueryString}`
+      : destinationUrl;
     log.debug(`Dynamic group detected, redirecting to ${destinationUrl}`);
     return {
       redirect: {
@@ -169,7 +171,7 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
     // Redirect but don't change the URL
     const urlDestination = `/${user.profile.username}/${eventTypes[0].slug}`;
     const { query } = context;
-    const urlQuery = new URLSearchParams(encode(query));
+    const urlQuery = new URLSearchParams(serializeNextQueryParams(query));
 
     return {
       redirect: {

--- a/apps/web/test/lib/serializeNextQueryParams.test.ts
+++ b/apps/web/test/lib/serializeNextQueryParams.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { serializeNextQueryParams } from "@calcom/web/lib/serializeNextQueryParams";
+
+describe("serializeNextQueryParams", () => {
+  it("preserves repeated query params instead of joining array values with commas", () => {
+    expect(
+      serializeNextQueryParams({
+        user: ["john", "doe"],
+        redirect: "false",
+      })
+    ).toBe("user=john&user=doe&redirect=false");
+  });
+
+  it("skips undefined values", () => {
+    expect(
+      serializeNextQueryParams({
+        layout: "week_view",
+        embed: undefined,
+      })
+    ).toBe("layout=week_view");
+  });
+});


### PR DESCRIPTION
Closes #28687.

## Summary
- preserve repeated query params when redirecting from dynamic group user pages
- stop serializing `string[]` query values as comma-joined strings
- reuse the same safe query serialization for the single-event redirect path
- add a focused regression test for array-valued Next.js query params

## What changed
- introduced `serializeNextQueryParams()` to serialize `Record<string, string | string[] | undefined>` by appending repeated keys correctly
- replaced `new URLSearchParams(context.query as Record<string, string>)` in `apps/web/server/lib/[user]/getServerSideProps.ts`
- updated the single-event redirect in the same file to use the same serializer for consistency

## Validation
- passed: `node .yarn/releases/yarn-4.12.0.cjs vitest run apps/web/test/lib/serializeNextQueryParams.test.ts`

## Example
Before:
- `user=john,doe`

After:
- `user=john&user=doe`