### PR TITLE
fix: add system-ui fallback to font stack for non-Latin script support

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -116,7 +116,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <head nonce={nonce}>
         <style>{`
           :root {
-            --font-sans: ${interFont.style.fontFamily.replace(/\'/g, "")};
+            --font-sans: ${interFont.style.fontFamily.replace(/\'/g, "")}, system-ui;
             --font-cal: ${calFont.style.fontFamily.replace(/\'/g, "")};
           }
         `}</style>

--- a/apps/web/components/PageWrapper.tsx
+++ b/apps/web/components/PageWrapper.tsx
@@ -89,7 +89,7 @@ function PageWrapper(props: AppProps) {
 
       <style jsx global>{`
         :root {
-          --font-sans: ${interFont.style.fontFamily};
+          --font-sans: ${interFont.style.fontFamily}, system-ui;
           --font-cal: ${calFont.style.fontFamily};
         }
       `}</style>


### PR DESCRIPTION
## What does this PR do?

When Inter doesn't cover a character (e.g., Arabic, Hebrew, Thai, CJK scripts), the browser falls all the way back to its default font (typically Arial or Times New Roman), which varies wildly across operating systems and often looks inconsistent or broken.

This PR adds system-ui as an explicit fallback after Inter in the --font-sans CSS variable. system-ui is the OS's native UI font on macOS it's San Francisco, on Windows it's Segoe UI, on Android it's Roboto. It's a well-supported, intentional fallback that keeps the visual style coherent when Inter's glyph coverage runs out.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Note: Cal.diy is a community-maintained open-source project. Contributions here do NOT flow to Cal.com's production service. -->

- Fixes #28976 (GitHub issue number)

## Visual Demo

#### Image Demo :
| BEFORE | AFTER |
|--------|-------|
| <img width="702" alt="after" src="https://github.com/user-attachments/assets/59947255-7395-4d9a-ab5a-b0a6e21921a4" /> | <img width="703" alt="before" src="https://github.com/user-attachments/assets/50207d85-3a25-4e6f-9168-0a5437cf6eba" /> |


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create or edit an event type with a non-Latin title, e.g.: احجز استشارة مجانية
2. Open the public booking page for that event type
3. Inspect the non-Latin text element in Chrome DevTools
4. Go to Computed tab → scroll to the bottom → check "Rendered Fonts"
5. Before fix: Arabic glyphs are rendered by Arial (local file)
6. After fix: Arabic glyphs are rendered by the OS system font (e.g., SF Pro on macOS, Segoe UI on Windows)

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- No environment variables needed
- No special test data beyond a non-Latin event title
- Expected: "Rendered Fonts" shows the system font instead of Arial for non-Latin glyphs

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I have read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have checked if my changes generate no new warnings
- My PR is small and focused (2 files, 2 lines changed)
