### PR TITLE
fix: use select instead of include to prevent credential exposure

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/util.ts
+++ b/packages/trpc/server/routers/viewer/bookings/util.ts
@@ -1,13 +1,5 @@
 import { prisma } from "@calcom/prisma";
-import type {
-  Booking,
-  EventType,
-  BookingReference,
-  Attendee,
-  Credential,
-  DestinationCalendar,
-  User,
-} from "@calcom/prisma/client";
+import type { Booking, BookingReference, Attendee } from "@calcom/prisma/client";
 import { MembershipRole, SchedulingType } from "@calcom/prisma/enums";
 
 import { TRPCError } from "@trpc/server";
@@ -24,7 +16,10 @@ export const bookingsProcedure = authedProcedure
     const bookingInclude = {
       attendees: true,
       eventType: {
-        include: {
+        select: {
+          id: true,
+          title: true,
+          slug: true,
           team: {
             select: {
               id: true,
@@ -34,12 +29,28 @@ export const bookingsProcedure = authedProcedure
           },
         },
       },
-      destinationCalendar: true,
+      destinationCalendar: {
+        select: {
+          id: true,
+          integration: true,
+          externalId: true,
+        },
+      },
       references: true,
       user: {
-        include: {
-          destinationCalendar: true,
-          credentials: true,
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          username: true,
+          timeZone: true,
+          destinationCalendar: {
+            select: {
+              id: true,
+              integration: true,
+              externalId: true,
+            },
+          },
           profiles: {
             select: {
               organizationId: true,
@@ -105,19 +116,22 @@ export const bookingsProcedure = authedProcedure
 
 export type BookingsProcedureContext = {
   booking: Booking & {
-    eventType:
-      | (EventType & {
-          team?: { id: number; name: string; parentId?: number | null } | null;
-        })
-      | null;
-    destinationCalendar: DestinationCalendar | null;
-    user:
-      | (User & {
-          destinationCalendar: DestinationCalendar | null;
-          credentials: Credential[];
-          profiles: { organizationId: number }[];
-        })
-      | null;
+    eventType: {
+      id: number;
+      title: string;
+      slug: string;
+      team?: { id: number; name: string; parentId?: number | null } | null;
+    } | null;
+    destinationCalendar: { id: number; integration: string; externalId: string } | null;
+    user: {
+      id: number;
+      name: string | null;
+      email: string;
+      username: string | null;
+      timeZone: string | null;
+      destinationCalendar: { id: number; integration: string; externalId: string } | null;
+      profiles: { organizationId: number }[];
+    } | null;
     references: BookingReference[];
     attendees: Attendee[];
   };

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/duplicate.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/duplicate.handler.ts
@@ -30,19 +30,62 @@ export const duplicateHandler = async ({ ctx, input }: DuplicateOptions) => {
       where: {
         id: originalEventTypeId,
       },
-      include: {
+      select: {
         customInputs: true,
-        schedule: true,
+        schedule: {
+          select: {
+            id: true,
+            name: true,
+            timeZone: true,
+            availability: true,
+            defaultWindowStart: true,
+            defaultWindowEnd: true,
+          },
+        },
         users: {
           select: {
             id: true,
           },
         },
-        hosts: true,
-        team: true,
-        webhooks: true,
-        hashedLink: true,
-        destinationCalendar: true,
+        hosts: {
+          select: {
+            id: true,
+            userId: true,
+            eventTypeId: true,
+            isFixed: true,
+          },
+        },
+        team: {
+          select: {
+            id: true,
+            name: true,
+            slug: true,
+          },
+        },
+        webhooks: {
+          select: {
+            id: true,
+            userId: true,
+            teamId: true,
+            eventTypeId: true,
+            triggerEvent: true,
+            subscriberUrl: true,
+            active: true,
+          },
+        },
+        hashedLink: {
+          select: {
+            id: true,
+            link: true,
+          },
+        },
+        destinationCalendar: {
+          select: {
+            id: true,
+            integration: true,
+            externalId: true,
+          },
+        },
         calVideoSettings: {
           select: {
             disableRecordingForOrganizer: true,
@@ -55,6 +98,27 @@ export const duplicateHandler = async ({ ctx, input }: DuplicateOptions) => {
             disableTranscriptionForOrganizer: true,
           },
         },
+        id: true,
+        title: true,
+        slug: true,
+        description: true,
+        length: true,
+        hidden: true,
+        locations: true,
+        recurringEvent: true,
+        bookingLimits: true,
+        durationLimits: true,
+        eventTypeColor: true,
+        customReplyToEmail: true,
+        metadata: true,
+        userId: true,
+        teamId: true,
+        bookingFields: true,
+        rrSegmentQueryValue: true,
+        assignRRMembersUsingSegment: true,
+        secondaryEmailId: true,
+        instantMeetingScheduleId: true,
+        restrictionScheduleId: true,
       },
     });
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #29348 

Prisma queries in tRPC routers were using `include` patterns that fetch ALL fields from related models, including sensitive data like `credential.key` (encrypted API keys). This creates a security risk and performance issues.

## Visual Demo (For contributors especially)

N/A - This is a backend code change, no visual output.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. (N/A - no documentation changes needed)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (Existing tests cover the functionality)

## How should this be tested?

- Run existing booking-related tests to verify authorization still works
- Verify API responses no longer include credential data
- No special environment variables needed

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I haven't commented my code (code is self-explanatory)
- [x] I haven't checked if my changes generate no new warnings
- [x] My PR is small (<500 lines, <10 files) and focused on one fix