### PR TITLE
fix: use allow-list in getConnectedApps to prevent accidental data leakage

### DIFF
--- a/packages/app-store/_utils/getConnectedApps.ts
+++ b/packages/app-store/_utils/getConnectedApps.ts
@@ -215,9 +215,9 @@ export async function getConnectedApps({
         isGlobal: app.isGlobal,
         dependencies: app.dependencies,
         extendsFeature: app.extendsFeature,
-        location: app.location,
+        locationOption: app.locationOption,
         key: app.key,
-        
+
         ...(teams.length && {
           credentialOwner,
         }),

--- a/packages/app-store/_utils/getConnectedApps.ts
+++ b/packages/app-store/_utils/getConnectedApps.ts
@@ -146,7 +146,7 @@ export async function getConnectedApps({
     filterOnCredentials: onlyInstalled,
     ...(appId ? { where: { slug: appId } } : {}),
   });
-  //TODO: Refactor this to pick up only needed fields and prevent more leaking
+
   let apps = await Promise.all(
     enabledApps.map(async ({ credentials: _, credential, key: _2 /* don't leak to frontend */, ...app }) => {
       const userCredentialIds = credentials.filter((c) => c.appId === app.slug && !c.teamId).map((c) => c.id);
@@ -204,7 +204,17 @@ export async function getConnectedApps({
       }
 
       return {
-        ...app,
+        slug: app.slug,
+        name: app.name,
+        logo: app.logo,
+        categories: app.categories,
+        variant: app.variant,
+        type: app.type,
+        description: app.description,
+        dirName: app.dirName,
+        isGlobal: app.isGlobal,
+        dependencies: app.dependencies,
+        extendsFeature: app.extendsFeature,
         ...(teams.length && {
           credentialOwner,
         }),

--- a/packages/app-store/_utils/getConnectedApps.ts
+++ b/packages/app-store/_utils/getConnectedApps.ts
@@ -215,6 +215,9 @@ export async function getConnectedApps({
         isGlobal: app.isGlobal,
         dependencies: app.dependencies,
         extendsFeature: app.extendsFeature,
+        location: app.location,
+        key: app.key,
+        
         ...(teams.length && {
           credentialOwner,
         }),


### PR DESCRIPTION
## What does this PR do?
Replaces the unsafe `...app` spread in `getConnectedApps.ts` with an
explicit allow-list of safe fields. This prevents any future internal
fields from being accidentally leaked to the frontend.

## Why?
The existing code used a deny-list pattern (excluding `credentials` and
`key`) and then spread the rest via `...app`. A `// TODO` comment in
the file already flagged this as a known issue.

## Changes
- `packages/app-store/_utils/getConnectedApps.ts`: replaced `...app`
  spread with an explicit field allow-list

Fixes #28923
