### PR TITLE
fix(security): replace Math.random() with crypto-secure alternatives

### DIFF
--- a/apps/web/components/apps/make/Setup.tsx
+++ b/apps/web/components/apps/make/Setup.tsx
@@ -35,7 +35,7 @@ export default function MakeSetup({ inviteLink }: InferGetServerSidePropsType<ty
 
   async function createApiKey(teamId?: number) {
     const event = { note: "Make", expiresAt: null, appId: MAKE, teamId };
-    const apiKey = `cal_live_${Math.random().toString(36).substring(2)}`;
+    const apiKey = `cal_live_${crypto.randomUUID().replace(/-/g, "")}`;
 
     if (oldApiKey?.data) {
       const oldKey = teamId

--- a/packages/lib/random.ts
+++ b/packages/lib/random.ts
@@ -1,15 +1,16 @@
+import crypto from "node:crypto";
+
 const CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 const CHARACTERS_LENGTH = CHARACTERS.length;
 
 /**
- * Generate a random string of a given length using alphanumeric characters.
+ * Generate a cryptographically secure random string of a given length using alphanumeric characters.
  */
 export const randomString = function (length = 12) {
+  const bytes = crypto.randomBytes(length);
   let result = "";
-
   for (let i = 0; i < length; i++) {
-    result += CHARACTERS.charAt(Math.floor(Math.random() * CHARACTERS_LENGTH));
+    result += CHARACTERS[bytes[i] % CHARACTERS_LENGTH];
   }
-
   return result;
 };


### PR DESCRIPTION
## Summary
- Replaces `Math.random()` with `crypto.randomBytes()` in `packages/lib/random.ts` (used for booking UIDs, slugs, reservation tokens)
- Replaces `Math.random()` with `crypto.randomUUID()` in `apps/web/components/apps/make/Setup.tsx` (API key generation)

## Why
`Math.random()` is not cryptographically secure — its output is predictable. An attacker who can determine the PRNG state can guess booking UIDs, slot reservation tokens, and API keys.

## Test plan
- [ ] Verify `randomString()` produces alphanumeric strings of correct length
- [ ] Verify Make API key generation works in app setup flow
- [ ] Run `yarn type-check:ci --force`

## Refs
- Closes #29363 (partial — addresses C2, C3 from the audit)

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)