### PR TITLE
fix: fail closed when rate limiter is unavailable

### DIFF
--- a/packages/lib/rateLimit.ts
+++ b/packages/lib/rateLimit.ts
@@ -29,19 +29,26 @@ export type RateLimitHelper = {
 export const API_KEY_RATE_LIMIT = 30;
 
 let warned = false;
+const rateLimitFailClosedResponse = {
+  success: false,
+  limit: 10,
+  remaining: 0,
+  reset: 0,
+} as RatelimitResponse;
 
 export function rateLimiter() {
   const { UNKEY_ROOT_KEY } = process.env;
+  
 
   if (!UNKEY_ROOT_KEY) {
     if (!warned) {
       log.warn("Disabled because the UNKEY_ROOT_KEY environment variable was not found.");
       warned = true;
     }
-    return () => ({ success: true, limit: 10, remaining: 999, reset: 0 }) as RatelimitResponse;
+    return () => rateLimitFailClosedResponse;
   }
   const timeout = {
-    fallback: { success: true, limit: 10, remaining: 999, reset: 0 },
+    fallback: rateLimitFailClosedResponse,
     ms: 5000,
   };
 
@@ -52,7 +59,7 @@ export function rateLimiter() {
       identifier,
       timestamp: new Date().toISOString(),
     });
-    return { success: true, limit: 10, remaining: 999, reset: 0 };
+    return rateLimitFailClosedResponse;
   };
 
   const limiter = {
@@ -132,3 +139,5 @@ export function rateLimiter() {
 
   return rateLimit;
 }
+
+how about now ?

--- a/packages/lib/rateLimit.ts
+++ b/packages/lib/rateLimit.ts
@@ -139,5 +139,3 @@ export function rateLimiter() {
 
   return rateLimit;
 }
-
-how about now ?


### PR DESCRIPTION
## What does this PR do?

- Fixes #29367

This PR updates the rate limiter fallback behavior in `packages/lib/rateLimit.ts` to fail closed instead of allowing requests when the rate limiter is unavailable.

The fallback response now returns `success: false` when:
- `UNKEY_ROOT_KEY` is missing
- the Unkey request times out
- the Unkey client throws an error

No new dependencies are required.

## Visual Demo (For contributors especially)

N/A — this is a backend rate limiter fallback behavior change and does not include a UI change.

#### Video Demo (if applicable):

N/A

#### Image Demo (if applicable):

N/A

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This can be tested by verifying the fallback response from `rateLimiter()`.

Test scenarios:
- Run the app without `UNKEY_ROOT_KEY` set.
- Trigger rate limiter initialization.
- Confirm the fallback response returns `success: false` instead of `success: true`.

Expected behavior:
- Missing `UNKEY_ROOT_KEY` should not allow requests by default.
- Unkey timeout fallback should return `success: false`.
- Unkey error fallback should return `success: false`.

I was not able to run the full test suite locally because dependency installation for the monorepo was not completed on my machine. GitHub CI should verify lint/type checks.


## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't commented my code, particularly in hard-to-understand areas


