### PR TITLE
fix: close idempotencyKey gaps for non-ACCEPTED creates and relation-form reassignment

### DIFF
--- a/packages/prisma/extensions/booking-idempotency-key.integration-test.ts
+++ b/packages/prisma/extensions/booking-idempotency-key.integration-test.ts
@@ -1,0 +1,281 @@
+import { prisma } from "@calcom/prisma";
+import { BookingStatus, CreationSource } from "@calcom/prisma/enums";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const createdBookingIds: number[] = [];
+const createdEventTypeIds: number[] = [];
+const createdUserIds: number[] = [];
+
+describe("bookingIdempotencyKeyExtension (Integration Tests)", () => {
+  const timestamp = Date.now();
+  let organizerId: number;
+  let eventTypeId: number;
+
+  // Same slot used across all tests so we exercise the deterministic-key collision path
+  const startTime = new Date("2030-06-01T10:00:00.000Z");
+  const endTime = new Date("2030-06-01T10:30:00.000Z");
+
+  beforeAll(async () => {
+    const organizer = await prisma.user.create({
+      data: {
+        email: `idempotency-key-${timestamp}@test.com`,
+        username: `idempotency-key-${timestamp}`,
+        name: "Test Organizer",
+        timeZone: "UTC",
+        locale: "en",
+        creationSource: CreationSource.WEBAPP,
+      },
+      select: { id: true },
+    });
+    organizerId = organizer.id;
+    createdUserIds.push(organizer.id);
+
+    const eventType = await prisma.eventType.create({
+      data: {
+        title: `idempotency-key-event-${timestamp}`,
+        slug: `idempotency-key-event-${timestamp}`,
+        length: 30,
+        userId: organizerId,
+      },
+      select: { id: true },
+    });
+    eventTypeId = eventType.id;
+    createdEventTypeIds.push(eventType.id);
+  });
+
+  afterAll(async () => {
+    if (createdBookingIds.length > 0) {
+      await prisma.booking.deleteMany({ where: { id: { in: createdBookingIds } } });
+    }
+    if (createdEventTypeIds.length > 0) {
+      await prisma.eventType.deleteMany({ where: { id: { in: createdEventTypeIds } } });
+    }
+    if (createdUserIds.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: createdUserIds } } });
+    }
+  });
+
+  it("stamps a deterministic idempotencyKey when a booking is created with status ACCEPTED", async () => {
+    const booking = await prisma.booking.create({
+      data: {
+        uid: `idem-create-${timestamp}`,
+        title: "First booking",
+        startTime,
+        endTime,
+        status: BookingStatus.ACCEPTED,
+        user: { connect: { id: organizerId } },
+        eventType: { connect: { id: eventTypeId } },
+      },
+      select: { id: true, idempotencyKey: true },
+    });
+    createdBookingIds.push(booking.id);
+
+    expect(booking.idempotencyKey).not.toBeNull();
+  });
+
+  it("clears the idempotencyKey when a booking is updated to CANCELLED", async () => {
+    const before = await prisma.booking.findFirstOrThrow({
+      where: { uid: `idem-create-${timestamp}` },
+      select: { id: true, idempotencyKey: true },
+    });
+    expect(before.idempotencyKey).not.toBeNull();
+
+    await prisma.booking.update({
+      where: { id: before.id },
+      data: { status: BookingStatus.CANCELLED },
+    });
+
+    const after = await prisma.booking.findUniqueOrThrow({
+      where: { id: before.id },
+      select: { idempotencyKey: true },
+    });
+    expect(after.idempotencyKey).toBeNull();
+  });
+
+  it("allows a fresh ACCEPTED booking on the same slot+user after the prior booking was CANCELLED (repro for #29291)", async () => {
+    // Sanity check: the prior booking from earlier tests is cancelled
+    const priorCancelled = await prisma.booking.findFirstOrThrow({
+      where: { uid: `idem-create-${timestamp}` },
+      select: { status: true, idempotencyKey: true },
+    });
+    expect(priorCancelled.status).toBe(BookingStatus.CANCELLED);
+    expect(priorCancelled.idempotencyKey).toBeNull();
+
+    // This must NOT throw P2002. Because the deterministic key is
+    // uuidv5(start.end.userId), it will be identical to the prior booking's
+    // stamped key. The extension is supposed to have nulled the prior one
+    // on cancel, leaving the slot free for a new ACCEPTED booking.
+    const second = await prisma.booking.create({
+      data: {
+        uid: `idem-rebook-${timestamp}`,
+        title: "Rebooking same slot after cancel",
+        startTime,
+        endTime,
+        status: BookingStatus.ACCEPTED,
+        user: { connect: { id: organizerId } },
+        eventType: { connect: { id: eventTypeId } },
+      },
+      select: { id: true, idempotencyKey: true },
+    });
+    createdBookingIds.push(second.id);
+
+    expect(second.idempotencyKey).not.toBeNull();
+  });
+
+  it("also clears the idempotencyKey when updateMany sets status to CANCELLED", async () => {
+    // Create a second ACCEPTED booking at a DIFFERENT slot so we don't collide with prior tests
+    const altStart = new Date("2030-06-02T10:00:00.000Z");
+    const altEnd = new Date("2030-06-02T10:30:00.000Z");
+
+    const booking = await prisma.booking.create({
+      data: {
+        uid: `idem-updatemany-${timestamp}`,
+        title: "updateMany target",
+        startTime: altStart,
+        endTime: altEnd,
+        status: BookingStatus.ACCEPTED,
+        user: { connect: { id: organizerId } },
+        eventType: { connect: { id: eventTypeId } },
+      },
+      select: { id: true, idempotencyKey: true },
+    });
+    createdBookingIds.push(booking.id);
+    expect(booking.idempotencyKey).not.toBeNull();
+
+    await prisma.booking.updateMany({
+      where: { id: booking.id },
+      data: { status: BookingStatus.CANCELLED },
+    });
+
+    const after = await prisma.booking.findUniqueOrThrow({
+      where: { id: booking.id },
+      select: { idempotencyKey: true },
+    });
+    expect(after.idempotencyKey).toBeNull();
+  });
+
+  it("stamps a key on PENDING create so the slot is protected while awaiting host confirmation", async () => {
+    const slotStart = new Date("2030-06-03T10:00:00.000Z");
+    const slotEnd = new Date("2030-06-03T10:30:00.000Z");
+
+    const booking = await prisma.booking.create({
+      data: {
+        uid: `idem-pending-${timestamp}`,
+        title: "Pending confirmation booking",
+        startTime: slotStart,
+        endTime: slotEnd,
+        status: BookingStatus.PENDING,
+        user: { connect: { id: organizerId } },
+        eventType: { connect: { id: eventTypeId } },
+      },
+      select: { id: true, idempotencyKey: true },
+    });
+    createdBookingIds.push(booking.id);
+
+    expect(booking.idempotencyKey).not.toBeNull();
+  });
+
+  it("preserves the existing key when a PENDING booking is confirmed to ACCEPTED via update", async () => {
+    // Reuses the PENDING booking from the previous test. Because PENDING
+    // creates are now stamped on create, the host's confirmation update is a
+    // no-op for the key: the row keeps the key it received at create time and
+    // the unique constraint continues to protect the slot.
+    const pendingBooking = await prisma.booking.findFirstOrThrow({
+      where: { uid: `idem-pending-${timestamp}` },
+      select: { id: true, idempotencyKey: true, status: true },
+    });
+    expect(pendingBooking.status).toBe(BookingStatus.PENDING);
+    expect(pendingBooking.idempotencyKey).not.toBeNull();
+    const keyBeforeConfirm = pendingBooking.idempotencyKey;
+
+    await prisma.booking.update({
+      where: { id: pendingBooking.id },
+      data: { status: BookingStatus.ACCEPTED },
+    });
+
+    const afterConfirm = await prisma.booking.findUniqueOrThrow({
+      where: { id: pendingBooking.id },
+      select: { idempotencyKey: true, status: true },
+    });
+    expect(afterConfirm.status).toBe(BookingStatus.ACCEPTED);
+    expect(afterConfirm.idempotencyKey).toBe(keyBeforeConfirm);
+  });
+
+  it("clears the idempotencyKey when a booking is REJECTED (extension covers both terminal states)", async () => {
+    const slotStart = new Date("2030-06-04T10:00:00.000Z");
+    const slotEnd = new Date("2030-06-04T10:30:00.000Z");
+
+    const booking = await prisma.booking.create({
+      data: {
+        uid: `idem-reject-${timestamp}`,
+        title: "Will be rejected",
+        startTime: slotStart,
+        endTime: slotEnd,
+        status: BookingStatus.ACCEPTED,
+        user: { connect: { id: organizerId } },
+        eventType: { connect: { id: eventTypeId } },
+      },
+      select: { id: true, idempotencyKey: true },
+    });
+    createdBookingIds.push(booking.id);
+    expect(booking.idempotencyKey).not.toBeNull();
+
+    await prisma.booking.update({
+      where: { id: booking.id },
+      data: { status: BookingStatus.REJECTED },
+    });
+
+    const after = await prisma.booking.findUniqueOrThrow({
+      where: { id: booking.id },
+      select: { idempotencyKey: true },
+    });
+    expect(after.idempotencyKey).toBeNull();
+  });
+
+  it("generates DIFFERENT keys for the same slot+user when reassignById differs (round-robin reassignment)", async () => {
+    const slotStart = new Date("2030-06-05T10:00:00.000Z");
+    const slotEnd = new Date("2030-06-05T10:30:00.000Z");
+
+    // First booking, no reassignment
+    const first = await prisma.booking.create({
+      data: {
+        uid: `idem-reassign-1-${timestamp}`,
+        title: "Original assignment",
+        startTime: slotStart,
+        endTime: slotEnd,
+        status: BookingStatus.ACCEPTED,
+        user: { connect: { id: organizerId } },
+        eventType: { connect: { id: eventTypeId } },
+      },
+      select: { id: true, idempotencyKey: true },
+    });
+    createdBookingIds.push(first.id);
+
+    // Cancel first so the slot is free
+    await prisma.booking.update({
+      where: { id: first.id },
+      data: { status: BookingStatus.CANCELLED },
+    });
+
+    // Re-book at same slot+user but with reassignById set: the key should differ
+    // from what `first` would have produced again, demonstrating the reassignment
+    // is correctly factored into the deterministic key.
+    const second = await prisma.booking.create({
+      data: {
+        uid: `idem-reassign-2-${timestamp}`,
+        title: "Reassigned target",
+        startTime: slotStart,
+        endTime: slotEnd,
+        status: BookingStatus.ACCEPTED,
+        user: { connect: { id: organizerId } },
+        reassignBy: { connect: { id: organizerId } },
+        eventType: { connect: { id: eventTypeId } },
+      },
+      select: { id: true, idempotencyKey: true },
+    });
+    createdBookingIds.push(second.id);
+
+    expect(second.idempotencyKey).not.toBeNull();
+    expect(second.idempotencyKey).not.toBe(first.idempotencyKey);
+  });
+});

