### PR TITLE
fix(security): replace MD5 with SHA-256 in TOTP secret derivation

### DIFF
--- a/packages/features/auth/lib/verifyCodeUnAuthenticated.ts
+++ b/packages/features/auth/lib/verifyCodeUnAuthenticated.ts
@@ -14,8 +14,12 @@ export const verifyCodeUnAuthenticated = async (email: string, code: string) => 
     identifier: `emailVerifyCode.${hashEmail(email)}`,
   });
 
-  const secret = createHash("md5")
-    .update(email + (process.env.CALENDSO_ENCRYPTION_KEY || ""))
+  const encryptionKey = process.env.CALENDSO_ENCRYPTION_KEY;
+  if (!encryptionKey) {
+    throw new Error("CALENDSO_ENCRYPTION_KEY is not set");
+  }
+  const secret = createHash("sha256")
+    .update(email + encryptionKey)
     .digest("hex");
 
   const isValidToken = totpRawCheck(code, secret, { step: 900 });

--- a/packages/features/auth/lib/verifyEmail.ts
+++ b/packages/features/auth/lib/verifyEmail.ts
@@ -102,8 +102,12 @@ export const sendEmailVerificationByCode = async ({
   }
 
   const translation = await getTranslation(language ?? "en", "common");
-  const secret = createHash("md5")
-    .update(email + process.env.CALENDSO_ENCRYPTION_KEY)
+  const encryptionKey = process.env.CALENDSO_ENCRYPTION_KEY;
+  if (!encryptionKey) {
+    throw new Error("CALENDSO_ENCRYPTION_KEY is not set");
+  }
+  const secret = createHash("sha256")
+    .update(email + encryptionKey)
     .digest("hex");
 
   totp.options = { step: 900 };


### PR DESCRIPTION
## Summary
- Replaces MD5 with SHA-256 in `verifyEmail.ts` and `verifyCodeUnAuthenticated.ts`
- Adds fail-loud check if `CALENDSO_ENCRYPTION_KEY` is missing (previously fell back to empty string)

## Why
MD5 is cryptographically broken. Using it for TOTP secret derivation means an attacker who intercepts the verification email or knows the encryption key can forge verification codes. The `verifyCodeUnAuthenticated.ts` fallback to empty string was especially dangerous — it reduced the secret to just `sha256(email)`.

## Breaking change
This changes the TOTP secret derivation algorithm. Existing verification codes in flight will become invalid. This is intentional — the old codes were generated with a broken algorithm.

## Test plan
- [ ] Verify email verification flow works end-to-end
- [ ] Verify TOTP verification codes validate correctly
- [ ] Verify missing CALENDSO_ENCRYPTION_KEY throws clear error
- [ ] Run `yarn type-check:ci --force`

## Refs
- Closes #29363 (partial — addresses C4 from the audit)

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)