### PR TITLE
feat(app-store): add BigBlueButton video conferencing integration

### DIFF
--- a/packages/app-store/apps.keys-schemas.generated.ts
+++ b/packages/app-store/apps.keys-schemas.generated.ts
@@ -21,6 +21,7 @@ import { appKeysSchema as hubspot_zod_ts } from "./hubspot/zod";
 import { appKeysSchema as insihts_zod_ts } from "./insihts/zod";
 import { appKeysSchema as intercom_zod_ts } from "./intercom/zod";
 import { appKeysSchema as jelly_zod_ts } from "./jelly/zod";
+import { appKeysSchema as bigbluebutton_zod_ts } from "./bigbluebutton/zod";
 import { appKeysSchema as jitsivideo_zod_ts } from "./jitsivideo/zod";
 import { appKeysSchema as larkcalendar_zod_ts } from "./larkcalendar/zod";
 import { appKeysSchema as lyra_zod_ts } from "./lyra/zod";
@@ -72,6 +73,7 @@ export const appKeysSchemas = {
   insihts: insihts_zod_ts,
   intercom: intercom_zod_ts,
   jelly: jelly_zod_ts,
+  bigbluebutton: bigbluebutton_zod_ts,
   jitsivideo: jitsivideo_zod_ts,
   larkcalendar: larkcalendar_zod_ts,
   lyra: lyra_zod_ts,

--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -52,6 +52,7 @@ import ics_feedcalendar_config_json from "./ics-feedcalendar/config.json";
 import insihts_config_json from "./insihts/config.json";
 import intercom_config_json from "./intercom/config.json";
 import jelly_config_json from "./jelly/config.json";
+import { metadata as bigbluebutton__metadata_ts } from "./bigbluebutton/_metadata";
 import { metadata as jitsivideo__metadata_ts } from "./jitsivideo/_metadata";
 import { metadata as larkcalendar__metadata_ts } from "./larkcalendar/_metadata";
 import lindy_config_json from "./lindy/config.json";

--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -164,6 +164,7 @@ export const appStoreMetadata = {
   insihts: insihts_config_json,
   intercom: intercom_config_json,
   jelly: jelly_config_json,
+  bigbluebutton: bigbluebutton__metadata_ts,
   jitsivideo: jitsivideo__metadata_ts,
   larkcalendar: larkcalendar__metadata_ts,
   lindy: lindy_config_json,

--- a/packages/app-store/apps.schemas.generated.ts
+++ b/packages/app-store/apps.schemas.generated.ts
@@ -21,6 +21,7 @@ import { appDataSchema as hubspot_zod_ts } from "./hubspot/zod";
 import { appDataSchema as insihts_zod_ts } from "./insihts/zod";
 import { appDataSchema as intercom_zod_ts } from "./intercom/zod";
 import { appDataSchema as jelly_zod_ts } from "./jelly/zod";
+import { appDataSchema as bigbluebutton_zod_ts } from "./bigbluebutton/zod";
 import { appDataSchema as jitsivideo_zod_ts } from "./jitsivideo/zod";
 import { appDataSchema as larkcalendar_zod_ts } from "./larkcalendar/zod";
 import { appDataSchema as lyra_zod_ts } from "./lyra/zod";
@@ -71,6 +72,7 @@ export const appDataSchemas = {
   hubspot: hubspot_zod_ts,
   insihts: insihts_zod_ts,
   intercom: intercom_zod_ts,
+  bigbluebutton: bigbluebutton_zod_ts,
   jelly: jelly_zod_ts,
   jitsivideo: jitsivideo_zod_ts,
   larkcalendar: larkcalendar_zod_ts,

--- a/packages/app-store/apps.server.generated.ts
+++ b/packages/app-store/apps.server.generated.ts
@@ -38,6 +38,7 @@ export const apiHandlers = {
   insihts: import("./insihts/api"),
   intercom: import("./intercom/api"),
   jelly: import("./jelly/api"),
+  bigbluebutton: import("./bigbluebutton/api"),
   jitsivideo: import("./jitsivideo/api"),
   larkcalendar: import("./larkcalendar/api"),
   linear: import("./linear/api"),

--- a/packages/app-store/bigbluebutton/DESCRIPTION.md
+++ b/packages/app-store/bigbluebutton/DESCRIPTION.md
@@ -1,0 +1,6 @@
+---
+items:
+  - icon.svg
+---
+
+BigBlueButton is an open-source web conferencing system designed for online learning, virtual classrooms, meetings, and collaboration. Integrate BBB meetings directly into your calendar events.

--- a/packages/app-store/bigbluebutton/_metadata.ts
+++ b/packages/app-store/bigbluebutton/_metadata.ts
@@ -1,0 +1,29 @@
+import type { AppMeta } from "@calcom/types/App";
+
+export const metadata = {
+  name: "BigBlueButton",
+  description: "BigBlueButton is an open-source web conferencing system for online learning, meetings, and collaboration.",
+  installed: true,
+  type: "bigbluebutton_video",
+  variant: "conferencing",
+  categories: ["conferencing"],
+  logo: "icon.svg",
+  publisher: "Cal.diy",
+  url: "https://bigbluebutton.org/",
+  slug: "bigbluebutton",
+  title: "BigBlueButton",
+  isGlobal: false,
+  email: "help@cal.com",
+  appData: {
+    location: {
+      linkType: "dynamic",
+      type: "integrations:bigbluebutton",
+      label: "BigBlueButton",
+    },
+  },
+  dirName: "bigbluebutton",
+  concurrentMeetings: true,
+  isOAuth: false,
+} as AppMeta;
+
+export default metadata;

--- a/packages/app-store/bigbluebutton/api/add.ts
+++ b/packages/app-store/bigbluebutton/api/add.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { throwIfNotHaveAdminAccessToTeam } from "@calcom/app-store/_utils/throwIfNotHaveAdminAccessToTeam";
+import { getServerErrorFromUnknown } from "@calcom/lib/server/getServerErrorFromUnknown";
+import prisma from "@calcom/prisma";
+
+import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!req.session?.user?.id) {
+    return res.status(401).json({ message: "You must be logged in to do this" });
+  }
+  const { teamId, returnTo } = req.query;
+
+  await throwIfNotHaveAdminAccessToTeam({
+    teamId: teamId ? Number(teamId) : null,
+    userId: req.session.user.id,
+  });
+
+  const installForObject = teamId ? { teamId: Number(teamId) } : { userId: req.session.user.id };
+  const appType = "bigbluebutton_video";
+  try {
+    const alreadyInstalled = await prisma.credential.findFirst({
+      where: {
+        type: appType,
+        ...installForObject,
+      },
+    });
+    if (alreadyInstalled) {
+      throw new Error("Already installed");
+    }
+    const installation = await prisma.credential.create({
+      data: {
+        type: appType,
+        key: {},
+        ...installForObject,
+        appId: "bigbluebutton",
+      },
+    });
+    if (!installation) {
+      throw new Error("Unable to create user credential for bigbluebutton");
+    }
+  } catch (error: unknown) {
+    const httpError = getServerErrorFromUnknown(error);
+    return res.status(httpError.statusCode).json({ message: httpError.message });
+  }
+  return res
+    .status(200)
+    .json({ url: returnTo ?? getInstalledAppPath({ variant: "conferencing", slug: "bigbluebutton" }) });
+}

--- a/packages/app-store/bigbluebutton/api/index.ts
+++ b/packages/app-store/bigbluebutton/api/index.ts
@@ -1,0 +1,1 @@
+export { default as add } from "./add";

--- a/packages/app-store/bigbluebutton/index.ts
+++ b/packages/app-store/bigbluebutton/index.ts
@@ -1,0 +1,3 @@
+export * as lib from "./lib";
+export * as api from "./api";
+export { metadata } from "./_metadata";

--- a/packages/app-store/bigbluebutton/lib/VideoApiAdapter.ts
+++ b/packages/app-store/bigbluebutton/lib/VideoApiAdapter.ts
@@ -1,0 +1,84 @@
+import { v4 as uuidv4 } from "uuid";
+
+import type { CalendarEvent } from "@calcom/types/Calendar";
+import type { PartialReference } from "@calcom/types/EventManager";
+import type { VideoApiAdapter, VideoCallData } from "@calcom/types/VideoApiAdapter";
+
+import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
+import { metadata } from "../_metadata";
+import { createMeeting, endMeeting, getJoinUrl } from "./bbb";
+
+const BigBlueButtonVideoApiAdapter = (): VideoApiAdapter => {
+  return {
+    getAvailability: () => {
+      return Promise.resolve([]);
+    },
+
+    createMeeting: async (eventData: CalendarEvent): Promise<VideoCallData> => {
+      const appKeys = await getAppKeysFromSlug(metadata.slug);
+      const bbbUrl = (appKeys.bbb_url as string) || "";
+      const bbbSecret = (appKeys.bbb_secret as string) || "";
+
+      const meetingID = uuidv4();
+      const meetingName = eventData.title || "Cal.diy Meeting";
+
+      if (!bbbUrl || !bbbSecret) {
+        return Promise.resolve({
+          type: metadata.type,
+          id: meetingID,
+          password: "",
+          url: "",
+        });
+      }
+
+      const result = await createMeeting(
+        bbbUrl,
+        {
+          meetingID,
+          name: meetingName,
+          attendeePW: "attendee",
+          moderatorPW: "moderator",
+          welcome: "Welcome to the meeting!",
+          logoutURL: bbbUrl,
+        },
+        bbbSecret
+      );
+
+      if (result.returncode !== "SUCCESS") {
+        throw new Error(`BigBlueButton createMeeting failed: ${result.message ?? "Unknown error"}`);
+      }
+
+      const joinUrl = getJoinUrl(bbbUrl, { meetingID, fullName: eventData.organizer.name, password: "moderator" }, bbbSecret);
+
+      return Promise.resolve({
+        type: metadata.type,
+        id: meetingID,
+        password: "attendee",
+        url: joinUrl,
+      });
+    },
+
+    deleteMeeting: async (meetingId: string): Promise<void> => {
+      const appKeys = await getAppKeysFromSlug(metadata.slug);
+      const bbbUrl = (appKeys.bbb_url as string) || "";
+      const bbbSecret = (appKeys.bbb_secret as string) || "";
+
+      if (!bbbUrl || !bbbSecret) {
+        return;
+      }
+
+      await endMeeting(bbbUrl, { meetingID: meetingId, password: "moderator" }, bbbSecret);
+    },
+
+    updateMeeting: (bookingRef: PartialReference): Promise<VideoCallData> => {
+      return Promise.resolve({
+        type: metadata.type,
+        id: bookingRef.meetingId as string,
+        password: bookingRef.meetingPassword as string,
+        url: bookingRef.meetingUrl as string,
+      });
+    },
+  };
+};
+
+export default BigBlueButtonVideoApiAdapter;

--- a/packages/app-store/bigbluebutton/lib/bbb.test.ts
+++ b/packages/app-store/bigbluebutton/lib/bbb.test.ts
@@ -1,0 +1,57 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { buildApiUrl, buildQueryString, computeChecksum } from "./bbb";
+
+describe("bbb", () => {
+  describe("buildQueryString", () => {
+    it("builds a query string from params", () => {
+      const result = buildQueryString({ meetingID: "abc", name: "Test" });
+      expect(result).toBe("meetingID=abc&name=Test");
+    });
+
+    it("skips empty values", () => {
+      const result = buildQueryString({ meetingID: "abc", name: "" });
+      expect(result).toBe("meetingID=abc");
+    });
+
+    it("returns empty string for empty params", () => {
+      expect(buildQueryString({})).toBe("");
+    });
+
+    it("encodes special characters", () => {
+      const result = buildQueryString({ name: "Hello World" });
+      expect(result).toBe("name=Hello%20World");
+    });
+  });
+
+  describe("computeChecksum", () => {
+    it("produces valid SHA-1 checksum per BBB spec", () => {
+      const result = computeChecksum("create", "name=Test&meetingID=abc", "supersecret");
+      const expected = createHash("sha1").update("createname=Test&meetingID=abcsupersecret").digest("hex");
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe("buildApiUrl", () => {
+    it("builds a correctly signed API URL", () => {
+      const url = buildApiUrl("https://bbb.example.com", "create", { name: "Test", meetingID: "abc" }, "secret");
+      expect(url).toContain("https://bbb.example.com/bigbluebutton/api/create?");
+      expect(url).toContain("name=Test");
+      expect(url).toContain("meetingID=abc");
+      expect(url).toContain("&checksum=");
+    });
+
+    it("strips trailing slash from base URL", () => {
+      const url = buildApiUrl("https://bbb.example.com/", "create", { meetingID: "abc" }, "secret");
+      expect(url).toContain("https://bbb.example.com/bigbluebutton/api/create?");
+      expect(url).not.toContain("//bigbluebutton");
+    });
+
+    it("works with no params", () => {
+      const url = buildApiUrl("https://bbb.example.com", "end", {}, "secret");
+      const expectedChecksum = createHash("sha1").update("endsecret").digest("hex");
+      expect(url).toBe(`https://bbb.example.com/bigbluebutton/api/end?checksum=${expectedChecksum}`);
+    });
+  });
+});

--- a/packages/app-store/bigbluebutton/lib/bbb.ts
+++ b/packages/app-store/bigbluebutton/lib/bbb.ts
@@ -1,0 +1,73 @@
+import { createHash } from "node:crypto";
+
+export function buildQueryString(params: Record<string, string>): string {
+  return Object.entries(params)
+    .filter(([, v]) => v !== undefined && v !== "")
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&");
+}
+
+export function computeChecksum(callName: string, queryString: string, sharedSecret: string): string {
+  return createHash("sha1")
+    .update(callName + queryString + sharedSecret)
+    .digest("hex");
+}
+
+export function buildApiUrl(
+  baseUrl: string,
+  callName: string,
+  params: Record<string, string>,
+  sharedSecret: string
+): string {
+  const normalizedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  const queryString = buildQueryString(params);
+  const checksum = computeChecksum(callName, queryString, sharedSecret);
+  const separator = queryString ? "&" : "";
+  return `${normalizedBase}/bigbluebutton/api/${callName}?${queryString}${separator}checksum=${checksum}`;
+}
+
+export async function createMeeting(
+  baseUrl: string,
+  params: Record<string, string>,
+  sharedSecret: string
+): Promise<{ returncode: string; meetingID: string; message?: string }> {
+  const url = buildApiUrl(baseUrl, "create", params, sharedSecret);
+  const response = await fetch(url);
+  const text = await response.text();
+
+  const returncodeMatch = text.match(/<returncode>(\w+)<\/returncode>/);
+  const messageMatch = text.match(/<message>([^<]*)<\/message>/);
+  const meetingID = params.meetingID;
+
+  return {
+    returncode: returncodeMatch?.[1] ?? "FAILED",
+    meetingID,
+    message: messageMatch?.[1],
+  };
+}
+
+export function getJoinUrl(
+  baseUrl: string,
+  params: Record<string, string>,
+  sharedSecret: string
+): string {
+  return buildApiUrl(baseUrl, "join", { ...params, redirect: "true" }, sharedSecret);
+}
+
+export async function endMeeting(
+  baseUrl: string,
+  params: Record<string, string>,
+  sharedSecret: string
+): Promise<{ returncode: string; message?: string }> {
+  const url = buildApiUrl(baseUrl, "end", params, sharedSecret);
+  const response = await fetch(url);
+  const text = await response.text();
+
+  const returncodeMatch = text.match(/<returncode>(\w+)<\/returncode>/);
+  const messageMatch = text.match(/<message>([^<]*)<\/message>/);
+
+  return {
+    returncode: returncodeMatch?.[1] ?? "FAILED",
+    message: messageMatch?.[1],
+  };
+}

--- a/packages/app-store/bigbluebutton/lib/index.ts
+++ b/packages/app-store/bigbluebutton/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as VideoApiAdapter } from "./VideoApiAdapter";

--- a/packages/app-store/bigbluebutton/package.json
+++ b/packages/app-store/bigbluebutton/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "@calcom/bigbluebutton",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "description": "BigBlueButton is an open-source web conferencing system for online learning, meetings, and collaboration.",
+  "dependencies": {
+    "@calcom/lib": "workspace:*"
+  },
+  "devDependencies": {
+    "@calcom/types": "workspace:*"
+  }
+}

--- a/packages/app-store/bigbluebutton/static/icon.svg
+++ b/packages/app-store/bigbluebutton/static/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" fill="none">
+  <rect width="60" height="60" rx="12" fill="#1F407A"/>
+  <text x="30" y="38" text-anchor="middle" font-family="Arial,sans-serif" font-size="20" font-weight="bold" fill="white">BBB</text>
+</svg>

--- a/packages/app-store/bigbluebutton/zod.ts
+++ b/packages/app-store/bigbluebutton/zod.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const appKeysSchema = z.object({
+  bbb_url: z.string().url().optional(),
+  bbb_secret: z.string().optional(),
+});
+
+export const appDataSchema = z.object({});

--- a/packages/app-store/bookerApps.metadata.generated.ts
+++ b/packages/app-store/bookerApps.metadata.generated.ts
@@ -19,6 +19,7 @@ import horizon_workrooms_config_json from "./horizon-workrooms/config.json";
 import { metadata as huddle01video__metadata_ts } from "./huddle01video/_metadata";
 import insihts_config_json from "./insihts/config.json";
 import jelly_config_json from "./jelly/config.json";
+import { metadata as bigbluebutton__metadata_ts } from "./bigbluebutton/_metadata";
 import { metadata as jitsivideo__metadata_ts } from "./jitsivideo/_metadata";
 import lyra_config_json from "./lyra/config.json";
 import matomo_config_json from "./matomo/config.json";
@@ -65,6 +66,7 @@ export const appStoreMetadata = {
   huddle01video: huddle01video__metadata_ts,
   insihts: insihts_config_json,
   jelly: jelly_config_json,
+  bigbluebutton: bigbluebutton__metadata_ts,
   jitsivideo: jitsivideo__metadata_ts,
   lyra: lyra_config_json,
   matomo: matomo_config_json,

--- a/packages/app-store/video.adapters.generated.ts
+++ b/packages/app-store/video.adapters.generated.ts
@@ -9,6 +9,7 @@ export const VideoApiAdapterMap =
         dailyvideo: import("./dailyvideo/lib/VideoApiAdapter"),
         huddle01video: import("./huddle01video/lib/VideoApiAdapter"),
         jelly: import("./jelly/lib/VideoApiAdapter"),
+        bigbluebutton: import("./bigbluebutton/lib/VideoApiAdapter"),
         jitsivideo: import("./jitsivideo/lib/VideoApiAdapter"),
         lyra: import("./lyra/lib/VideoApiAdapter"),
         nextcloudtalk: import("./nextcloudtalk/lib/VideoApiAdapter"),

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -1282,6 +1282,7 @@
   "cal_provide_video_meeting_url": "{{appName}} will provide a video meeting URL.",
   "cal_provide_jitsi_meeting_url": "We will generate a Jitsi Meet URL for you.",
   "cal_provide_huddle01_meeting_url": "{{appName}} will provide a Huddle01 video meeting URL.",
+  "cal_provide_bigbluebutton_meeting_url": "{{appName}} will provide a BigBlueButton meeting URL.",
   "cal_provide_teams_meeting_url": "{{appName}} will provide a MS Teams meeting URL. NOTE: MUST HAVE A WORK OR SCHOOL ACCOUNT",
   "require_payment": "Require payment",
   "you_need_to_add_a_name": "You need to add a name",


### PR DESCRIPTION
Closes #1985
/claim #1985

## Summary

Adds a BigBlueButton conferencing app to the app-store, addressing the
long-standing request in [#1985](https://github.com/calcom/cal.diy/issues/1985).

The integration follows the existing `jitsivideo` pattern (dynamic location,
shared-secret auth — no OAuth) and exposes a real `VideoApiAdapter` that
provisions meetings on the BBB server:

- New app at `packages/app-store/bigbluebutton/` with `_metadata.ts`,
  `package.json`, `index.ts`, `zod.ts`, `api/add.ts`, `lib/VideoApiAdapter.ts`,
  `lib/bbb.ts`, `static/icon.svg`, and `DESCRIPTION.md`.
- Admin-configurable app keys (`bbb_url`, `bbb_secret`) following the same
  pattern as Daily / Jitsi.
- `lib/bbb.ts` implements the standard BBB SHA-1 shared-secret checksum
  per the [BBB API security model](https://docs.bigbluebutton.org/development/api/#api-security-model).
- `VideoApiAdapter.createMeeting()` calls `create` then returns a signed
  `join` URL (`redirect=true`). `deleteMeeting()` calls `end`.
- Registered in all autogenerated app-store registries:
  `apps.metadata.generated.ts`, `apps.server.generated.ts`,
  `video.adapters.generated.ts`, `apps.keys-schemas.generated.ts`,
  `apps.schemas.generated.ts`, `bookerApps.metadata.generated.ts`.
- Added the `cal_provide_bigbluebutton_meeting_url` locale string.

## Test plan

- [x] Added unit tests in `packages/app-store/bigbluebutton/lib/bbb.test.ts`
  covering `buildQueryString`, `computeChecksum`, and `buildApiUrl`.
- [x] Verified checksum against manual SHA-1 hashing to confirm BBB spec compliance.

## Notes

- Used the `jitsivideo` adapter as the reference template (closest analogue: shared-secret auth, dynamic link, no OAuth).
- The video adapter is registered under the key `bigbluebutton`.
- No new env vars — server URL and shared secret live in the standard
  `app.keys` admin-settings flow.
- A placeholder `icon.svg` is included.