### PR TITLE
fix(security): replace Math.random() with crypto for secure random generation

### DIFF
--- a/apps/web/components/apps/make/Setup.tsx
+++ b/apps/web/components/apps/make/Setup.tsx
@@ -1,4 +1,5 @@
 import type { InferGetServerSidePropsType } from "next";
+import { randomBytes } from "crypto";
 import { useState } from "react";
 import { Toaster } from "sonner";
 
@@ -35,7 +36,7 @@ export default function MakeSetup({ inviteLink }: InferGetServerSidePropsType<ty
 
   async function createApiKey(teamId?: number) {
     const event = { note: "Make", expiresAt: null, appId: MAKE, teamId };
-    const apiKey = `cal_live_${Math.random().toString(36).substring(2)}`;
+    const apiKey = `cal_live_${randomBytes(32).toString("hex")}`;
 
     if (oldApiKey?.data) {
       const oldKey = teamId

--- a/packages/lib/random.ts
+++ b/packages/lib/random.ts
@@ -1,14 +1,16 @@
+import { randomInt } from "crypto";
+
 const CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 const CHARACTERS_LENGTH = CHARACTERS.length;
 
 /**
- * Generate a random string of a given length using alphanumeric characters.
+ * Generate a cryptographically secure random string of a given length using alphanumeric characters.
  */
 export const randomString = function (length = 12) {
   let result = "";
 
   for (let i = 0; i < length; i++) {
-    result += CHARACTERS.charAt(Math.floor(Math.random() * CHARACTERS_LENGTH));
+    result += CHARACTERS.charAt(randomInt(CHARACTERS_LENGTH));
   }
 
   return result;


### PR DESCRIPTION
## Security Fix: Cryptographically Secure Random Generation

### Problem
Math.random() is not cryptographically secure and can be predicted. This was used for:
- API key generation in Make integration setup
- Random string generation utility function

### Changes
- Replaced Math.random() with crypto.randomBytes() in apps/web/components/apps/make/Setup.tsx
- Replaced Math.random() with crypto.randomInt() in packages/lib/random.ts

### Security Impact
HIGH - Prevents token prediction attacks. Generated tokens and API keys are now resistant to brute-force prediction.

### Testing
- Verify API key generation works correctly
- Verify random string generation produces expected output

### References
- Node.js Crypto Documentation
- OWASP Cryptographic Storage Cheat Sheet

🤖 Generated with OpenClaude