### PR TITLE
fix(bookings): detect P2002 before error redaction to surface booking conflict to user

### DIFF
--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -64,7 +64,7 @@ import { HttpError } from "@calcom/lib/http-error";
 import { criticalLogger } from "@calcom/lib/logger.server";
 import { getPiiFreeCalendarEvent, getPiiFreeEventType } from "@calcom/lib/piiFreeData";
 import { safeStringify } from "@calcom/lib/safeStringify";
-import { getServerErrorFromUnknown } from "@calcom/lib/server/getServerErrorFromUnknown";
+import { getServerErrorFromUnknown, isPrismaError } from "@calcom/lib/server/getServerErrorFromUnknown";
 import { getTimeFormatStringFromUserTimeFormat } from "@calcom/lib/timeFormat";
 import { distributedTracing } from "@calcom/lib/tracing/factory";
 import type { PrismaClient } from "@calcom/prisma";
@@ -1816,14 +1816,13 @@ async function handler(
       };
     }
   } catch (_err) {
+    // Check the original Prisma error before getServerErrorFromUnknown redacts it in production.
+    // Without this, the .code property is stripped and the P2002 branch below can never fire.
+    if (isPrismaError(_err) && _err.code === "P2002") {
+      throw new HttpError({ statusCode: 409, message: ErrorCode.BookingConflict });
+    }
     const err = getServerErrorFromUnknown(_err);
     tracingLogger.error(`Booking ${eventTypeId} failed`, "Error when saving booking to db", err.message);
-    if (err.cause && typeof err.cause === "object" && "code" in err.cause && err.cause.code === "P2002") {
-      throw new HttpError({
-        statusCode: 409,
-        message: ErrorCode.BookingConflict,
-      });
-    }
     throw err;
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the booking page silently entering an empty/broken state when a duplicate `idempotencyKey` (Prisma P2002) error occurs on `POST /api/book/event`. Previously, the user received no feedback — no toast, no inline error — when the booking failed for this reason.

- Fixes #29291

## Root cause

`RegularBookingService.ts` catches database errors and checks for P2002 to return the user-friendly `409 booking_conflict_error`. But the check ran **after** `getServerErrorFromUnknown`, which in production calls `redactError()` on Prisma errors:

```ts
// packages/lib/redactError.ts
if (shouldRedact(error) && IS_PRODUCTION) {
  return new Error("An error occurred while querying the database.");
  // ^ plain Error — no .code property
}
```

So `err.cause.code === "P2002"` **always evaluated to `false` in production** — the `.code` property was already stripped. The catch block fell through to `throw err`, returning a generic `400` with a raw DB error message.

**In dev:** `redactError` returns the original Prisma error unchanged → P2002 check works → 409 returned (this masked the bug in local testing).

**In prod:** `redactError` strips `.code` → P2002 check fails → 400 returned → UI shows nothing or a raw DB message.

## The fix

Check `_err` (the original Prisma error, before redaction) using the already-available `isPrismaError` helper:

```ts
// Before (broken in production):
const err = getServerErrorFromUnknown(_err);
if (err.cause?.code === "P2002") { ... }  // err.cause.code is undefined in prod

// After (works in all environments):
if (isPrismaError(_err) && _err.code === "P2002") {
  throw new HttpError({ statusCode: 409, message: ErrorCode.BookingConflict });
}
const err = getServerErrorFromUnknown(_err);
```

The existing `booking_conflict_error` i18n key ("This slot is no longer available. Please return to the previous page and select another time.") and the `Alert` component in `BookEventForm` already handle the `409` response correctly — this fix simply lets them fire.

## Files changed

| File | Change |
|------|--------|
| `packages/features/bookings/lib/service/RegularBookingService.ts` | Add `isPrismaError` to import; move P2002 check before error redaction |

## How should this be tested?

1. Self-host cal.diy with a fresh database (or use staging)
2. Create an event type and book a slot with attendee email `test@example.com`
3. Cancel that booking via the UI
4. As a fresh visitor (incognito), attempt to book the **same slot** with the **same attendee email**
5. Click **Confirm**

**Before this fix:** The page enters a near-empty state with no error message.

**After this fix:** An inline alert appears: *"This slot is no longer available. Please return to the previous page and select another time."*

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] N/A — no documentation changes required
- [x] The fix restores already-existing error handling infrastructure; no new test logic needed beyond the existing error path