### PR TITLE
fix(event-types): load requiresCancellationReason from eventType in form defaultValues

### DIFF
--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -95,6 +95,7 @@ export const useEventTypeForm = ({
       minimumRescheduleNotice: eventType.minimumRescheduleNotice ?? null,
       disabledCancelling: eventType.disableCancelling ?? false,
       disabledRescheduling: eventType.disableRescheduling ?? false,
+      requiresCancellationReason: eventType.requiresCancellationReason ?? null,
       allowReschedulingPastBookings: eventType.allowReschedulingPastBookings,
       hideOrganizerEmail: eventType.hideOrganizerEmail,
       metadata: eventType.metadata,


### PR DESCRIPTION
## What does this PR do?

Fixes the **Require cancellation reason** setting not appearing to persist on the event type Advanced tab.

- Fixes #29263

## Root cause

`requiresCancellationReason` was missing from the `defaultValues` object in `useEventTypeForm.ts`. Every other `eventType` field is mapped there, but this one was omitted.

Because the field was never seeded into React Hook Form's initial state, `form.getValues("requiresCancellationReason")` returned `undefined` on page load. The `Select` in `EventAdvancedTab.tsx` then rendered:

```tsx
value={cancellationReasonOptions.find(
  (opt) => opt.value === (value || CancellationReasonRequirement.MANDATORY_HOST_ONLY)
)}
```

`undefined` is falsy, so the fallback always fired — the UI always displayed **"Mandatory for host only"** regardless of what was stored in the DB.

The setting itself **was saving correctly** to the database (the tRPC handler spreads `...rest` into the Prisma update and the Zod schema includes the field). The bug was purely a display/initialization problem: the saved value was never read back into the form.

## The fix

One line added to `defaultValues` in `useEventTypeForm.ts`, matching the exact pattern used for adjacent nullable fields:

```ts
requiresCancellationReason: eventType.requiresCancellationReason ?? null,
```

This ensures the form initializes with the DB value on every page load, so the UI correctly reflects what was previously saved.

## Visual Demo

**Before:** Opening event type settings always shows "Mandatory for host only" regardless of what was saved; changing and saving appeared to have no effect.

**After:** The dropdown correctly reflects the saved value on every page load.

## How should this be tested?

1. Open any event type → Advanced tab
2. Change **Require cancellation reason** to **Mandatory for attendee only** (or any non-default option)
3. Save
4. Refresh the page
5. Verify the dropdown shows **Mandatory for attendee only** (previously it always reverted to "Mandatory for host only")

## Mandatory Tasks

- [x] I have self-reviewed the code (1-line change in `useEventTypeForm.ts`, mirrors existing pattern on line 95)
- [x] N/A — no documentation changes required for this fix
- [x] The fix is covered by the existing save/load flow; the bug was a missing initialization, not missing logic