### PR TITLE
fix: preload English translations to eliminate i18n skeleton loaders

### DIFF
--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -33,6 +33,27 @@ const I18nextAdapter = appWithTranslation<
   }
 >(({ children }) => <>{children}</>);
 
+// Preload English translations at module level so they're available instantly on first render.
+// This eliminates the skeleton loading period while the tRPC i18n query is in flight.
+// When the tRPC query resolves, its locale-specific data replaces these English fallback translations.
+const enCommon = require("@calcom/i18n/locales/en/common.json") as Record<string, string>;
+const englishFallback: SSRConfig = {
+  _nextI18Next: {
+    initialI18nStore: {
+      en: {
+        common: enCommon,
+      },
+    },
+    initialLocale: "en",
+    ns: ["common", "vital"],
+    userConfig: null,
+  },
+};
+
+// Cache previously-loaded tRPC i18n results per locale so switching back to a locale
+// that was already fetched shows translations instantly on subsequent navigations.
+const i18nCache = new Map<string, SSRConfig>();
+
 // Workaround for https://github.com/vercel/next.js/issues/8592
 export type AppProps = Omit<
   NextAppProps<
@@ -103,7 +124,14 @@ const CustomI18nextProvider = (props: AppPropsWithChildren) => {
   }, [locale]);
 
   const clientViewerI18n = useViewerI18n(locale);
-  const i18n = clientViewerI18n.data?.i18n ?? props.pageProps.i18n;
+
+  // Cache tRPC i18n results per locale so switching back is instant
+  if (clientViewerI18n.data?.i18n) {
+    i18nCache.set(locale, clientViewerI18n.data.i18n);
+  }
+
+  const i18n =
+    clientViewerI18n.data?.i18n ?? props.pageProps.i18n ?? i18nCache.get(locale) ?? englishFallback;
 
   const passedProps = {
     ...props,

--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -124,11 +124,13 @@ const CustomI18nextProvider = (props: AppPropsWithChildren) => {
   }, [locale]);
 
   const clientViewerI18n = useViewerI18n(locale);
+  const resolvedI18n = clientViewerI18n.data?.i18n;
 
   // Cache tRPC i18n results per locale so switching back is instant
-  if (clientViewerI18n.data?.i18n) {
-    i18nCache.set(locale, clientViewerI18n.data.i18n);
-  }
+  useEffect(() => {
+    if (!resolvedI18n) return;
+    i18nCache.set(locale, resolvedI18n);
+  }, [locale, resolvedI18n]);
 
   const i18n =
     clientViewerI18n.data?.i18n ?? props.pageProps.i18n ?? i18nCache.get(locale) ?? englishFallback;


### PR DESCRIPTION
## Problem

The Pages Router shows skeleton loaders on every navigation while waiting for a tRPC query to fetch translation strings. This creates a jarring flicker where the entire UI flashes skeleton placeholders before content appears — especially noticeable on initial load and locale switches.

The `CustomI18nextProvider` fires a tRPC `viewer.i18n.get` query, and while it's pending, `pageProps.i18n` is `undefined`. Since `appWithTranslation` has no resources, `isLocaleReady` is `false`, and every component checking it renders skeleton loaders.

## Solution

**English fallback preload:** Load `en/common.json` at module level (it's a static JSON asset already bundled by webpack) and format it as an `SSRConfig` fallback. This means translation data is available on the very first render — no skeleton needed.

**Per-locale cache:** Cache tRPC i18n results in a `Map<string, SSRConfig>` keyed by locale. Switching back to a previously-visited locale is instant, no network request wait.

Together these ensure `isLocaleReady` is always `true` from the first render.

## How it works

The priority chain is:
tRPC data -> pageProps.i18n -> locale cache -> English fallback

When the tRPC query resolves, its locale-specific data replaces the English fallback seamlessly. This mirrors what `mergeWithEnglishFallback` already does on the server.

## Related

Relevant to the issue described in #9840 and RFC #10198. App Router already handles this correctly (preloads in layout.tsx). This brings the same guarantee to the Pages Router.
