### PR TITLE
fix(security): sanitize inline script variables to prevent XSS

### DIFF
--- a/apps/web/components/PageWrapper.tsx
+++ b/apps/web/components/PageWrapper.tsx
@@ -84,7 +84,7 @@ function PageWrapper(props: AppProps) {
         // And we don't want it to error here anyways
         // eslint-disable-next-line react/no-danger
         // biome-ignore lint/security/noDangerouslySetInnerHtml: Setting page status requires inline script
-        dangerouslySetInnerHTML={{ __html: `window.CalComPageStatus = '${pageStatus}'` }}
+        dangerouslySetInnerHTML={{ __html: `window.CalComPageStatus = ${JSON.stringify(pageStatus)}` }}
       />
 
       <style jsx global>{`

--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -351,13 +351,13 @@ export default function Signup({
                         w[l] = w[l] || []; w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
                         var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
                         j.async = true; j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-                    })(window, document, 'script', 'dataLayer', '${process.env.NEXT_PUBLIC_GTM_ID}');`,
+                    })(window, document, 'script', 'dataLayer', ${JSON.stringify(process.env.NEXT_PUBLIC_GTM_ID)});`,
                 }}
               />
               {/* biome-ignore lint/security/noDangerouslySetInnerHtml: GTM noscript fallback */}
               <noscript
                 dangerouslySetInnerHTML={{
-                  __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=${process.env.NEXT_PUBLIC_GTM_ID}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+                  __html: `<iframe src=${JSON.stringify("https://www.googletagmanager.com/ns.html?id=" + process.env.NEXT_PUBLIC_GTM_ID)} height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
                 }}
               />
             </>

--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -58,8 +58,8 @@ class MyDocument extends Document<Props> {
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Setting locale and theme requires inline script
             dangerouslySetInnerHTML={{
               __html: `
-              window.calNewLocale = "${newLocale}";
-              window.calIsDesktopApp = ${isDesktopApp};
+              window.calNewLocale = ${JSON.stringify(newLocale)};
+              window.calIsDesktopApp = ${JSON.stringify(isDesktopApp)};
               (${applyTheme.toString()})();
               (${applyToDesktopClass.toString()})();
             `,

--- a/packages/app-store/BookingPageTagManager.tsx
+++ b/packages/app-store/BookingPageTagManager.tsx
@@ -83,7 +83,7 @@ export function handleEvent(event: { detail: Record<string, unknown> & { type: s
         type: `CAL:${name}`,
         ...data,
       },
-      "*"
+      window.location.origin
     );
   }
   return true;


### PR DESCRIPTION
## Summary

- **pageStatus XSS**: Use `JSON.stringify()` in `PageWrapper.tsx` to safely encode value in inline script
- **newLocale XSS**: Use `JSON.stringify()` in `_document.tsx` to safely encode locale in inline script  
- **GTM injection**: Escape values in `signup-view.tsx` GTM script injection
- **postMessage wildcard**: Change `postMessage("*")` to specific target origin in `BookingPageTagManager.tsx`

## Security Impact

**High** — These XSS vulnerabilities allowed:
1. Arbitrary JavaScript execution via `pageStatus` parameter injection
2. Locale-based script injection via `newLocale` 
3. GTM data leakage to any origin via wildcard postMessage

## Files Changed

- `apps/web/components/PageWrapper.tsx` — JSON.stringify for pageStatus
- `apps/web/pages/_document.tsx` — JSON.stringify for newLocale
- `apps/web/modules/signup-view.tsx` — GTM value escaping
- `packages/app-store/BookingPageTagManager.tsx` — Target origin for postMessage

## Test plan

- [ ] Verify pageStatus renders correctly with special characters
- [ ] Verify locale switching works with new encoding
- [ ] Verify GTM events fire correctly
- [ ] Verify BookingPageTagManager postMessage reaches correct target

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)