### PR TITLE
fix(security): remove allowDangerousEmailAccountLinking from OAuth providers

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -318,7 +318,6 @@ if (IS_GOOGLE_LOGIN_ENABLED) {
     GoogleProvider({
       clientId: GOOGLE_CLIENT_ID,
       clientSecret: GOOGLE_CLIENT_SECRET,
-      allowDangerousEmailAccountLinking: true,
       authorization: {
         params: {
           scope: [...GOOGLE_OAUTH_SCOPES, ...GOOGLE_CALENDAR_SCOPES].join(" "),
@@ -335,7 +334,6 @@ if (OUTLOOK_LOGIN_ENABLED && OUTLOOK_CLIENT_ID && OUTLOOK_CLIENT_SECRET) {
     AzureADProvider({
       clientId: OUTLOOK_CLIENT_ID,
       clientSecret: OUTLOOK_CLIENT_SECRET,
-      allowDangerousEmailAccountLinking: true,
       authorization: {
         params: {
           scope: ["openid", "profile", "email", ...MICROSOFT_CALENDAR_SCOPES].join(" "),


### PR DESCRIPTION
## Summary
Remove `allowDangerousEmailAccountLinking: true` from OAuth provider configurations. This flag allows attackers to link their OAuth account to any existing user account by matching email addresses, enabling account takeover.

Fixes #29364

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)