### PR TITLE
refactor(settings): improve out-of-office entries list readability and testability

### DIFF
--- a/apps/web/modules/settings/outOfOffice/OutOfOfficeEntriesList.tsx
+++ b/apps/web/modules/settings/outOfOffice/OutOfOfficeEntriesList.tsx
@@ -103,6 +103,34 @@ function OutOfOfficeEntriesListContent({
   const { t } = useLocale();
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [deletedEntry, setDeletedEntry] = useState(0);
+  const getFallbackUserName = (user: OutOfOfficeEntry["user"]) => {
+    if (!user?.email) return undefined;
+    const emailName = user.email.split("@")[0];
+    return emailName.charAt(0).toUpperCase() + emailName.slice(1);
+  };
+
+  const toBookingRedirectForm = (item: OutOfOfficeEntry): BookingRedirectForm => {
+    const startDateOffset = -1 * item.start.getTimezoneOffset();
+    const endDateOffset = -1 * item.end.getTimezoneOffset();
+
+    return {
+      uuid: item.uuid,
+      dateRange: {
+        startDate: dayjs(item.start).subtract(startDateOffset, "minute").toDate(),
+        endDate: dayjs(item.end).subtract(endDateOffset, "minute").startOf("d").toDate(),
+      },
+      startDateOffset,
+      endDateOffset,
+      toTeamUserId: item.toUserId,
+      reasonId: item.reason?.id ?? 1,
+      notes: item.notes ?? undefined,
+      showNotePublicly: item.showNotePublicly ?? false,
+      forUserId: item.user?.id || null,
+      forUserName: item.user?.name || getFallbackUserName(item.user),
+      forUserAvatar: item.user?.avatarUrl,
+      toUserName: item.toUser?.name || item.toUser?.username,
+    };
+  };
 
   const { searchTerm } = useDataTable();
   const searchParams = useCompatSearchParams();
@@ -233,34 +261,7 @@ function OutOfOfficeEntriesListContent({
                       variant="icon"
                       data-testid={`ooo-edit-${item.toUser?.username || "n-a"}`}
                       StartIcon="pencil"
-                      onClick={() => {
-                        const startDateOffset = -1 * item.start.getTimezoneOffset();
-                        const endDateOffset = -1 * item.end.getTimezoneOffset();
-                        const outOfOfficeEntryData: BookingRedirectForm = {
-                          uuid: item.uuid,
-                          dateRange: {
-                            startDate: dayjs(item.start).subtract(startDateOffset, "minute").toDate(),
-                            endDate: dayjs(item.end).subtract(endDateOffset, "minute").startOf("d").toDate(),
-                          },
-                          startDateOffset,
-                          endDateOffset,
-                          toTeamUserId: item.toUserId,
-                          reasonId: item.reason?.id ?? 1,
-                          notes: item.notes ?? undefined,
-                          showNotePublicly: item.showNotePublicly ?? false,
-                          forUserId: item.user?.id || null,
-                          forUserName:
-                            item.user?.name ||
-                            (item.user?.email &&
-                              (() => {
-                                const emailName = item.user?.email.split("@")[0];
-                                return emailName.charAt(0).toUpperCase() + emailName.slice(1);
-                              })()),
-                          forUserAvatar: item.user?.avatarUrl,
-                          toUserName: item.toUser?.name || item.toUser?.username,
-                        };
-                        onOpenEditDialog(outOfOfficeEntryData);
-                      }}
+                      onClick={() => onOpenEditDialog(toBookingRedirectForm(item))}
                       disabled={isPending || isFetching || !item.canEditAndDelete}
                     />
                   </Tooltip>


### PR DESCRIPTION
## What does this PR do?

Refactors `apps/web/modules/settings/outOfOffice/OutOfOfficeEntriesList.tsx` to improve readability while keeping behavior unchanged.

Changes made:
- Moved helper logic into `OutOfOfficeEntriesListContent` to match local module style.
- Extracted inline “edit payload” mapping into a local helper (`toBookingRedirectForm`).
- Extracted fallback user name derivation into a local helper (`getFallbackUserName`).
- Simplified edit button click handler by reusing the helper.

No API contract, UI behavior, or data flow changes were introduced.

- Fixes #XXXX

## Visual Demo (For contributors especially)

N/A (refactor-only; no visual or behavioral change)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.  
N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.  
No new tests were added because this is a readability-only refactor with no behavior change.

## How should this be tested?

1. Run app and open Settings → Out of Office page.
2. Verify list renders as before.
3. Verify clicking Edit still opens modal with prefilled values identical to previous behavior.
4. Verify Delete still works and success toast appears.

Suggested checks:
- `yarn workspace @calcom/web type-check`
- `yarn lint:fix` (or repo lint flow)

- Are there environment variables that should be set?  
Use existing local `.env` used for web app development.
- What are the minimal test data to have?  
At least one Out of Office entry for the logged-in user.
- What is expected (happy path) to have (input and output)?  
Input: Click Edit/Delete on an entry.  
Output: Edit modal opens with correct data / entry deletion flow remains unchanged.
- Any other important info that could help to test that PR  
This PR intentionally avoids functional changes.

## Checklist

- My code follows the style guidelines of this project
- I have checked that my changes generate no new warnings
- My PR is small and focused (<500 lines, <10 files)