--- a/packages/prisma/extensions/booking-idempotency-key.ts
+++ b/packages/prisma/extensions/booking-idempotency-key.ts
@@ -1,22 +1,48 @@
 import { v5 as uuidv5 } from "uuid";
-
 import { Prisma } from "../client";
 import { BookingStatus } from "../enums";
 
-function generateIdempotencyKey({
-  startTime,
-  endTime,
-  userId,
-  reassignedById,
-}: {
+type IdempotencyKeySeed = {
   startTime: Date | string;
   endTime: Date | string;
-  userId?: number;
+  userId?: number | null;
   reassignedById?: number | null;
-}) {
+};
+
+function generateIdempotencyKey({ startTime, endTime, userId, reassignedById }: IdempotencyKeySeed) {
   return uuidv5(
     `${startTime.valueOf()}.${endTime.valueOf()}.${userId}${reassignedById ? `.${reassignedById}` : ""}`,
     uuidv5.URL
+  );
+}
+
+// Prisma accepts either scalar form (`userId: 5`) or relation-connect form
+// (`user: { connect: { id: 5 } }`); both are present in current call sites.
+function readUserId(data: Prisma.BookingCreateInput | Prisma.BookingUncheckedCreateInput) {
+  if ("userId" in data && typeof data.userId === "number") return data.userId;
+  if ("user" in data && data.user && "connect" in data.user) {
+    return data.user.connect?.id ?? null;
+  }
+  return null;
+}
+
+function readReassignedById(data: Prisma.BookingCreateInput | Prisma.BookingUncheckedCreateInput) {
+  if ("reassignById" in data && typeof data.reassignById === "number") return data.reassignById;
+  if ("reassignBy" in data && data.reassignBy && "connect" in data.reassignBy) {
+    return data.reassignBy.connect?.id ?? null;
+  }
+  return null;
+}
+
+function isTerminalCancel(status: unknown) {
+  return status === BookingStatus.CANCELLED || status === BookingStatus.REJECTED;
+}
+
+function isActiveBookingStatus(status: unknown) {
+  return (
+    status === BookingStatus.ACCEPTED ||
+    status === BookingStatus.PENDING ||
+    status === BookingStatus.AWAITING_HOST
   );
 }
 
@@ -25,25 +51,27 @@ export function bookingIdempotencyKeyExtension() {
     query: {
       booking: {
         async create({ args, query }) {
-          if (args.data.status === BookingStatus.ACCEPTED) {
-            const idempotencyKey = generateIdempotencyKey({
+          // Stamp on every active status, not just ACCEPTED: bookings created as
+          // PENDING/AWAITING_HOST and later confirmed via update() would otherwise
+          // end up ACCEPTED with idempotencyKey = null, defeating the unique constraint.
+          if (isActiveBookingStatus(args.data.status)) {
+            args.data.idempotencyKey = generateIdempotencyKey({
               startTime: args.data.startTime,
               endTime: args.data.endTime,
-              userId: args.data.user?.connect?.id,
-              reassignedById: args.data.reassignById,
+              userId: readUserId(args.data),
+              reassignedById: readReassignedById(args.data),
             });
-            args.data.idempotencyKey = idempotencyKey;
           }
           return query(args);
         },
         async update({ args, query }) {
-          if (args.data.status === BookingStatus.CANCELLED || args.data.status === BookingStatus.REJECTED) {
+          if (isTerminalCancel(args.data.status)) {
             args.data.idempotencyKey = null;
           }
           return query(args);
         },
         async updateMany({ args, query }) {
-          if (args.data.status === BookingStatus.CANCELLED || args.data.status === BookingStatus.REJECTED) {
+          if (isTerminalCancel(args.data.status)) {
             args.data.idempotencyKey = null;
           }
           return query(args);


### PR DESCRIPTION
Related to [#29291](https://github.com/calcom/cal.diy/issues/29291)

## What does this PR do?

Closes two paths in `bookingIdempotencyKeyExtension` that silently skip key stamping, leaving the `Booking.idempotencyKey` unique constraint unable to protect a slot from duplicates.

Previously:

* The `create` interceptor only stamped a key when `status === ACCEPTED`. Bookings created as `PENDING` or `AWAITING_HOST` (event types that require host confirmation) were written with `idempotencyKey = null`. When the host later confirmed via `prisma.booking.update({ data: { status: ACCEPTED } })`, the row ended up `ACCEPTED` with the key still `null`.
* The interceptor read `args.data.reassignById` (scalar form) but call sites use the relation-connect form `reassignBy: { connect: { id } }`. The round-robin reassignment differentiation introduced in #22065 was dropped on that path. `userId` had the same dual-form issue.

Now:

* The key is stamped for any active status (ACCEPTED, PENDING, AWAITING_HOST).
* `userId` and `reassignedById` are read from both scalar and relation-connect input forms.
* Cancel / reject nullification is unchanged.

Note on #29291: the specific repro in that issue (book → cancel → rebook same slot) does **not** reproduce against current `main`. The new test `allows a fresh ACCEPTED booking on the same slot+user after the prior booking was CANCELLED` confirms this. The latent gaps closed here were surfaced while investigating it.

---

## Visual Demo

N/A — internal data-layer change with no UI or API response surface impact.

---

## How should this be tested?

Run the new integration suite against a Postgres dev database (the local `yarn dx` instance is sufficient):

\`\`\`sh
VITEST_MODE=integration yarn vitest run packages/prisma/extensions/booking-idempotency-key.integration-test.ts
\`\`\`

Expected: 8 tests pass, covering ACCEPTED / PENDING / REJECTED creates, `update` and `updateMany` cancellation, the PENDING → ACCEPTED confirmation flow, the rebook-after-cancel scenario from #29291, and `reassignBy: { connect: ... }` producing a distinct key.

No environment variables beyond standard `DATABASE_URL` are required.

---

## Mandatory Tasks

* I have self-reviewed the code
* I have updated the developer docs — N/A, no public API or documented behavior changes
* I confirm automated tests are in place that prove my fix is effective

---

## Checklist

* My code follows the style guidelines of this project
* I have commented my code where the *why* is non-obvious
* I have checked that my changes generate no new warnings
* My PR is within the size limits (2 files, ~150 LOC of production code + ~280 LOC of tests)
