### PR TITLE
fix(trpc): stop fetching credential.key in bookingsProcedure context

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/util.ts
+++ b/packages/trpc/server/routers/viewer/bookings/util.ts
@@ -1,17 +1,14 @@
 import { prisma } from "@calcom/prisma";
 import type {
-  Booking,
-  EventType,
-  BookingReference,
   Attendee,
-  Credential,
+  Booking,
+  BookingReference,
   DestinationCalendar,
+  EventType,
   User,
 } from "@calcom/prisma/client";
 import { MembershipRole, SchedulingType } from "@calcom/prisma/enums";
-
 import { TRPCError } from "@trpc/server";
-
 import authedProcedure from "../../../procedures/authedProcedure";
 import { commonBookingSchema } from "./types";
 
@@ -39,7 +36,6 @@ export const bookingsProcedure = authedProcedure
       user: {
         include: {
           destinationCalendar: true,
-          credentials: true,
           profiles: {
             select: {
               organizationId: true,
@@ -114,7 +110,6 @@ export type BookingsProcedureContext = {
     user:
       | (User & {
           destinationCalendar: DestinationCalendar | null;
-          credentials: Credential[];
           profiles: { organizationId: number }[];
         })
       | null;


### PR DESCRIPTION
## Summary

Fixes #29348.

The `bookingsProcedure` middleware in `packages/trpc/server/routers/viewer/bookings/util.ts` fetched `user.credentials` (which carries the encrypted `credential.key` field) via Prisma `include` and surfaced it on the typed `BookingsProcedureContext`. This violates the repo's own engineering rule: *"Make sure the credential.key field is never returned back from tRPC endpoints or APIs"* ([quality-review-checklist.md](agents/rules/quality-review-checklist.md)).

## Scope check

`bookingsProcedure` has a single consumer: `editLocation.handler.ts`. The handler does not read `ctx.booking.user.credentials` — it re-fetches what it needs through `getUsersCredentialsIncludeServiceAccountKey(ctx.user)` and `CredentialAccessService.ensureAccessible(...)`. So removing the field is safe and the type drop is a no-op for consumers.

## Changes

- Drop `credentials: true` from the user `include` in `bookingInclude`
- Drop the corresponding `credentials: Credential[]` from the exported `BookingsProcedureContext` type
- Drop the now-unused `Credential` type import (Biome re-sorted the remaining imports)

## Test plan

- [ ] Manual: open a booking, edit its location — flow unchanged
- [ ] Type check: `yarn type-check:ci --force`
- [ ] Lint: `yarn biome check .`

## Follow-up (not in this PR)

The broader migration from `include` → `select` across `bookingInclude` (and similar middlewares in `packages/trpc`) is worth doing per the repo's own *Prefer Select Over Include* rule, but I kept this PR scoped to the security-sensitive field only so it stays small and surgical (1 file, 7 lines removed).