### PR TITLE
fix(security): restrict CORS wildcard in API v2 and add missing secur…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -481,3 +481,6 @@ TRIGGER_DEV_PROJECT_REF=
 
 GOOGLE_ADS_ENABLED=1      # To enable Google Ads tracking (gclid)
 LINKEDIN_ADS_ENABLED=1    # To enable LinkedIn Ads tracking (li_fat_id)
+# Comma-separated list of allowed CORS origins for the v2 API
+# Example: https://app.cal.com,https://cal.yourdomain.com
+CORS_ALLOWED_ORIGINS=http://localhost:3000

--- a/apps/api/v2/src/bootstrap.ts
+++ b/apps/api/v2/src/bootstrap.ts
@@ -58,7 +58,14 @@ export const bootstrap = (app: NestExpressApplication): NestExpressApplication =
         return callback(new Error(`Origin ${origin} not allowed by CORS policy`));
       },
       methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "OPTIONS"],
-      allowedHeaders: ["Content-Type", "Authorization", "X-Cal-Secret-Key"],
+      allowedHeaders: [
+        "Content-Type",
+        "Authorization",
+        "X-Cal-Secret-Key",
+        CAL_API_VERSION_HEADER,
+        X_CAL_CLIENT_ID,
+        X_CAL_PLATFORM_EMBED,
+      ],
       credentials: true,
       maxAge: 86400, // Cache preflight for 24 hours
     });

--- a/apps/api/v2/src/bootstrap.ts
+++ b/apps/api/v2/src/bootstrap.ts
@@ -40,20 +40,27 @@ export const bootstrap = (app: NestExpressApplication): NestExpressApplication =
       defaultVersion: VERSION_2024_04_15,
     });
     app.use(helmet());
+    // FIXED
+    const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS ?? process.env.NEXT_PUBLIC_WEBAPP_URL ?? "")
+      .split(",")
+      .map((o) => o.trim())
+      .filter(Boolean);
+
     app.enableCors({
-      origin: "*",
-      methods: ["GET", "PATCH", "DELETE", "HEAD", "POST", "PUT", "OPTIONS"],
-      allowedHeaders: [
-        X_CAL_CLIENT_ID,
-        X_CAL_SECRET_KEY,
-        X_CAL_PLATFORM_EMBED,
-        CAL_API_VERSION_HEADER,
-        "Accept",
-        "Authorization",
-        "Content-Type",
-        "Origin",
-      ],
-      maxAge: 86_400,
+      origin: (origin, callback) => {
+        // Allow server-to-server requests (no origin header) and tools like Swagger UI
+        if (!origin) {
+          return callback(null, true);
+        }
+        if (allowedOrigins.includes(origin)) {
+          return callback(null, true);
+        }
+        return callback(new Error(`Origin ${origin} not allowed by CORS policy`));
+      },
+      methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "OPTIONS"],
+      allowedHeaders: ["Content-Type", "Authorization", "X-Cal-Secret-Key"],
+      credentials: true,
+      maxAge: 86400, // Cache preflight for 24 hours
     });
     app.useGlobalPipes(
       new ValidationPipe({

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -383,21 +383,24 @@ const nextConfig = (phase: string): NextConfig => {
   };
 
   const CSP_HEADER = {
-    key: "Content-Security-Policy",
-    value: [
-      "default-src 'self'",
-      "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://js.stripe.com https://maps.googleapis.com",
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-      "font-src 'self' https://fonts.gstatic.com",
-      "img-src 'self' data: blob: https:",
-      "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
-      "connect-src 'self' https:" + (isDev ? " ws://localhost:*" : ""),
-      "object-src 'none'",
-      "base-uri 'self'",
-      "form-action 'self'",
-      "upgrade-insecure-requests",
-    ].join("; "),
-  };
+  key: "Content-Security-Policy",
+  value: [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://js.stripe.com https://maps.googleapis.com",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    "img-src 'self' data: blob: https:",
+    "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
+    "connect-src 'self' https:" + (isDev ? " ws://localhost:*" : ""),
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    // Only upgrade insecure requests in HTTPS environments (same condition as HSTS)
+    ...(!isDev && process.env.NEXT_PUBLIC_DISABLE_HSTS !== "true"
+      ? ["upgrade-insecure-requests"]
+      : []),
+  ].join("; "),
+};
 
   // HSTS is skipped in dev to avoid breaking local HTTP.
   // Self-hosters on HTTP-only can set NEXT_PUBLIC_DISABLE_HSTS=true.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -368,136 +368,181 @@ const nextConfig = (phase: string): NextConfig => {
         afterFiles,
       };
     },
