### PR TITLE
fix: remove duplicate-word typos in API description, log message, and atoms README

### DIFF
--- a/packages/features/bookings/lib/EventManager.ts
+++ b/packages/features/bookings/lib/EventManager.ts
@@ -712,7 +712,7 @@ export default class EventManager {
           });
         }
 
-        log.debug("RescheduleOrganizerChanged: Creating Event and Meeting for for new booking");
+        log.debug("RescheduleOrganizerChanged: Creating Event and Meeting for new booking");
         const createdEvent = await this.create(originalEvt);
         results.push(...createdEvent.results);
         updatedBookingReferences.push(...createdEvent.referencesToCreate);

--- a/packages/platform/atoms/README.md
+++ b/packages/platform/atoms/README.md
@@ -31,7 +31,7 @@ atoms versioning and publishing to [npm](https://www.npmjs.com/package/@calcom/a
 - Then, you have to write a description of the change and press enter. This will generate a log file in the `.changeset` directory e.g. `.changeset/hungry-donuts-cross.md`. 
 - Commit this log file to your development branch and push it.
 Notably, you do not have to change `"version"` in the atoms `package.json` file because changesets will do it in the next step.
-2. After the development branch is merged changesets will open a pull request titled `chore: version packages` containing next release changes. This pull request will contain the new log file, it being added to the atoms `CHANGELOG.md` file and changesets will update the atoms `package.json` file based whether or not is is major, minor or patch update. When we want to release atoms we simply have to merge this pull request and changesets will publish the new atoms version to npm. Notably,
+2. After the development branch is merged changesets will open a pull request titled `chore: version packages` containing next release changes. This pull request will contain the new log file, it being added to the atoms `CHANGELOG.md` file and changesets will update the atoms `package.json` file based on whether it is a major, minor or patch update. When we want to release atoms we simply have to merge this pull request and changesets will publish the new atoms version to npm. Notably,
 changesets will publish atoms to npm only if the `"version"` in the atoms `package.json` of changeset's PR is higher than in the npm.
 
 The following 2 articles teach how to write good change summaries for each PR when it deserves to end up in CHANGELOG.md

--- a/packages/platform/types/slots/slots-2024-09-04/inputs/get-slots.input.ts
+++ b/packages/platform/types/slots/slots-2024-09-04/inputs/get-slots.input.ts
@@ -176,7 +176,7 @@ export class ByTeamSlugAndEventTypeSlug_2024_09_04 extends GetAvailableSlotsInpu
   @ApiProperty({
     type: String,
     description:
-      "When searching by eventTypeSlug a teamSlug must be provided too aka team who owns the the event type.",
+      "When searching by eventTypeSlug a teamSlug must be provided too aka team who owns the event type.",
     example: "bob",
   })
   teamSlug!: string;


### PR DESCRIPTION
## Summary

Three small duplicate-word typos:

| File:line | Fix |
|---|---|
| \`packages/platform/types/slots/slots-2024-09-04/inputs/get-slots.input.ts:179\` | \`owns the the event type\` → \`owns the event type\` (visible in the API description / Swagger docs) |
| \`packages/features/bookings/lib/EventManager.ts:715\` | \`Creating Event and Meeting for for new booking\` → \`...for new booking\` (debug log) |
| \`packages/platform/atoms/README.md:34\` | \`based whether or not is is major, minor or patch update\` → \`based on whether it is a major, minor or patch update\` (sentence was also slightly malformed) |

Diff is exactly 3 lines.

## Novelty

\`gh pr list -R calcom/cal.diy --search\` for each path returned no open PR; no open \`typo\` PRs at all. Verified via direct gh CLI searches.

## Test plan

- [x] No runtime behaviour changes. API description string is metadata, the log line is a debug message, and the README is text only.
- [x] \`grep -rn 'the the \\|for for new'\` across the affected files returns no matches after the fix.

> Draft per Cal.diy CONTRIBUTING — please mark ready for review when it makes sense.