### PR TITLE
feat(app-store): add Proton Calendar integration

### DIFF
--- a/apps/web/components/apps/AppSetupPage.tsx
+++ b/apps/web/components/apps/AppSetupPage.tsx
@@ -9,6 +9,7 @@ export const AppSetupMap = {
   "exchange2016-calendar": dynamic(() => import("@calcom/web/components/apps/exchange2016calendar/Setup")),
   "caldav-calendar": dynamic(() => import("@calcom/web/components/apps/caldavcalendar/Setup")),
   "ics-feed": dynamic(() => import("@calcom/web/components/apps/ics-feedcalendar/Setup")),
+  "proton-calendar": dynamic(() => import("@calcom/web/components/apps/protoncalendar/Setup")),
   make: dynamic(() => import("@calcom/web/components/apps/make/Setup")),
   sendgrid: dynamic(() => import("@calcom/web/components/apps/sendgrid/Setup")),
   stripe: dynamic(() => import("@calcom/web/components/apps/stripepayment/Setup")),

--- a/apps/web/components/apps/protoncalendar/Setup.tsx
+++ b/apps/web/components/apps/protoncalendar/Setup.tsx
@@ -1,0 +1,108 @@
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Alert } from "@calcom/ui/components/alert";
+import { Button } from "@calcom/ui/components/button";
+import { Form, TextField } from "@calcom/ui/components/form";
+import { PlusIcon, TrashIcon } from "@coss/ui/icons";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { Toaster } from "sonner";
+
+export default function ProtonCalendarSetup() {
+  const { t } = useLocale();
+  const router = useRouter();
+  const form = useForm({
+    defaultValues: {},
+  });
+
+  const [urls, setUrls] = useState<string[]>([""]);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  return (
+    <div className="bg-emphasis flex h-screen">
+      <div className="bg-default m-auto rounded p-5 md:w-[560px] md:p-10">
+        <div className="flex flex-col stack-y-5 md:flex-row md:space-x-5 md:stack-y-0">
+          <div>
+            {/* eslint-disable @next/next/no-img-element */}
+            <img
+              src="/api/app-store/protoncalendar/icon.svg"
+              alt="Proton Calendar"
+              className="h-12 w-12 max-w-2xl"
+            />
+          </div>
+          <div className="flex w-10/12 flex-col">
+            <h1 className="text-default">Connect Proton Calendar</h1>
+            <div className="mt-1 text-sm">{t("credentials_stored_encrypted")}</div>
+            <div className="my-2 mt-3">
+              <Form
+                form={form}
+                handleSubmit={async (_) => {
+                  setErrorMessage("");
+                  const res = await fetch("/api/integrations/protoncalendar/add", {
+                    method: "POST",
+                    body: JSON.stringify({ urls }),
+                    headers: {
+                      "Content-Type": "application/json",
+                    },
+                  });
+                  const json = await res.json();
+                  if (!res.ok) {
+                    setErrorMessage(json?.message || t("something_went_wrong"));
+                  } else {
+                    router.push(json.url);
+                  }
+                }}>
+                <fieldset className="stack-y-2" disabled={form.formState.isSubmitting}>
+                  {urls.map((url, i) => (
+                    <div key={i} className="flex w-full items-center gap-2">
+                      <TextField
+                        required
+                        type="text"
+                        label={t("calendar_url")}
+                        value={url}
+                        containerClassName={`w-full ${i === 0 ? "mr-6" : ""}`}
+                        onChange={(e) => {
+                          const newVal = e.target.value as string;
+                          setUrls((urls) => urls.map((x, ii) => (ii === i ? newVal : x)));
+                        }}
+                        placeholder="https://calendar.proton.me/..."
+                      />
+                      {i !== 0 ? (
+                        <button
+                          type="button"
+                          className="mb-2 h-min text-sm"
+                          onClick={() => setUrls((urls) => urls.filter((_, ii) => i !== ii))}>
+                          <TrashIcon size={16} />
+                        </button>
+                      ) : null}
+                    </div>
+                  ))}
+                </fieldset>
+
+                <button
+                  className="text-sm"
+                  type="button"
+                  onClick={() => {
+                    setUrls((urls) => urls.concat(""));
+                  }}>
+                  {t("add")} <PlusIcon className="inline" size={16} />
+                </button>
+
+                {errorMessage && <Alert severity="error" title={errorMessage} className="my-4" />}
+                <div className="mt-5 justify-end space-x-2 rtl:space-x-reverse sm:mt-4 sm:flex">
+                  <Button type="button" color="secondary" onClick={() => router.back()}>
+                    {t("cancel")}
+                  </Button>
+                  <Button type="submit" loading={form.formState.isSubmitting}>
+                    {t("save")}
+                  </Button>
+                </div>
+              </Form>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Toaster position="bottom-right" />
+    </div>
+  );
+}

