### PR TITLE
fix(security): use timingSafeEqual for webhook signature comparison

### DIFF
--- a/apps/web/app/api/sync/helpscout/route.ts
+++ b/apps/web/app/api/sync/helpscout/route.ts
@@ -1,5 +1,5 @@
 import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
-import { createHmac } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { headers } from "next/headers";
 import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
@@ -43,7 +43,9 @@ async function postHandler(request: NextRequest) {
       .update(rawBody)
       .digest("base64");
 
-    if (hsSignature !== calculatedSig)
+    const sigBuffer = Buffer.from(hsSignature);
+    const calcBuffer = Buffer.from(calculatedSig);
+    if (sigBuffer.length !== calcBuffer.length || !timingSafeEqual(sigBuffer, calcBuffer))
       return NextResponse.json({ message: "Invalid signature" }, { status: 400 });
 
     const user = await webPrisma.user.findFirst({


### PR DESCRIPTION
## Summary
Replaces `===` with `crypto.timingSafeEqual()` in the HelpScout webhook signature verification.

## Why
Using `===` for cryptographic signature comparison is vulnerable to timing attacks. An attacker can determine the correct HMAC signature byte-by-byte by measuring response time differences. `timingSafeEqual()` ensures constant-time comparison regardless of where buffers differ.

## Test plan
- [ ] Verify valid HelpScout webhooks still process correctly
- [ ] Verify invalid signatures are still rejected
- [ ] Run `yarn type-check:ci --force`

## Refs
- Closes #29363 (partial — addresses H6 from the audit)

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)