### PR TITLE
fix: accept ICS feeds without .ics suffix

### DIFF
--- a/apps/api/v2/src/platform/calendars/controllers/calendars.controller.e2e-spec.ts
+++ b/apps/api/v2/src/platform/calendars/controllers/calendars.controller.e2e-spec.ts
@@ -218,7 +218,7 @@ describeCalendars("Platform Calendars Endpoints", () => {
 
   it(`/POST/v2/calendars/${ICS_CALENDAR}/save with access token should fail to create a new ics feed calendar credentials with invalid urls`, async () => {
     const body = {
-      urls: ["https://cal.com/ics/feed.ics", "https://not-an-ics-feed.com"],
+      urls: ["https://cal.com/ics/feed.ics", "not-a-url"],
       readOnly: false,
     };
     await request(app.getHttpServer())
@@ -231,7 +231,7 @@ describeCalendars("Platform Calendars Endpoints", () => {
 
   it(`/POST/v2/calendars/${ICS_CALENDAR}/save with access token should create a new ics feed calendar credentials`, async () => {
     const body = {
-      urls: ["https://cal.com/ics/feed.ics"],
+      urls: ["https://caldav.soverin.net/calendars/MyCalendar?export"],
       readOnly: false,
     };
     mockBuildIcsFeedCalendarService.mockReturnValue({

--- a/apps/api/v2/src/platform/calendars/input/create-ics.input.ts
+++ b/apps/api/v2/src/platform/calendars/input/create-ics.input.ts
@@ -33,12 +33,12 @@ export class IsICSUrlConstraint implements ValidatorConstraintInterface {
 
 export class CreateIcsFeedInputDto {
   @ApiProperty({
-    example: ["https://cal.com/ics/feed.ics", "http://cal.com/ics/feed.ics"],
+    example: ["https://cal.com/ics/feed.ics", "https://caldav.example.com/calendars/user@example.com?export"],
     description: "An array of ICS URLs",
     type: "array",
     items: {
       type: "string",
-      example: "https://cal.com/ics/feed.ics",
+      example: "https://caldav.example.com/calendars/user@example.com?export",
     },
     required: true,
   })

--- a/apps/api/v2/src/platform/calendars/input/create-ics.input.ts
+++ b/apps/api/v2/src/platform/calendars/input/create-ics.input.ts
@@ -15,20 +15,19 @@ export class IsICSUrlConstraint implements ValidatorConstraintInterface {
   validate(url: unknown) {
     if (typeof url !== "string") return false;
 
-    // Check if it's a valid URL and ends with .ics
+    // Check if it's a valid HTTP(S) URL
+    // Per RFC 5545 and RFC 4791, ICS feeds don't require .ics suffix
+    // Validation should be based on response content-type, not URL structure
     try {
       const urlObject = new URL(url);
-      return (
-        (urlObject.protocol === "http:" || urlObject.protocol === "https:") &&
-        urlObject.pathname.endsWith(".ics")
-      );
+      return urlObject.protocol === "http:" || urlObject.protocol === "https:";
     } catch (error) {
       return false;
     }
   }
 
   defaultMessage() {
-    return "The URL must be a valid ICS URL (ending with .ics)";
+    return "The URL must be a valid HTTP(S) URL pointing to a public host";
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove the `.ics` suffix requirement from the ICS feed DTO validator
- Accept valid HTTP(S) calendar feed URLs such as CalDAV export endpoints with query parameters
- Update the invalid URL test to use a malformed URL
- Update the success test to use a CalDAV-style feed URL without `.ics` suffix

Per RFC 5545 (iCalendar) and RFC 4791 (CalDAV), feed URLs are not required to end with `.ics`; the URL shape alone should not reject valid iCalendar feeds.

Fixes #29286

## Verification
- Updated existing e2e coverage in `apps/api/v2/src/platform/calendars/controllers/calendars.controller.e2e-spec.ts`
- Could not run full Cal.com monorepo tests locally because dependencies are not installed in this fresh clone; CI should run the existing suite.