### PR TITLE
fix(security): prevent credential.key exposure in API responses

### DIFF
--- a/example-apps/credential-sync/lib/integrations.ts
+++ b/example-apps/credential-sync/lib/integrations.ts
@@ -39,10 +39,9 @@ export async function generateGoogleCalendarAccessToken() {
 
     const json = await response.json();
     if (json.access_token) {
-      console.log("Access Token:", json.access_token);
       return json.access_token;
     } else {
-      console.error("Failed to retrieve access token:", json);
+      console.error("Failed to retrieve access token");
       return null;
     }
   } catch (error) {
@@ -75,11 +74,9 @@ export async function generateZoomAccessToken() {
 
     const json = await response.json();
     if (json.access_token) {
-      console.log("New Access Token:", json.access_token);
-      console.log("New Refresh Token:", json.refresh_token); // Save this refresh token securely
-      return json.access_token; // You might also want to return the new refresh token if applicable
+      return json.access_token;
     } else {
-      console.error("Failed to refresh access token:", json);
+      console.error("Failed to refresh access token");
       return null;
     }
   } catch (error) {

--- a/packages/features/eventtypes/repositories/eventTypeRepository.ts
+++ b/packages/features/eventtypes/repositories/eventTypeRepository.ts
@@ -12,7 +12,7 @@ import type { PrismaClient } from "@calcom/prisma";
 import { availabilityUserSelect, userSelect as userSelectWithSelectedCalendars } from "@calcom/prisma";
 import type { Prisma, EventType as PrismaEventType } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
-import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
+import { credentialForCalendarServiceSelect, safeCredentialSelect } from "@calcom/prisma/selects/credential";
 import { EventTypeMetaDataSchema, rrSegmentQueryValueSchema } from "@calcom/prisma/zod-utils";
 import type { Ensure } from "@calcom/types/utils";
 
@@ -1152,7 +1152,7 @@ export class EventTypeRepository implements IEventTypesRepository {
                 name: true,
                 email: true,
                 credentials: {
-                  select: credentialForCalendarServiceSelect,
+                  select: safeCredentialSelect,
                 },
                 selectedCalendars: true,
               },


### PR DESCRIPTION
## Summary

- **eventTypeRepository**: Replaced `credentialForCalendarServiceSelect` with `safeCredentialSelect` in `findByIdIncludeHostsAndTeam` to prevent OAuth token leakage through host user data
- **credential-sync example**: Removed console.log statements that logged access/refresh tokens

## Security Impact

**High** — OAuth tokens could leak through:
1. Event type queries that include host credentials with `key: true`
2. Console logs in example credential-sync app exposing tokens

## Files Changed

- `packages/features/eventtypes/repositories/eventTypeRepository.ts`
- `example-apps/credential-sync/lib/integrations.ts`

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)