### PR TITLE
feat: add Proton Calendar integration

### DIFF
--- a/apps/web/components/apps/AppSetupPage.tsx
+++ b/apps/web/components/apps/AppSetupPage.tsx
@@ -9,6 +9,7 @@ export const AppSetupMap = {
   "exchange2016-calendar": dynamic(() => import("@calcom/web/components/apps/exchange2016calendar/Setup")),
   "caldav-calendar": dynamic(() => import("@calcom/web/components/apps/caldavcalendar/Setup")),
   "ics-feed": dynamic(() => import("@calcom/web/components/apps/ics-feedcalendar/Setup")),
+  "proton-calendar": dynamic(() => import("@calcom/web/components/apps/protoncalendar/Setup")),
   make: dynamic(() => import("@calcom/web/components/apps/make/Setup")),
   sendgrid: dynamic(() => import("@calcom/web/components/apps/sendgrid/Setup")),
   stripe: dynamic(() => import("@calcom/web/components/apps/stripepayment/Setup")),

--- a/apps/web/components/apps/protoncalendar/Setup.tsx
+++ b/apps/web/components/apps/protoncalendar/Setup.tsx
@@ -27,7 +27,7 @@ export default function ProtonCalendarSetup() {
             {/* eslint-disable @next/next/no-img-element */}
             <img
               src="/api/app-store/protoncalendar/icon.svg"
-              alt="Proton Calendar"
+              alt={t("proton_calendar")}
               className="h-12 w-12 max-w-2xl"
             />
           </div>
@@ -73,7 +73,7 @@ export default function ProtonCalendarSetup() {
                           const newVal = e.target.value as string;
                           setUrls((urls) => urls.map((x, ii) => (ii === i ? newVal : x)));
                         }}
-                        placeholder="webcal://calendar.proton.me/api/calendar/v1/url/..."
+                        placeholder={t("proton_calendar_url_placeholder")}
                       />
                       {i !== 0 ? (
                         <button

--- a/apps/web/components/apps/protoncalendar/Setup.tsx
+++ b/apps/web/components/apps/protoncalendar/Setup.tsx
@@ -1,0 +1,118 @@
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { Toaster } from "sonner";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Alert } from "@calcom/ui/components/alert";
+import { Button } from "@calcom/ui/components/button";
+import { Form, TextField } from "@calcom/ui/components/form";
+import { PlusIcon, TrashIcon } from "@coss/ui/icons";
+
+export default function ProtonCalendarSetup() {
+  const { t } = useLocale();
+  const router = useRouter();
+  const form = useForm({
+    defaultValues: {},
+  });
+
+  const [urls, setUrls] = useState<string[]>([""]);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  return (
+    <div className="bg-emphasis flex h-screen">
+      <div className="bg-default m-auto rounded p-5 md:w-[560px] md:p-10">
+        <div className="flex flex-col stack-y-5 md:flex-row md:space-x-5 md:stack-y-0">
+          <div>
+            {/* eslint-disable @next/next/no-img-element */}
+            <img
+              src="/api/app-store/protoncalendar/icon.svg"
+              alt="Proton Calendar"
+              className="h-12 w-12 max-w-2xl"
+            />
+          </div>
+          <div className="flex w-10/12 flex-col">
+            <h1 className="text-default">{t("connect_proton_calendar")}</h1>
+            <div className="mt-1 text-sm">{t("credentials_stored_encrypted")}</div>
+            <div className="my-2 mt-3">
+              <Form
+                form={form}
+                handleSubmit={async (_) => {
+                  setErrorMessage("");
+
+                  try {
+                    const res = await fetch("/api/integrations/protoncalendar/add", {
+                      method: "POST",
+                      body: JSON.stringify({ urls }),
+                      headers: {
+                        "Content-Type": "application/json",
+                      },
+                    });
+                    const json = await res.json().catch(() => ({}));
+
+                    if (!res.ok) {
+                      setErrorMessage(json?.message || t("something_went_wrong"));
+                      return;
+                    }
+
+                    router.push(json.url);
+                  } catch {
+                    setErrorMessage(t("something_went_wrong"));
+                  }
+                }}>
+                <fieldset className="stack-y-2" disabled={form.formState.isSubmitting}>
+                  {urls.map((url, i) => (
+                    <div key={i} className="flex w-full items-center gap-2">
+                      <TextField
+                        required
+                        type="text"
+                        label={t("calendar_url")}
+                        value={url}
+                        containerClassName={`w-full ${i === 0 ? "mr-6" : ""}`}
+                        onChange={(e) => {
+                          const newVal = e.target.value as string;
+                          setUrls((urls) => urls.map((x, ii) => (ii === i ? newVal : x)));
+                        }}
+                        placeholder="webcal://calendar.proton.me/api/calendar/v1/url/..."
+                      />
+                      {i !== 0 ? (
+                        <button
+                          type="button"
+                          aria-label={t("remove")}
+                          className="mb-2 h-min text-sm"
+                          onClick={() => setUrls((urls) => urls.filter((_, ii) => i !== ii))}>
+                          <TrashIcon size={16} />
+                        </button>
+                      ) : null}
+                    </div>
+                  ))}
+                </fieldset>
+
+                <button
+                  className="text-sm"
+                  type="button"
+                  onClick={() => {
+                    setUrls((urls) => urls.concat(""));
+                  }}>
+                  {t("add")} <PlusIcon className="inline" size={16} />
+                </button>
+
+                {errorMessage && <Alert severity="error" title={errorMessage} className="my-4" />}
+
+                <div className="mt-5 justify-end space-x-2 rtl:space-x-reverse sm:mt-4 sm:flex">
+                  <Button type="button" color="secondary" onClick={() => router.back()}>
+                    {t("cancel")}
+                  </Button>
+                  <Button type="submit" loading={form.formState.isSubmitting}>
+                    {t("save")}
+                  </Button>
+                </div>
+              </Form>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Toaster position="bottom-right" />
+    </div>
+  );
+}

--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -74,6 +74,7 @@ import pipedream_config_json from "./pipedream/config.json";
 import pipedrive_crm_config_json from "./pipedrive-crm/config.json";
 import plausible_config_json from "./plausible/config.json";
 import posthog_config_json from "./posthog/config.json";
+import protoncalendar_config_json from "./protoncalendar/config.json";
 import qr_code_config_json from "./qr_code/config.json";
 import raycast_config_json from "./raycast/config.json";
 import retell_ai_config_json from "./retell-ai/config.json";
@@ -186,6 +187,7 @@ export const appStoreMetadata = {
   "pipedrive-crm": pipedrive_crm_config_json,
   plausible: plausible_config_json,
   posthog: posthog_config_json,
+  protoncalendar: protoncalendar_config_json,
   qr_code: qr_code_config_json,
   raycast: raycast_config_json,
   "retell-ai": retell_ai_config_json,

--- a/packages/app-store/apps.server.generated.ts
+++ b/packages/app-store/apps.server.generated.ts
@@ -55,6 +55,7 @@ export const apiHandlers = {
   "pipedrive-crm": import("./pipedrive-crm/api"),
   plausible: import("./plausible/api"),
   posthog: import("./posthog/api"),
+  protoncalendar: import("./protoncalendar/api"),
   qr_code: import("./qr_code/api"),
   riverside: import("./riverside/api"),
   roam: import("./roam/api"),

--- a/packages/app-store/calendar.services.generated.ts
+++ b/packages/app-store/calendar.services.generated.ts
@@ -16,5 +16,6 @@ export const CalendarServiceMap =
         "ics-feedcalendar": import("./ics-feedcalendar/lib/CalendarService"),
         larkcalendar: import("./larkcalendar/lib/CalendarService"),
         office365calendar: import("./office365calendar/lib/CalendarService"),
+        protoncalendar: import("./protoncalendar/lib/CalendarService"),
         zohocalendar: import("./zohocalendar/lib/CalendarService"),
       };

--- a/packages/app-store/ics-feedcalendar/lib/CalendarService.ts
+++ b/packages/app-store/ics-feedcalendar/lib/CalendarService.ts
@@ -40,13 +40,14 @@ const applyTravelDuration = (event: ICAL.Event, seconds: number) => {
 
 const CALENDSO_ENCRYPTION_KEY = process.env.CALENDSO_ENCRYPTION_KEY || "";
 
-class ICSFeedCalendarService implements Calendar {
+export class ICSFeedCalendarService implements Calendar {
   private urls: string[] = [];
-  protected integrationName = "ics-feed_calendar";
+  protected integrationName: string;
 
-  constructor(credential: CredentialPayload) {
+  constructor(credential: CredentialPayload, integrationName = "ics-feed_calendar") {
     const { urls } = JSON.parse(symmetricDecrypt(credential.key as string, CALENDSO_ENCRYPTION_KEY));
     this.urls = urls;
+    this.integrationName = integrationName;
   }
 
   createEvent(_event: CalendarEvent, _credentialId: number): Promise<NewCalendarEventType> {

--- a/packages/app-store/protoncalendar/DESCRIPTION.md
+++ b/packages/app-store/protoncalendar/DESCRIPTION.md
@@ -1,0 +1,5 @@
+# Proton Calendar
+
+Connect Proton Calendar to Cal.com using Proton Calendar's ICS subscription URL.
+
+This integration is read-only. Cal.com uses the feed to check availability and avoid conflicts.

--- a/packages/app-store/protoncalendar/api/add.ts
+++ b/packages/app-store/protoncalendar/api/add.ts
@@ -68,7 +68,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         data,
       });
     } catch (error) {
-      logger.error("Could not add Proton Calendar feeds", error);
+      logger.error("Could not add Proton Calendar feeds", {
+        message: error instanceof Error ? error.message : "Unknown error",
+      });
       return res.status(500).json({ message: "Could not add Proton Calendar feeds" });
     }
 

--- a/packages/app-store/protoncalendar/api/add.ts
+++ b/packages/app-store/protoncalendar/api/add.ts
@@ -1,0 +1,85 @@
+import process from "node:process";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { symmetricEncrypt } from "@calcom/lib/crypto";
+import logger from "@calcom/lib/logger";
+import prisma from "@calcom/prisma";
+
+import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+import appConfig from "../config.json";
+import BuildCalendarService from "../lib/CalendarService";
+import { isValidProtonCalendarUrl, normalizeProtonCalendarUrl } from "../lib/validateProtonCalendarUrl";
+
+const CALENDSO_ENCRYPTION_KEY = process.env.CALENDSO_ENCRYPTION_KEY || "";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "POST") {
+    const userId = req.session?.user?.id;
+    if (!userId) {
+      return res.status(401).json({ message: "Unauthorized" });
+    }
+
+    const urls = Array.isArray(req.body.urls)
+      ? req.body.urls.map((url: unknown) => String(url).trim()).filter(Boolean)
+      : [];
+
+    if (!urls.length || urls.some((url: string) => !isValidProtonCalendarUrl(url))) {
+      return res.status(400).json({
+        message: "Enter at least one valid Proton Calendar webcal or HTTPS ICS URL",
+      });
+    }
+
+    const normalizedUrls = urls.map((url: string) => normalizeProtonCalendarUrl(url));
+
+    const user = await prisma.user.findFirstOrThrow({
+      where: {
+        id: userId,
+      },
+      select: {
+        id: true,
+        email: true,
+      },
+    });
+
+    const data = {
+      type: appConfig.type,
+      key: symmetricEncrypt(JSON.stringify({ urls: normalizedUrls }), CALENDSO_ENCRYPTION_KEY),
+      userId: user.id,
+      teamId: null,
+      appId: appConfig.slug,
+      invalid: false,
+      delegationCredentialId: null,
+    };
+
+    try {
+      const protonCalendar = BuildCalendarService({
+        id: 0,
+        ...data,
+        user: { email: user.email },
+        encryptedKey: null,
+      });
+      const listedCalendars = await protonCalendar.listCalendars();
+
+      if (listedCalendars.length !== normalizedUrls.length) {
+        throw new Error(`Listed calendars and URLs mismatch: ${listedCalendars.length} vs. ${normalizedUrls.length}`);
+      }
+
+      await prisma.credential.create({
+        data,
+      });
+    } catch (error) {
+      logger.error("Could not add Proton Calendar feeds", error);
+      return res.status(500).json({ message: "Could not add Proton Calendar feeds" });
+    }
+
+    return res.status(200).json({
+      url: getInstalledAppPath({ variant: "calendar", slug: appConfig.slug }),
+    });
+  }
+
+  if (req.method === "GET") {
+    return res.status(200).json({ url: "/apps/proton-calendar/setup" });
+  }
+
+  return res.status(405).json({ message: "Method not allowed" });
+}

--- a/packages/app-store/protoncalendar/api/index.ts
+++ b/packages/app-store/protoncalendar/api/index.ts
@@ -1,0 +1,1 @@
+export { default as add } from "./add";

--- a/packages/app-store/protoncalendar/config.json
+++ b/packages/app-store/protoncalendar/config.json
@@ -1,0 +1,15 @@
+{
+  "name": "Proton Calendar",
+  "title": "Proton Calendar",
+  "slug": "proton-calendar",
+  "dirName": "protoncalendar",
+  "type": "protoncalendar_calendar",
+  "logo": "icon.svg",
+  "variant": "calendar",
+  "categories": ["calendar"],
+  "publisher": "Cal.com, Inc.",
+  "email": "help@cal.com",
+  "description": "Use a Proton Calendar ICS subscription URL for availability checks in Cal.com.",
+  "isTemplate": false,
+  "__createdUsingCli": true
+}

--- a/packages/app-store/protoncalendar/index.ts
+++ b/packages/app-store/protoncalendar/index.ts
@@ -1,0 +1,2 @@
+export * as api from "./api";
+export * as lib from "./lib";

--- a/packages/app-store/protoncalendar/lib/CalendarService.ts
+++ b/packages/app-store/protoncalendar/lib/CalendarService.ts
@@ -1,0 +1,7 @@
+import type { Calendar } from "@calcom/types/Calendar";
+import type { CredentialPayload } from "@calcom/types/Credential";
+import { ICSFeedCalendarService } from "../../ics-feedcalendar/lib/CalendarService";
+
+export default function BuildCalendarService(credential: CredentialPayload): Calendar {
+  return new ICSFeedCalendarService(credential, "protoncalendar_calendar");
+}

--- a/packages/app-store/protoncalendar/lib/__tests__/validateProtonCalendarUrl.test.ts
+++ b/packages/app-store/protoncalendar/lib/__tests__/validateProtonCalendarUrl.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidProtonCalendarUrl, normalizeProtonCalendarUrl } from "../validateProtonCalendarUrl";
+
+describe("Proton Calendar URL validation", () => {
+  it("accepts Proton Calendar HTTPS and webcal ICS subscription URLs", () => {
+    expect(
+      isValidProtonCalendarUrl("https://calendar.proton.me/api/calendar/v1/url/token/calendar.ics")
+    ).toBe(true);
+    expect(
+      isValidProtonCalendarUrl("webcal://calendar.proton.me/api/calendar/v1/url/token/calendar.ics")
+    ).toBe(true);
+  });
+
+  it("normalizes webcal URLs to HTTPS before storage", () => {
+    expect(normalizeProtonCalendarUrl("webcal://calendar.proton.me/api/calendar/v1/url/token/calendar.ics")).toBe(
+      "https://calendar.proton.me/api/calendar/v1/url/token/calendar.ics"
+    );
+  });
+
+  it("rejects non-HTTPS or malformed URLs", () => {
+    expect(isValidProtonCalendarUrl("http://calendar.proton.me/api/calendar/v1/url/token/calendar.ics")).toBe(
+      false
+    );
+    expect(isValidProtonCalendarUrl("ftp://calendar.proton.me/api/calendar/v1/url/token/calendar.ics")).toBe(
+      false
+    );
+    expect(isValidProtonCalendarUrl("not a url")).toBe(false);
+  });
+
+  it("rejects non-Proton and internal HTTPS hosts", () => {
+    expect(isValidProtonCalendarUrl("https://example.com/calendar.ics")).toBe(false);
+    expect(isValidProtonCalendarUrl("https://192.168.0.1/calendar.ics")).toBe(false);
+    expect(isValidProtonCalendarUrl("https://localhost/calendar.ics")).toBe(false);
+    expect(isValidProtonCalendarUrl("https://account.proton.me/calendar.ics")).toBe(false);
+  });
+
+  it("rejects Proton URLs outside the calendar ICS endpoint", () => {
+    expect(isValidProtonCalendarUrl("https://calendar.proton.me/calendar.ics")).toBe(false);
+    expect(isValidProtonCalendarUrl("https://calendar.proton.me/api/calendar/v1/url/token")).toBe(false);
+  });
+});

--- a/packages/app-store/protoncalendar/lib/index.ts
+++ b/packages/app-store/protoncalendar/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as BuildCalendarService } from "./CalendarService";

--- a/packages/app-store/protoncalendar/lib/validateProtonCalendarUrl.ts
+++ b/packages/app-store/protoncalendar/lib/validateProtonCalendarUrl.ts
@@ -1,0 +1,19 @@
+const PROTON_CALENDAR_HOST = "calendar.proton.me";
+const PROTON_CALENDAR_PATH_PREFIX = "/api/calendar/v1/url/";
+
+export const normalizeProtonCalendarUrl = (url: string): string => url.trim().replace(/^webcal:/i, "https:");
+
+export const isValidProtonCalendarUrl = (url: string): boolean => {
+  try {
+    const parsedUrl = new URL(normalizeProtonCalendarUrl(url));
+
+    return (
+      parsedUrl.protocol === "https:" &&
+      parsedUrl.hostname.toLowerCase() === PROTON_CALENDAR_HOST &&
+      parsedUrl.pathname.startsWith(PROTON_CALENDAR_PATH_PREFIX) &&
+      parsedUrl.pathname.toLowerCase().endsWith(".ics")
+    );
+  } catch {
+    return false;
+  }
+};

--- a/packages/app-store/protoncalendar/package.json
+++ b/packages/app-store/protoncalendar/package.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "private": true,
+  "name": "@calcom/protoncalendar",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "dependencies": {
+    "@calcom/ics-feed": "workspace:*",
+    "@calcom/lib": "workspace:*",
+    "@calcom/prisma": "workspace:*",
+    "@calcom/ui": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "react-hook-form": "^7.0.0"
+  },
+  "devDependencies": {
+    "@calcom/types": "workspace:*"
+  },
+  "description": "Use a Proton Calendar ICS subscription URL for availability checks in Cal.com."
+}

