### PR TITLE
fix(security): pin 'latest' dependencies to specific versions

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -61,7 +61,7 @@
     "@sentry/nestjs": "9.46.0",
     "@sentry/node": "9.46.0",
     "@sentry/profiling-node": "9.46.0",
-    "@snyk/protect": "latest",
+    "@snyk/protect": "1.1295.4",
     "axios": "1.15.0",
     "body-parser": "1.20.3",
     "bull": "4.15.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@vitest/coverage-v8": "4.0.16",
     "@vitest/ui": "4.0.16",
     "c8": "7.13.0",
-    "checkly": "latest",
+    "checkly": "4.2.0",
     "dotenv-checker": "1.1.5",
     "husky": "9.1.7",
     "i18n-unused": "0.13.0",


### PR DESCRIPTION
## Security Fix: Pin Dependencies to Specific Versions

### Problem
Two dependencies were using 'latest' version specifier, which is a supply chain security risk:
- package.json: checkly = 'latest'
- apps/api/v2/package.json: @snyk/protect = 'latest'

Using 'latest' allows automatic updates to potentially compromised versions without review.

### Changes
- Pinned checkly to version 4.2.0 (current installed version)
- Pinned @snyk/protect to version 1.1295.4 (current installed version)

### Security Impact
MEDIUM - Prevents supply chain attacks by ensuring dependency versions are reviewed before updates.

### Testing
- Verify yarn install works correctly
- Verify checkly and snyk-protect commands function as expected

### References
- OWASP Software Component Verification Standard
- Supply Chain Security Best Practices

🤖 Generated with OpenClaude