### PR TITLE
fix: count overlapping bookings in limit checks

### DIFF
--- a/packages/features/busyTimes/lib/getBusyTimesFromLimits.ts
+++ b/packages/features/busyTimes/lib/getBusyTimesFromLimits.ts
@@ -145,7 +145,7 @@ const _getBusyTimesFromBookingLimits = async (params: {
       let totalBookings = 0;
 
       for (const booking of bookings) {
-        // consider booking part of period independent of end date
+        // consider booking part of period if it overlaps at all (checks both start and end)
         if (!isBookingWithinPeriod(booking, periodStart, periodEnd, timeZone || "UTC")) {
           continue;
         }
@@ -225,7 +225,7 @@ const _getBusyTimesFromDurationLimits = async (
       let totalDuration = selectedDuration;
 
       for (const booking of bookings) {
-        // consider booking part of period independent of end date
+        // consider booking part of period if it overlaps at all (checks both start and end)
         if (!isBookingWithinPeriod(booking, periodStart, periodEnd, timeZone || "UTC")) {
           continue;
         }

--- a/packages/features/busyTimes/services/getBusyTimes.integration-test.ts
+++ b/packages/features/busyTimes/services/getBusyTimes.integration-test.ts
@@ -157,4 +157,33 @@ describe("getBusyTimesForLimitChecks (integration)", () => {
 
     expect(busyTimes).toHaveLength(0);
   });
+
+  it("includes cross-midnight bookings that overlap the checked period", async () => {
+    const user = await createTestUser();
+    const eventType = await createTestEventType(user.id);
+
+    const dayStart = dayjs().add(3, "day").startOf("day");
+    const dayEnd = dayStart.endOf("day");
+
+    // Booking that crosses midnight: 23:30 on the checked day -> 00:30 next day
+    await createTestBooking({
+      userId: user.id,
+      eventTypeId: eventType.id,
+      uid: `busy-times-${Date.now()}-cross-midnight`,
+      startTime: dayStart.set("hour", 23).set("minute", 30).toDate(),
+      endTime: dayStart.add(1, "day").set("hour", 0).set("minute", 30).toDate(),
+    });
+
+    const busyTimes = await getBusyTimesService().getBusyTimesForLimitChecks({
+      userIds: [user.id],
+      eventTypeId: eventType.id,
+      startDate: dayStart.toISOString(),
+      endDate: dayEnd.toISOString(),
+      bookingLimits: { PER_DAY: 1 },
+    });
+
+    // The cross-midnight booking should be counted because it overlaps the checked day
+    expect(busyTimes).toHaveLength(1);
+    expect(busyTimes[0].userId).toBe(user.id);
+  });
 });

--- a/packages/features/busyTimes/services/getBusyTimes.test.ts
+++ b/packages/features/busyTimes/services/getBusyTimes.test.ts
@@ -397,4 +397,33 @@ describe("getBusyTimesForLimitChecks", () => {
     expect(busyTimes).toHaveLength(1);
     expect(busyTimes[0].userId).toBeNull();
   });
+
+  it("should use overlap query to catch bookings that cross period boundaries", async () => {
+    // Booking that crosses midnight: starts at 23:30 on the checked day and ends 00:30 next day
+    const crossMidnightBooking = createMockBookingResult({
+      id: 10,
+      startTime: startOfTomorrow.set("hour", 23).set("minute", 30).toDate(),
+      endTime: startOfTomorrow.add(1, "day").set("hour", 0).set("minute", 30).toDate(),
+    });
+    vi.mocked(prisma.booking.findMany).mockResolvedValue([crossMidnightBooking]);
+
+    const busyTimesService = getBusyTimesService();
+    const busyTimes = await busyTimesService.getBusyTimesForLimitChecks({
+      userIds: [1],
+      eventTypeId: 1,
+      startDate: startOfTomorrow.format(),
+      endDate: startOfTomorrow.endOf("day").format(),
+      bookingLimits: { PER_DAY: 1 },
+    });
+
+    expect(busyTimes).toHaveLength(1);
+    expect(busyTimes[0].start).toEqual(crossMidnightBooking.startTime);
+    expect(busyTimes[0].end).toEqual(crossMidnightBooking.endTime);
+
+    // Verify the query uses overlap logic (lt/gt) not containment logic (gte/lte)
+    const callArgs = vi.mocked(prisma.booking.findMany).mock.calls[0][0];
+    const where = callArgs?.where as Record<string, unknown>;
+    expect(where.startTime).toEqual({ lt: expect.any(Date) });
+    expect(where.endTime).toEqual({ gt: expect.any(Date) });
+  });
 });

--- a/packages/features/busyTimes/services/getBusyTimes.ts
+++ b/packages/features/busyTimes/services/getBusyTimes.ts
@@ -469,12 +469,13 @@ export class BusyTimesService {
       },
       eventTypeId,
       status: BookingStatus.ACCEPTED,
-      // FIXME: bookings that overlap on one side will never be counted
+      // Use interval overlap logic: a booking overlaps the period when
+      // booking.start < period.end AND booking.end > period.start
       startTime: {
-        gte: startTimeDate,
+        lt: endTimeDate,
       },
       endTime: {
-        lte: endTimeDate,
+        gt: startTimeDate,
       },
     };
 

