### PR TITLE
fix(atoms): handle undefined config in booking error callbacks

### DIFF
--- a/packages/platform/atoms/hooks/bookings/useCreateBooking.ts
+++ b/packages/platform/atoms/hooks/bookings/useCreateBooking.ts
@@ -1,11 +1,10 @@
-import { useMutation } from "@tanstack/react-query";
-
 import type { BookingCreateBody } from "@calcom/features/bookings/lib/bookingCreateBodySchema";
 import type { BookingResponse } from "@calcom/features/bookings/types";
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import type { ApiResponse, ApiErrorResponse, ApiSuccessResponse } from "@calcom/platform-types";
-
+import type { ApiErrorResponse, ApiResponse, ApiSuccessResponse } from "@calcom/platform-types";
+import { useMutation } from "@tanstack/react-query";
 import http from "../../lib/http";
+import { normalizeBookingError } from "../../lib/normalizeError";
 
 export type UseCreateBookingInput = BookingCreateBody & { locationUrl?: string };
 
@@ -40,18 +39,7 @@ export const useCreateBooking = (
       }
     },
     onError: (err) => {
-      // Normalize error to ensure consistent structure for consumers
-      // Some errors may be plain Error objects without axios properties
-      const normalizedError = {
-        message: err.message || "An error occurred",
-        // Preserve axios properties if they exist
-        ...("config" in err && err.config ? { config: err.config } : {}),
-        ...("response" in err && err.response ? { response: err.response } : {}),
-        ...("request" in err && err.request ? { request: err.request } : {}),
-        // Include original error for debugging
-        originalError: err,
-      };
-      onError?.(normalizedError as ApiErrorResponse | Error);
+      onError?.(normalizeBookingError(err));
     },
   });
   return createBooking;

--- a/packages/platform/atoms/hooks/bookings/useCreateBooking.ts
+++ b/packages/platform/atoms/hooks/bookings/useCreateBooking.ts
@@ -40,7 +40,18 @@ export const useCreateBooking = (
       }
     },
     onError: (err) => {
-      onError?.(err);
+      // Normalize error to ensure consistent structure for consumers
+      // Some errors may be plain Error objects without axios properties
+      const normalizedError = {
+        message: err.message || "An error occurred",
+        // Preserve axios properties if they exist
+        ...("config" in err && err.config ? { config: err.config } : {}),
+        ...("response" in err && err.response ? { response: err.response } : {}),
+        ...("request" in err && err.request ? { request: err.request } : {}),
+        // Include original error for debugging
+        originalError: err,
+      };
+      onError?.(normalizedError as ApiErrorResponse | Error);
     },
   });
   return createBooking;

--- a/packages/platform/atoms/hooks/bookings/useCreateRecurringBooking.ts
+++ b/packages/platform/atoms/hooks/bookings/useCreateRecurringBooking.ts
@@ -1,10 +1,9 @@
-import { useMutation } from "@tanstack/react-query";
-
 import type { BookingResponse, RecurringBookingCreateBody } from "@calcom/features/bookings/types";
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import type { ApiResponse, ApiErrorResponse, ApiSuccessResponse } from "@calcom/platform-types";
-
+import type { ApiErrorResponse, ApiResponse, ApiSuccessResponse } from "@calcom/platform-types";
+import { useMutation } from "@tanstack/react-query";
 import http from "../../lib/http";
+import { normalizeBookingError } from "../../lib/normalizeError";
 
 interface IUseCreateRecurringBooking {
   onSuccess?: (res: ApiSuccessResponse<BookingResponse[]>) => void;
@@ -37,18 +36,7 @@ export const useCreateRecurringBooking = (
       }
     },
     onError: (err) => {
-      // Normalize error to ensure consistent structure for consumers
-      // Some errors may be plain Error objects without axios properties
-      const normalizedError = {
-        message: err.message || "An error occurred",
-        // Preserve axios properties if they exist
-        ...("config" in err && err.config ? { config: err.config } : {}),
-        ...("response" in err && err.response ? { response: err.response } : {}),
-        ...("request" in err && err.request ? { request: err.request } : {}),
-        // Include original error for debugging
-        originalError: err,
-      };
-      onError?.(normalizedError as ApiErrorResponse | Error);
+      onError?.(normalizeBookingError(err));
     },
   });
   return createRecurringBooking;

--- a/packages/platform/atoms/hooks/bookings/useCreateRecurringBooking.ts
+++ b/packages/platform/atoms/hooks/bookings/useCreateRecurringBooking.ts
@@ -37,7 +37,18 @@ export const useCreateRecurringBooking = (
       }
     },
     onError: (err) => {
-      onError?.(err);
+      // Normalize error to ensure consistent structure for consumers
+      // Some errors may be plain Error objects without axios properties
+      const normalizedError = {
+        message: err.message || "An error occurred",
+        // Preserve axios properties if they exist
+        ...("config" in err && err.config ? { config: err.config } : {}),
+        ...("response" in err && err.response ? { response: err.response } : {}),
+        ...("request" in err && err.request ? { request: err.request } : {}),
+        // Include original error for debugging
+        originalError: err,
+      };
+      onError?.(normalizedError as ApiErrorResponse | Error);
     },
   });
   return createRecurringBooking;

--- a/packages/platform/atoms/lib/normalizeError.ts
+++ b/packages/platform/atoms/lib/normalizeError.ts
@@ -1,0 +1,42 @@
+import type { ApiErrorResponse } from "@calcom/platform-types";
+
+/**
+ * Normalizes various error types into a consistent Error instance with axios properties
+ * Handles: plain Error, axios errors, and ApiErrorResponse objects
+ */
+export function normalizeBookingError(err: Error | ApiErrorResponse): Error {
+  // If it's already an Error with all properties, return as-is
+  if (err instanceof Error && "config" in err) {
+    return err;
+  }
+
+  // Create proper Error instance with message
+  let message = "An error occurred";
+  if (err instanceof Error) {
+    message = err.message;
+  } else if ("message" in err) {
+    message = err.message;
+  }
+  const error = new Error(message);
+
+  // Preserve stack trace if available
+  if (err instanceof Error && err.stack) {
+    error.stack = err.stack;
+  }
+
+  // Attach axios properties if they exist (safely typed)
+  if ("config" in err && err.config) {
+    Object.defineProperty(error, "config", { value: err.config, enumerable: true });
+  }
+  if ("response" in err && err.response) {
+    Object.defineProperty(error, "response", { value: err.response, enumerable: true });
+  }
+  if ("request" in err && err.request) {
+    Object.defineProperty(error, "request", { value: err.request, enumerable: true });
+  }
+
+  // Include original error for debugging
+  Object.defineProperty(error, "originalError", { value: err, enumerable: true });
+
+  return error;
+}


### PR DESCRIPTION
Fixes https://github.com/calcom/cal.diy/issues/21846

## Problem
Booking rescheduling crashes with `TypeError: Cannot read properties of undefined (reading 'config')` when error handlers receive plain Error objects without axios properties.

## Solution
- Created `normalizeBookingError` utility that returns proper Error instances with axios properties safely attached
- Extracted duplicated error handling logic from both hooks
- Ensures type-safe error handling without unsafe casts

## Changes
- Added `packages/platform/atoms/lib/normalizeError.ts` - shared error normalization utility
- Updated `useCreateBooking` to use normalizeBookingError
- Updated `useCreateRecurringBooking` to use normalizeBookingError

## Testing
✅ Type check passed
✅ Lint passed (only pre-existing nursery warnings)
✅ Proper Error instances with preserved axios properties

Made with [Cursor](https://cursor.com)