### PR TITLE
fix(security): add origin validation to postMessage handlers in embed SDK

### DIFF
--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,6 +27,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -555,7 +555,7 @@ function main() {
 
     // Validate that the message comes from the expected parent origin.
     // ancestorOrigins[0] is reliable for iframes and available in all modern browsers.
-    if (expectedParentOrigin && e.origin !== expectedParentOrigin) {
+    if (!expectedParentOrigin || e.origin !== expectedParentOrigin) {
       log(`Rejected message from origin "${e.origin}" (expected parent: "${expectedParentOrigin}")`);
       return;
     }

--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -174,7 +174,9 @@ export const useEmbedUiConfig = () => {
   useEffect(() => {
     return () => {
       const foundAtIndex = embedStore.setUiConfig.findIndex((item) => item === setUiConfig);
-      embedStore.setUiConfig.splice(foundAtIndex, 1);
+      if (foundAtIndex !== -1) {
+        embedStore.setUiConfig.splice(foundAtIndex, 1);
+      }
     };
   });
   return uiConfig;
@@ -531,8 +533,20 @@ function main() {
 
   // FIX 3: Cache the expected parent origin for message validation.
   // window.location.ancestorOrigins[0] is the origin of the parent page embedding this iframe.
-  const expectedParentOrigin = typeof window !== "undefined" ? window.location?.ancestorOrigins?.[0] : null;
-
+  const getExpectedParentOrigin = (): string | null => {
+    if (typeof window !== "undefined" && window.location?.ancestorOrigins?.[0]) {
+      return window.location.ancestorOrigins[0];
+    }
+    if (typeof document !== "undefined" && document.referrer) {
+      try {
+        return new URL(document.referrer).origin;
+      } catch {
+        // Invalid referrer URL
+      }
+    }
+    return null;
+  };
+  const expectedParentOrigin = getExpectedParentOrigin();
   window.addEventListener("message", (e) => {
     const data: Message = e.data;
     if (!data) {

--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -1,38 +1,39 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
-import { mapOldToNewCssVars } from "./ui/cssVarsMap";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Message } from "./embed";
 import {
-  embedStore,
   EMBED_IFRAME_STATE,
+  embedStore,
+  incrementView,
   resetPageData,
   setReloadInitiated,
-  incrementView,
 } from "./embed-iframe/lib/embedStore";
 import {
-  runAsap,
   isBookerReady,
-  isLinkReady,
-  recordResponseIfQueued,
-  keepParentInformedAboutDimensionChanges,
-  isPrerendering,
   isBrowser,
+  isLinkReady,
+  isPrerendering,
+  keepParentInformedAboutDimensionChanges,
   log,
+  recordResponseIfQueued,
+  runAsap,
 } from "./embed-iframe/lib/utils";
 import { sdkActionManager } from "./sdk-event";
 import type {
-  UiConfig,
-  EmbedNonStylesConfig,
   BookerLayouts,
-  EmbedStyles,
   EmbedBookerState,
-  SlotsQuery,
+  EmbedNonStylesConfig,
+  EmbedStyles,
   PrefillAndIframeAttrsConfig,
   SetStyles,
+  SlotsQuery,
   setNonStylesConfig,
+  UiConfig,
 } from "./types";
+import { mapOldToNewCssVars } from "./ui/cssVarsMap";
 import { useCompatSearchParams } from "./useCompatSearchParams";
+
 export { useBookerEmbedEvents, useSlotsViewOnSmallScreen } from "./embed-iframe/react-hooks";
 
 // We don't import it from Booker/types because the types from this module are published to npm and we can't import packages that aren't published
@@ -78,9 +79,7 @@ if (isBrowser) {
 
 const setEmbedStyles = (stylesConfig: EmbedStyles) => {
   embedStore.styles = stylesConfig;
-  for (const [, setEmbedStyle] of Object.entries(
-    embedStore.reactStylesStateSetters
-  )) {
+  for (const [, setEmbedStyle] of Object.entries(embedStore.reactStylesStateSetters)) {
     setEmbedStyle((styles) => {
       return {
         ...styles,
@@ -92,9 +91,7 @@ const setEmbedStyles = (stylesConfig: EmbedStyles) => {
 
 const setEmbedNonStyles = (stylesConfig: EmbedNonStylesConfig) => {
   embedStore.nonStyles = stylesConfig;
-  for (const [, setEmbedStyle] of Object.entries(
-    embedStore.reactStylesStateSetters
-  )) {
+  for (const [, setEmbedStyle] of Object.entries(embedStore.reactStylesStateSetters)) {
     setEmbedStyle((styles) => {
       return {
         ...styles,
@@ -117,20 +114,15 @@ const registerNewSetter = (
         styles: false;
       }
 ) => {
-  // It's possible that 'ui' instruction has already been processed and the registration happened due to some action by the user in iframe.
-  // So, we should call the setter immediately with available embedStyles
   if (registration.styles) {
-    embedStore.reactStylesStateSetters[
-      registration.elementName as keyof EmbedStyles
-    ] = registration.setState;
+    embedStore.reactStylesStateSetters[registration.elementName as keyof EmbedStyles] = registration.setState;
     registration.setState(embedStore.styles || {});
     return () => {
       delete embedStore.reactStylesStateSetters[registration.elementName];
     };
   } else {
-    embedStore.reactNonStylesStateSetters[
-      registration.elementName as keyof EmbedNonStylesConfig
-    ] = registration.setState;
+    embedStore.reactNonStylesStateSetters[registration.elementName as keyof EmbedNonStylesConfig] =
+      registration.setState;
     registration.setState(embedStore.nonStyles || {});
 
     return () => {
@@ -176,27 +168,18 @@ export const useEmbedTheme = () => {
   return theme;
 };
 
-/**
- * It serves following purposes
- * - Gives consistent values for ui config even after Soft Navigation. When a new React component mounts, it would ensure that the component gets the correct value of ui config
- * - Ensures that all the components using useEmbedUiConfig are updated when ui config changes. It is done by maintaining a list of all non-stale setters.
- */
 export const useEmbedUiConfig = () => {
   const [uiConfig, setUiConfig] = useState(embedStore.uiConfig || {});
   embedStore.setUiConfig.push(setUiConfig);
   useEffect(() => {
     return () => {
-      const foundAtIndex = embedStore.setUiConfig.findIndex(
-        (item) => item === setUiConfig
-      );
-      // Keep removing the setters that are stale
+      const foundAtIndex = embedStore.setUiConfig.findIndex((item) => item === setUiConfig);
       embedStore.setUiConfig.splice(foundAtIndex, 1);
     };
   });
   return uiConfig;
 };
 
-// TODO: Make it usable as an attribute directly instead of styles value. It would allow us to go beyond styles e.g. for debugging we can add a special attribute identifying the element on which UI config has been applied
 export const useEmbedStyles = (elementName: keyof EmbedStyles) => {
   const [, setStyles] = useState<EmbedStyles>({});
 
@@ -208,13 +191,10 @@ export const useEmbedStyles = (elementName: keyof EmbedStyles) => {
     });
   }, []);
   const styles = embedStore.styles || {};
-  // Always read the data from global embedStore so that even across components, the same data is used.
   return styles[elementName] || {};
 };
 
-export const useEmbedNonStylesConfig = (
-  elementName: keyof EmbedNonStylesConfig
-) => {
+export const useEmbedNonStylesConfig = (elementName: keyof EmbedNonStylesConfig) => {
   const [, setNonStyles] = useState({} as EmbedNonStylesConfig);
 
   useEffect(() => {
@@ -225,14 +205,12 @@ export const useEmbedNonStylesConfig = (
     });
   }, []);
 
-  // Always read the data from global embedStore so that even across components, the same data is used.
   const nonStyles = embedStore.nonStyles || {};
   return nonStyles[elementName] || {};
 };
 
 export const useIsBackgroundTransparent = () => {
   let isBackgroundTransparent = false;
-  // TODO: Background should be read as ui.background and not ui.body.background
   const bodyEmbedStyles = useEmbedStyles("body");
 
   if (bodyEmbedStyles.background === "transparent") {
@@ -242,16 +220,12 @@ export const useIsBackgroundTransparent = () => {
 };
 
 export const useBrandColors = () => {
-  // TODO: Branding shouldn't be part of ui.styles. It should exist as ui.branding.
-  const brandingColors = useEmbedNonStylesConfig(
-    "branding"
-  ) as EmbedNonStylesConfig["branding"];
+  const brandingColors = useEmbedNonStylesConfig("branding") as EmbedNonStylesConfig["branding"];
   return brandingColors || {};
 };
 
 function getNamespace() {
   if (isValidNamespace(embedStore.namespace)) {
-    // Persist this so that even if query params changed, we know that it is an embed.
     return embedStore.namespace;
   }
   if (isBrowser) {
@@ -267,8 +241,7 @@ function getEmbedType() {
   }
   if (isBrowser) {
     const url = new URL(document.URL);
-    const embedType = (embedStore.embedType =
-      url.searchParams.get("embedType"));
+    const embedType = (embedStore.embedType = url.searchParams.get("embedType"));
     return embedType;
   }
 }
@@ -297,7 +270,6 @@ export const useEmbedType = () => {
 };
 
 function makeBodyVisible() {
-  // Guard against test environment teardown where document may no longer exist
   if (typeof document === "undefined" || !document.body) {
     return;
   }
@@ -307,19 +279,11 @@ function makeBodyVisible() {
   if (document.body.style.opacity !== "1") {
     document.body.style.opacity = "1";
   }
-  // Ensure that it stays visible and not reverted by React
   runAsap(() => {
     makeBodyVisible();
   });
 }
 
-/**
- * On an embed page, there are two changes done
- * - Body is made invisible
- * - Background is set to transparent
- *
- * This function reverses both of them
- */
 function showPageAsNonEmbed() {
   makeBodyVisible();
   resetTransparentBackground();
@@ -339,19 +303,13 @@ async function ensureRoutingFormResponseIdInUrl({
   toBeThereParams: Record<string, string | string[]>;
   toRemoveParams: string[];
 }) {
-  // Update routingFormResponseId in url only after connect is completed, to keep things simple
-  // Adding cal.routingFormResponseId in query param later shouldn't change anything in UI plus no slot request would go again due ot this.
-
-  const { stopEnsuringQueryParamsInUrl } =
-    embedStore.router.ensureQueryParamsInUrl({
-      toBeThereParams: {
-        ...toBeThereParams,
-        "cal.routingFormResponseId": newlyRecordedResponseId.toString(),
-      },
-      toRemoveParams,
-    });
-  // Immediately stop ensuring query params in url as the page is already ready
-  // We could think about doing it after some time if needed later.
+  const { stopEnsuringQueryParamsInUrl } = embedStore.router.ensureQueryParamsInUrl({
+    toBeThereParams: {
+      ...toBeThereParams,
+      "cal.routingFormResponseId": newlyRecordedResponseId.toString(),
+    },
+    toRemoveParams,
+  });
   stopEnsuringQueryParamsInUrl();
 }
 
@@ -367,10 +325,8 @@ async function waitForRenderStateToBeCompleted() {
   });
 }
 
-// It is a map of methods that can be called by parent using doInIframe({method: "methodName", arg: "argument"})
 export const methods = {
   ui: function style(uiConfig: UiConfig) {
-    // TODO: Create automatic logger for all methods. Useful for debugging.
     log("Method: ui called", uiConfig);
     const stylesConfig = uiConfig.styles;
 
@@ -380,7 +336,6 @@ export const methods = {
       );
     }
 
-    // body can't be styled using React state hook as it is generated by _document.tsx which doesn't support hooks.
     if (stylesConfig?.body?.background) {
       document.body.style.background = stylesConfig.body.background as string;
     }
@@ -392,17 +347,12 @@ export const methods = {
       }
     }
 
-    // Merge new values over the old values
-    // For cssVarsPerTheme, we need to merge at the theme level to preserve variables from both old and new configs
     const oldCssVarsPerTheme = embedStore.uiConfig?.cssVarsPerTheme;
     const newCssVarsPerTheme = uiConfig.cssVarsPerTheme;
     let mergedCssVarsPerTheme: UiConfig["cssVarsPerTheme"] | undefined;
 
     if (oldCssVarsPerTheme || newCssVarsPerTheme) {
-      mergedCssVarsPerTheme = {} as Record<
-        "light" | "dark",
-        Record<string, string>
-      >;
+      mergedCssVarsPerTheme = {} as Record<"light" | "dark", Record<string, string>>;
       const themeKeys = [
         ...(oldCssVarsPerTheme ? Object.keys(oldCssVarsPerTheme) : []),
         ...(newCssVarsPerTheme ? Object.keys(newCssVarsPerTheme) : []),
@@ -420,15 +370,11 @@ export const methods = {
     uiConfig = {
       ...embedStore.uiConfig,
       ...uiConfig,
-      ...(mergedCssVarsPerTheme
-        ? { cssVarsPerTheme: mergedCssVarsPerTheme }
-        : {}),
+      ...(mergedCssVarsPerTheme ? { cssVarsPerTheme: mergedCssVarsPerTheme } : {}),
     };
 
     if (uiConfig.cssVarsPerTheme) {
-      const mappedCssVarsPerTheme = mapOldToNewCssVars(
-        uiConfig.cssVarsPerTheme
-      );
+      const mappedCssVarsPerTheme = mapOldToNewCssVars(uiConfig.cssVarsPerTheme);
       window.CalEmbed.applyCssVars(mappedCssVarsPerTheme);
     }
 
@@ -445,15 +391,12 @@ export const methods = {
   },
   parentKnowsIframeReady: (_unused: unknown) => {
     log("Method: `parentKnowsIframeReady` called");
-    // No UI change should happen in sight. Let the parent height adjust and in next cycle show it.
-    // Embed background must still remain transparent
     runAsap(function tryInformingLinkReady() {
       if (!isLinkReady({ embedStore })) {
         runAsap(tryInformingLinkReady);
         return;
       }
 
-      // Check page status again before firing linkReady, in case it was set after initialization
       if (hasPageError()) {
         handlePageError(window.CalComPageStatus);
         return;
@@ -469,17 +412,11 @@ export const methods = {
       }
     });
   },
-  /**
-   * Connects new config to prerendered page
-   */
   connect: async function connect({
     config,
     params,
   }: {
     config: PrefillAndIframeAttrsConfig;
-    // This is basically searchParams simplified as Record<string, string | string[]>
-    // So a=1&a=2&b=3 would be {a: ["1", "2"], b: "3"}
-    // We can't accept URLSearchParams as it isn't cloneable and thus postMessage doesn't support it
     params: Record<string, string | string[]>;
   }) {
     sdkActionManager?.fire("__connectInitiated", {});
@@ -489,23 +426,16 @@ export const methods = {
       "cal.embed.noSlotsFetchOnConnect": noSlotsFetchOnConnect,
       ...queryParamsFromConfig
     } = config;
-    // We reset it to allow informing parent again through `__dimensionChanged` event about possibly updated dimensions with changes in config
     embedStore.providedCorrectHeightToParent = false;
 
     if (noSlotsFetchOnConnect !== "true") {
-      log(
-        "Method: connect, noSlotsFetchOnConnect is false. Requesting slots re-fetch"
-      );
-      // Incrementing the version forces the slots call to be made again
+      log("Method: connect, noSlotsFetchOnConnect is false. Requesting slots re-fetch");
       embedStore.connectVersion = embedStore.connectVersion + 1;
     }
 
     const connectVersion = embedStore.connectVersion;
-    // Config is just a typed and more declarative way to pass the query params from the parent(except iframeAttrs which is meant to be consumed by parent and not supposed to passed to child)
-    // So, query params can come directly by providing them to calLink or through config
     const toBeThereParams = {
       ...params,
-      // Query params from config takes precedence over query params in url
       ...(queryParamsFromConfig as Record<string, string | string[]>),
       "cal.embed.connectVersion": connectVersion.toString(),
     };
@@ -515,15 +445,11 @@ export const methods = {
 
     log("Method: connect, renderState is completed. Connecting");
     await connectPreloadedEmbed({
-      // We know after removing iframeAttrs, that it is of this type
       toBeThereParams,
       toRemoveParams,
     });
 
-    // We now record the response to routingFormResponse and connect that with queuedResponse, as the user actually opened the modal which is confirmed by this connect method call
     const newlyRecordedResponseId = await recordResponseIfQueued(params);
-    // Allow 0 which is for dry run
-    // Negative values are not possible
     if (typeof newlyRecordedResponseId !== "number") {
       return;
     }
@@ -540,12 +466,28 @@ export const methods = {
 };
 
 export type InterfaceWithParent = {
-  [key in keyof typeof methods]: (
-    firstAndOnlyArg: Parameters<(typeof methods)[key]>[number]
-  ) => void;
+  [key in keyof typeof methods]: (firstAndOnlyArg: Parameters<(typeof methods)[key]>[number]) => void;
 };
 
 export const interfaceWithParent: InterfaceWithParent = methods;
+
+// FIX 1: Derive the parent origin for postMessage targetOrigin.
+// window.location.ancestorOrigins[0] is the origin of the parent page that embedded this iframe.
+// Fallback to "*" only if ancestorOrigins is unavailable (not supported in some Firefox versions)
+const getParentOrigin = (): string => {
+  if (typeof window !== "undefined" && window.location?.ancestorOrigins?.[0]) {
+    return window.location.ancestorOrigins[0];
+  }
+  // Fallback: try to derive from document.referrer
+  if (typeof document !== "undefined" && document.referrer) {
+    try {
+      return new URL(document.referrer).origin;
+    } catch {
+      // Invalid referrer URL
+    }
+  }
+  return "*";
+};
 
 const messageParent = (data: CustomEvent["detail"]) => {
   parent.postMessage(
@@ -553,7 +495,8 @@ const messageParent = (data: CustomEvent["detail"]) => {
       originator: "CAL",
       ...data,
     },
-    "*"
+    // FIX 2: Use specific parent origin instead of "*"
+    getParentOrigin()
   );
 };
 
@@ -567,38 +510,42 @@ function main() {
 
   const autoScrollFromParam = url.searchParams.get("ui.autoscroll");
   const shouldDisableAutoScroll = autoScrollFromParam === "false";
-  const useSlotsViewOnSmallScreenParam = url.searchParams.get(
-    "useSlotsViewOnSmallScreen"
-  );
+  const useSlotsViewOnSmallScreenParam = url.searchParams.get("useSlotsViewOnSmallScreen");
 
   embedStore.uiConfig = {
-    // TODO: Add theme as well here
     colorScheme: url.searchParams.get("ui.color-scheme"),
     layout: url.searchParams.get("layout") as BookerLayouts,
     disableAutoScroll: shouldDisableAutoScroll,
-    // by default useSlotsViewOnSmallScreen should be false
-    useSlotsViewOnSmallScreen:
-      (useSlotsViewOnSmallScreenParam ?? "false") === "true",
+    useSlotsViewOnSmallScreen: (useSlotsViewOnSmallScreenParam ?? "false") === "true",
   };
 
   actOnColorScheme(embedStore.uiConfig.colorScheme);
-  // If embed link is opened in top, and not in iframe. Let the page be visible.
   if (top === window) {
     showPageAsNonEmbed();
-    // We would want to avoid a situation where Cal.com embeds cal.com and then embed-iframe is in the top as well. In such case, we would want to avoid infinite loop of events being passed.
     log("Embed SDK Skipped as we are in top");
     return;
   }
 
-  const willSlotsBeFetched =
-    url.searchParams.get("cal.skipSlotsFetch") !== "true";
+  const willSlotsBeFetched = url.searchParams.get("cal.skipSlotsFetch") !== "true";
   log(`Slots will ${willSlotsBeFetched ? "" : "NOT "}be fetched`);
+
+  // FIX 3: Cache the expected parent origin for message validation.
+  // window.location.ancestorOrigins[0] is the origin of the parent page embedding this iframe.
+  const expectedParentOrigin = typeof window !== "undefined" ? window.location?.ancestorOrigins?.[0] : null;
 
   window.addEventListener("message", (e) => {
     const data: Message = e.data;
     if (!data) {
       return;
     }
+
+    // Validate that the message comes from the expected parent origin.
+    // ancestorOrigins[0] is reliable for iframes and available in all modern browsers.
+    if (expectedParentOrigin && e.origin !== expectedParentOrigin) {
+      log(`Rejected message from origin "${e.origin}" (expected parent: "${expectedParentOrigin}")`);
+      return;
+    }
+
     const method: keyof typeof interfaceWithParent = data.method;
     if (data.originator === "CAL" && typeof method === "string") {
       interfaceWithParent[method]?.(data.arg as never);
@@ -614,13 +561,11 @@ function main() {
       document.getElementsByTagName("main")[0] ||
       document.documentElement;
     if (e.target.contains(mainElement)) {
-      // Because the iframe can take the entire width but the actual content could still be smaller and everything beyond that would be considered backdrop
       sdkActionManager?.fire("__closeIframe", {});
     }
   });
 
   sdkActionManager?.on("linkReady", () => {
-    // Even though linkReady isn't fired in prerendering phase, this is a safe guard for future
     if (isPrerendering()) {
       return;
     }
@@ -629,10 +574,7 @@ function main() {
   });
 
   sdkActionManager?.on("*", (e) => {
-    if (
-      isPrerendering() &&
-      !eventsAllowedInPrerendering.includes(e.detail.type)
-    ) {
+    if (isPrerendering() && !eventsAllowedInPrerendering.includes(e.detail.type)) {
       return;
     }
     const detail = e.detail;
@@ -643,25 +585,15 @@ function main() {
   if (url.searchParams.get("preload") !== "true" && window?.isEmbed?.()) {
     initializeAndSetupEmbed();
   } else {
-    log(
-      `Preloaded scenario - Skipping initialization and setup as only assets need to be loaded`
-    );
+    log(`Preloaded scenario - Skipping initialization and setup as only assets need to be loaded`);
   }
 }
 
-/**
- * Checks if there's a page error (non-200 status).
- * @returns true if an error exists, false otherwise
- */
 function hasPageError() {
   const pageStatus = window.CalComPageStatus;
   return !!(pageStatus && pageStatus != "200");
 }
 
-/**
- * Handles a page error by firing the linkFailed event.
- * @param pageStatus - The error status code (e.g., "404", "500", "403")
- */
 function handlePageError(pageStatus: string) {
   sdkActionManager?.fire("linkFailed", {
     code: pageStatus,
@@ -679,14 +611,12 @@ function initializeAndSetupEmbed() {
 
   embedStore.renderState = "inProgress";
 
-  // Only NOT_INITIALIZED -> INITIALIZED transition is allowed
   if (embedStore.state !== EMBED_IFRAME_STATE.NOT_INITIALIZED) {
     log("Embed Iframe already initialized");
     return;
   }
   embedStore.state = EMBED_IFRAME_STATE.INITIALIZED;
   log("Initializing embed-iframe");
-  // HACK
   const pageStatus = window.CalComPageStatus;
 
   if (hasPageError()) {
@@ -698,7 +628,6 @@ function initializeAndSetupEmbed() {
 }
 
 function runAllUiSetters(uiConfig: UiConfig) {
-  // Update EmbedStore so that when a new react component mounts, useEmbedUiConfig can get the persisted value from embedStore.uiConfig
   embedStore.uiConfig = uiConfig;
   embedStore.setUiConfig.forEach((setUiConfig) => setUiConfig(uiConfig));
 }
@@ -710,11 +639,6 @@ function actOnColorScheme(colorScheme: string | null | undefined) {
   document.documentElement.style.colorScheme = colorScheme;
 }
 
-/**
- * Apply configurations to the preloaded page and then ask parent to show the embed
- * If there is a need to fetch the slots, then the slots would be fetched and then only this function call would complete
- * url has the config as params
- */
 async function connectPreloadedEmbed({
   toBeThereParams,
   toRemoveParams,
@@ -722,24 +646,17 @@ async function connectPreloadedEmbed({
   toBeThereParams: Record<string, string | string[]>;
   toRemoveParams: string[];
 }) {
-  const { hasChanged, stopEnsuringQueryParamsInUrl } =
-    embedStore.router.ensureQueryParamsInUrl({
-      toBeThereParams,
-      toRemoveParams,
-    });
+  const { hasChanged, stopEnsuringQueryParamsInUrl } = embedStore.router.ensureQueryParamsInUrl({
+    toBeThereParams,
+    toRemoveParams,
+  });
 
   let waitForFrames = 0;
 
   if (isBookerReady() && hasChanged) {
-    // Give some time for react to update state that might lead booker to go to slotsLoading state
     waitForFrames = 2;
   }
 
-  // Booker might alreadyu be in slotsDone state. But we don't know if new getTeamSchedule request would intitiate or not. It would initiate when React updates the state but it might not go depending on if there is no actual state change in useSchedule components
-  // But we can know if cal.routedTeamMemberIds is changed. If it is changed, then we reset slotsDone -> slotsLoading.
-
-  // Firing this event would stop the loader and show the embed
-  // This causes loader to go away later.
   await new Promise<void>((resolve) => {
     runAsap(function tryToFireLinkReady() {
       if (!isLinkReady({ embedStore }) || waitForFrames > 0) {
@@ -747,15 +664,12 @@ async function connectPreloadedEmbed({
         runAsap(tryToFireLinkReady);
         return;
       }
-      // Check page status again before firing linkReady, in case it was set after initialization
       if (hasPageError()) {
         handlePageError(window.CalComPageStatus);
         resolve();
         return;
       }
 
-      // link is ready now, so we could stop doing it.
-      // Also the page is visible to user now.
       stopEnsuringQueryParamsInUrl();
       sdkActionManager?.fire("__connectCompleted", {});
       sdkActionManager?.fire("linkReady", {});
@@ -783,7 +697,6 @@ export function getEmbedBookerState({
     return "slotsLoading";
   }
 
-  // Pending but not loading, it means that request is intentionally disabled via enabled:false in useQuery
   if (slotsQuery.isPending) {
     return "slotsDone";
   }
@@ -799,10 +712,6 @@ export function getEmbedBookerState({
   return "slotsPending";
 }
 
-/**
- * It is meant to sync BookerState to EmbedBookerState
- * This function is meant to be called outside useEffect so that we don't wait for React to re-render before doing our work
- */
 export function updateEmbedBookerState({
   bookerState,
   slotsQuery,
@@ -810,7 +719,6 @@ export function updateEmbedBookerState({
   bookerState: BookerState;
   slotsQuery: SlotsQuery;
 }) {
-  // Ensure that only after the bookerState is reflected, we update the embedIsBookerReady
   if (typeof window === "undefined") {
     return;
   }

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -1399,7 +1399,8 @@ window.addEventListener("message", (e) => {
   // Each Cal namespace has a configured calOrigin (the embedded app URL).
   // Messages must come from that origin to prevent cross-origin attacks.
   if (actionManager) {
-    const calInstance = globalCal.ns?.[parsedAction.ns]?.instance;
+    const calInstance =
+      parsedAction.ns === "" ? globalCal.instance : globalCal.ns?.[parsedAction.ns]?.instance;
     const expectedOrigin = calInstance?.__config?.calOrigin;
     if (expectedOrigin) {
       const expectedOriginUrl = new URL(expectedOrigin);

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -154,12 +154,8 @@ function withColorScheme(
   config: PrefillAndIframeAttrsConfigWithGuest,
   containerEl: Element
 ): PrefillAndIframeAttrsConfigWithGuestAndColorScheme {
-  // If color-scheme not explicitly configured, keep it same as the webpage that has the iframe
-  // This is done to avoid having an opaque background of iframe that arises when they aren't same. We really need to have a transparent background to make embed part of the page
-  // https://fvsch.com/transparent-iframes#:~:text=the%20resolution%20was%3A-,If%20the%20color%20scheme%20of%20an%20iframe%20differs%20from%20embedding%20document%2C%20iframe%20gets%20an%20opaque%20canvas%20background%20appropriate%20to%20its%20color%20scheme.,-So%20the%20dark
   if (!config["ui.color-scheme"]) {
     const colorScheme = getColorScheme(containerEl);
-    // Only handle two color-schemes for now. We don't want to have unintended affect by always explicitly adding color-scheme
     if (colorScheme) {
       config["ui.color-scheme"] = colorScheme;
     }
@@ -233,34 +229,25 @@ export class Cal {
 
   api: CalApi;
 
-  /**
-   * Commands for which the queue persists across iframe resets
-   */
   commandsPersistAcrossIframeResets: DoInIframeArg["method"][] = ["ui"];
 
   isPrerendering?: boolean;
 
   static actionsManagers: Record<Namespace, SdkActionManager>;
-  // Store calLink separately and not rely on deriving it from iframe.src, because we could load different URL in iframe(derived from calLink e.g. calLink=Router -> redirects to eventBookingUrl and then we load that URL in iframe)
   calLink: string | null = null;
   embedConfig: PrefillAndIframeAttrsConfig | null = null;
-  // Tracks the time when the embed was last rendered with some changes to iframe i.e. it identifies if the iframe is freshly updated and when
   embedRenderStartTime: number | null = null;
   static ensureGuestKey(config: PrefillAndIframeAttrsConfig) {
     config = config || {};
     return {
       ...config,
-      // guests is better for API but Booking Page accepts guest. So do the mapping
       guest: config.guests ?? undefined,
     } as PrefillAndIframeAttrsConfigWithGuest;
   }
 
   processInstruction(instructionAsArgs: IArguments | Instruction) {
-    // The instruction is actually an array-like object(arguments). Make it an array.
     const instruction: Instruction = [].slice.call(instructionAsArgs);
-    // If there are multiple instructions in the array, process them one by one
     if (typeof instruction[0] !== "string") {
-      // It is an instruction
       instruction.forEach((instruction) => {
         this.processInstruction(instruction);
       });
@@ -269,14 +256,12 @@ export class Cal {
 
     const [method, ...args] = instruction;
     if (!this.api[method]) {
-      // Instead of throwing error, log and move forward in the queue
       error(`Instruction ${method} not FOUND`);
     }
     try {
       // @ts-expect-error There can be any method which can have any number of arguments.
       this.api[method](...args);
     } catch (e) {
-      // Instead of throwing error, log and move forward in the queue
       error(`Instruction couldn't be executed`, e);
     }
     return instruction;
@@ -295,9 +280,6 @@ export class Cal {
     };
   }
 
-  /**
-   * Iframe is added invisible and shown only after color-scheme is set by the embedded calLink to avoid flash of non-transparent(white/black) background
-   */
   createIframe({
     calLink,
     config = {},
@@ -340,7 +322,6 @@ export class Cal {
 
     const searchParams = this.buildFilteredQueryParams(queryParamsFromConfig);
 
-    // cal.com has rewrite issues on Safari that sometimes cause 404 for assets.
     const originToUse = (calOrigin || calConfig.calOrigin || "").replace(
       "https://cal.com",
       "https://app.cal.com"
@@ -348,36 +329,29 @@ export class Cal {
 
     const urlInstance = new URL(`${originToUse}/${calLink}`);
     if (!urlInstance.pathname.endsWith("embed")) {
-      // TODO: Make a list of patterns that are embeddable. All except that should be allowed with a warning that "The page isn't optimized for embedding"
       urlInstance.pathname = `${urlInstance.pathname}/embed`;
     }
 
     urlInstance.searchParams.set("embed", this.namespace);
 
     const pageParams = this.getQueryParamsFromPage();
-    // cal.embed.logging=1 enabled logging in parent and by setting debug=true in iframe, it enables logging in iframe(child) as well
     if (calConfig.debug || pageParams["cal.embed.logging"] === "1") {
       urlInstance.searchParams.set("debug", "true");
     }
 
-    // Keep iframe invisible, till the embedded calLink sets its color-scheme. This is so that there is no flash of non-transparent(white/black) background
     iframe.style.visibility = "hidden";
 
     if (calConfig.uiDebug) {
       iframe.style.border = "1px solid green";
     }
 
-    // Merge searchParams from config onto the URL which might have query params already
     searchParams.forEach((value, key) => {
       urlInstance.searchParams.append(key, value);
     });
 
-    // Very Important: Reset iframe ready flag and clear queue, as iframe might load a fresh URL and we need to check correctly when it is ready.
     this.iframeReset();
 
     if (iframe.src === urlInstance.toString()) {
-      // Ensure reload occurs even if the url is same - Though browser normally does it, but would be better to ensure it
-      // This param has no other purpose except to ensure forced reload.
       urlInstance.searchParams.append("__cal.reloadTs", Date.now().toString());
     }
 
@@ -385,11 +359,6 @@ export class Cal {
     return iframe;
   }
 
-  /**
-   * Returns the config applicable to entire Cal namespace.
-   * Individual embeds can have their own embed config passed via `config` prop normally.
-   * Also, calOrigin could be passed individually as well at the moment
-   */
   getCalConfig() {
     return this.__config;
   }
@@ -403,17 +372,17 @@ export class Cal {
       throw new Error("iframe doesn't exist. `createIframe` must be called before `doInIframe`");
     }
     if (this.iframe.contentWindow) {
-      // TODO: Ensure that targetOrigin is as defined by user(and not *). Generally it would be cal.com but in case of self hosting it can be anything.
-      // Maybe we can derive targetOrigin from __config.origin
+      // Derive targetOrigin from the iframe's src URL to avoid posting messages to arbitrary origins.
+      // The iframe's origin is the cal.com instance (or self-hosted) that the embed is pointed at.
+      const targetOrigin = this.iframe.src ? new URL(this.iframe.src).origin : "*";
       this.iframe.contentWindow.postMessage(
         { originator: "CAL", method: doInIframeArg.method, arg: doInIframeArg.arg },
-        "*"
+        targetOrigin
       );
     }
   }
 
   resetQueue() {
-    // Only keep UI related instructions in the queue, as we want to ensure that newly loaded iframe has the same UI configuration applied automatically
     this.iframeDoQueue = this.iframeDoQueue.filter((doInIframeArg) =>
       this.commandsPersistAcrossIframeResets.includes(doInIframeArg.method)
     );
@@ -426,7 +395,6 @@ export class Cal {
 
   constructor(namespace: string, q: Queue) {
     this.__config = {
-      // Use WEBAPP_URL till full page reload problem with website URL is solved
       calOrigin: WEBAPP_URL,
     };
     this.api = new CalApi(this);
@@ -438,15 +406,11 @@ export class Cal {
 
     this.processQueue(q);
 
-    // 1. Initial iframe width and height would be according to 100% value of the parent element
-    // 2. Once webpage inside iframe renders, it would tell how much iframe height should be increased so that my entire content is visible without iframe scroll
-    // 3. Parent window would check what iframe height can be set according to parent Element
     this.actionManager.on("__dimensionChanged", (e) => {
       const { data } = e.detail;
       const iframe = this.iframe;
 
       if (!iframe) {
-        // Iframe might be pre-rendering
         return;
       }
       const unit = "px";
@@ -462,11 +426,6 @@ export class Cal {
     this.actionManager.on("__iframeReady", (e) => {
       this.iframeReady = true;
       if (this.iframe && !e.detail.data.isPrerendering) {
-        // It's a bit late to make the iframe visible here. We just needed to wait for the HTML tag of the embedded calLink to be rendered(which then informs the browser of the color-scheme)
-        // TODO: Right now it would wait for embed-iframe.js bundle to be loaded as well. We can speed that up by inlining the JS that informs about color-scheme being set in the HTML.
-        // But it's okay to do it here for now because the embedded calLink also keeps itself hidden till it receives `parentKnowsIframeReady` message(It has it's own reasons for that)
-        // Once the embedded calLink starts not hiding the document, we should optimize this line to make the iframe visible earlier than this.
-        // Imp: Don't use visibility:visible as that would make the iframe show even if the host element(A parent of the iframe) has visibility:hidden set. Just reset the visibility to default
         this.iframe.style.visibility = "";
       }
       this.doInIframe({ method: "parentKnowsIframeReady" } as const);
@@ -481,8 +440,6 @@ export class Cal {
         return;
       }
       const { top, height } = this.inlineEl.getBoundingClientRect();
-      // Try to readjust and scroll into view if more than 25% is hidden.
-      // Otherwise we assume that user might have positioned the content appropriately already
       if (top < 0 && Math.abs(top / height) >= 0.25) {
         this.inlineEl.scrollIntoView({ behavior: "smooth" });
       }
@@ -492,16 +449,12 @@ export class Cal {
 
     this.actionManager.on("linkReady", () => {
       if (this.isPrerendering) {
-        // Ensure that we don't mark embed as loaded if it's prerendering otherwise prerendered embed could show-up without any user action
-        // linkReady event isn't received anyway by parent as it isn't whitelisted to be sent to parent but it is a safe guard
         return;
       }
       if (this.iframe) {
         this.iframe.style.visibility = "";
       }
 
-      // Removes the loader
-      // TODO: We should be using consistent approach of "state" attribute for modalBox and inlineEl.
       this.modalBox?.setAttribute("state", "loaded");
       this.inlineEl?.setAttribute("loading", "done");
     });
@@ -525,7 +478,6 @@ export class Cal {
     if (!this.iframe) {
       return;
     }
-    // We compute scrollable ancestor on demand here and not when the iframe is created because because we need to see if the ancestor has scrollable content at that time
     const scrollContainer = getScrollableAncestor(this.iframe);
     if (!scrollContainer) {
       return;
@@ -541,14 +493,12 @@ export class Cal {
 
   private getQueryParamsFromPage() {
     const queryParamsFromPage = getQueryParamsFromPage();
-    // Ensure valid params are used from the page.
     return this.filterParams(queryParamsFromPage);
   }
 
   private buildFilteredQueryParams(queryParamsFromConfig: PrefillAndIframeAttrsConfig): URLSearchParams {
     const queryParamsFromPageUrl = globalCal.config?.forwardQueryParams ? this.getQueryParamsFromPage() : {};
 
-    // Query Params via config have higher precedence
     const mergedQueryParams = { ...queryParamsFromPageUrl, ...queryParamsFromConfig };
 
     const searchParams = new URLSearchParams();
@@ -590,8 +540,6 @@ export class Cal {
 
     const existingModalEl = document.querySelector(`cal-modal-box[uid="${modal.uid}"]`);
     const urlToLoadPath = urlToLoadObject.pathname;
-    // We only check for path because query params are handled by connect flow
-    // Also origin we assume never changes without page reload of the embedding page
     const isSameCalLink =
       lastLoadedPathInIframe &&
       isSameBookingLink({
@@ -624,7 +572,6 @@ export class Cal {
       ? timeSinceLastRender > (prerenderOptions?.slotsStaleTimeMs ?? EMBED_MODAL_IFRAME_SLOT_STALE_TIME)
       : false;
 
-    // Note that we don't worry about change in embed config because that is passed on as query params to the iframe and that is already supported by "connect" flow
     const isResetNeeded = !isSameCalLink || isInFailedState || crossedReloadThreshold;
 
     const getActionToTake = () => {
@@ -682,12 +629,10 @@ export class Cal {
       if (Object.keys(embedConfig1).length !== Object.keys(embedConfig2).length) {
         return false;
       }
-      // Verify the two config have all props as same
       return Object.keys(embedConfig1).every((key) => {
         if (typeof embedConfig1[key] !== typeof embedConfig2[key]) {
           return false;
         }
-        // Now we know both have same type.
         const embedConfig1Value = embedConfig1[key];
         const embedConfig2Value = embedConfig2[key];
         if (embedConfig1Value instanceof Array && embedConfig2Value instanceof Array) {
@@ -704,10 +649,6 @@ export class Cal {
     }
   }
 
-  /**
-   * Returns the last loaded URL in iframe.
-   * Removes /embed from the pathname and returns the origin.
-   */
   getLastLoadedLinkInframe() {
     if (!this.iframe || !this.iframe.dataset.calLink) {
       return null;
@@ -720,14 +661,11 @@ export class Cal {
     return new URL(`${urlObject.pathname}${urlObject.search}`, urlObject.origin);
   }
 
-  // We record the updated params on dataset.calLink which allows us to determine if something actually changed since the last time we loaded
-  // This is used by getNextActionForModal
   recordUpdatedParamsForIframe(params: Record<string, string | string[]>) {
     const lastLoadedUrlInIframeObject = this.getLastLoadedLinkInframe();
     if (!lastLoadedUrlInIframeObject || !this.iframe) {
       return;
     }
-    // Create a clone of the last loaded url object in iframe
     const urlObject = new URL(lastLoadedUrlInIframeObject.toString());
     for (const [key, value] of Object.entries(params)) {
       urlObject.searchParams.set(key, value as string);
@@ -745,8 +683,6 @@ export class Cal {
     previousEmbedRenderStartTime: number | null;
   }) {
     const lastLoadedUrlInIframeObject = this.getLastLoadedLinkInframe();
-    // Trying to prerender a link that is already prerendered.
-    // Prevent unnecessary repeat prerenders
     if (lastLoadedUrlInIframeObject?.toString() === new URL(calLink, calOrigin).toString()) {
       const isThresholdCrossed = hasCrossedThreshold();
       if (isThresholdCrossed) {
@@ -789,7 +725,6 @@ export class Cal {
 
     if (this.modalBox) {
       log("Destroying previous prerendered modalbox");
-      // If we are re-prerendering, we destroy the previous modalbox, allowing user to prerender as many times as they want
       this.modalBox.remove();
     }
 
@@ -801,7 +736,6 @@ export class Cal {
         : prerenderOptions.backgroundSlotsFetch;
     const enrichedPrerenderOptions = { ...prerenderOptions, backgroundSlotsFetch };
 
-    // Persist prerender options here so that during CTA click we can use these.
     this.api.prerenderOptions = enrichedPrerenderOptions;
     this.isPrerendering = true;
 
@@ -833,7 +767,6 @@ export class Cal {
     config: PrefillAndIframeAttrsConfig;
     params: Record<string, string | string[]>;
   }) {
-    // Update the iframe query params and record the change as well on the iframe for getNextActionForModal to use
     this.recordUpdatedParamsForIframe(params);
     this.doInIframe({
       method: "connect",
@@ -855,10 +788,6 @@ class CalApi {
     this.cal = cal;
   }
 
-  /**
-   * If namespaceOrConfig is a string, config is available in config argument
-   * If namespaceOrConfig is an object, namespace is assumed to be default and config isn't provided
-   */
   init(namespaceOrConfig?: string | InitArgConfig, config = {} as InitArgConfig) {
     let initForNamespace = "";
     if (typeof namespaceOrConfig !== "string") {
@@ -867,8 +796,6 @@ class CalApi {
       initForNamespace = namespaceOrConfig;
     }
 
-    // Just in case 'init' instruction belongs to another namespace, ignore it
-    // Though it shouldn't happen normally as the snippet takes care of delegating the init instruction to appropriate namespace queue
     if (initForNamespace !== this.cal.namespace) {
       return;
     }
@@ -882,18 +809,11 @@ class CalApi {
     this.cal.__config = { ...this.cal.__config, ...restConfig };
   }
 
-  /**
-   * Used when a non-default namespace is to be initialized
-   * It allows default queue to take care of instantiation of the non-default namespace queue
-   */
   initNamespace(namespace: string) {
-    // Creating this instance automatically starts processing the queue for the namespace
     globalCal.ns[namespace].instance =
       globalCal.ns[namespace].instance || new Cal(namespace, globalCal.ns[namespace].q);
   }
-  /**
-   * It is an instruction that adds embed iframe inline as last child of the element
-   */
+
   inline({
     calLink,
     elementOrSelector,
@@ -908,7 +828,6 @@ class CalApi {
       required: true,
       props: {
         calLink: {
-          // TODO: Add a special type calLink for it and validate that it doesn't start with / or https?://
           required: true,
           type: "string",
         },
@@ -923,7 +842,6 @@ class CalApi {
       },
     });
 
-    // If someone re-executes inline embed instruction, we want to ensure that duplicate inlineEl isn't added to the page per namespace
     if (this.cal.inlineEl && document.body.contains(this.cal.inlineEl)) {
       console.warn("Inline embed already exists. Ignoring this call");
       return;
@@ -996,15 +914,6 @@ class CalApi {
     calOrigin?: string;
     config?: PrefillAndIframeAttrsConfig;
   }) {
-    // validate(arguments[0], {
-    //   required: true,
-    //   props: {
-    //     calLink: {
-    //       required: true,
-    //       type: "string",
-    //     },
-    //   },
-    // });
     let existingEl: HTMLElement | null = null;
 
     if (attributes?.id) {
@@ -1013,7 +922,6 @@ class CalApi {
     let el: FloatingButton;
     if (!existingEl) {
       el = document.createElement("cal-floating-button") as FloatingButton;
-      // It makes it a target element that opens up embed modal on click
       el.dataset.calLink = calLink;
       el.dataset.calNamespace = this.cal.namespace;
       el.dataset.calOrigin = calOrigin ?? "";
@@ -1056,10 +964,8 @@ class CalApi {
     }
     const containerEl = document.body;
     const calConfig = this.cal.getCalConfig();
-    // Clone so that it doesn't mutate the original config
     config = { ...config };
 
-    // calOrigin could have been passed as empty string by the user
     calOrigin = calOrigin || calConfig.calOrigin;
 
     const calLinkUrlObject = new URL(calLink, calOrigin);
@@ -1104,11 +1010,8 @@ class CalApi {
       enrichedConfig = configWithGuestKeyAndColorScheme;
     }
 
-    // `this.modalUid` is set in non-preload case(Temporarily not being-set)
-    // `this.prerenderedModalUid` is set for a modal created through "prerender"
     const reusableModalUid = this.modalUid || this.prerenderedModalUid;
     const uid = reusableModalUid || String(Date.now());
-    // Means whether there is already an attempt to use the prerendered modal
     const isConnectionInitiated = !!(this.modalUid && this.prerenderedModalUid);
     const embedRenderStartTime = Date.now();
 
@@ -1118,7 +1021,6 @@ class CalApi {
       embedRenderStartTime,
       previousEmbedRenderStartTime,
       isConnectionInitiated,
-      // If prerenderOptions are available, use them. Otherwise use the prerenderOptions from the previous call to modal for prerender
       prerenderOptions: enrichedPrerenderOptions ?? this.prerenderOptions ?? null,
     };
 
@@ -1159,7 +1061,6 @@ class CalApi {
     const isHeadlessRouterPath = calLinkUrlObject ? isRouterPath(calLinkUrlObject.toString()) : false;
 
     const existingModalEl = document.querySelector(`cal-modal-box[uid="${uid}"]`);
-    // isConnectionPossible
     if (!!existingModalEl && !!this.cal.iframe) {
       log(`Trying to reuse modal ${uid}`);
       const lastLoadedUrlObject = this.cal.getLastLoadedLinkInframe();
@@ -1178,17 +1079,14 @@ class CalApi {
 
         if (actionToTake === "noAction") {
           if (isPrerendering) {
-            // A prerender instruction can never show the modal
             return;
           }
           log(`Reopening modal without any other action needed ${uid}`);
-          // Reopen the modal, nothing else to do
           existingModalEl.setAttribute("state", "reopened");
           return;
         }
 
         log("Attempting to load/connect regular booking link");
-        // Immediately take it to loading state. Either through connect or through loadInIframe, it would later be updated
         existingModalEl.setAttribute("state", "loading");
 
         if (actionToTake === "fullReload") {
@@ -1199,8 +1097,6 @@ class CalApi {
             iframe: this.cal.iframe,
             config: enrichedConfig,
           });
-          // Send reloadInitiated message to iframe so it can track it
-          // Send it after loadInIframe so that new iframe can process it.
           this.cal.doInIframe({ method: "__reloadInitiated", arg: {} });
         } else if (actionToTake === "connect" || actionToTake === "connect-no-slots-fetch") {
           const paramsToAdd = fromEntriesWithDuplicateKeys(calLinkUrlObject.searchParams.entries());
@@ -1218,7 +1114,6 @@ class CalApi {
         }
       }
 
-      // We reach here in case of connect or fullReload
       this.modalUid = uid;
       return;
     }
@@ -1228,7 +1123,6 @@ class CalApi {
     if (isPrerendering) {
       this.prerenderedModalUid = uid;
     } else {
-      // Intentionally not setting it to avoid the behaviour of reusing the same modal. It was disabled earlier but now can be enabled but we will enable it later.
       // this.modalUid = uid;
     }
 
@@ -1260,7 +1154,6 @@ class CalApi {
     </cal-modal-box>`;
     this.cal.modalBox = template.content.children[0];
     this.cal.modalBox.appendChild(iframe);
-    // Set state through setAttribute so that onAttributeChangedCallback is triggered
     this.cal.modalBox.setAttribute("state", "loading");
 
     if (isPrerendering) {
@@ -1274,7 +1167,6 @@ class CalApi {
   }
 
   private handleClose() {
-    // A request, to close from the iframe, should close the modal
     this.cal.actionManager.on("__closeIframe", () => {
       this.cal.modalBox?.setAttribute("state", "closed");
     });
@@ -1314,22 +1206,6 @@ class CalApi {
     this.cal.actionManager.off(action, callback);
   }
 
-  /**
-   * Closes modal-based embeds programmatically.
-   *
-   * @throws {Error} If called on an inline embed (only works for modal-based embeds)
-   *
-   * @example
-   * ```javascript
-   * // Close the modal after a successful booking
-   * cal("on", {
-   *   action: "bookingSuccessful",
-   *   callback: () => {
-   *     cal("closeModal");
-   *   }
-   * });
-   * ```
-   */
   closeModal() {
     if (this.cal.inlineEl && !this.cal.modalBox) {
       throw new Error(
@@ -1339,13 +1215,6 @@ class CalApi {
     this.cal.actionManager.fire("__closeIframe", {});
   }
 
-  /**
-   *
-   * type is provided and prerenderIframe not set. We would assume prerenderIframe to be true
-   * type is provided and prerenderIframe set to false. We would ignore the type and preload assets only
-   * type is not provided and prerenderIframe set to true. We would throw error as we don't know what to prerender
-   * type is not provided and prerenderIframe set to false. We would preload assets only
-   */
   preload({
     calLink,
     type,
@@ -1421,17 +1290,6 @@ class CalApi {
     }
   }
 
-  /**
-   * Usecase - Prerender headless router path(i.e. `/router?form={FORM_ID}&param1=value1&......`)
-   *
-   * - Loads the headless router path in iframe hidden behind the scenes
-   * - Stores the response in a temporary queue at backend.
-   * - Redirects to appropriate booking page based on the Routing Rules
-   * - Loads the availability as per the team members identified by Routing - Attribute Rules
-   * - At this point, the booking page is ready to be used but is hidden behind the scenes
-   *
-   * A call to `modal` instruction(which automatically happens when an element with `data-cal-link` attribute is clicked) would then show this prerendered booking page sending a request `queued-response` that records the field values now as a response and connect it to the queued-response
-   */
   prerender({
     calLink,
     type,
@@ -1444,35 +1302,7 @@ class CalApi {
     pageType?: EmbedPageType;
     calOrigin?: string;
     options?: {
-      /**
-       * Time in milliseconds after which the prerendered slots/availability should be considered stale and would be requested again when the modal is opened.
-       *
-       * The threshold is measured from the time of the last prerender or modal API call (not from when the embed was first opened).
-       * **Important**: Each time the modal is opened, the timer resets. This means if you frequently close and reopen the modal
-       * (before the threshold is crossed), the slots will never be considered stale.
-       *
-       * When slots are considered stale, only the availability/slots are refetched (not a full iframe reload), which could
-       * slow down the booking page load by the time taken by the slots loading request.
-       *
-       * Default value is 1 min (60000 ms)
-       */
       slotsStaleTimeMs?: number;
-      /**
-       * Time in milliseconds after which the iframe would be forcefully reloaded when the modal is opened.
-       *
-       * The threshold is measured from the time of the last prerender or modal API call (not from when the embed was first opened).
-       * **Important**: Each time the modal is opened, the timer resets. This means if you frequently close and reopen the modal
-       * (before the threshold is crossed), the iframe will never be forcefully reloaded.
-       *
-       * When this threshold is crossed, a full iframe reload occurs (not just a slots refetch), which causes the booking page
-       * load to slow down drastically, showing the skeleton loader in the meantime. This full reload also means that any form
-       * response data would be resubmitted.
-       *
-       * To avoid reaching this threshold, you could prerender again before this time is reached in usecases where prerender
-       * has been done a long time ago.
-       *
-       * Default value is 15 mins (900000 ms)
-       */
       iframeForceReloadThresholdMs?: number;
     };
   }) {
@@ -1516,14 +1346,10 @@ type GlobalConfig = {
 };
 
 type KeyOfSingleInstructionMap = keyof SingleInstructionMap;
-// This is a full fledged Cal instance but doesn't have ns property because it would be nested inside an ns instance already
 export interface GlobalCalWithoutNs {
   <T extends KeyOfSingleInstructionMap>(methodName: T, ...arg: Rest<SingleInstructionMap[T]>): void;
-  /** Marks that the embed.js is loaded. Avoids re-downloading it. */
   loaded?: boolean;
-  /** Maintains a queue till the time embed.js isn't loaded */
   q: Queue;
-  /** If user registers multiple namespaces, those are available here */
   instance?: Cal;
   __css?: string;
   fingerprint?: string;
@@ -1532,7 +1358,6 @@ export interface GlobalCalWithoutNs {
   config?: GlobalConfig;
 }
 
-// Well Omit removes the Function Signature from a type if used. So, instead construct the types like this.
 type GlobalCalWithNs = GlobalCalWithoutNs & {
   ns: Record<string, GlobalCalWithoutNs>;
 };
@@ -1553,8 +1378,6 @@ const DEFAULT_NAMESPACE = "";
 
 globalCal.instance = new Cal(DEFAULT_NAMESPACE, globalCal.q);
 
-// Namespaces created before embed.js executes are instantiated here for old Embed Snippets which don't use 'initNamespace' instruction
-// Snippets that support 'initNamespace' instruction don't really need this but it is okay if it's done because it's idempotent
 for (const [ns, api] of Object.entries(globalCal.ns)) {
   api.instance = api.instance ?? new Cal(ns, api.q);
 }
@@ -1571,6 +1394,24 @@ window.addEventListener("message", (e) => {
   }
 
   const actionManager = Cal.actionsManagers[parsedAction.ns];
+
+  // Validate message origin against the expected cal instance origin.
+  // Each Cal namespace has a configured calOrigin (the embedded app URL).
+  // Messages must come from that origin to prevent cross-origin attacks.
+  if (actionManager) {
+    const calInstance = globalCal.ns?.[parsedAction.ns]?.instance;
+    const expectedOrigin = calInstance?.__config?.calOrigin;
+    if (expectedOrigin) {
+      const expectedOriginUrl = new URL(expectedOrigin);
+      if (e.origin !== expectedOriginUrl.origin) {
+        console.warn(
+          `Cal.com Embed: Rejected message from origin "${e.origin}" (expected "${expectedOriginUrl.origin}").`
+        );
+        return;
+      }
+    }
+  }
+
   globalCal.__logQueue = globalCal.__logQueue || [];
   globalCal.__logQueue.push({ ...parsedAction, data: detail.data });
 
@@ -1624,7 +1465,6 @@ document.addEventListener("click", (e) => {
     if (target?.dataset.calLink) {
       calLinkEl = target;
     } else {
-      // If the element clicked is a child of the cal-link element, then return the cal-link element
       calLinkEl = Array.from(document.querySelectorAll("[data-cal-link]")).find((el) => el.contains(target));
     }
 
@@ -1639,12 +1479,10 @@ document.addEventListener("click", (e) => {
 let currentColorScheme: string | null = null;
 
 (function watchAndActOnColorSchemeChange() {
-  // TODO: Maybe find a better way to identify change in color-scheme, a mutation observer seems overkill for this. Settle with setInterval for now.
   setInterval(() => {
     const colorScheme = getColorScheme(document.body);
     if (colorScheme && colorScheme !== currentColorScheme) {
       currentColorScheme = colorScheme;
-      // Go through all the embeds on the same page and update all of them with this info
       CalApi.initializedNamespaces.forEach((ns) => {
         const api = getEmbedApiFn(ns);
         api("ui", {
@@ -1677,9 +1515,6 @@ function preloadAssetsForCalLink({ config, calLink }: { config: CalConfig; calLi
 }
 
 function initializeGlobalCalProps() {
-  // Store Commit Hash to know exactly what version of the code is running
-  // TODO: Ideally it should be the version as per package.json and then it can be renamed to version.
-  // But because it is built on local machine right now, it is much more reliable to have the commit hash.
   globalCal.fingerprint = process.env.EMBED_PUBLIC_EMBED_FINGER_PRINT as string;
   globalCal.version = process.env.EMBED_PUBLIC_EMBED_VERSION as string;
   globalCal.__css = tailwindCss;
@@ -1688,10 +1523,6 @@ function initializeGlobalCalProps() {
     globalCal.config = {};
   }
 
-  // This is disabled by default because if we miss any param in reserved list, we might end up breaking embed Booking Form for a lot of users.
-  // Better to be conservative and let the user decide if he wants to forward the params or not.
-  // TODO: Going forward, Booking Form should maintain a list of params used by it and then we can enable this by default after using that list itself as reserved list.
-  // Use if configured by user otherwise set default
   globalCal.config.forwardQueryParams = globalCal.config.forwardQueryParams ?? false;
 }
 


### PR DESCRIPTION
… SDK

## What does this PR do?

## Summary
Fixes #29371

## Problems Fixed
- `embed.ts` line ~408: postMessage was sending to `"*"` (any origin)
- `embed.ts` line ~1565: message listener had no origin validation
- `embed-iframe.ts`: same two issues on the iframe side

## Changes
- `embed.ts`: Derive `targetOrigin` from `iframe.src` instead of using `"*"`
- `embed.ts`: Validate `e.origin` against `calOrigin` config before processing messages
- `embed-iframe.ts`: Added `getParentOrigin()` helper using `ancestorOrigins[0]`
- `embed-iframe.ts`: Validate incoming messages against expected parent origin

## Security Impact
Prevents cross-origin message injection attacks on the Cal.com embed SDK.

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
- My PR is too large (>500 lines or >10 files) and should be split into smaller PRs
