### PR TITLE
feat: support read-only ICS feeds in setup

### DIFF
--- a/apps/web/components/apps/ics-feedcalendar/Setup.tsx
+++ b/apps/web/components/apps/ics-feedcalendar/Setup.tsx
@@ -10,6 +10,17 @@ import { useForm } from "react-hook-form";
 import { Toaster } from "sonner";
 
 type IcsFeedSetupFormValues = Record<string, never>;
+type UrlEntry = {
+  id: string;
+  value: string;
+};
+
+function createUrlEntry(value: string = ""): UrlEntry {
+  return {
+    id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`,
+    value,
+  };
+}
 
 function getUrlContainerClassName(index: number): string {
   let className = "w-full";
@@ -22,16 +33,16 @@ function getUrlContainerClassName(index: number): string {
 }
 
 function createUrlChangeHandler(
-  setUrls: Dispatch<SetStateAction<string[]>>,
-  index: number
+  setUrls: Dispatch<SetStateAction<UrlEntry[]>>,
+  id: string
 ): (event: ChangeEvent<HTMLInputElement>) => void {
   return function handleUrlChange(event: ChangeEvent<HTMLInputElement>): void {
     const newValue = event.target.value;
 
     setUrls((currentUrls) =>
-      currentUrls.map((currentUrl, currentIndex) => {
-        if (currentIndex === index) {
-          return newValue;
+      currentUrls.map((currentUrl) => {
+        if (currentUrl.id === id) {
+          return { ...currentUrl, value: newValue };
         }
 
         return currentUrl;
@@ -40,9 +51,9 @@ function createUrlChangeHandler(
   };
 }
 
-function createUrlRemovalHandler(setUrls: Dispatch<SetStateAction<string[]>>, index: number): () => void {
+function createUrlRemovalHandler(setUrls: Dispatch<SetStateAction<UrlEntry[]>>, id: string): () => void {
   return function handleUrlRemoval(): void {
-    setUrls((currentUrls) => currentUrls.filter((_, currentIndex) => currentIndex !== index));
+    setUrls((currentUrls) => currentUrls.filter((currentUrl) => currentUrl.id !== id));
   };
 }
 
@@ -53,7 +64,7 @@ export default function ICSFeedSetup(): JSX.Element {
     defaultValues: {},
   });
 
-  const [urls, setUrls] = useState<string[]>([""]);
+  const [urls, setUrls] = useState<UrlEntry[]>([createUrlEntry()]);
   const [skipWritingToCalendar, setSkipWritingToCalendar] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
   const [errorActionUrl, setErrorActionUrl] = useState("");
@@ -63,7 +74,7 @@ export default function ICSFeedSetup(): JSX.Element {
   };
 
   const handleAddUrl = (): void => {
-    setUrls((currentUrls) => currentUrls.concat(""));
+    setUrls((currentUrls) => currentUrls.concat(createUrlEntry()));
   };
 
   const handleCancelClick = (): void => {
@@ -72,9 +83,13 @@ export default function ICSFeedSetup(): JSX.Element {
 
   const handleFormSubmit = async (_values: IcsFeedSetupFormValues): Promise<void> => {
     setErrorMessage("");
+    setErrorActionUrl("");
     const res = await fetch("/api/integrations/ics-feedcalendar/add", {
       method: "POST",
-      body: JSON.stringify({ urls, skipWriting: skipWritingToCalendar }),
+      body: JSON.stringify({
+        urls: urls.map(({ value }) => value),
+        skipWriting: skipWritingToCalendar,
+      }),
       headers: {
         "Content-Type": "application/json",
       },
@@ -86,6 +101,7 @@ export default function ICSFeedSetup(): JSX.Element {
         setErrorActionUrl(json.actionUrl);
       }
     } else {
+      setErrorActionUrl("");
       router.push(json.url);
     }
   };
@@ -110,21 +126,22 @@ export default function ICSFeedSetup(): JSX.Element {
               <Form form={form} handleSubmit={handleFormSubmit}>
                 <fieldset className="stack-y-2" disabled={form.formState.isSubmitting}>
                   {urls.map((url, i) => (
-                    <div key={url} className="flex w-full items-center gap-2">
+                    <div key={url.id} className="flex w-full items-center gap-2">
                       <TextField
                         required
                         type="text"
                         label={t("calendar_url")}
-                        value={url}
+                        value={url.value}
                         containerClassName={getUrlContainerClassName(i)}
-                        onChange={createUrlChangeHandler(setUrls, i)}
+                        onChange={createUrlChangeHandler(setUrls, url.id)}
                         placeholder="https://example.com/calendar.ics"
                       />
                       {i !== 0 && (
                         <button
                           type="button"
+                          aria-label={`Remove URL ${i + 1}`}
                           className="mb-2 h-min text-sm"
-                          onClick={createUrlRemovalHandler(setUrls, i)}>
+                          onClick={createUrlRemovalHandler(setUrls, url.id)}>
                           <TrashIcon size={16} />
                         </button>
                       )}

--- a/apps/web/components/apps/ics-feedcalendar/Setup.tsx
+++ b/apps/web/components/apps/ics-feedcalendar/Setup.tsx
@@ -1,35 +1,105 @@
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { Toaster } from "sonner";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Alert } from "@calcom/ui/components/alert";
 import { Button } from "@calcom/ui/components/button";
-import { Form } from "@calcom/ui/components/form";
-import { TextField } from "@calcom/ui/components/form";
+import { CheckboxField, Form, TextField } from "@calcom/ui/components/form";
 import { PlusIcon, TrashIcon } from "@coss/ui/icons";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { type ChangeEvent, type Dispatch, type SetStateAction, useState } from "react";
+import { useForm } from "react-hook-form";
+import { Toaster } from "sonner";
 
-export default function ICSFeedSetup() {
+type IcsFeedSetupFormValues = Record<string, never>;
+
+function getUrlContainerClassName(index: number): string {
+  let className = "w-full";
+
+  if (index === 0) {
+    className += " mr-6";
+  }
+
+  return className;
+}
+
+function createUrlChangeHandler(
+  setUrls: Dispatch<SetStateAction<string[]>>,
+  index: number
+): (event: ChangeEvent<HTMLInputElement>) => void {
+  return function handleUrlChange(event: ChangeEvent<HTMLInputElement>): void {
+    const newValue = event.target.value;
+
+    setUrls((currentUrls) =>
+      currentUrls.map((currentUrl, currentIndex) => {
+        if (currentIndex === index) {
+          return newValue;
+        }
+
+        return currentUrl;
+      })
+    );
+  };
+}
+
+function createUrlRemovalHandler(setUrls: Dispatch<SetStateAction<string[]>>, index: number): () => void {
+  return function handleUrlRemoval(): void {
+    setUrls((currentUrls) => currentUrls.filter((_, currentIndex) => currentIndex !== index));
+  };
+}
+
+export default function ICSFeedSetup(): JSX.Element {
   const { t } = useLocale();
   const router = useRouter();
-  const form = useForm({
+  const form = useForm<IcsFeedSetupFormValues>({
     defaultValues: {},
   });
 
   const [urls, setUrls] = useState<string[]>([""]);
+  const [skipWritingToCalendar, setSkipWritingToCalendar] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
   const [errorActionUrl, setErrorActionUrl] = useState("");
 
+  const handleSkipWritingChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setSkipWritingToCalendar(event.target.checked);
+  };
+
+  const handleAddUrl = (): void => {
+    setUrls((currentUrls) => currentUrls.concat(""));
+  };
+
+  const handleCancelClick = (): void => {
+    router.back();
+  };
+
+  const handleFormSubmit = async (_values: IcsFeedSetupFormValues): Promise<void> => {
+    setErrorMessage("");
+    const res = await fetch("/api/integrations/ics-feedcalendar/add", {
+      method: "POST",
+      body: JSON.stringify({ urls, skipWriting: skipWritingToCalendar }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    const json = await res.json();
+    if (!res.ok) {
+      setErrorMessage(json?.message || t("something_went_wrong"));
+      if (json.actionUrl) {
+        setErrorActionUrl(json.actionUrl);
+      }
+    } else {
+      router.push(json.url);
+    }
+  };
+
   return (
-    <div className="bg-emphasis flex h-screen">
-      <div className="bg-default m-auto rounded p-5 md:w-[560px] md:p-10">
-        <div className="flex flex-col stack-y-5 md:flex-row md:space-x-5 md:stack-y-0">
+    <div className="flex h-screen bg-emphasis">
+      <div className="m-auto rounded bg-default p-5 md:w-[560px] md:p-10">
+        <div className="stack-y-5 md:stack-y-0 flex flex-col md:flex-row md:space-x-5">
           <div>
-            {/* eslint-disable @next/next/no-img-element */}
-            <img
+            <Image
               src="/api/app-store/ics-feedcalendar/icon.svg"
               alt="ICS Feed"
+              width={48}
+              height={48}
               className="h-12 w-12 max-w-2xl"
             />
           </div>
@@ -37,69 +107,46 @@ export default function ICSFeedSetup() {
             <h1 className="text-default">{t("connect_ics_feed")}</h1>
             <div className="mt-1 text-sm">{t("credentials_stored_encrypted")}</div>
             <div className="my-2 mt-3">
-              <Form
-                form={form}
-                handleSubmit={async (_) => {
-                  setErrorMessage("");
-                  const res = await fetch("/api/integrations/ics-feedcalendar/add", {
-                    method: "POST",
-                    body: JSON.stringify({ urls }),
-                    headers: {
-                      "Content-Type": "application/json",
-                    },
-                  });
-                  const json = await res.json();
-                  if (!res.ok) {
-                    setErrorMessage(json?.message || t("something_went_wrong"));
-                    if (json.actionUrl) {
-                      setErrorActionUrl(json.actionUrl);
-                    }
-                  } else {
-                    router.push(json.url);
-                  }
-                }}>
+              <Form form={form} handleSubmit={handleFormSubmit}>
                 <fieldset className="stack-y-2" disabled={form.formState.isSubmitting}>
                   {urls.map((url, i) => (
-                    <div key={i} className="flex w-full items-center gap-2">
+                    <div key={url} className="flex w-full items-center gap-2">
                       <TextField
                         required
                         type="text"
                         label={t("calendar_url")}
                         value={url}
-                        containerClassName={`w-full ${i === 0 ? "mr-6" : ""}`}
-                        onChange={(e) => {
-                          const newVal = e.target.value as string;
-                          setUrls((urls) => urls.map((x, ii) => (ii === i ? newVal : x)));
-                        }}
+                        containerClassName={getUrlContainerClassName(i)}
+                        onChange={createUrlChangeHandler(setUrls, i)}
                         placeholder="https://example.com/calendar.ics"
                       />
-                      {i !== 0 ? (
+                      {i !== 0 && (
                         <button
                           type="button"
                           className="mb-2 h-min text-sm"
-                          onClick={() => setUrls((urls) => urls.filter((_, ii) => i !== ii))}>
+                          onClick={createUrlRemovalHandler(setUrls, i)}>
                           <TrashIcon size={16} />
                         </button>
-                      ) : null}
+                      )}
                     </div>
                   ))}
+                  <CheckboxField
+                    checked={skipWritingToCalendar}
+                    onChange={handleSkipWritingChange}
+                    label={t("skip_writing_to_calendar")}
+                    description={t("skip_writing_to_calendar_note")}
+                  />
                 </fieldset>
 
-                <button
-                  className="text-sm"
-                  type="button"
-                  onClick={() => {
-                    setUrls((urls) => urls.concat(""));
-                  }}>
+                <button className="text-sm" type="button" onClick={handleAddUrl}>
                   {t("add")} <PlusIcon className="inline" size={16} />
                 </button>
 
-                {errorMessage && (
-                  <Alert
-                    severity="error"
-                    title={errorMessage}
-                    actions={
-                      errorActionUrl !== "" ? (
+                {errorMessage &&
+                  (() => {
+                    let actions: JSX.Element | undefined;
+                    if (errorActionUrl !== "") {
+                      actions = (
                         <Button
                           href={errorActionUrl}
                           color="secondary"
@@ -107,13 +154,13 @@ export default function ICSFeedSetup() {
                           className="ml-5 w-32 p-5!">
                           Go to Admin
                         </Button>
-                      ) : undefined
+                      );
                     }
-                    className="my-4"
-                  />
-                )}
-                <div className="mt-5 justify-end space-x-2 rtl:space-x-reverse sm:mt-4 sm:flex">
-                  <Button type="button" color="secondary" onClick={() => router.back()}>
+
+                    return <Alert severity="error" title={errorMessage} actions={actions} className="my-4" />;
+                  })()}
+                <div className="mt-5 justify-end space-x-2 sm:mt-4 sm:flex rtl:space-x-reverse">
+                  <Button type="button" color="secondary" onClick={handleCancelClick}>
                     {t("cancel")}
                   </Button>
                   <Button type="submit" loading={form.formState.isSubmitting}>

--- a/packages/app-store/ics-feedcalendar/api/__tests__/add.test.ts
+++ b/packages/app-store/ics-feedcalendar/api/__tests__/add.test.ts
@@ -65,6 +65,7 @@ function createRes(): Pick<NextApiResponse, "status" | "json"> {
 describe("ics-feedcalendar add API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv("CALENDSO_ENCRYPTION_KEY", "test-calendso-encryption-key");
 
     mockPrisma.user.findFirstOrThrow.mockResolvedValue({
       id: 1,
@@ -132,5 +133,75 @@ describe("ics-feedcalendar add API", () => {
       urls: ["https://example.com/calendar.ics"],
       skipWriting: true,
     });
+  });
+
+  it("persists skipWriting when explicitly requested as false", async () => {
+    const { default: handler } = await import("../add");
+    const req = {
+      method: "POST",
+      session: {
+        user: {
+          id: 1,
+        },
+      },
+      body: {
+        urls: ["https://example.com/calendar.ics"],
+        skipWriting: false,
+      },
+    } as Partial<NextApiRequest> as NextApiRequest;
+    const res = createRes();
+
+    await handler(req, res);
+
+    const credentialCreateArg = mockPrisma.credential.create.mock.calls[0][0];
+    expect(JSON.parse(credentialCreateArg.data.key as string)).toEqual({
+      urls: ["https://example.com/calendar.ics"],
+      skipWriting: false,
+    });
+  });
+
+  it("rejects invalid urls payloads", async () => {
+    const { default: handler } = await import("../add");
+    const req = {
+      method: "POST",
+      session: {
+        user: {
+          id: 1,
+        },
+      },
+      body: {
+        urls: "https://example.com/calendar.ics",
+        skipWriting: true,
+      },
+    } as Partial<NextApiRequest> as NextApiRequest;
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockPrisma.credential.create).not.toHaveBeenCalled();
+  });
+
+  it("fails fast when the encryption key is missing", async () => {
+    vi.stubEnv("CALENDSO_ENCRYPTION_KEY", "");
+    const { default: handler } = await import("../add");
+    const req = {
+      method: "POST",
+      session: {
+        user: {
+          id: 1,
+        },
+      },
+      body: {
+        urls: ["https://example.com/calendar.ics"],
+        skipWriting: true,
+      },
+    } as Partial<NextApiRequest> as NextApiRequest;
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(mockPrisma.credential.create).not.toHaveBeenCalled();
   });
 });

--- a/packages/app-store/ics-feedcalendar/api/__tests__/add.test.ts
+++ b/packages/app-store/ics-feedcalendar/api/__tests__/add.test.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type IcsFeedCalendarApiMocks = {
   mockPrisma: {
@@ -73,6 +73,10 @@ describe("ics-feedcalendar add API", () => {
     });
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("persists skipWriting when the setup form requests a read-only feed", async () => {
     const { default: handler } = await import("../add");
     const req = {
@@ -133,6 +137,7 @@ describe("ics-feedcalendar add API", () => {
       urls: ["https://example.com/calendar.ics"],
       skipWriting: true,
     });
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 
   it("persists skipWriting when explicitly requested as false", async () => {
@@ -158,6 +163,7 @@ describe("ics-feedcalendar add API", () => {
       urls: ["https://example.com/calendar.ics"],
       skipWriting: false,
     });
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 
   it("rejects invalid urls payloads", async () => {
@@ -172,6 +178,28 @@ describe("ics-feedcalendar add API", () => {
       body: {
         urls: "https://example.com/calendar.ics",
         skipWriting: true,
+      },
+    } as Partial<NextApiRequest> as NextApiRequest;
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockPrisma.credential.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-boolean skipWriting payloads", async () => {
+    const { default: handler } = await import("../add");
+    const req = {
+      method: "POST",
+      session: {
+        user: {
+          id: 1,
+        },
+      },
+      body: {
+        urls: ["https://example.com/calendar.ics"],
+        skipWriting: "true",
       },
     } as Partial<NextApiRequest> as NextApiRequest;
     const res = createRes();

--- a/packages/app-store/ics-feedcalendar/api/__tests__/add.test.ts
+++ b/packages/app-store/ics-feedcalendar/api/__tests__/add.test.ts
@@ -1,0 +1,136 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type IcsFeedCalendarApiMocks = {
+  mockPrisma: {
+    user: {
+      findFirstOrThrow: ReturnType<typeof vi.fn>;
+    };
+    credential: {
+      create: ReturnType<typeof vi.fn>;
+    };
+  };
+  mockBuildCalendarService: ReturnType<typeof vi.fn>;
+  mockListCalendars: ReturnType<typeof vi.fn>;
+};
+
+const { mockPrisma, mockBuildCalendarService, mockListCalendars }: IcsFeedCalendarApiMocks = vi.hoisted(
+  () => {
+    const mockListCalendars = vi.fn().mockResolvedValue([{ id: "calendar-1" }]);
+    const mockBuildCalendarService = vi.fn(() => ({
+      listCalendars: mockListCalendars,
+    }));
+    const mockPrisma = {
+      user: {
+        findFirstOrThrow: vi.fn(),
+      },
+      credential: {
+        create: vi.fn(),
+      },
+    };
+
+    return { mockPrisma, mockBuildCalendarService, mockListCalendars };
+  }
+);
+
+vi.mock("@calcom/lib/crypto", () => ({
+  symmetricEncrypt: vi.fn((value: string) => value),
+}));
+
+vi.mock("@calcom/lib/logger", () => ({
+  default: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@calcom/prisma", () => ({
+  default: mockPrisma,
+}));
+
+vi.mock("../../../_utils/getInstalledAppPath", () => ({
+  default: vi.fn(() => "/apps/ics-feed"),
+}));
+
+vi.mock("../../lib", () => ({
+  BuildCalendarService: mockBuildCalendarService,
+}));
+
+function createRes(): Pick<NextApiResponse, "status" | "json"> {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as NextApiResponse;
+}
+
+describe("ics-feedcalendar add API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockPrisma.user.findFirstOrThrow.mockResolvedValue({
+      id: 1,
+      email: "person@example.com",
+    });
+  });
+
+  it("persists skipWriting when the setup form requests a read-only feed", async () => {
+    const { default: handler } = await import("../add");
+    const req = {
+      method: "POST",
+      session: {
+        user: {
+          id: 1,
+        },
+      },
+      body: {
+        urls: ["https://example.com/calendar.ics"],
+        skipWriting: true,
+      },
+    } as Partial<NextApiRequest> as NextApiRequest;
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(mockBuildCalendarService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: JSON.stringify({
+          urls: ["https://example.com/calendar.ics"],
+          skipWriting: true,
+        }),
+      })
+    );
+    expect(mockPrisma.credential.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        key: JSON.stringify({
+          urls: ["https://example.com/calendar.ics"],
+          skipWriting: true,
+        }),
+      }),
+    });
+    expect(mockListCalendars).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("defaults skipWriting to true when omitted", async () => {
+    const { default: handler } = await import("../add");
+    const req = {
+      method: "POST",
+      session: {
+        user: {
+          id: 1,
+        },
+      },
+      body: {
+        urls: ["https://example.com/calendar.ics"],
+      },
+    } as Partial<NextApiRequest> as NextApiRequest;
+    const res = createRes();
+
+    await handler(req, res);
+
+    const credentialCreateArg = mockPrisma.credential.create.mock.calls[0][0];
+    expect(JSON.parse(credentialCreateArg.data.key as string)).toEqual({
+      urls: ["https://example.com/calendar.ics"],
+      skipWriting: true,
+    });
+  });
+});

--- a/packages/app-store/ics-feedcalendar/api/add.ts
+++ b/packages/app-store/ics-feedcalendar/api/add.ts
@@ -9,7 +9,28 @@ import { BuildCalendarService } from "../lib";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   if (req.method === "POST") {
-    const { urls, skipWriting = true } = req.body;
+    if (!req.body || typeof req.body !== "object") {
+      return res.status(400).json({ message: "Invalid request body" });
+    }
+
+    const { urls, skipWriting = true } = req.body as {
+      urls?: unknown;
+      skipWriting?: unknown;
+    };
+
+    if (!Array.isArray(urls) || !urls.every((url) => typeof url === "string")) {
+      return res.status(400).json({ message: "urls must be an array of strings" });
+    }
+
+    if (typeof skipWriting !== "boolean") {
+      return res.status(400).json({ message: "skipWriting must be a boolean" });
+    }
+
+    const encryptionKey = env.CALENDSO_ENCRYPTION_KEY;
+    if (!encryptionKey) {
+      return res.status(500).json({ message: "CALENDSO_ENCRYPTION_KEY is required" });
+    }
+
     // Get user
     const user = await prisma.user.findFirstOrThrow({
       where: {
@@ -23,7 +44,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const data = {
       type: appConfig.type,
-      key: symmetricEncrypt(JSON.stringify({ urls, skipWriting }), env.CALENDSO_ENCRYPTION_KEY || ""),
+      key: symmetricEncrypt(JSON.stringify({ urls, skipWriting }), encryptionKey),
       userId: user.id,
       teamId: null,
       appId: appConfig.slug,

--- a/packages/app-store/ics-feedcalendar/api/add.ts
+++ b/packages/app-store/ics-feedcalendar/api/add.ts
@@ -1,16 +1,15 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-
+import { env } from "node:process";
 import { symmetricEncrypt } from "@calcom/lib/crypto";
 import logger from "@calcom/lib/logger";
 import prisma from "@calcom/prisma";
-
+import type { NextApiRequest, NextApiResponse } from "next";
 import getInstalledAppPath from "../../_utils/getInstalledAppPath";
 import appConfig from "../config.json";
 import { BuildCalendarService } from "../lib";
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   if (req.method === "POST") {
-    const { urls } = req.body;
+    const { urls, skipWriting = true } = req.body;
     // Get user
     const user = await prisma.user.findFirstOrThrow({
       where: {
@@ -24,7 +23,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const data = {
       type: appConfig.type,
-      key: symmetricEncrypt(JSON.stringify({ urls }), process.env.CALENDSO_ENCRYPTION_KEY || ""),
+      key: symmetricEncrypt(JSON.stringify({ urls, skipWriting }), env.CALENDSO_ENCRYPTION_KEY || ""),
       userId: user.id,
       teamId: null,
       appId: appConfig.slug,


### PR DESCRIPTION
## Summary

This updates the legacy ICS feed setup flow so users can explicitly mark a feed as read-only. That matches the current ICS/Proton use case, where the shared calendar feed can be used for availability checks but cannot accept writes.

### What changed
- Added a "Do not write to the ICS feed" checkbox to the ICS feed setup page.
- Persisted the read-only choice alongside the encrypted feed URLs when saving credentials.
- Added focused tests for the save API to cover explicit and default read-only handling.

### Why
The existing setup flow only collected URLs, which left no way to record that a feed should be treated as read-only. That created a mismatch between the user-facing setup and the existing read-only ICS behavior.

### Fixes
- Fixes #108312

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change (video / image - any one).

_N/A for this PR._

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- `corepack yarn vitest run packages/app-store/ics-feedcalendar/api/__tests__/add.test.ts`
- `corepack yarn biome check apps/web/components/apps/ics-feedcalendar/Setup.tsx packages/app-store/ics-feedcalendar/api/add.ts packages/app-store/ics-feedcalendar/api/__tests__/add.test.ts`
- `git diff --check`
