### PR TITLE
fix(booker): toast booking errors so they survive modal unmount

### DIFF
--- a/apps/web/modules/bookings/hooks/useBookings.ts
+++ b/apps/web/modules/bookings/hooks/useBookings.ts
@@ -17,6 +17,7 @@ import { getFullName } from "@calcom/features/form-builder/utils";
 import { ErrorCode } from "@calcom/lib/errorCodes";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { BookingStatus } from "@calcom/prisma/enums";
+import { showToast } from "@calcom/ui/components/toast";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useRef } from "react";
@@ -303,6 +304,17 @@ export const useBookings = ({ event, hashedLink, bookingForm, metadata, isBookin
           attendees: error.data?.attendees,
         } as unknown as GetBookingType);
       }
+
+      // Surface the failure as a toast as a defence-in-depth signal — the
+      // inline <Alert> in BookEventForm covers the common case, but the booker
+      // modal unmounts whenever `selectedTimeslot` clears, which can hide the
+      // alert. A toast guarantees the user sees something instead of a
+      // near-empty container. See issue #29291.
+      const errorMessage = error?.message;
+      const translated = errorMessage
+        ? (t(errorMessage, { defaultValue: errorMessage }) as string)
+        : t("can_you_try_again");
+      showToast(translated, "error");
     },
   });
 
@@ -406,6 +418,15 @@ export const useBookings = ({ event, hashedLink, bookingForm, metadata, isBookin
       console.error("Error creating recurring booking", err);
       // eslint-disable-next-line @calcom/eslint/no-scroll-into-view-embed -- It is only called when user takes an action in embed
       bookerFormErrorRef && bookerFormErrorRef.current?.scrollIntoView({ behavior: "smooth" });
+
+      // Mirror the toast added on createBookingMutation onError — same
+      // rationale: the inline alert can be hidden when the booker modal
+      // unmounts on `selectedTimeslot` clearing. See issue #29291.
+      const errorMessage = err instanceof Error ? err.message : "";
+      const translated = errorMessage
+        ? (t(errorMessage, { defaultValue: errorMessage }) as string)
+        : t("can_you_try_again");
+      showToast(translated, "error");
     },
   });
 


### PR DESCRIPTION
## Summary

Refs #29291 (this is the small client-only fix; server-side root-cause is a separate conversation per the investigation comment on the issue.)

Adds a defence-in-depth \`showToast\` call to both \`createBookingMutation\` and \`createRecurringBookingMutation\` \`onError\` handlers in \`apps/web/modules/bookings/hooks/useBookings.ts\`, so a failed booking surfaces a user-visible message even when the inline \`<Alert>\` in BookEventForm is hidden.

## Why

The booker form mutations already have \`onError\` handlers that scroll the inline \`<Alert>\` into view. But the form lives inside \`BookFormAsModal\` which short-circuits to \`null\` whenever \`selectedTimeslot\` is falsy:

\`\`\`tsx
// apps/web/modules/bookings/components/BookEventForm/BookFormAsModal.tsx:51
if (!selectedTimeslot) {
  return null;
}
\`\`\`

If anything in the booker store clears \`selectedTimeslot\` on a failed mutation — or the user races a state transition — the modal unmounts and the inline alert is never seen, leaving a near-empty container with no indication of what went wrong (the symptom reported in the issue).

A toast is independent of the modal lifecycle, so the user always sees something.

## Diff

\`\`\`
apps/web/modules/bookings/hooks/useBookings.ts | 21 +++++++++++++++++++++
1 file changed, 21 insertions(+)
\`\`\`

The translation strategy mirrors the existing \`getError\` helper in BookEventForm.tsx:
- If \`error.message\` matches an \`ErrorCode\` i18n key → translate it
- Otherwise → use the raw message as the default value
- Final fallback → \`can_you_try_again\`

## Out of scope (intentionally)

The investigation comment on #29291 lays out two paths:
1. **Client defence-in-depth** (this PR) — toast on error
2. **Server root cause** — the issue reports a 400 (not the expected 409 from \`BookingConflict\`), which suggests P2002 is reaching a code path that doesn't have the existing P2002 catch. Tracing that to closure is a bigger conversation.

I'm opening (1) as a **draft** so it doesn't block (2) — happy to land it independently if useful, or close it in favour of a richer fix if (2) lands first. Either way, the toast is purely additive (the inline alert still wins when it can render).

## Test plan

- [x] Type-check (no new types introduced; \`showToast\` already used across 50+ files)
- [ ] Reviewer step: reproduce the issue per #29291 steps and confirm a toast renders
- [ ] Reviewer step: confirm the existing inline \`<Alert>\` still renders for the common (modal-stays-mounted) case
- [ ] Reviewer step: confirm \`BookerLimitExceededReschedule\` reschedule-state setting still works (the new toast call is additive, not replacing)