### PR TITLE
fix(booker): add bottom padding to modal content to prevent sticky action bar overlap on mobile

### DIFF
--- a/apps/web/modules/bookings/components/BookEventForm/BookFormAsModal.tsx
+++ b/apps/web/modules/bookings/components/BookEventForm/BookFormAsModal.tsx
@@ -100,7 +100,7 @@ export const BookFormAsModal = ({
       <DialogContent
         type={undefined}
         enableOverflow
-        className="[&_.modalsticky]:border-t-subtle [&_.modalsticky]:bg-default max-h-[80vh] pb-0 [&_.modalsticky]:sticky [&_.modalsticky]:bottom-0 [&_.modalsticky]:left-0 [&_.modalsticky]:right-0 [&_.modalsticky]:-mx-8 [&_.modalsticky]:border-t [&_.modalsticky]:px-8 [&_.modalsticky]:py-4">
+        className="[&_.modalsticky]:border-t-subtle [&_.modalsticky]:bg-default max-h-[80vh] [&_.modalsticky]:sticky [&_.modalsticky]:bottom-0 [&_.modalsticky]:left-0 [&_.modalsticky]:right-0 [&_.modalsticky]:-mx-8 [&_.modalsticky]:border-t [&_.modalsticky]:px-8 [&_.modalsticky]:py-4 pb-24">
         {!isPlatform ? (
           <BookEventFormWrapper onCancel={onCancel}>{children}</BookEventFormWrapper>
         ) : (


### PR DESCRIPTION
## Summary

On mobile, the sticky bottom bar containing 'Back' and 'Pay to book' buttons in the booking confirmation modal overlaps form fields (phone number, notes), making them inaccessible without scrolling — and even then the bar covers the fields.

## Root Cause

In `BookFormAsModal.tsx`, the `DialogContent` had `pb-0` (zero bottom padding), so the scrollable content area ends flush with the sticky footer at `bottom-0`.

## Fix

Replace `pb-0` with `pb-24` (~96px bottom padding) on the modal's DialogContent. This pushes the scrollable content well above the sticky footer, preventing overlap on all standard mobile viewport sizes.

**Changed:**
```
-className="[...max-h-[80vh] pb-0 [...]]"
+className="[...max-h-[80vh] pb-24 [...]]"
```

## Testing

- Verified locally at mobile viewport widths (375px, 390px, 414px)
- The form's lower fields (phone, notes) are now reachable by scrolling above the sticky footer
- The sticky footer remains visible at the bottom as intended

Closes #29265