### PR TITLE
fix: start API v2 on proxy port in dev:api

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "deploy": "turbo run deploy",
     "dev:all": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/website\" --filter=\"@calcom/console\"",
     "dev:ai": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/api-proxy\" --filter=\"@calcom/ai\"",
-    "dev:api": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/api-proxy\"",
+    "dev:api": "API_PORT=3004 turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/api-proxy\" --filter=\"@calcom/api-v2\"",
     "dev:api:console": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/api-proxy\" --filter=\"@calcom/console\"",
     "dev:console": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/console\"",
     "dev:swagger": "turbo run dev --filter=\"@calcom/api-proxy\" --filter=\"@calcom/swagger\"",


### PR DESCRIPTION
## Summary

- Starts the API v2 package as part of the root `dev:api` workflow.
- Sets `API_PORT=3004` so API v2 listens on the same port that the API proxy forwards `/v2` traffic to.
- Keeps the fix scoped to the root development command instead of changing proxy routing behavior.

## Why

This addresses https://github.com/calcom/cal.diy/issues/28736. The proxy sends v2 requests to `localhost:3004`, while API v2 defaults to `5555` unless `API_PORT` is set. Starting `@calcom/api-v2` without aligning the port still leaves the dev flow broken.

## Shadow Validation

- Repair audit: `PR_READY` (80/100)
- Changed files: `package.json`
- Verified proxy target: `/v2` routes to `localhost:3004`.
- Verified API v2 default: `API_PORT` falls back to `5555`.
- Verified patch: `dev:api` now starts `@calcom/api-v2` with `API_PORT=3004`.

## Adversarial Review

- PASS `runtime-contract-breaker`: could not break the runtime contract from the collected proxy/config evidence
- PASS `downstream-user-simulator`: patched command appears to include the needed runtime pieces (-    "dev:api": "turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/api-proxy\"", | +    "dev:api": "API_PORT=3004 turbo run dev --filter=\"@calcom/web\" --filter=\"@calcom/api-proxy\" --filter=\"@calcom/api-v2\"",)
- PASS `blast-radius-skeptic`: change is narrow and limited to the command definition
- WARN `issue-fit-prosecutor`: issue names repo file(s), but patch touches none directly: apps/api/index.js
- WARN `validation-skeptic`: yarn is unavailable, so runtime task graph was not executed

## Test Plan

- Parsed `package.json` successfully.
- Ran the `community-ops` adversarial repair audit in shadow mode.
- Did not run the full Cal.com dev task graph locally because dependencies/tooling are not installed in this shadow worktree.

## Shadow Metadata

- Repo: `calcom/cal.com`
- Source branch/worktree: `cursor-shadow-fix` at `fb01494`