--- a/apps/web/components/apps/protoncalendar/Setup.tsx
+++ b/apps/web/components/apps/protoncalendar/Setup.tsx
@@ -18,6 +18,14 @@ export default function ProtonCalendarSetup() {
   const [urls, setUrls] = useState<string[]>([""]);
   const [errorMessage, setErrorMessage] = useState("");
 
+  const parseJsonResponse = async (res: Response) => {
+    try {
+      return await res.json();
+    } catch {
+      return null;
+    }
+  };
+
   return (
     <div className="bg-emphasis flex h-screen">
       <div className="bg-default m-auto rounded p-5 md:w-[560px] md:p-10">
@@ -26,30 +34,40 @@ export default function ProtonCalendarSetup() {
             {/* eslint-disable @next/next/no-img-element */}
             <img
               src="/api/app-store/protoncalendar/icon.svg"
-              alt="Proton Calendar"
+              alt={t("proton_calendar.alt")}
               className="h-12 w-12 max-w-2xl"
             />
           </div>
           <div className="flex w-10/12 flex-col">
-            <h1 className="text-default">Connect Proton Calendar</h1>
+            <h1 className="text-default">{t("proton_calendar.title")}</h1>
             <div className="mt-1 text-sm">{t("credentials_stored_encrypted")}</div>
             <div className="my-2 mt-3">
               <Form
                 form={form}
                 handleSubmit={async (_) => {
                   setErrorMessage("");
-                  const res = await fetch("/api/integrations/protoncalendar/add", {
-                    method: "POST",
-                    body: JSON.stringify({ urls }),
-                    headers: {
-                      "Content-Type": "application/json",
-                    },
-                  });
-                  const json = await res.json();
-                  if (!res.ok) {
-                    setErrorMessage(json?.message || t("something_went_wrong"));
-                  } else {
+                  try {
+                    const res = await fetch("/api/integrations/protoncalendar/add", {
+                      method: "POST",
+                      body: JSON.stringify({ urls }),
+                      headers: {
+                        "Content-Type": "application/json",
+                      },
+                    });
+                    const json = await parseJsonResponse(res);
+                    if (!res.ok) {
+                      setErrorMessage(json?.message || t("something_went_wrong"));
+                      return;
+                    }
+
+                    if (typeof json?.url !== "string") {
+                      setErrorMessage(t("something_went_wrong"));
+                      return;
+                    }
+
                     router.push(json.url);
+                  } catch {
+                    setErrorMessage(t("something_went_wrong"));
                   }
                 }}>
                 <fieldset className="stack-y-2" disabled={form.formState.isSubmitting}>
@@ -65,11 +83,12 @@ export default function ProtonCalendarSetup() {
                           const newVal = e.target.value as string;
                           setUrls((urls) => urls.map((x, ii) => (ii === i ? newVal : x)));
                         }}
-                        placeholder="https://calendar.proton.me/..."
+                        placeholder={t("proton_calendar.placeholder")}
                       />
                       {i !== 0 ? (
                         <button
                           type="button"
+                          aria-label={t("proton_calendar.remove_url", { index: i + 1 })}
                           className="mb-2 h-min text-sm"
                           onClick={() => setUrls((urls) => urls.filter((_, ii) => i !== ii))}>
                           <TrashIcon size={16} />

--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -74,6 +74,7 @@ import pipedream_config_json from "./pipedream/config.json";
 import pipedrive_crm_config_json from "./pipedrive-crm/config.json";
 import plausible_config_json from "./plausible/config.json";
 import posthog_config_json from "./posthog/config.json";
+import protoncalendar_config_json from "./protoncalendar/config.json";
 import qr_code_config_json from "./qr_code/config.json";
 import raycast_config_json from "./raycast/config.json";
 import retell_ai_config_json from "./retell-ai/config.json";
@@ -186,6 +187,7 @@ export const appStoreMetadata = {
   "pipedrive-crm": pipedrive_crm_config_json,
   plausible: plausible_config_json,
   posthog: posthog_config_json,
+  protoncalendar: protoncalendar_config_json,
   qr_code: qr_code_config_json,
   raycast: raycast_config_json,
   "retell-ai": retell_ai_config_json,

--- a/packages/app-store/apps.server.generated.ts
+++ b/packages/app-store/apps.server.generated.ts
@@ -55,6 +55,7 @@ export const apiHandlers = {
   "pipedrive-crm": import("./pipedrive-crm/api"),
   plausible: import("./plausible/api"),
   posthog: import("./posthog/api"),
+  protoncalendar: import("./protoncalendar/api"),
   qr_code: import("./qr_code/api"),
   riverside: import("./riverside/api"),
   roam: import("./roam/api"),

--- a/packages/app-store/calendar.services.generated.ts
+++ b/packages/app-store/calendar.services.generated.ts
@@ -16,5 +16,6 @@ export const CalendarServiceMap =
         "ics-feedcalendar": import("./ics-feedcalendar/lib/CalendarService"),
         larkcalendar: import("./larkcalendar/lib/CalendarService"),
         office365calendar: import("./office365calendar/lib/CalendarService"),
+        protoncalendar: import("./protoncalendar/lib/CalendarService"),
         zohocalendar: import("./zohocalendar/lib/CalendarService"),
       };

--- a/packages/app-store/ics-feedcalendar/api/add.ts
+++ b/packages/app-store/ics-feedcalendar/api/add.ts
@@ -23,6 +23,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     const normalizedUrls = urls.map((url) => url.trim());
+    const encryptionKey = process.env.CALENDSO_ENCRYPTION_KEY;
+    if (!encryptionKey) {
+      logger.error("Missing CALENDSO_ENCRYPTION_KEY while adding ICS feeds");
+      return res.status(500).json({ message: "Could not add ICS feeds" });
+    }
 
     // Get user
     const user = await prisma.user.findFirstOrThrow({
@@ -37,10 +42,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const data = {
       type: appConfig.type,
-      key: symmetricEncrypt(
-        JSON.stringify({ urls: normalizedUrls }),
-        process.env.CALENDSO_ENCRYPTION_KEY || ""
-      ),
+      key: symmetricEncrypt(JSON.stringify({ urls: normalizedUrls }), encryptionKey),
       userId: user.id,
       teamId: null,
       appId: appConfig.slug,

--- a/packages/app-store/ics-feedcalendar/api/add.ts
+++ b/packages/app-store/ics-feedcalendar/api/add.ts
@@ -14,9 +14,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ message: "You must be logged in to do this" });
     }
 
-    if (!Array.isArray(urls) || urls.length === 0 || urls.some((url) => typeof url !== "string")) {
+    if (
+      !Array.isArray(urls) ||
+      urls.length === 0 ||
+      urls.some((url) => typeof url !== "string" || url.trim().length === 0)
+    ) {
       return res.status(400).json({ message: "Invalid ICS feed URLs" });
     }
+
+    const normalizedUrls = urls.map((url) => url.trim());
 
     // Get user
     const user = await prisma.user.findFirstOrThrow({
@@ -31,7 +37,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const data = {
       type: appConfig.type,
-      key: symmetricEncrypt(JSON.stringify({ urls }), process.env.CALENDSO_ENCRYPTION_KEY || ""),
+      key: symmetricEncrypt(
+        JSON.stringify({ urls: normalizedUrls }),
+        process.env.CALENDSO_ENCRYPTION_KEY || ""
+      ),
       userId: user.id,
       teamId: null,
       appId: appConfig.slug,
@@ -48,8 +57,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
       const listedCals = await dav.listCalendars();
 
-      if (listedCals.length !== urls.length) {
-        throw new Error(`Listed cals and URLs mismatch: ${listedCals.length} vs. ${urls.length}`);
+      if (listedCals.length !== normalizedUrls.length) {
+        throw new Error(`Listed cals and URLs mismatch: ${listedCals.length} vs. ${normalizedUrls.length}`);
       }
 
       await prisma.credential.create({

--- a/packages/app-store/ics-feedcalendar/lib/CalendarService.ts
+++ b/packages/app-store/ics-feedcalendar/lib/CalendarService.ts
@@ -4,6 +4,8 @@
 import process from "node:process";
 import dayjs from "@calcom/dayjs";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import { logBlockedSSRFAttempt, validateUrlForSSRF } from "@calcom/lib/ssrfProtection";
 import type {
   Calendar,
@@ -123,7 +125,7 @@ export class ICSFeedCalendarService implements Calendar {
       logBlockedSSRFAttempt(url, validation.error || "Invalid ICS feed URL", {
         integration: this.integrationName,
       });
-      throw new Error("Invalid ICS feed URL");
+      throw new ErrorWithCode(ErrorCode.BadRequest, "Invalid ICS feed URL");
     }
 
     const parsedUrl = new URL(url);
@@ -131,14 +133,14 @@ export class ICSFeedCalendarService implements Calendar {
       logBlockedSSRFAttempt(url, "Only HTTPS URLs are allowed for this calendar integration", {
         integration: this.integrationName,
       });
-      throw new Error("Only HTTPS URLs are supported by this integration");
+      throw new ErrorWithCode(ErrorCode.BadRequest, "Only HTTPS URLs are supported by this integration");
     }
 
     if (!isHostnameAllowed(parsedUrl.hostname, this.allowedHostnames)) {
       logBlockedSSRFAttempt(url, "Hostname is not allowed for this calendar integration", {
         integration: this.integrationName,
       });
-      throw new Error("This calendar URL is not supported by this integration");
+      throw new ErrorWithCode(ErrorCode.BadRequest, "This calendar URL is not supported by this integration");
     }
 
     return parsedUrl;
@@ -157,19 +159,19 @@ export class ICSFeedCalendarService implements Calendar {
 
       if (response.status >= 300 && response.status < 400) {
         if (redirects >= MAX_ICS_REDIRECTS) {
-          throw new Error("Too many redirects while fetching ICS feed");
+          throw new ErrorWithCode(ErrorCode.BadRequest, "Too many redirects while fetching ICS feed");
         }
 
         const location = response.headers.get("location");
         if (!location) {
-          throw new Error("ICS feed redirected without a location header");
+          throw new ErrorWithCode(ErrorCode.BadRequest, "ICS feed redirected without a location header");
         }
 
         return this.fetchCalendarText(new URL(location, parsedUrl).toString(), redirects + 1);
       }
 
       if (!response.ok) {
-        throw new Error("Could not fetch ICS feed");
+        throw new ErrorWithCode(ErrorCode.BadRequest, "Could not fetch ICS feed");
       }
 
       return response.text();

--- a/packages/app-store/ics-feedcalendar/lib/CalendarService.ts
+++ b/packages/app-store/ics-feedcalendar/lib/CalendarService.ts
@@ -4,6 +4,7 @@
 import process from "node:process";
 import dayjs from "@calcom/dayjs";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
+import { logBlockedSSRFAttempt, validateUrlForSSRF } from "@calcom/lib/ssrfProtection";
 import type {
   Calendar,
   CalendarEvent,
@@ -39,14 +40,48 @@ const applyTravelDuration = (event: ICAL.Event, seconds: number) => {
 };
 
 const CALENDSO_ENCRYPTION_KEY = process.env.CALENDSO_ENCRYPTION_KEY || "";
+const ICS_FETCH_TIMEOUT_MS = 10000;
+const MAX_ICS_REDIRECTS = 3;
 
-class ICSFeedCalendarService implements Calendar {
+type ICSFeedCalendarServiceOptions = {
+  integrationName?: string;
+  allowedHostnames?: string[];
+  defaultCalendarName?: string;
+  requireHttps?: boolean;
+};
+
+const isHostnameAllowed = (hostname: string, allowedHostnames?: string[]) => {
+  if (!allowedHostnames?.length) return true;
+
+  const normalizedHostname = hostname.toLowerCase().replace(/\.$/, "");
+  return allowedHostnames.some((allowedHostname) => {
+    const normalizedAllowedHostname = allowedHostname.toLowerCase().replace(/\.$/, "");
+    return (
+      normalizedHostname === normalizedAllowedHostname ||
+      normalizedHostname.endsWith(`.${normalizedAllowedHostname}`)
+    );
+  });
+};
+
+const getRecurrenceKey = (uid: string | undefined, recurrenceId: ICAL.Time | undefined) => {
+  if (!uid || !recurrenceId) return null;
+  return `${uid}:${recurrenceId.toString()}`;
+};
+
+export class ICSFeedCalendarService implements Calendar {
   private urls: string[] = [];
   protected integrationName = "ics-feed_calendar";
+  private allowedHostnames?: string[];
+  private defaultCalendarName = "ICS Feed";
+  private requireHttps = false;
 
-  constructor(credential: CredentialPayload) {
+  constructor(credential: CredentialPayload, options?: ICSFeedCalendarServiceOptions) {
     const { urls } = JSON.parse(symmetricDecrypt(credential.key as string, CALENDSO_ENCRYPTION_KEY));
     this.urls = urls;
+    this.integrationName = options?.integrationName || this.integrationName;
+    this.allowedHostnames = options?.allowedHostnames;
+    this.defaultCalendarName = options?.defaultCalendarName || this.defaultCalendarName;
+    this.requireHttps = options?.requireHttps || false;
   }
 
   createEvent(_event: CalendarEvent, _credentialId: number): Promise<NewCalendarEventType> {
@@ -82,13 +117,75 @@ class ICSFeedCalendarService implements Calendar {
     });
   }
 
+  private validateCalendarUrl = async (url: string) => {
+    const validation = await validateUrlForSSRF(url);
+    if (!validation.isValid) {
+      logBlockedSSRFAttempt(url, validation.error || "Invalid ICS feed URL", {
+        integration: this.integrationName,
+      });
+      throw new Error("Invalid ICS feed URL");
+    }
+
+    const parsedUrl = new URL(url);
+    if (this.requireHttps && parsedUrl.protocol !== "https:") {
+      logBlockedSSRFAttempt(url, "Only HTTPS URLs are allowed for this calendar integration", {
+        integration: this.integrationName,
+      });
+      throw new Error("Only HTTPS URLs are supported by this integration");
+    }
+
+    if (!isHostnameAllowed(parsedUrl.hostname, this.allowedHostnames)) {
+      logBlockedSSRFAttempt(url, "Hostname is not allowed for this calendar integration", {
+        integration: this.integrationName,
+      });
+      throw new Error("This calendar URL is not supported by this integration");
+    }
+
+    return parsedUrl;
+  };
+
+  private fetchCalendarText = async (url: string, redirects = 0): Promise<string> => {
+    const parsedUrl = await this.validateCalendarUrl(url);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ICS_FETCH_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(parsedUrl.toString(), {
+        redirect: "manual",
+        signal: controller.signal,
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        if (redirects >= MAX_ICS_REDIRECTS) {
+          throw new Error("Too many redirects while fetching ICS feed");
+        }
+
+        const location = response.headers.get("location");
+        if (!location) {
+          throw new Error("ICS feed redirected without a location header");
+        }
+
+        return this.fetchCalendarText(new URL(location, parsedUrl).toString(), redirects + 1);
+      }
+
+      if (!response.ok) {
+        throw new Error("Could not fetch ICS feed");
+      }
+
+      return response.text();
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+
   fetchCalendars = async (): Promise<{ url: string; vcalendar: ICAL.Component }[]> => {
-    const reqPromises = await Promise.allSettled(this.urls.map((x) => fetch(x).then((y) => [x, y])));
+    const reqPromises = await Promise.allSettled(
+      this.urls.map((url) => this.fetchCalendarText(url).then((text) => [url, text] as [string, string]))
+    );
     const reqs = reqPromises
       .filter((x) => x.status === "fulfilled")
-      .map((x) => (x as PromiseFulfilledResult<[string, Response]>).value);
-    const res = await Promise.all(reqs.map((x) => x[1].text().then((y) => [x[0], y])));
-    return res
+      .map((x) => (x as PromiseFulfilledResult<[string, string]>).value);
+    return reqs
       .map((x) => {
         try {
           const jcalData = ICAL.parse(x[1]);
@@ -149,7 +246,23 @@ class ICSFeedCalendarService implements Calendar {
 
     calendars.forEach(({ vcalendar }) => {
       const vevents = vcalendar.getAllSubcomponents("vevent");
+      const cancelledRecurringInstances = new Set<string>();
+
       vevents.forEach((vevent) => {
+        const status = String(vevent.getFirstPropertyValue("status") || "").toUpperCase();
+        if (status !== "CANCELLED") return;
+
+        const recurrenceKey = getRecurrenceKey(
+          vevent.getFirstPropertyValue("uid"),
+          vevent.getFirstPropertyValue("recurrence-id")
+        );
+        if (recurrenceKey) cancelledRecurringInstances.add(recurrenceKey);
+      });
+
+      vevents.forEach((vevent) => {
+        const status = String(vevent.getFirstPropertyValue("status") || "").toUpperCase();
+        if (status === "CANCELLED") return;
+
         // if event status is free or transparent, DON'T return (unlike usual getAvailability)
         //
         // commented out because a lot of public ICS feeds that describe stuff like
@@ -261,6 +374,11 @@ class ICSFeedCalendarService implements Calendar {
             currentStart = dayjs(currentEvent.startDate.toJSDate());
 
             if (currentStart.isBetween(start, end) === true) {
+              const recurrenceKey = getRecurrenceKey(vevent.getFirstPropertyValue("uid"), current);
+              if (recurrenceKey && cancelledRecurringInstances.has(recurrenceKey)) {
+                continue;
+              }
+
               events.push({
                 start: currentStart.toISOString(),
                 end: dayjs(currentEvent.endDate.toJSDate()).toISOString(),
@@ -299,7 +417,7 @@ class ICSFeedCalendarService implements Calendar {
     return vcals.map(({ url, vcalendar }) => {
       const name: string = vcalendar.getFirstPropertyValue("x-wr-calname");
       return {
-        name,
+        name: name || this.defaultCalendarName,
         readOnly: true,
         externalId: url,
         integration: this.integrationName,

--- a/packages/app-store/protoncalendar/DESCRIPTION.md
+++ b/packages/app-store/protoncalendar/DESCRIPTION.md
@@ -1,0 +1,5 @@
+Connect a Proton Calendar sharing link to Cal.com.
+
+This integration is read-only. Proton Calendar does not provide third-party write access, so Cal.com uses Proton's standard calendar sharing link to check availability and continues to send booking updates by email.
+
+Create a sharing link in Proton Calendar, paste it into the setup form, and Cal.com will use the feed for busy-time checks.

--- a/packages/app-store/protoncalendar/api/add.ts
+++ b/packages/app-store/protoncalendar/api/add.ts
@@ -11,11 +11,15 @@ import BuildCalendarService from "../lib/CalendarService";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "POST") {
-    const { urls } = req.body;
     if (!req.session?.user?.id) {
       return res.status(401).json({ message: "You must be logged in to do this" });
     }
 
+    if (!req.body || typeof req.body !== "object") {
+      return res.status(400).json({ message: "Invalid Proton Calendar URLs" });
+    }
+
+    const urls = req.body.urls;
     if (
       !Array.isArray(urls) ||
       urls.length === 0 ||
@@ -87,5 +91,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   res.setHeader("Allow", "GET, POST");
-  return res.status(405).json({ error: "Method Not Allowed" });
+  return res.status(405).json({ message: "Method Not Allowed" });
 }

--- a/packages/app-store/protoncalendar/api/add.ts
+++ b/packages/app-store/protoncalendar/api/add.ts
@@ -15,10 +15,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     if (!Array.isArray(urls) || urls.length === 0 || urls.some((url) => typeof url !== "string")) {
-      return res.status(400).json({ message: "Invalid ICS feed URLs" });
+      return res.status(400).json({ message: "Invalid Proton Calendar URLs" });
     }
 
-    // Get user
     const user = await prisma.user.findFirstOrThrow({
       where: {
         id: req.session.user.id,
@@ -40,30 +39,32 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     };
 
     try {
-      const dav = BuildCalendarService({
+      const protonCalendar = BuildCalendarService({
         id: 0,
         ...data,
         user: { email: user.email },
         encryptedKey: null,
       });
-      const listedCals = await dav.listCalendars();
+      const listedCals = await protonCalendar.listCalendars();
 
       if (listedCals.length !== urls.length) {
-        throw new Error(`Listed cals and URLs mismatch: ${listedCals.length} vs. ${urls.length}`);
+        throw new Error(`Listed calendars and URLs mismatch: ${listedCals.length} vs. ${urls.length}`);
       }
 
       await prisma.credential.create({
         data,
       });
     } catch (e) {
-      logger.error("Could not add ICS feeds", e);
-      return res.status(500).json({ message: "Could not add ICS feeds" });
+      logger.error("Could not add Proton Calendar", e);
+      return res.status(500).json({ message: "Could not add Proton Calendar" });
     }
 
-    return res.status(200).json({ url: getInstalledAppPath({ variant: "calendar", slug: "ics-feed" }) });
+    return res
+      .status(200)
+      .json({ url: getInstalledAppPath({ variant: "calendar", slug: "proton-calendar" }) });
   }
 
   if (req.method === "GET") {
-    return res.status(200).json({ url: "/apps/ics-feed/setup" });
+    return res.status(200).json({ url: "/apps/proton-calendar/setup" });
   }
 }

--- a/packages/app-store/protoncalendar/api/add.ts
+++ b/packages/app-store/protoncalendar/api/add.ts
@@ -5,7 +5,7 @@ import prisma from "@calcom/prisma";
 import type { NextApiRequest, NextApiResponse } from "next";
 import getInstalledAppPath from "../../_utils/getInstalledAppPath";
 import appConfig from "../config.json";
-import { BuildCalendarService } from "../lib";
+import BuildCalendarService from "../lib/CalendarService";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "POST") {
@@ -14,9 +14,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ message: "You must be logged in to do this" });
     }
 
-    if (!Array.isArray(urls) || urls.length === 0 || urls.some((url) => typeof url !== "string")) {
+    if (
+      !Array.isArray(urls) ||
+      urls.length === 0 ||
+      urls.some((url) => typeof url !== "string" || url.trim().length === 0)
+    ) {
       return res.status(400).json({ message: "Invalid Proton Calendar URLs" });
     }
+
+    const encryptionKey = process.env.CALENDSO_ENCRYPTION_KEY;
+    if (!encryptionKey) {
+      logger.error("Missing CALENDSO_ENCRYPTION_KEY while adding Proton Calendar");
+      return res.status(500).json({ message: "Could not add Proton Calendar" });
+    }
+
+    const normalizedUrls = urls.map((url) => url.trim());
 
     const user = await prisma.user.findFirstOrThrow({
       where: {
@@ -30,7 +42,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const data = {
       type: appConfig.type,
-      key: symmetricEncrypt(JSON.stringify({ urls }), process.env.CALENDSO_ENCRYPTION_KEY || ""),
+      key: symmetricEncrypt(JSON.stringify({ urls: normalizedUrls }), encryptionKey),
       userId: user.id,
       teamId: null,
       appId: appConfig.slug,
@@ -47,8 +59,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
       const listedCals = await protonCalendar.listCalendars();
 
-      if (listedCals.length !== urls.length) {
-        throw new Error(`Listed calendars and URLs mismatch: ${listedCals.length} vs. ${urls.length}`);
+      if (listedCals.length !== normalizedUrls.length) {
+        throw new Error(
+          `Listed calendars and URLs mismatch: ${listedCals.length} vs. ${normalizedUrls.length}`
+        );
       }
 
       await prisma.credential.create({
@@ -67,4 +81,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === "GET") {
     return res.status(200).json({ url: "/apps/proton-calendar/setup" });
   }
+
+  res.setHeader("Allow", "GET, POST");
+  return res.status(405).json({ error: "Method Not Allowed" });
 }

--- a/packages/app-store/protoncalendar/api/add.ts
+++ b/packages/app-store/protoncalendar/api/add.ts
@@ -1,5 +1,7 @@
 import process from "node:process";
 import { symmetricEncrypt } from "@calcom/lib/crypto";
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import logger from "@calcom/lib/logger";
 import prisma from "@calcom/prisma";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -30,27 +32,27 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const normalizedUrls = urls.map((url) => url.trim());
 
-    const user = await prisma.user.findFirstOrThrow({
-      where: {
-        id: req.session.user.id,
-      },
-      select: {
-        id: true,
-        email: true,
-      },
-    });
-
-    const data = {
-      type: appConfig.type,
-      key: symmetricEncrypt(JSON.stringify({ urls: normalizedUrls }), encryptionKey),
-      userId: user.id,
-      teamId: null,
-      appId: appConfig.slug,
-      invalid: false,
-      delegationCredentialId: null,
-    };
-
     try {
+      const user = await prisma.user.findUniqueOrThrow({
+        where: {
+          id: req.session.user.id,
+        },
+        select: {
+          id: true,
+          email: true,
+        },
+      });
+
+      const data = {
+        type: appConfig.type,
+        key: symmetricEncrypt(JSON.stringify({ urls: normalizedUrls }), encryptionKey),
+        userId: user.id,
+        teamId: null,
+        appId: appConfig.slug,
+        invalid: false,
+        delegationCredentialId: null,
+      };
+
       const protonCalendar = BuildCalendarService({
         id: 0,
         ...data,
@@ -60,7 +62,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const listedCals = await protonCalendar.listCalendars();
 
       if (listedCals.length !== normalizedUrls.length) {
-        throw new Error(
+        throw new ErrorWithCode(
+          ErrorCode.BadRequest,
           `Listed calendars and URLs mismatch: ${listedCals.length} vs. ${normalizedUrls.length}`
         );
       }
@@ -70,12 +73,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
     } catch (e) {
       logger.error("Could not add Proton Calendar", e);
+      if (e instanceof ErrorWithCode && e.code === ErrorCode.BadRequest) {
+        return res.status(400).json({ message: e.message });
+      }
       return res.status(500).json({ message: "Could not add Proton Calendar" });
     }
 
-    return res
-      .status(200)
-      .json({ url: getInstalledAppPath({ variant: "calendar", slug: "proton-calendar" }) });
+    return res.status(200).json({ url: getInstalledAppPath({ variant: "calendar", slug: appConfig.slug }) });
   }
 
   if (req.method === "GET") {

--- a/packages/app-store/protoncalendar/api/index.ts
+++ b/packages/app-store/protoncalendar/api/index.ts
@@ -1,0 +1,1 @@
+export { default as add } from "./add";

--- a/packages/app-store/protoncalendar/config.json
+++ b/packages/app-store/protoncalendar/config.json
@@ -1,0 +1,15 @@
+{
+  "name": "Proton Calendar",
+  "title": "Proton Calendar",
+  "slug": "proton-calendar",
+  "dirName": "protoncalendar",
+  "type": "proton_calendar",
+  "logo": "icon.svg",
+  "variant": "calendar",
+  "categories": ["calendar"],
+  "publisher": "Cal.com, Inc.",
+  "email": "help@cal.com",
+  "description": "Check availability from a read-only Proton Calendar sharing link.",
+  "isTemplate": false,
+  "__createdUsingCli": true
+}

--- a/packages/app-store/protoncalendar/index.ts
+++ b/packages/app-store/protoncalendar/index.ts
@@ -1,0 +1,2 @@
+export * as api from "./api";
+export * as lib from "./lib";

--- a/packages/app-store/protoncalendar/lib/CalendarService.ts
+++ b/packages/app-store/protoncalendar/lib/CalendarService.ts
@@ -1,0 +1,20 @@
+import type { Calendar } from "@calcom/types/Calendar";
+import type { CredentialPayload } from "@calcom/types/Credential";
+import { ICSFeedCalendarService } from "../../ics-feedcalendar/lib/CalendarService";
+
+const PROTON_CALENDAR_HOSTNAMES = ["proton.me", "protonmail.com"];
+
+class ProtonCalendarService extends ICSFeedCalendarService {
+  constructor(credential: CredentialPayload) {
+    super(credential, {
+      integrationName: "proton_calendar",
+      allowedHostnames: PROTON_CALENDAR_HOSTNAMES,
+      defaultCalendarName: "Proton Calendar",
+      requireHttps: true,
+    });
+  }
+}
+
+export default function BuildCalendarService(credential: CredentialPayload): Calendar {
+  return new ProtonCalendarService(credential);
+}

--- a/packages/app-store/protoncalendar/lib/index.ts
+++ b/packages/app-store/protoncalendar/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as BuildCalendarService } from "./CalendarService";

--- a/packages/app-store/protoncalendar/package.json
+++ b/packages/app-store/protoncalendar/package.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "private": true,
+  "name": "@calcom/proton-calendar",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "dependencies": {
+    "@calcom/lib": "workspace:*",
+    "@calcom/prisma": "workspace:*",
+    "@calcom/ui": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "react-hook-form": "^7.0.0"
+  },
+  "devDependencies": {
+    "@calcom/types": "workspace:*"
+  },
+  "description": "Check availability from a read-only Proton Calendar sharing link."
+}

--- a/packages/app-store/protoncalendar/static/icon.svg
+++ b/packages/app-store/protoncalendar/static/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="14" fill="#6D4AFF"/>
+  <path d="M18 18h18.5C44 18 49 22.7 49 29.7C49 36.8 44 41.5 36.5 41.5H28v8.5H18V18Z" fill="white"/>
+  <path d="M28 27v6h7.8c2.1 0 3.3-1.2 3.3-3s-1.2-3-3.3-3H28Z" fill="#6D4AFF"/>
+</svg>

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -439,6 +439,12 @@
   "welcome_instructions": "Tell us what to call you and let us know what timezone you're in. You'll be able to edit this later.",
   "connect_caldav": "Connect to CalDav (Beta)",
   "connect_ics_feed": "Connect to an ICS Feed",
+  "proton_calendar": {
+    "alt": "Proton Calendar",
+    "placeholder": "https://calendar.proton.me/...",
+    "remove_url": "Remove URL {{index}}",
+    "title": "Connect Proton Calendar"
+  },
   "connect": "Connect",
   "try_for_free": "Try it for free",
   "create_booking_link_with_calcom": "Create your own booking link with {{appName}}",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,6 +2965,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@calcom/proton-calendar@workspace:packages/app-store/protoncalendar":
+  version: 0.0.0-use.local
+  resolution: "@calcom/proton-calendar@workspace:packages/app-store/protoncalendar"
+  dependencies:
+    "@calcom/lib": "workspace:*"
+    "@calcom/prisma": "workspace:*"
+    "@calcom/types": "workspace:*"
+    "@calcom/ui": "workspace:*"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    react-hook-form: ^7.0.0
+  languageName: unknown
+  linkType: soft
+
 "@calcom/qr_code@workspace:packages/app-store/qr_code":
   version: 0.0.0-use.local
   resolution: "@calcom/qr_code@workspace:packages/app-store/qr_code"


### PR DESCRIPTION
/claim #5756

## What does this PR do?

Adds a dedicated, read-only Proton Calendar integration for availability checks using Proton's public calendar sharing links.

Proton Calendar does not currently provide third-party OAuth/write APIs, so this integration intentionally treats Proton as a read-only calendar source. Cal.com can use the shared ICS feed for busy-time checks while booking creation/update notifications continue through the existing email flow.

## Implementation

- Adds `packages/app-store/protoncalendar`
- Adds a Proton setup page at `apps/web/components/apps/protoncalendar/Setup.tsx`
- Registers the app in app-store metadata, API handlers, setup routing, calendar service mapping, and `yarn.lock`
- Reuses the existing ICS feed calendar service instead of duplicating a separate 300+ line calendar parser

## Hardening included

- Adds an explicit auth guard before creating ICS feed credentials
- Validates user-supplied ICS URLs with the existing SSRF protection helper before fetch
- Uses manual redirect handling and revalidates every redirect hop
- Adds a fetch timeout
- Supports a provider hostname allowlist; Proton allows only `proton.me` and `protonmail.com` hostnames/subdomains
- Filters `STATUS:CANCELLED` events
- Filters cancelled recurring instances with `UID:RECURRENCE-ID`
- Adds a fallback calendar name when `X-WR-CALNAME` is absent

## Verification

- `node .yarn/releases/yarn-4.12.0.cjs install`
- `tsc --pretty --noEmit --project packages/app-store/tsconfig.json`
- `biome format --write` on touched files
- Commit hook completed successfully, including `biome lint --reporter summary --config-path=biome-staged.json` and `yarn app-store:build`

## Notes

This is deliberately read-only. It does not attempt to create, update, or delete Proton Calendar events because Proton's E2EE calendar model does not expose that kind of third-party write API.
