### PR TITLE
fix: make org CSV export import-friendly

### DIFF
--- a/apps/web/modules/users/lib/UserListTableUtils.test.ts
+++ b/apps/web/modules/users/lib/UserListTableUtils.test.ts
@@ -50,7 +50,9 @@ function createMockTable(data: UserTableUser[]): Table<UserTableUser> {
         ],
       },
     ]),
-    getRowModel: vi.fn().mockReturnValue({ rows: data.map((item) => ({ original: item })) }),
+    getRowModel: vi
+      .fn()
+      .mockReturnValue({ rows: data.map((item) => ({ original: item })) }),
   } as unknown as Table<UserTableUser>;
 }
 
@@ -79,7 +81,9 @@ describe("generate Csv for Org Users Table", () => {
   };
 
   it("should throw if no headers", () => {
-    expect(() => generateCsvRawForMembersTable([], [], mockAttributeIds, orgDomain)).toThrow();
+    expect(() =>
+      generateCsvRawForMembersTable([], [], mockAttributeIds, orgDomain)
+    ).toThrow();
   });
 
   it("should generate correct CSV headers", () => {
@@ -91,7 +95,7 @@ describe("generate Csv for Org Users Table", () => {
       orgDomain
     );
     const headers = csv?.split("\n")[0];
-    expect(headers).toBe("Members,Link,Role,Teams,Attribute 1,Attribute 2");
+    expect(headers).toBe("email,link,role,teams,Attribute 1,Attribute 2");
   });
 
   it("should handle user with single attribute value", () => {
@@ -119,7 +123,7 @@ describe("generate Csv for Org Users Table", () => {
     );
 
     expect(csv).toMatchInlineSnapshot(`
-      "Members,Link,Role,Teams,Attribute 1,Attribute 2
+      "email,link,role,teams,Attribute 1,Attribute 2
       test@example.com,https://acme.cal.com/testuser,MEMBER,Team1,value1,"
     `);
   });
@@ -155,7 +159,7 @@ describe("generate Csv for Org Users Table", () => {
     );
 
     expect(csv).toMatchInlineSnapshot(`
-      "Members,Link,Role,Teams,Attribute 1,Attribute 2
+      "email,link,role,teams,Attribute 1,Attribute 2
       test@example.com,https://acme.cal.com/testuser,MEMBER,Team1,"value1,value2","
     `);
   });
@@ -181,7 +185,7 @@ describe("generate Csv for Org Users Table", () => {
     );
 
     expect(csv).toMatchInlineSnapshot(`
-      "Members,Link,Role,Teams,Attribute 1,Attribute 2
+      "email,link,role,teams,Attribute 1,Attribute 2
       test@example.com,https://acme.cal.com/testuser,MEMBER,"Team1,Team2",,"
     `);
   });
@@ -211,7 +215,7 @@ describe("generate Csv for Org Users Table", () => {
     );
 
     expect(csv).toMatchInlineSnapshot(`
-      "Members,Link,Role,Teams,Attribute 1,Attribute 2
+      "email,link,role,teams,Attribute 1,Attribute 2
       test@example.com,https://acme.cal.com/testuser,MEMBER,"Team,1","value,1","
     `);
   });
