### PR TITLE
fix: return 404 for unknown rescheduleUid instead of opening booking flow

### DIFF
--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from "uuid";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { generateHashedLink } from "@calcom/lib/generateHashedLink";
 import { randomString } from "@calcom/lib/random";
@@ -187,6 +188,27 @@ test.describe("pro user", () => {
     const [pro] = users.get();
     const unexistingPageUrl = new URL(`${pro.username}/invalid-event-type`, WEBAPP_URL);
     const response = await page.goto(unexistingPageUrl.href);
+    expect(response?.status()).toBe(404);
+  });
+
+  /**
+   * Verifies that navigating to a booking page with an unknown `rescheduleUid`
+   * returns a 404 HTTP response instead of silently opening the normal booking
+   * flow. This guards against the regression introduced when `processReschedule`
+   * did not check whether the booking lookup returned `null`.
+   */
+  test("should return 404 when rescheduleUid does not correspond to a real booking", async ({
+    page,
+    users,
+  }) => {
+    const user = await users.create();
+    const eventType = user.eventTypes[0];
+    const unknownUid = `missing-${uuidv4()}`;
+
+    const response = await page.goto(
+      `/${user.username}/${eventType.slug}?rescheduleUid=${unknownUid}&bookingUid=null`
+    );
+
     expect(response?.status()).toBe(404);
   });
 

--- a/apps/web/playwright/booking-seats.e2e.ts
+++ b/apps/web/playwright/booking-seats.e2e.ts
@@ -602,25 +602,4 @@ test.describe("Reschedule for booking with seats", () => {
     await expect(page).toHaveURL(/\/booking\/.*/);
   });
 
-
-  /**
-   * Verifies that navigating to a booking page with an unknown `rescheduleUid`
-   * returns a 404 HTTP response instead of silently opening the normal booking
-   * flow. This guards against the regression introduced when `processReschedule`
-   * did not check whether the booking lookup returned `null`.
-   */
-  test("should return 404 when rescheduleUid does not correspond to a real booking", async ({
-    page,
-    users,
-  }) => {
-    const user = await users.create();
-    const eventType = user.eventTypes[0];
-    const unknownUid = `missing-${uuidv4()}`;
-
-    const response = await page.goto(
-      `/${user.username}/${eventType.slug}?rescheduleUid=${unknownUid}&bookingUid=null`
-    );
-
-    expect(response?.status()).toBe(404);
-  });
 });

--- a/apps/web/playwright/booking-seats.e2e.ts
+++ b/apps/web/playwright/booking-seats.e2e.ts
@@ -602,5 +602,18 @@ test.describe("Reschedule for booking with seats", () => {
     await expect(page).toHaveURL(/\/booking\/.*/);
   });
 
-  // @TODO: force 404 when rescheduleUid is not found
+  test("should return 404 when rescheduleUid does not correspond to a real booking", async ({
+    page,
+    users,
+  }) => {
+    const user = await users.create();
+    const eventType = user.eventTypes[0];
+    const unknownUid = `missing-${uuidv4()}`;
+
+    const response = await page.goto(
+      `/${user.username}/${eventType.slug}?rescheduleUid=${unknownUid}&bookingUid=null`
+    );
+
+    expect(response?.status()).toBe(404);
+  });
 });

--- a/apps/web/playwright/booking-seats.e2e.ts
+++ b/apps/web/playwright/booking-seats.e2e.ts
@@ -602,6 +602,13 @@ test.describe("Reschedule for booking with seats", () => {
     await expect(page).toHaveURL(/\/booking\/.*/);
   });
 
