### PR TITLE
fix(test): remove phantom `createdById` field from Watchlist.create

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/test/spam-booking.integration-test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/spam-booking.integration-test.ts
@@ -33,7 +33,6 @@ const createTestWatchlistEntry = async (overrides: {
       type: overrides.type,
       value: overrides.value,
       action: overrides.action,
-      createdById: 0,
       organizationId: overrides.organizationId,
       isGlobal: overrides.organizationId !== null ? false : true,
     },


### PR DESCRIPTION
## Summary

`createTestWatchlistEntry` in `spam-booking.integration-test.ts` passes `createdById: 0` to `prisma.watchlist.create()`, but the `Watchlist` model in `packages/prisma/schema.prisma` has no `createdById` column or `createdBy` relation. Prisma would throw `PrismaClientValidationError` if this code path were exercised.

The canonical Watchlist create call in `GlobalWatchlistRepository.createEntry()` (`packages/features/watchlist/lib/repository/GlobalWatchlistRepository.ts:130`) does not pass this field. Likely a holdover from a column that was renamed or removed; the test was missed during the cleanup.

## Fix

Single-line removal of `createdById: 0,` from the test's data payload. The shape now matches `GlobalWatchlistRepository.createEntry()`'s shape and the schema.

## How this was found

Static analysis with [`@certnode/silent-write-audit`](https://github.com/srbryant86/silent-write-audit) v0.3 (Prisma adapter). The tool walks every `prisma.<model>.<method>(...)` call site via the TypeScript compiler API and cross-references payload / `where` / `select` keys against the parsed `schema.prisma`. Findings are exact-line locations of code that diverges from the schema.

For context: the audit caught this on a full scan of the cal.com monorepo (4367 TypeScript files, 100 Prisma models, plus the sub-schema in `packages/platform/examples/base` which is auto-skipped because it has its own `schema.prisma`). Single real finding after compound-unique-key support and multi-schema detection — this PR.

## Test plan

- [ ] CI passes (the test file's other assertions are unchanged; only an unused phantom field is removed)
- [ ] Verify locally via `pnpm test:integration` (or whatever the integration-test runner is) on the affected suite — though the field was probably blocking the suite from running cleanly to begin with
- [ ] Confirm the fix matches existing canonical pattern in `GlobalWatchlistRepository.createEntry()`

## Run the audit on your repo

If useful, the same audit is `npx @certnode/silent-write-audit --skip-supabase --prisma-schema packages/prisma/schema.prisma --scan packages,apps/web` from the repo root. Free, MIT-licensed, no telemetry. Pre-commit hook variant in [`examples/pre-commit`](https://github.com/srbryant86/silent-write-audit/tree/main/examples).