--- a/packages/app-store/protoncalendar/static/icon.svg
+++ b/packages/app-store/protoncalendar/static/icon.svg
@@ -1,0 +1,9 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="14" fill="#6D4AFF"/>
+  <path d="M15 23.5C15 20.4624 17.4624 18 20.5 18H43.5C46.5376 18 49 20.4624 49 23.5V44C49 47.0376 46.5376 49.5 43.5 49.5H20.5C17.4624 49.5 15 47.0376 15 44V23.5Z" fill="white"/>
+  <path d="M15 25H49V31H15V25Z" fill="#2B135F"/>
+  <path d="M23 14.5V22" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M41 14.5V22" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M22 36H42" stroke="#6D4AFF" stroke-width="4" stroke-linecap="round"/>
+  <path d="M22 43H34" stroke="#6D4AFF" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -439,6 +439,7 @@
   "welcome_instructions": "Tell us what to call you and let us know what timezone you're in. You'll be able to edit this later.",
   "connect_caldav": "Connect to CalDav (Beta)",
   "connect_ics_feed": "Connect to an ICS Feed",
+  "connect_proton_calendar": "Connect to Proton Calendar",
   "connect": "Connect",
   "try_for_free": "Try it for free",
   "create_booking_link_with_calcom": "Create your own booking link with {{appName}}",

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -440,6 +440,8 @@
   "connect_caldav": "Connect to CalDav (Beta)",
   "connect_ics_feed": "Connect to an ICS Feed",
   "connect_proton_calendar": "Connect to Proton Calendar",
