### PR TITLE
fix(security): Replaced credential:true key expose with safeCredentialSelect for trpc booking query

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build": "turbo run build --filter=@calcom/web...",
     "build:ai": "turbo run build --filter=\"@calcom/ai\"",
     "clean": "find . -name node_modules -o -name .next -o -name .turbo -o -name dist -type d -prune | xargs rm -rf",
+    "check:credentials-fetch": "node scripts/check-no-unsafe-credential-fetch.js",
     "db-deploy": "turbo run db-deploy",
     "db-seed": "turbo run db-seed",
     "db-studio": "yarn prisma studio",

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -3,7 +3,7 @@ import type { PrismaClient } from "@calcom/prisma";
 import type { Booking, Prisma } from "@calcom/prisma/client";
 import { BookingStatus, RRTimestampBasis } from "@calcom/prisma/enums";
 import { bookingDetailsSelect, bookingMinimalSelect } from "@calcom/prisma/selects/booking";
-import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
+import { credentialForCalendarServiceSelect, safeCredentialSelect } from "@calcom/prisma/selects/credential";
 import type {
   BookingUpdateData,
   BookingWhereInput,
@@ -1668,7 +1668,9 @@ export class BookingRepository implements IBookingRepository {
         user: {
           include: {
             destinationCalendar: true,
-            credentials: true,
+            credentials: {
+              select: safeCredentialSelect,
+            },
             profiles: {
               select: {
                 organizationId: true,

--- a/packages/trpc/server/routers/viewer/bookings/util.ts
+++ b/packages/trpc/server/routers/viewer/bookings/util.ts
@@ -1,11 +1,12 @@
 import { prisma } from "@calcom/prisma";
+import { safeCredentialSelect } from "@calcom/prisma/selects/credential";
 import type {
   Booking,
   EventType,
   BookingReference,
   Attendee,
-  Credential,
   DestinationCalendar,
+  Prisma,
   User,
 } from "@calcom/prisma/client";
 import { MembershipRole, SchedulingType } from "@calcom/prisma/enums";
@@ -14,6 +15,10 @@ import { TRPCError } from "@trpc/server";
 
 import authedProcedure from "../../../procedures/authedProcedure";
 import { commonBookingSchema } from "./types";
+
+type SafeCredential = Prisma.CredentialGetPayload<{
+  select: typeof safeCredentialSelect;
+}>;
 
 export const bookingsProcedure = authedProcedure
   .input(commonBookingSchema)
@@ -39,7 +44,9 @@ export const bookingsProcedure = authedProcedure
       user: {
         include: {
           destinationCalendar: true,
-          credentials: true,
+          credentials: {
+            select: safeCredentialSelect,
+          },
           profiles: {
             select: {
               organizationId: true,
@@ -114,7 +121,7 @@ export type BookingsProcedureContext = {
     user:
       | (User & {
           destinationCalendar: DestinationCalendar | null;
-          credentials: Credential[];
+          credentials: SafeCredential[];
           profiles: { organizationId: number }[];
         })
       | null;

--- a/scripts/check-no-unsafe-credential-fetch.js
+++ b/scripts/check-no-unsafe-credential-fetch.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const rootDir = path.resolve(__dirname, "..");
+const targetDirs = [
+  path.join(rootDir, "packages", "trpc", "server"),
+  path.join(rootDir, "packages", "features", "bookings"),
+];
+
+const allowedFiles = new Set([
+  path.join(rootDir, "packages", "features", "bookings", "lib", "test", "builder.ts"),
+]);
+
+const disallowedPattern = /\bcredentials\s*:\s*true\b/g;
+const ignoredDirectories = new Set(["node_modules", ".git", "dist", "build", ".next", ".turbo", "coverage"]);
+const supportedExtensions = new Set([".ts", ".tsx", ".js", ".mjs", ".cjs"]);
+
+function walk(dir, output = []) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (ignoredDirectories.has(entry.name)) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, output);
+      continue;
+    }
+    if (supportedExtensions.has(path.extname(entry.name))) {
+      output.push(fullPath);
+    }
+  }
+  return output;
+}
+
+const violations = [];
+for (const targetDir of targetDirs) {
+  if (!fs.existsSync(targetDir)) continue;
+  const files = walk(targetDir);
+  for (const filePath of files) {
+    if (allowedFiles.has(filePath)) continue;
+    const content = fs.readFileSync(filePath, "utf8");
+    const matches = content.match(disallowedPattern);
+    if (!matches?.length) continue;
+    violations.push(path.relative(rootDir, filePath));
+  }
+}
+
+if (violations.length) {
+  console.error("Found disallowed `credentials: true` usage in sensitive server paths:");
+  for (const violation of violations) {
+    console.error(` - ${violation}`);
+  }
+  console.error(
+    "Replace with an explicit select (for example `safeCredentialSelect`) or use an access-checked repository method."
+  );
+  process.exit(1);
+}
+
+console.log("No unsafe `credentials: true` usage found in protected server paths.");


### PR DESCRIPTION
**Summary**
### 
Validation of the active flow and confirmed this is currently an over-fetching risk rather than an immediate response leak next I’m applying the concrete code hardening in the booking middleware/repository and then adding an automated guard check.

**What I changed**

- Hardened booking middleware fetch:
  - packages/trpc/server/routers/viewer/bookings/util.ts
  - Replaced credentials: true with credentials: { select: safeCredentialSelect }
  - Updated context typing to use a safe credential shape (no key / encryptedKey)

- Hardened booking repository fetch:
  - packages/features/bookings/repositories/BookingRepository.ts
  - In findByIdIncludeDestinationCalendar, replaced credentials: true with credentials: { select: safeCredentialSelect }
  
 - Added guardrail:
  - New script: scripts/check-no-unsafe-credential-fetch.js
  - New npm script: check:credentials-fetch in package.json
  - This blocks future credentials: true usage in sensitive server paths (packages/trpc/server and packages/features/bookings)

Fixes #29366 

