### PR TITLE
feat(app-store): add BigBlueButton video conferencing integration

### DIFF
--- a/packages/app-store/apps.keys-schemas.generated.ts
+++ b/packages/app-store/apps.keys-schemas.generated.ts
@@ -21,6 +21,7 @@ import { appKeysSchema as hubspot_zod_ts } from "./hubspot/zod";
 import { appKeysSchema as insihts_zod_ts } from "./insihts/zod";
 import { appKeysSchema as intercom_zod_ts } from "./intercom/zod";
 import { appKeysSchema as jelly_zod_ts } from "./jelly/zod";
+import { appKeysSchema as bigbluebutton_zod_ts } from "./bigbluebutton/zod";
 import { appKeysSchema as jitsivideo_zod_ts } from "./jitsivideo/zod";
 import { appKeysSchema as larkcalendar_zod_ts } from "./larkcalendar/zod";
 import { appKeysSchema as lyra_zod_ts } from "./lyra/zod";
@@ -72,6 +73,7 @@ export const appKeysSchemas = {
   insihts: insihts_zod_ts,
   intercom: intercom_zod_ts,
   jelly: jelly_zod_ts,
+  bigbluebutton: bigbluebutton_zod_ts,
   jitsivideo: jitsivideo_zod_ts,
   larkcalendar: larkcalendar_zod_ts,
   lyra: lyra_zod_ts,

--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -52,6 +52,7 @@ import ics_feedcalendar_config_json from "./ics-feedcalendar/config.json";
 import insihts_config_json from "./insihts/config.json";
 import intercom_config_json from "./intercom/config.json";
 import jelly_config_json from "./jelly/config.json";
+import { metadata as bigbluebutton__metadata_ts } from "./bigbluebutton/_metadata";
 import { metadata as jitsivideo__metadata_ts } from "./jitsivideo/_metadata";
 import { metadata as larkcalendar__metadata_ts } from "./larkcalendar/_metadata";
 import lindy_config_json from "./lindy/config.json";
@@ -164,6 +165,7 @@ export const appStoreMetadata = {
   insihts: insihts_config_json,
   intercom: intercom_config_json,
   jelly: jelly_config_json,
+  bigbluebutton: bigbluebutton__metadata_ts,
   jitsivideo: jitsivideo__metadata_ts,
   larkcalendar: larkcalendar__metadata_ts,
   lindy: lindy_config_json,

--- a/packages/app-store/apps.schemas.generated.ts
+++ b/packages/app-store/apps.schemas.generated.ts
@@ -21,6 +21,7 @@ import { appDataSchema as hubspot_zod_ts } from "./hubspot/zod";
 import { appDataSchema as insihts_zod_ts } from "./insihts/zod";
 import { appDataSchema as intercom_zod_ts } from "./intercom/zod";
 import { appDataSchema as jelly_zod_ts } from "./jelly/zod";
+import { appDataSchema as bigbluebutton_zod_ts } from "./bigbluebutton/zod";
 import { appDataSchema as jitsivideo_zod_ts } from "./jitsivideo/zod";
 import { appDataSchema as larkcalendar_zod_ts } from "./larkcalendar/zod";
 import { appDataSchema as lyra_zod_ts } from "./lyra/zod";
@@ -72,6 +73,7 @@ export const appDataSchemas = {
   insihts: insihts_zod_ts,
   intercom: intercom_zod_ts,
   jelly: jelly_zod_ts,
+  bigbluebutton: bigbluebutton_zod_ts,
   jitsivideo: jitsivideo_zod_ts,
   larkcalendar: larkcalendar_zod_ts,
   lyra: lyra_zod_ts,

--- a/packages/app-store/apps.server.generated.ts
+++ b/packages/app-store/apps.server.generated.ts
@@ -38,6 +38,7 @@ export const apiHandlers = {
   insihts: import("./insihts/api"),
   intercom: import("./intercom/api"),
   jelly: import("./jelly/api"),
+  bigbluebutton: import("./bigbluebutton/api"),
   jitsivideo: import("./jitsivideo/api"),
   larkcalendar: import("./larkcalendar/api"),
   linear: import("./linear/api"),

--- a/packages/app-store/bigbluebutton/DESCRIPTION.md
+++ b/packages/app-store/bigbluebutton/DESCRIPTION.md
@@ -1,0 +1,6 @@
+---
+items:
+  - icon.svg
+---
+
+BigBlueButton is an open-source web conferencing system designed for online learning. It supports real-time sharing of audio, video, slides, and screen with features like breakout rooms, polling, and shared notes.

--- a/packages/app-store/bigbluebutton/_metadata.ts
+++ b/packages/app-store/bigbluebutton/_metadata.ts
@@ -14,4 +14,13 @@ export const metadata = {
   slug: "bigbluebutton",
   title: "BigBlueButton",
   isGlobal: false,
+  email: "support@bigbluebutton.org",
+  appData: {
+    location: {
+      linkType: "dynamic",
+      type: "integrations:bigbluebutton_video",
+      label: "BigBlueButton",
+    },
+  },
+  dirName: "bigbluebutton",
 } as AppMeta;

--- a/packages/app-store/bigbluebutton/_metadata.ts
+++ b/packages/app-store/bigbluebutton/_metadata.ts
@@ -1,0 +1,17 @@
+import type { AppMeta } from "@calcom/types/App";
+
+export const metadata = {
+  name: "BigBlueButton Video",
+  description:
+    "BigBlueButton is an open-source web conferencing system designed for online learning. It supports real-time sharing of audio, video, slides, and screen.",
+  installed: true,
+  type: "bigbluebutton_video",
+  variant: "conferencing",
+  categories: ["conferencing"],
+  logo: "icon.svg",
+  publisher: "Cal.diy",
+  url: "https://bigbluebutton.org/",
+  slug: "bigbluebutton",
+  title: "BigBlueButton",
+  isGlobal: false,
+} as AppMeta;

--- a/packages/app-store/bigbluebutton/api/add.ts
+++ b/packages/app-store/bigbluebutton/api/add.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { throwIfNotHaveAdminAccessToTeam } from "@calcom/app-store/_utils/throwIfNotHaveAdminAccessToTeam";
+import { getServerErrorFromUnknown } from "@calcom/lib/server/getServerErrorFromUnknown";
+import prisma from "@calcom/prisma";
+
+import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!req.session?.user?.id) {
+    return res.status(401).json({ message: "You must be logged in to do this" });
+  }
+  const { teamId, returnTo } = req.query;
+
+  await throwIfNotHaveAdminAccessToTeam({
+    teamId: teamId ? Number(teamId) : null,
+    userId: req.session.user.id,
+  });
+
+  const installForObject = teamId ? { teamId: Number(teamId) } : { userId: req.session.user.id };
+  const appType = "bigbluebutton_video";
+  try {
+    const alreadyInstalled = await prisma.credential.findFirst({
+      where: {
+        type: appType,
+        ...installForObject,
+      },
+    });
+    if (alreadyInstalled) {
+      throw new Error("Already installed");
+    }
+    const installation = await prisma.credential.create({
+      data: {
+        type: appType,
+        key: {},
+        ...installForObject,
+        appId: "bigbluebutton",
+      },
+    });
+    if (!installation) {
+      throw new Error("Unable to create user credential for bigbluebutton");
+    }
+  } catch (error: unknown) {
+    const httpError = getServerErrorFromUnknown(error);
+    return res.status(httpError.statusCode).json({ message: httpError.message });
+  }
+  return res
+    .status(200)
+    .json({ url: returnTo ?? getInstalledAppPath({ variant: "conferencing", slug: "bigbluebutton" }) });
+}

--- a/packages/app-store/bigbluebutton/api/add.ts
+++ b/packages/app-store/bigbluebutton/api/add.ts
@@ -6,6 +6,11 @@ import prisma from "@calcom/prisma";
 
 import getInstalledAppPath from "../../_utils/getInstalledAppPath";
 
+/**
+ * Next.js API handler for installing the BigBlueButton app.
+ * Validates admin access, checks for existing installation,
+ * and creates a new credential record for the user or team.
+ */
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (!req.session?.user?.id) {
     return res.status(401).json({ message: "You must be logged in to do this" });

--- a/packages/app-store/bigbluebutton/api/index.ts
+++ b/packages/app-store/bigbluebutton/api/index.ts
@@ -1,0 +1,1 @@
+export { default as add } from "./add";

--- a/packages/app-store/bigbluebutton/index.ts
+++ b/packages/app-store/bigbluebutton/index.ts
@@ -1,0 +1,3 @@
+export * as lib from "./lib";
+export * as api from "./api";
+export { metadata } from "./_metadata";

--- a/packages/app-store/bigbluebutton/lib/VideoApiAdapter.ts
+++ b/packages/app-store/bigbluebutton/lib/VideoApiAdapter.ts
@@ -1,0 +1,92 @@
+import { v4 as uuidv4 } from "uuid";
+
+import type { CalendarEvent } from "@calcom/types/Calendar";
+import type { PartialReference } from "@calcom/types/EventManager";
+import type { VideoApiAdapter, VideoCallData } from "@calcom/types/VideoApiAdapter";
+
+import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
+import { metadata } from "../_metadata";
+
+import { buildApiUrl } from "./bbb";
+
+const BigBlueButtonVideoApiAdapter = (): VideoApiAdapter => {
+  return {
+    getAvailability: () => {
+      return Promise.resolve([]);
+    },
+    createMeeting: async (eventData: CalendarEvent): Promise<VideoCallData> => {
+      const appKeys = await getAppKeysFromSlug(metadata.slug);
+      const bbbUrl = appKeys.bbb_url as string;
+      const bbbSecret = appKeys.bbb_secret as string;
+
+      const meetingID = uuidv4();
+      const meetingName = eventData.title || "Cal Meeting";
+      const attendeePW = uuidv4().slice(0, 8);
+      const moderatorPW = uuidv4().slice(0, 8);
+
+      const createUrl = buildApiUrl(
+        bbbUrl,
+        "create",
+        {
+          meetingID,
+          name: meetingName,
+          attendeePW,
+          moderatorPW,
+          welcome: `<br>Welcome to <b>${meetingName}</b>!`,
+        },
+        bbbSecret
+      );
+
+      const response = await fetch(createUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to create BBB meeting: ${response.statusText}`);
+      }
+
+      const joinUrl = buildApiUrl(
+        bbbUrl,
+        "join",
+        {
+          meetingID,
+          fullName: eventData.organizer.name,
+          password: moderatorPW,
+          redirect: "true",
+        },
+        bbbSecret
+      );
+
+      return {
+        type: metadata.type,
+        id: meetingID,
+        password: moderatorPW,
+        url: joinUrl,
+      };
+    },
+    deleteMeeting: async (bookingRef: PartialReference): Promise<void> => {
+      const appKeys = await getAppKeysFromSlug(metadata.slug);
+      const bbbUrl = appKeys.bbb_url as string;
+      const bbbSecret = appKeys.bbb_secret as string;
+
+      const endUrl = buildApiUrl(
+        bbbUrl,
+        "end",
+        {
+          meetingID: bookingRef.meetingId as string,
+          password: bookingRef.meetingPassword as string,
+        },
+        bbbSecret
+      );
+
+      await fetch(endUrl);
+    },
+    updateMeeting: (bookingRef: PartialReference): Promise<VideoCallData> => {
+      return Promise.resolve({
+        type: metadata.type,
+        id: bookingRef.meetingId as string,
+        password: bookingRef.meetingPassword as string,
+        url: bookingRef.meetingUrl as string,
+      });
+    },
+  };
+};
+
+export default BigBlueButtonVideoApiAdapter;

--- a/packages/app-store/bigbluebutton/lib/VideoApiAdapter.ts
+++ b/packages/app-store/bigbluebutton/lib/VideoApiAdapter.ts
@@ -9,11 +9,22 @@ import { metadata } from "../_metadata";
 
 import { buildApiUrl } from "./bbb";
 
+/**
+ * BigBlueButton video conferencing adapter for Cal.diy.
+ * Implements the VideoApiAdapter interface to create, update, and delete
+ * BBB meetings via the BBB API with SHA-1 checksum authentication.
+ */
 const BigBlueButtonVideoApiAdapter = (): VideoApiAdapter => {
   return {
+    /** BBB does not expose availability via API; always returns empty. */
     getAvailability: () => {
       return Promise.resolve([]);
     },
+    /**
+     * Create a new BigBlueButton meeting for a Cal booking.
+     * Generates unique meeting ID and passwords, calls BBB create API,
+     * and returns a join URL for the organizer (moderator role).
+     */
     createMeeting: async (eventData: CalendarEvent): Promise<VideoCallData> => {
       const appKeys = await getAppKeysFromSlug(metadata.slug);
       const bbbUrl = appKeys.bbb_url as string;
@@ -61,6 +72,7 @@ const BigBlueButtonVideoApiAdapter = (): VideoApiAdapter => {
         url: joinUrl,
       };
     },
+    /** End a running BBB meeting by calling the BBB end API with the meeting ID and password. */
     deleteMeeting: async (bookingRef: PartialReference): Promise<void> => {
       const appKeys = await getAppKeysFromSlug(metadata.slug);
       const bbbUrl = appKeys.bbb_url as string;
@@ -78,6 +90,7 @@ const BigBlueButtonVideoApiAdapter = (): VideoApiAdapter => {
 
       await fetch(endUrl);
     },
+    /** BBB meetings are immutable; returns existing meeting data without modification. */
     updateMeeting: (bookingRef: PartialReference): Promise<VideoCallData> => {
       return Promise.resolve({
         type: metadata.type,

--- a/packages/app-store/bigbluebutton/lib/bbb.test.ts
+++ b/packages/app-store/bigbluebutton/lib/bbb.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+
+import { buildQueryString, computeChecksum, buildApiUrl } from "./bbb";
+
+describe("BigBlueButton API helpers", () => {
+  describe("buildQueryString", () => {
+    it("encodes params into a query string", () => {
+      const qs = buildQueryString({ meetingID: "abc-123", name: "Test Meeting" });
+      expect(qs).toBe("meetingID=abc-123&name=Test%20Meeting");
+    });
+
+    it("skips empty values", () => {
+      const qs = buildQueryString({ a: "1", b: "", c: "3" });
+      expect(qs).toBe("a=1&c=3");
+    });
+  });
+
+  describe("computeChecksum", () => {
+    it("produces a valid SHA-1 hex digest", () => {
+      const checksum = computeChecksum("create", "meetingID=test", "secret123");
+      expect(checksum).toMatch(/^[a-f0-9]{40}$/);
+    });
+
+    it("produces different checksums for different inputs", () => {
+      const a = computeChecksum("create", "meetingID=1", "secret");
+      const b = computeChecksum("create", "meetingID=2", "secret");
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe("buildApiUrl", () => {
+    it("builds a complete BBB API URL with checksum", () => {
+      const url = buildApiUrl("https://bbb.example.com", "create", { meetingID: "test" }, "secret");
+      expect(url).toContain("https://bbb.example.com/api/create?");
+      expect(url).toContain("meetingID=test");
+      expect(url).toContain("checksum=");
+    });
+
+    it("strips trailing slashes from base URL", () => {
+      const url = buildApiUrl("https://bbb.example.com///", "join", { meetingID: "x" }, "s");
+      expect(url).toContain("https://bbb.example.com/api/join?");
+    });
+  });
+});

--- a/packages/app-store/bigbluebutton/lib/bbb.ts
+++ b/packages/app-store/bigbluebutton/lib/bbb.ts
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Build a BigBlueButton API query string with the correct checksum.
+ *
+ * BBB uses SHA-1 shared-secret checksums per:
+ * https://docs.bigbluebutton.org/development/api/#api-security-model
+ */
+
+export function computeChecksum(callName: string, queryString: string, secret: string): string {
+  const data = callName + queryString + secret;
+  return createHash("sha1").update(data).digest("hex");
+}
+
+export function buildQueryString(params: Record<string, string>): string {
+  return Object.entries(params)
+    .filter(([, v]) => v !== undefined && v !== "")
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&");
+}
+
+export function buildApiUrl(
+  bbbUrl: string,
+  callName: string,
+  params: Record<string, string>,
+  secret: string
+): string {
+  const qs = buildQueryString(params);
+  const checksum = computeChecksum(callName, qs, secret);
+  const baseUrl = bbbUrl.replace(/\/+$/, "");
+  return `${baseUrl}/api/${callName}?${qs}&checksum=${checksum}`;
+}

--- a/packages/app-store/bigbluebutton/lib/bbb.ts
+++ b/packages/app-store/bigbluebutton/lib/bbb.ts
@@ -12,6 +12,10 @@ export function computeChecksum(callName: string, queryString: string, secret: s
   return createHash("sha1").update(data).digest("hex");
 }
 
+/**
+ * Encode an object of key-value pairs into a URL query string.
+ * Keys and values are URI-encoded; entries with empty or undefined values are omitted.
+ */
 export function buildQueryString(params: Record<string, string>): string {
   return Object.entries(params)
     .filter(([, v]) => v !== undefined && v !== "")
@@ -19,6 +23,11 @@ export function buildQueryString(params: Record<string, string>): string {
     .join("&");
 }
 
+/**
+ * Construct a fully authenticated BigBlueButton API URL.
+ * Builds the query string, computes the SHA-1 checksum, and returns
+ * the complete URL ready for a GET request to the BBB server.
+ */
 export function buildApiUrl(
   bbbUrl: string,
   callName: string,

--- a/packages/app-store/bigbluebutton/lib/index.ts
+++ b/packages/app-store/bigbluebutton/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as VideoApiAdapter } from "./VideoApiAdapter";

--- a/packages/app-store/bigbluebutton/package.json
+++ b/packages/app-store/bigbluebutton/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "@calcom/bigbluebutton",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "description": "BigBlueButton is an open-source web conferencing system designed for online learning.",
+  "dependencies": {
+    "@calcom/lib": "workspace:*"
+  },
+  "devDependencies": {
+    "@calcom/types": "workspace:*"
+  }
+}

--- a/packages/app-store/bigbluebutton/static/icon.svg
+++ b/packages/app-store/bigbluebutton/static/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <rect width="100" height="100" rx="20" fill="#283848"/>
+  <circle cx="50" cy="40" r="18" fill="#5DB5A5"/>
+  <rect x="30" y="62" width="40" height="8" rx="4" fill="#5DB5A5"/>
+  <rect x="24" y="74" width="52" height="8" rx="4" fill="#4A9E90"/>
+</svg>

--- a/packages/app-store/bigbluebutton/zod.ts
+++ b/packages/app-store/bigbluebutton/zod.ts
@@ -1,8 +1,13 @@
 import { z } from "zod";
 
+/**
+ * Zod schema for BigBlueButton app keys stored in the database.
+ * Requires a valid BBB server URL and a non-empty shared secret.
+ */
 export const appKeysSchema = z.object({
   bbb_url: z.string().url(),
   bbb_secret: z.string().min(1),
 });
 
+/** Zod schema for BigBlueButton app-specific data (currently unused). */
 export const appDataSchema = z.object({});

--- a/packages/app-store/bigbluebutton/zod.ts
+++ b/packages/app-store/bigbluebutton/zod.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const appKeysSchema = z.object({
+  bbb_url: z.string().url(),
+  bbb_secret: z.string().min(1),
+});
+
+export const appDataSchema = z.object({});

--- a/packages/app-store/bookerApps.metadata.generated.ts
+++ b/packages/app-store/bookerApps.metadata.generated.ts
@@ -19,6 +19,7 @@ import horizon_workrooms_config_json from "./horizon-workrooms/config.json";
 import { metadata as huddle01video__metadata_ts } from "./huddle01video/_metadata";
 import insihts_config_json from "./insihts/config.json";
 import jelly_config_json from "./jelly/config.json";
+import { metadata as bigbluebutton__metadata_ts } from "./bigbluebutton/_metadata";
 import { metadata as jitsivideo__metadata_ts } from "./jitsivideo/_metadata";
 import lyra_config_json from "./lyra/config.json";
 import matomo_config_json from "./matomo/config.json";
@@ -65,6 +66,7 @@ export const appStoreMetadata = {
   huddle01video: huddle01video__metadata_ts,
   insihts: insihts_config_json,
   jelly: jelly_config_json,
+  bigbluebutton: bigbluebutton__metadata_ts,
   jitsivideo: jitsivideo__metadata_ts,
   lyra: lyra_config_json,
   matomo: matomo_config_json,

--- a/packages/app-store/video.adapters.generated.ts
+++ b/packages/app-store/video.adapters.generated.ts
@@ -9,6 +9,7 @@ export const VideoApiAdapterMap =
         dailyvideo: import("./dailyvideo/lib/VideoApiAdapter"),
         huddle01video: import("./huddle01video/lib/VideoApiAdapter"),
         jelly: import("./jelly/lib/VideoApiAdapter"),
+        bigbluebutton: import("./bigbluebutton/lib/VideoApiAdapter"),
         jitsivideo: import("./jitsivideo/lib/VideoApiAdapter"),
         lyra: import("./lyra/lib/VideoApiAdapter"),
         nextcloudtalk: import("./nextcloudtalk/lib/VideoApiAdapter"),

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4768,5 +4768,6 @@
   "user_updated_successfully": "User updated successfully.",
   "error_updating_user": "There was an error updating this user.",
   "please_reschedule": "Please reschedule.",
+  "cal_provide_bigbluebutton_meeting_url": "We will generate a BigBlueButton meeting URL for you.",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }


### PR DESCRIPTION
Adds BigBlueButton as a video conferencing option in the app store.

Follows the same pattern as Jitsi (shared-secret auth, dynamic location, no OAuth). The adapter calls BBB create/join/end APIs with SHA-1 checksum authentication.

**What changed:**
- New app at `packages/app-store/bigbluebutton/`
- Admin-configurable keys (`bbb_url`, `bbb_secret`) via the standard app settings
- `VideoApiAdapter` that creates meetings and returns join URLs
- Registered in all the generated app-store files
- Added locale string for the meeting URL message
- Unit tests for the BBB API helpers (checksum, query string, URL building)

**Setup:** Install from the app store, enter your BBB server URL and shared secret in settings, then select BigBlueButton as the location when creating an event type.

Closes #29488
Closes #1985