### PR TITLE
fix: validate Webhook URLs to prevent SSRF against internal services

### DIFF
--- a/packages/features/webhooks/lib/validateWebhookUrl.ts
+++ b/packages/features/webhooks/lib/validateWebhookUrl.ts
@@ -1,0 +1,68 @@
+/**
+ * Webhook URL validation — blocks SSRF via internal/loopback destinations.
+ *
+ * Cal.diy lets users register arbitrary webhook URLs. Without this guard,
+ * an attacker can point a webhook at internal services (metadata APIs,
+ * localhost, RFC-1918 ranges) and use Cal as a proxy to exfiltrate data
+ * or hit unauthenticated internal endpoints.
+ */
+
+import { URL } from "url";
+
+/** RFC-1918 + loopback + link-local ranges */
+const BLOCKED_CIDRS = [
+  /^127\./,                        // 127.0.0.0/8  loopback
+  /^10\./,                         // 10.0.0.0/8   private
+  /^192\.168\./,                  // 192.168.0.0/16 private
+  /^172\.(1[6-9]|2\d|3[01])\./,  // 172.16-31.x   private
+  /^169\.254\./,                  // 169.254.0.0/16 link-local
+  /^0\./,                          // 0.0.0.0/8
+  /^::1$/,                          // IPv6 loopback
+  /^fc00:/i,                        // IPv6 unique-local
+  /^fe80:/i,                        // IPv6 link-local
+];
+
+const BLOCKED_HOSTS = new Set([
+  "localhost",
+  "metadata.google.internal",       // GCP metadata
+  "169.254.169.254",                 // AWS/Azure/GCP IMDS
+  "100.100.100.200",                 // Alibaba Cloud metadata
+]);
+
+export interface WebhookUrlValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+export function validateWebhookUrl(raw: string): WebhookUrlValidationResult {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return { valid: false, reason: "Invalid URL format" };
+  }
+
+  // Only allow https in production
+  if (process.env.NODE_ENV === "production" && parsed.protocol !== "https:") {
+    return { valid: false, reason: "Webhook URL must use HTTPS in production" };
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    return { valid: false, reason: `Disallowed protocol: ${parsed.protocol}` };
+  }
+
+  const host = parsed.hostname.toLowerCase();
+
+  if (BLOCKED_HOSTS.has(host)) {
+    return { valid: false, reason: `Blocked host: ${host}` };
+  }
+
+  for (const pattern of BLOCKED_CIDRS) {
+    if (pattern.test(host)) {
+      return { valid: false, reason: `Blocked IP range: ${host}` };
+    }
+  }
+
+  return { valid: true };
+}


### PR DESCRIPTION
## Summary

Cal.diy allows users to register arbitrary webhook URLs for booking events, cancellations, etc. There is currently no validation preventing those URLs from pointing at internal/private destinations.

## The vulnerability

An attacker with a Cal.diy account can register a webhook pointing at:
- `http://169.254.169.254/latest/meta-data/` (AWS/GCP/Azure instance metadata — leaks cloud credentials)
- `http://10.0.0.x/admin` (internal services not exposed to the internet)
- `http://localhost:5432` (internal databases, Redis, etc.)
- `http://metadata.google.internal/computeMetadata/v1/` (GCP service account tokens)

When a booking is made, Cal.diy's webhook dispatcher fetches the registered URL server-side, effectively using the Cal server as a proxy to reach destinations the attacker cannot reach directly. On cloud-hosted deployments this is an immediate credential leak path.

## What this PR adds

A new utility at `packages/features/webhooks/lib/validateWebhookUrl.ts` that:
- Blocks loopback (`127.x`, `::1`)
- Blocks RFC-1918 private ranges (`10.x`, `172.16-31.x`, `192.168.x`)
- Blocks link-local (`169.254.x`) — covers AWS/Azure/GCP IMDS
- Blocks known cloud metadata hostnames explicitly
- Enforces HTTPS in production
- Returns a typed result so callers can surface a user-facing error

## Usage

```ts
import { validateWebhookUrl } from "./lib/validateWebhookUrl";

const { valid, reason } = validateWebhookUrl(input.url);
if (!valid) {
  throw new TRPCError({ code: "BAD_REQUEST", message: reason });
}
```

This should be wired into the webhook create/update tRPC procedures (`packages/features/webhooks/lib/`) before persisting the URL.

Happy to follow up with a second PR adding that wiring and a test suite if preferred.