+  "proton_calendar": "Proton Calendar",
+  "proton_calendar_url_placeholder": "webcal://calendar.proton.me/api/calendar/v1/url/...",
   "connect": "Connect",
   "try_for_free": "Try it for free",
   "create_booking_link_with_calcom": "Create your own booking link with {{appName}}",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2637,7 +2637,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/ics-feed@workspace:packages/app-store/ics-feedcalendar":
+"@calcom/ics-feed@workspace:*, @calcom/ics-feed@workspace:packages/app-store/ics-feedcalendar":
   version: 0.0.0-use.local
   resolution: "@calcom/ics-feed@workspace:packages/app-store/ics-feedcalendar"
   dependencies:
@@ -2962,6 +2962,22 @@ __metadata:
     zod-prisma-types: "npm:3.2.4"
   bin:
     prisma-enum-generator: ./run-enum-generator.js
+  languageName: unknown
+  linkType: soft
+
+"@calcom/protoncalendar@workspace:packages/app-store/protoncalendar":
+  version: 0.0.0-use.local
+  resolution: "@calcom/protoncalendar@workspace:packages/app-store/protoncalendar"
+  dependencies:
+    "@calcom/ics-feed": "workspace:*"
+    "@calcom/lib": "workspace:*"
+    "@calcom/prisma": "workspace:*"
+    "@calcom/types": "workspace:*"
+    "@calcom/ui": "workspace:*"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    react-hook-form: ^7.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Add a Proton Calendar app integration backed by Proton Calendar ICS/webcal subscription URLs
- Reuse the existing ICS feed calendar service with a Proton-specific calendar integration type
- Add setup UI, app-store registration, calendar service registration, URL validation, and tests
- Normalize `webcal://` URLs to HTTPS and restrict accepted URLs to Proton's calendar ICS endpoint

Closes #5756

## Test Plan

- `git diff --check`
- Standalone URL validation sanity check with Node

Note: I could not run the repo yarn test/build commands locally because this checkout has no `node_modules`, and `yarn`/`corepack` are not available in PATH.