### PR TITLE
fix: render non-prerendered embed UI on iframe handshake

### DIFF
--- a/packages/embeds/LIFECYCLE.md
+++ b/packages/embeds/LIFECYCLE.md
@@ -53,8 +53,8 @@ The embed system carefully manages visibility to prevent visual glitches:
 
 1. **Initial Creation**: Both iframe and body start hidden while the page loads
 2. **After Communication Established**: iframe becomes visible once it's ready to communicate
-3. **After Content Ready**: Loader is removed and iframe is fully visible
-4. **After Parent Acknowledges**: Body content becomes visible, background stays transparent
+3. **After Parent Acknowledges**: Non-prerendered embeds reveal their in-iframe UI immediately, while keeping the final `linkReady` completion signal for full readiness
+4. **After Content Ready**: Final readiness events fire and any remaining outer loading affordances stay cleared
 
 ## Event Details
 
@@ -88,12 +88,12 @@ The embed system carefully manages visibility to prevent visual glitches:
    - Fired by: Iframe
    - Indicates: iframe content is fully ready for user interaction
    - Requirements: Content height is known, and for booker pages, slots are loaded (if skeleton loader is used)
-   - Actions: Parent removes loader and makes iframe visible
+   - Actions: Signals full readiness after the initial UI is already visible
 
 7. **parentKnowsIframeReady Event**
    - Fired by: Parent
    - Indicates: Parent acknowledges that iframe is ready
-   - Actions: Makes body content visible
+   - Actions: Makes body content visible for non-prerendered embeds
    - Note: During prerendering, this triggers linkPrerendered event instead
 
 8. **__connectInitiated Event**

--- a/packages/embeds/embed-core/src/__tests__/embed-iframe-methods.test.ts
+++ b/packages/embeds/embed-core/src/__tests__/embed-iframe-methods.test.ts
@@ -107,5 +107,17 @@ describe("embed-iframe.methods", async () => {
             nextTick();
             expect(embedStore.renderState).toBe("completed");
         });
+
+        it("should make the body visible before linkReady completes for non-prerendered embeds", () => {
+            document.body.style.visibility = "hidden";
+            document.body.style.opacity = "0";
+            isLinkReadyMock?.mockReturnValue(false);
+
+            methods.parentKnowsIframeReady({});
+
+            expect(document.body.style.visibility).toBe("visible");
+            expect(document.body.style.opacity).toBe("1");
+            expect(embedStore.renderState).not.toBe("completed");
+        });
     });
 });

--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -419,8 +419,10 @@ export const methods = {
   },
   parentKnowsIframeReady: (_unused: unknown) => {
     log("Method: `parentKnowsIframeReady` called");
-    // No UI change should happen in sight. Let the parent height adjust and in next cycle show it.
-    // Embed background must still remain transparent
+    if (!isPrerendering()) {
+      makeBodyVisible();
+    }
+
     runAsap(function tryInformingLinkReady() {
       if (!isLinkReady({ embedStore })) {
         runAsap(tryInformingLinkReady);
@@ -433,7 +435,6 @@ export const methods = {
         return;
       }
 
-      makeBodyVisible();
       log("renderState is 'completed'");
       embedStore.renderState = "completed";
       if (isPrerendering()) {

--- a/packages/embeds/embed-core/src/embed.test.ts
+++ b/packages/embeds/embed-core/src/embed.test.ts
@@ -364,6 +364,21 @@ describe("Cal", () => {
       });
     });
 
+    it("should stop showing the outer loader as soon as the iframe handshake completes", () => {
+      calInstance.api.modal(baseModalArgs);
+
+      const modalBox = expectCalModalBoxToBeInDocument({
+        theme: "light",
+        layout: "modern",
+        pageType: null,
+        state: initialStateOfModal,
+      });
+
+      calInstance.actionManager.fire("__iframeReady", { isPrerendering: false });
+
+      expect(modalBox.getAttribute("state")).toBe("loaded");
+    });
+
     describe("Prerendering", () => {
       it("should create modal having iframe with correct attributes when in prerendering mode", () => {
         const modalArg = {

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -424,6 +424,19 @@ export class Cal {
     this.resetQueue();
   }
 
+  markEmbedUiReady() {
+    if (this.isPrerendering) {
+      return;
+    }
+
+    if (this.iframe) {
+      this.iframe.style.visibility = "";
+    }
+
+    this.modalBox?.setAttribute("state", "loaded");
+    this.inlineEl?.setAttribute("loading", "done");
+  }
+
   constructor(namespace: string, q: Queue) {
     this.__config = {
       // Use WEBAPP_URL till full page reload problem with website URL is solved
@@ -469,6 +482,7 @@ export class Cal {
         // Imp: Don't use visibility:visible as that would make the iframe show even if the host element(A parent of the iframe) has visibility:hidden set. Just reset the visibility to default
         this.iframe.style.visibility = "";
       }
+      this.markEmbedUiReady();
       this.doInIframe({ method: "parentKnowsIframeReady" } as const);
       this.iframeDoQueue.forEach((doInIframeArg) => {
         this.doInIframe(doInIframeArg);
@@ -491,19 +505,7 @@ export class Cal {
     this.actionManager.on("__scrollByDistance", getScrollByDistanceHandler(this));
 
     this.actionManager.on("linkReady", () => {
-      if (this.isPrerendering) {
-        // Ensure that we don't mark embed as loaded if it's prerendering otherwise prerendered embed could show-up without any user action
-        // linkReady event isn't received anyway by parent as it isn't whitelisted to be sent to parent but it is a safe guard
-        return;
-      }
-      if (this.iframe) {
-        this.iframe.style.visibility = "";
-      }
-
-      // Removes the loader
-      // TODO: We should be using consistent approach of "state" attribute for modalBox and inlineEl.
-      this.modalBox?.setAttribute("state", "loaded");
-      this.inlineEl?.setAttribute("loading", "done");
+      this.markEmbedUiReady();
     });
 
     this.actionManager.on("linkFailed", (e) => {


### PR DESCRIPTION
## What does this PR do?

This changes the embed handshake so non-prerendered embeds reveal visible UI as soon as the iframe handshake completes, instead of waiting for the later `linkReady` event.

That keeps the final readiness signal intact for slower downstream work such as slots/data loading, but removes the blank/loading-first experience described in this issue.

- Fixes #18297

## Visual Demo (For contributors especially)

N/A for this change. The behavior difference is in handshake timing rather than a layout change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Run the focused embed tests:
  - `yarn vitest run packages/embeds/embed-core/src/__tests__/embed-iframe-methods.test.ts packages/embeds/embed-core/src/embed.test.ts`
- Verify the expected behavior:
  - the parent-side loader clears when `__iframeReady` fires for a non-prerendered embed
  - the iframe body becomes visible on `parentKnowsIframeReady`
  - `linkReady` still remains the later full-readiness event
- Relevant local limitation while preparing this PR:
  - I added the regression tests, but I could not complete local execution in my partial-clone checkout because workspace install resolution failed on `@calcom/i18n@workspace:*`

## Checklist

- None
