### PR TITLE
fix(api): add missing apiKeys trpc route

### DIFF
--- a/apps/web/pages/api/trpc/apiKeys/[trpc].ts
+++ b/apps/web/pages/api/trpc/apiKeys/[trpc].ts
@@ -1,0 +1,4 @@
+import { createNextApiHandler } from "@calcom/trpc/server/createNextApiHandler";
+import { apiKeysRouter } from "@calcom/trpc/server/routers/viewer/apiKeys/_router";
+
+export default createNextApiHandler(apiKeysRouter);


### PR DESCRIPTION
Fixes #29475 
## Summary

Fixes API key creation failure caused by a missing standalone tRPC endpoint.

## Problem

Creating API keys from `/settings/developer/api-keys` returned:

Unexpected token '<', "<!DOCTYPE "... is not valid JSON

because `/api/trpc/apiKeys/create` returned an HTML 404 page instead of a JSON tRPC response.

## Root Cause

The API keys router existed, but the Next API route exposing the standalone endpoint was missing.

## Fix

Added:

`apps/web/pages/api/trpc/apiKeys/[trpc].ts`

to expose the existing `apiKeysRouter` through `createNextApiHandler`.

## Before

The issue reported that API key creation failed because the standalone
tRPC endpoint route was missing.

<img width="1171" height="958" alt="image" src="https://github.com/user-attachments/assets/9fa2328e-3e33-40a6-92fe-c7a2885a657c" />


## After

Added the missing route:

apps/web/pages/api/trpc/apiKeys/[trpc].ts

<img width="1212" height="259" alt="image" src="https://github.com/user-attachments/assets/e8ea56d7-53b0-404f-be26-d76e26b5cf7c" />

## Notes
The fix follows the same standalone endpoint pattern used by other tRPC routes in the repository.