+
+  /**
+   * Verifies that navigating to a booking page with an unknown `rescheduleUid`
+   * returns a 404 HTTP response instead of silently opening the normal booking
+   * flow. This guards against the regression introduced when `processReschedule`
+   * did not check whether the booking lookup returned `null`.
+   */
   test("should return 404 when rescheduleUid does not correspond to a real booking", async ({
     page,
     users,

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -52,18 +52,18 @@ async function processReschedule({
 
   const booking = await getBookingForReschedule(`${rescheduleUid}`, session?.user?.id);
 
-  if (booking?.eventType?.disableRescheduling) {
+  // if no booking found, return 404 immediately.
+  if (booking === null) {
+    return { notFound: true } as const;
+  }
+
+  if (booking.eventType?.disableRescheduling) {
     return {
       redirect: {
         destination: `/booking/${rescheduleUid}`,
         permanent: false,
       },
     };
-  }
-
-  // if no booking found, return 404 immediately.
-  if (booking === null) {
-    return { notFound: true } as const;
   }
 
   // if no eventTypeId (dynamic) or it matches this eventData - return void (success).

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -52,9 +52,13 @@ async function processReschedule({
     };
   }
 
-  // if no booking found, no eventTypeId (dynamic) or it matches this eventData - return void (success).
+  // if no booking found, return 404 immediately.
+  if (booking === null) {
+    return { notFound: true } as const;
+  }
+
+  // if no eventTypeId (dynamic) or it matches this eventData - return void (success).
   if (
-    booking === null ||
     !booking.eventTypeId ||
     (booking?.eventTypeId === props.eventData?.id &&
       (booking.status !== BookingStatus.CANCELLED ||

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -28,6 +28,15 @@ type Props = {
   orgBannerUrl: null;
 };
 
+/**
+ * Processes a reschedule request for a booking page.
+ *
+ * Looks up the existing booking by `rescheduleUid`. Returns `{ notFound: true }`
+ * when the UID does not correspond to any existing booking, preventing unknown
+ * UIDs from silently falling through to the normal booking flow. Returns a
+ * redirect when the booking belongs to a different event type, and returns
+ * `void` (mutating `props`) on success so the caller can proceed with rendering.
+ */
 async function processReschedule({
   props,
   rescheduleUid,
@@ -91,6 +100,13 @@ async function processReschedule({
   };
 }
 
+/**
+ * Processes a seated-event booking lookup for a booking page.
+ *
+ * Fetches the existing booking by `bookingUid` and attaches it to `props` so
+ * the booker UI can display the correct seat-reservation context. When
+ * `bookingUid` is absent the function is a no-op.
+ */
 async function processSeatedEvent({
   props,
   bookingUid,
@@ -115,6 +131,13 @@ async function processSeatedEvent({
   }
 }
 
+/**
+ * Fetches server-side props for a dynamic group booking page (multiple usernames joined by "+").
+ *
+ * Validates that all users in the group exist and that the requested event type is found.
+ * Handles org-domain redirects, reschedule flows, and seated-event lookups before returning
+ * the serialized `Props` for the booker UI.
+ */
 async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
   const session = await getServerSession({ req: context.req });
   const { user: usernames, type: slug } = paramsSchema.parse(context.params);
@@ -213,6 +236,14 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
   };
 }
 
+/**
+ * Fetches server-side props for a single-user booking page.
+ *
+ * Resolves the user and event type from the URL params, applies org-domain
+ * redirects when necessary, and populates SEO/branding fields. Delegates
+ * reschedule and seated-event lookups to `processReschedule` and
+ * `processSeatedEvent` respectively before returning the serialized `Props`.
+ */
 async function getUserPageProps(context: GetServerSidePropsContext) {
   const session = await getServerSession({ req: context.req });
   const { user: usernames, type: slug } = paramsSchema.parse(context.params);
@@ -313,8 +344,14 @@ const paramsSchema = z.object({
   user: z.string().transform((s) => getUsernameList(s)),
 });
 
-// Booker page fetches a tiny bit of data server side, to determine early
-// whether the page should show an away state or dynamic booking not allowed.
+/**
+ * Next.js `getServerSideProps` entry point for the `[user]/[type]` booking page.
+ *
+ * Delegates to `getDynamicGroupPageProps` for multi-user (dynamic group) URLs and
+ * to `getUserPageProps` for standard single-user URLs. Fetches a small amount of
+ * data server-side to determine early whether the page should show an away state
+ * or whether dynamic booking is disallowed.
+ */
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
   const { user } = paramsSchema.parse(context.params);
   const isDynamicGroup = user.length > 1;


### PR DESCRIPTION
## Summary

- Fixes unknown `rescheduleUid` silently falling through to the normal booking flow (HTTP 200 instead of 404)
- In `processReschedule()`, when `getBookingForReschedule()` returns `null`, now returns `{ notFound: true }` immediately
- Implements the existing `@TODO: force 404 when rescheduleUid is not found` in `booking-seats.e2e.ts`

## Root Cause

In `apps/web/server/lib/[user]/[type]/getServerSideProps.ts`, the `processReschedule` function had this logic:

```ts
if (booking === null || !booking.eventTypeId || ...) {
  props.booking = booking;  // sets booking = null
  return;                   // returns void — no 404, renders 200
}
```

When `booking === null` (uid not found), it short-circuited and returned `void`, which the caller treated as "proceed normally."

## Fix

Split the condition so a truly missing booking uid returns `{ notFound: true }`:

```ts
if (booking === null) {
  return { notFound: true } as const;
}
// ... rest of original condition
```

## Test

Added Playwright test in `booking-seats.e2e.ts` that visits `/{user}/{type}?rescheduleUid=missing-xxx&bookingUid=null` and asserts a 404 response, fulfilling the `@TODO` that was already there.

Closes #29399

🤖 Generated with [Claude Code](https://claude.com/claude-code)