### PR TITLE
fix: "Deadlinks" → "Dead links" in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,7 @@ better protect our clients and our systems.
 - Email spoofing
 - Missing DNSSEC, CAA, CSP headers
 - Lack of Secure or HTTP only flag on non-sensitive cookies
-- Deadlinks
+- Dead links
 
 ## Please do the following
 


### PR DESCRIPTION
## Summary

- Fix typo in `SECURITY.md` "Out of scope vulnerabilities" section: `Deadlinks` → `Dead links`

Closes #29279

## Test plan

- [x] Visual verification of `SECURITY.md` line 26
- [x] Single-line text change, no code paths affected
- [x] No build / type-check impact

## Diff

```diff
- - Deadlinks
+ - Dead links
```