@@ -234,7 +238,7 @@ describe("generate Csv for Org Users Table", () => {
     );
 
     expect(csv).toMatchInlineSnapshot(`
-      "Members,Link,Role,Teams,Attribute 1,Attribute 2
+      "email,link,role,teams,Attribute 1,Attribute 2
       owner@example.com,https://acme.cal.com/owner,OWNER,,,
       admin@example.com,https://acme.cal.com/admin,ADMIN,,,
       member@example.com,https://acme.cal.com/member,MEMBER,,,"
@@ -259,7 +263,7 @@ describe("generate Csv for Org Users Table", () => {
     );
 
     expect(csv).toMatchInlineSnapshot(`
-      "Members,Link,Role,Teams,Attribute 1,Attribute 2
+      "email,link,role,teams,Attribute 1,Attribute 2
       test@example.com,https://acme.cal.com/testuser,MEMBER,,,"
     `);
   });

--- a/apps/web/modules/users/lib/UserListTableUtils.ts
+++ b/apps/web/modules/users/lib/UserListTableUtils.ts
@@ -2,7 +2,9 @@ import { sanitizeValue } from "@calcom/lib/csvUtils";
 import type { UserTableUser } from "@calcom/web/modules/users/components/UserTable/types";
 import type { Table } from "@tanstack/react-table";
 
-export const generateHeaderFromReactTable = (table: Table<UserTableUser>): string[] | null => {
+export const generateHeaderFromReactTable = (
+  table: Table<UserTableUser>
+): string[] | null => {
   const headerGroups = table.getHeaderGroups();
   if (!headerGroups.length) {
     return null;
@@ -10,7 +12,9 @@ export const generateHeaderFromReactTable = (table: Table<UserTableUser>): strin
 
   const { headers } = headerGroups[0];
   const HEADER_IDS_TO_EXCLUDE = ["select", "actions"]; // these columns only make sense in web page
-  const filteredHeaders = headers.filter((header) => !HEADER_IDS_TO_EXCLUDE.includes(header.id));
+  const filteredHeaders = headers.filter(
+    (header) => !HEADER_IDS_TO_EXCLUDE.includes(header.id)
+  );
   const headerNames = filteredHeaders.map((header) => {
     const h = header.column.columnDef.header;
     if (typeof h === "string") {
@@ -22,15 +26,26 @@ export const generateHeaderFromReactTable = (table: Table<UserTableUser>): strin
     return "Unknown";
   });
 
-  // Add "Link" column (member's public page)
-  const MEMBERS_COLUMN = "Members";
-  const LINK_COLUMN = "Link";
-  const memberIndex = headerNames.findIndex((name) => name === MEMBERS_COLUMN);
+  const CSV_HEADER_ALIASES: Record<string, string> = {
+    Members: "email",
+    Role: "role",
+    Teams: "teams",
+  };
+
+  const normalizedHeaders = headerNames.map(
+    (header) => CSV_HEADER_ALIASES[header] ?? header
+  );
+
+  // Add "link" column (member's public page) right after email so exported files
+  // can be re-imported while still preserving the public profile URL.
+  const EMAIL_COLUMN = "email";
+  const LINK_COLUMN = "link";
+  const memberIndex = normalizedHeaders.indexOf(EMAIL_COLUMN);
   if (memberIndex > -1) {
-    headerNames.splice(memberIndex + 1, 0, LINK_COLUMN);
+    normalizedHeaders.splice(memberIndex + 1, 0, LINK_COLUMN);
   }
 
-  return headerNames;
+  return normalizedHeaders;
 };
 
 export const generateCsvRawForMembersTable = (
@@ -43,12 +58,18 @@ export const generateCsvRawForMembersTable = (
     throw new Error("The header is empty.");
   }
 
-  const REQUIRED_HEADERS = ["Members", "Link", "Role", "Teams"] as const;
+  const REQUIRED_HEADERS = ["email", "link", "role", "teams"] as const;
   // Validate required headers are present and in correct order
   const firstFourHeaders = headers.slice(0, REQUIRED_HEADERS.length);
-  if (!REQUIRED_HEADERS.every((header, index) => header === firstFourHeaders[index])) {
+  if (
+    !REQUIRED_HEADERS.every(
+      (header, index) => header === firstFourHeaders[index]
+    )
+  ) {
     throw new Error(
-      `Invalid headers structure. Expected headers to start with: ${JSON.stringify(REQUIRED_HEADERS)}`
+      `Invalid headers structure. Expected headers to start with: ${JSON.stringify(
+        REQUIRED_HEADERS
+      )}`
     );
   }
 
@@ -78,7 +99,9 @@ export const generateCsvRawForMembersTable = (
       email, // Members column
       `${orgDomain}/${username}`, // Link column
       role, // Role column
-      sanitizeValue(teams.map((team: { id: number; name: string }) => team.name).join(",")), // Teams column
+      sanitizeValue(
+        teams.map((team: { id: number; name: string }) => team.name).join(",")
+      ), // Teams column
     ];
 
     // Add attribute columns
@@ -90,7 +113,10 @@ export const generateCsvRawForMembersTable = (
         attributes
           .map((attr) => {
             if (typeof attr === "string") return attr;
-            return attr.weight ? `${attr.value} (${attr.weight}%)` : attr.value;
+            if (attr.weight) {
+              return `${attr.value} (${attr.weight}%)`;
+            }
+            return attr.value;
           })
           .join(",")
       );


### PR DESCRIPTION
## Summary
- make the organization members CSV export use import-friendly machine headers (`email`, `link`, `role`, `teams`) instead of display-only labels like `Members` and `Role`
- keep the exported `link` column and attribute columns intact so exported files remain useful while becoming closer to the onboarding CSV import contract
- update the members CSV utility tests to lock the new header format in place

## Why
Organization CSV import currently expects an `email` column, while the organization members export uses UI labels such as `Members`. This change makes the exported file much easier to round-trip back into CSV import without changing the row payload format.

## Validation
- `yarn vitest run apps/web/modules/users/lib/UserListTableUtils.test.ts`
- `./node_modules/.bin/prettier --check apps/web/modules/users/lib/UserListTableUtils.ts apps/web/modules/users/lib/UserListTableUtils.test.ts`
- `./node_modules/.bin/biome lint apps/web/modules/users/lib/UserListTableUtils.ts apps/web/modules/users/lib/UserListTableUtils.test.ts`
- `yarn workspace @calcom/web type-check` *(blocked locally by existing repo-wide TRPC/generated-types errors unrelated to this change)*
- `yarn type-check --filter=@calcom/web` *(blocked locally by an existing `@calcom/prisma` post-install generator error on this checkout)*

Closes #19765