-    async headers() {
-      const { orgSlug } = nextJsOrgRewriteConfig;
-      const CORP_CROSS_ORIGIN_HEADER = {
-        key: "Cross-Origin-Resource-Policy",
-        value: "cross-origin",
-      };
+  async headers() {
+  const { orgSlug } = nextJsOrgRewriteConfig;
+  const isDev = process.env.NODE_ENV === "development";
 
-      const ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = {
-        key: "Access-Control-Allow-Origin",
-        value: "*",
-      };
+  const CORP_CROSS_ORIGIN_HEADER = {
+    key: "Cross-Origin-Resource-Policy",
+    value: "cross-origin",
+  };
 
-      return [
+  const ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = {
+    key: "Access-Control-Allow-Origin",
+    value: "*",
+  };
+
+  const CSP_HEADER = {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://js.stripe.com https://maps.googleapis.com",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+      "font-src 'self' https://fonts.gstatic.com",
+      "img-src 'self' data: blob: https:",
+      "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
+      "connect-src 'self' https:" + (isDev ? " ws://localhost:*" : ""),
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "upgrade-insecure-requests",
+    ].join("; "),
+  };
+
+  // HSTS is skipped in dev to avoid breaking local HTTP.
+  // Self-hosters on HTTP-only can set NEXT_PUBLIC_DISABLE_HSTS=true.
+  const HSTS_HEADER =
+    !isDev && process.env.NEXT_PUBLIC_DISABLE_HSTS !== "true"
+      ? {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload",
+        }
+      : null;
+
+  return [
+    {
+      source: "/auth/:path*",
+      headers: [
         {
-          source: "/auth/:path*",
-          headers: [
-            {
-              key: "X-Frame-Options",
-              value: "DENY",
-            },
-          ],
+          key: "X-Frame-Options",
+          value: "DENY",
         },
-        {
-          source: "/signup",
-          headers: [
-            {
-              key: "X-Frame-Options",
-              value: "DENY",
-            },
-          ],
-        },
-        {
-          source: "/:path*",
-          headers: [
-            {
-              key: "X-Content-Type-Options",
-              value: "nosniff",
-            },
-            {
-              key: "Referrer-Policy",
-              value: "strict-origin-when-cross-origin",
-            },
-          ],
-        },
-        {
-          source: "/embed/embed.js",
-          headers: [CORP_CROSS_ORIGIN_HEADER],
-        },
-        {
-          source: "/:path*/embed",
-          headers: [CORP_CROSS_ORIGIN_HEADER],
-        },
-        {
-          source: "/:path*",
-          has: [
-            {
-              type: "host" as const,
-              value: "cal.com",
-            },
-          ],
-          headers: [
-            {
-              key: "Referrer-Policy",
-              value: "no-referrer-when-downgrade",
-            },
-          ],
-        },
-        {
-          source: "/api/avatar/:path*",
-          headers: [CORP_CROSS_ORIGIN_HEADER],
-        },
-        {
-          source: "/avatar.svg",
-          headers: [CORP_CROSS_ORIGIN_HEADER],
-        },
-        {
-          source: "/icons/sprite.svg(\\?v=[0-9a-zA-Z\\-\\.]+)?",
-          headers: [
-            CORP_CROSS_ORIGIN_HEADER,
-            ACCESS_CONTROL_ALLOW_ORIGIN_HEADER,
-            {
-              key: "Cache-Control",
-              value: "public, max-age=31536000, immutable",
-            },
-          ],
-        },
-        ...(isOrganizationsEnabled
-          ? [
-              orgDomainMatcherConfig.root
-                ? {
-                    ...orgDomainMatcherConfig.root,
-                    headers: [
-                      {
-                        key: "X-Cal-Org-path",
-                        value: `/team/${orgSlug}`,
-                      },
-                    ],
-                  }
-                : null,
-              {
-                ...orgDomainMatcherConfig.user,
-                headers: [
-                  {
-                    key: "X-Cal-Org-path",
-                    value: `/org/${orgSlug}/:user`,
-                  },
-                ],
-              },
-              {
-                ...orgDomainMatcherConfig.userType,
-                headers: [
-                  {
-                    key: "X-Cal-Org-path",
-                    value: `/org/${orgSlug}/:user/:type`,
-                  },
-                ],
-              },
-              {
-                ...orgDomainMatcherConfig.userTypeEmbed,
-                headers: [
-                  {
-                    key: "X-Cal-Org-path",
-                    value: `/org/${orgSlug}/:user/:type/embed`,
-                  },
-                ],
-              },
-            ]
-          : []),
-      ].filter(isNotNull);
+      ],
     },
+    {
+      source: "/signup",
+      headers: [
+        {
+          key: "X-Frame-Options",
+          value: "DENY",
+        },
+      ],
+    },
+    {
+      source: "/:path*",
+      headers: [
+        {
+          key: "X-Content-Type-Options",
+          value: "nosniff",
+        },
+        {
+          key: "Referrer-Policy",
+          value: "strict-origin-when-cross-origin",
+        },
+        // Protect older browsers that don't support CSP
+        {
+          key: "X-XSS-Protection",
+          value: "1; mode=block",
+        },
+        // Restrict access to sensitive browser features
+        {
+          key: "Permissions-Policy",
+          value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+        },
+        // CSP: unsafe-inline/unsafe-eval retained to avoid regressions.
+        // Follow-up: migrate to nonce-based CSP using existing getCspNonce
+        // scaffolding in middleware.ts
+        CSP_HEADER,
+        // Only injected in production and when not explicitly disabled
+        ...(HSTS_HEADER ? [HSTS_HEADER] : []),
+      ],
+    },
+    {
+      source: "/embed/embed.js",
+      headers: [CORP_CROSS_ORIGIN_HEADER],
+    },
+    {
+      source: "/:path*/embed",
+      headers: [CORP_CROSS_ORIGIN_HEADER],
+    },
+    {
+      source: "/:path*",
+      has: [
+        {
+          type: "host" as const,
+          value: "cal.com",
+        },
+      ],
+      headers: [
+        {
+          key: "Referrer-Policy",
+          value: "no-referrer-when-downgrade",
+        },
+      ],
+    },
+    {
+      source: "/api/avatar/:path*",
+      headers: [CORP_CROSS_ORIGIN_HEADER],
+    },
+    {
+      source: "/avatar.svg",
+      headers: [CORP_CROSS_ORIGIN_HEADER],
+    },
+    {
+      source: "/icons/sprite.svg(\\?v=[0-9a-zA-Z\\-\\.]+)?",
+      headers: [
+        CORP_CROSS_ORIGIN_HEADER,
+        ACCESS_CONTROL_ALLOW_ORIGIN_HEADER,
+        {
+          key: "Cache-Control",
+          value: "public, max-age=31536000, immutable",
+        },
+      ],
+    },
+    ...(isOrganizationsEnabled
+      ? [
+          orgDomainMatcherConfig.root
+            ? {
+                ...orgDomainMatcherConfig.root,
+                headers: [
+                  {
+                    key: "X-Cal-Org-path",
+                    value: `/team/${orgSlug}`,
+                  },
+                ],
+              }
+            : null,
+          {
+            ...orgDomainMatcherConfig.user,
+            headers: [
+              {
+                key: "X-Cal-Org-path",
+                value: `/org/${orgSlug}/:user`,
+              },
+            ],
+          },
+          {
+            ...orgDomainMatcherConfig.userType,
+            headers: [
+              {
+                key: "X-Cal-Org-path",
+                value: `/org/${orgSlug}/:user/:type`,
+              },
+            ],
+          },
+          {
+            ...orgDomainMatcherConfig.userTypeEmbed,
+            headers: [
+              {
+                key: "X-Cal-Org-path",
+                value: `/org/${orgSlug}/:user/:type/embed`,
+              },
+            ],
+          },
+        ]
+      : []),
+  ].filter(isNotNull);
+},
     async redirects() {
       const redirects = [
         {


### PR DESCRIPTION
## Problem
Sub-issue of #29364 (CRITICAL severity)

1. `apps/api/v2/src/bootstrap.ts` — `origin: "*"` allowed any website to
   make credentialed cross-origin requests to the API
2. `apps/web/next.config.ts` — Missing CSP, HSTS, X-XSS-Protection, and
   Permissions-Policy headers, leaving the frontend exposed to XSS,
   clickjacking, and protocol downgrade attacks

## Changes

### `apps/api/v2/src/bootstrap.ts`
- Replaced `origin: "*"` with an origin allowlist callback
- Reads from `CORS_ALLOWED_ORIGINS` env var (comma-separated)
- Falls back to `NEXT_PUBLIC_WEBAPP_URL` if not set
- Server-to-server requests with no Origin header are still allowed

### `apps/web/next.config.ts`
- Added to the existing `/:path*` headers block:
  - `Content-Security-Policy`
  - `Strict-Transport-Security` (production only, skippable via `NEXT_PUBLIC_DISABLE_HSTS=true` for self-hosters on HTTP)
  - `X-XSS-Protection`
  - `Permissions-Policy`

### `.env.example`
- Documented new `CORS_ALLOWED_ORIGINS` variable

## Notes
- CSP uses `unsafe-inline`/`unsafe-eval` as a starting point to avoid
  regressions. Nonce-based CSP is the right follow-up — `middleware.ts`
  already has `getCspNonce` scaffolding for this.
- All existing headers (embed routes, org headers, avatar routes) are untouched.

Closes #29364