--- a/packages/lib/intervalLimits/utils.ts
+++ b/packages/lib/intervalLimits/utils.ts
@@ -32,12 +32,14 @@ export function extractDateParameters(
 }
 
 /**
- * Checks if a booking is within a given period
+ * Checks if a booking overlaps a given period using interval overlap logic.
+ * A booking overlaps the period when booking.start < period.end AND booking.end > period.start.
+ * This correctly handles bookings that cross period boundaries (e.g., midnight).
  * @param booking The booking to check
  * @param periodStart The start of the period
  * @param periodEnd The end of the period
  * @param timeZone The timezone to use
- * @returns Boolean indicating if the booking is within the period
+ * @returns Boolean indicating if the booking overlaps the period
  */
 export function isBookingWithinPeriod(
   booking: EventBusyDetails,
@@ -45,14 +47,11 @@ export function isBookingWithinPeriod(
   periodEnd: Dayjs,
   timeZone: string
 ) {
-  const { bookingDay, periodStartDay, periodEndDay } = extractDateParameters(
-    booking,
-    periodStart,
-    periodEnd,
-    timeZone
-  );
+  const bookingStart = dayjs(booking.start).tz(timeZone);
+  const bookingEnd = dayjs(booking.end).tz(timeZone);
 
-  return !(bookingDay < periodStartDay || bookingDay > periodEndDay);
+  // Standard interval overlap: not (bookingEnd <= periodStart || bookingStart >= periodEnd)
+  return !(bookingEnd.isSameOrBefore(periodStart) || bookingStart.isSameOrAfter(periodEnd));
 }
 
 /**


### PR DESCRIPTION
## What changed

Limit checks only fetched bookings **fully contained** inside the checked period (`startTime >= periodStart AND endTime <= periodEnd`). A booking crossing a period boundary (e.g., 23:30→00:30 crossing midnight) was silently missed, allowing users to exceed their configured limits.

**Before (broken):**

| Checked day | Booking | Counted? |
|---|---|---|
| Apr 24 00:00 → 23:59 | 23:30 → 00:30 | ❌ No — endTime > periodEnd |

**After (fixed):** uses standard interval overlap (`startTime < periodEnd AND endTime > periodStart`):

| Checked day | Booking | Counted? |
|---|---|---|
| Apr 24 00:00 → 23:59 | 23:30 → 00:30 | ✅ Yes — overlaps the period |

## Why it matters

If edge-crossing bookings are missed, Cal under-counts usage and leaves slots available when the configured limit should already be exhausted. This affects daily, weekly, monthly booking limits and duration limits.

## Changes

### 1. Prisma query — `getBusyTimes.ts`

`fetchBookingsForLimitChecksBatch`: containment → overlap logic. Removes the `FIXME` comment.

```diff
- startTime: { gte: startTimeDate },
- endTime:   { lte: endTimeDate },
+ startTime: { lt: endTimeDate },
+ endTime:   { gt: startTimeDate },
```

### 2. Period check — `utils.ts`

`isBookingWithinPeriod`: previously only compared the booking's start-day string. Now uses both start and end with interval overlap semantics.

```diff
- const { bookingDay, periodStartDay, periodEndDay } = extractDateParameters(...);
- return !(bookingDay < periodStartDay || bookingDay > periodEndDay);
+ const bookingStart = dayjs(booking.start).tz(timeZone);
+ const bookingEnd = dayjs(booking.end).tz(timeZone);
+ return !(bookingEnd.isSameOrBefore(periodStart) || bookingStart.isSameOrAfter(periodEnd));
```

### 3. Stale comments — `getBusyTimesFromLimits.ts`

Updated two comments from *"independent of end date"* → *"if it overlaps at all (checks both start and end)"*.

### 4. Tests

- **Unit test** (`getBusyTimes.test.ts`): proves cross-midnight bookings are captured and the query uses `lt`/`gt`.
- **Integration test** (`getBusyTimes.integration-test.ts`): creates a 23:30→00:30 booking and verifies it's included in limit results.

## Verification

- ✅ All 16 unit tests pass
- ✅ Biome lint: zero errors
- ✅ TypeScript type check passes on changed files
- ✅ `git diff --check` clean

## Related

Fixes the same issue as #28964
