### PR TITLE
fix(auth): persist user locale on signup for all code paths

### DIFF
--- a/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/calcomSignupHandler.ts
@@ -57,11 +57,13 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
     email: _email,
     password,
     token,
+    language,
   } = signupSchema
     .pick({
       email: true,
       password: true,
       token: true,
+      language: true,
     })
     .parse(body);
 
@@ -218,6 +220,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
             username,
             emailVerified: new Date(Date.now()),
             identityProvider: IdentityProvider.CAL,
+            locale: language,
             password: {
               upsert: {
                 create: { hash: hashedPassword },
@@ -231,6 +234,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
             email,
             emailVerified: new Date(Date.now()),
             identityProvider: IdentityProvider.CAL,
+            locale: language,
             password: { create: { hash: hashedPassword } },
             organizationId,
           },
@@ -274,6 +278,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus, query) => {
           username,
           email,
           locked: shouldLockByDefault,
+          locale: language,
           password: { create: { hash: hashedPassword } },
           metadata: {
             stripeCustomerId: customer.stripeCustomerId,

--- a/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
+++ b/apps/web/app/api/auth/signup/handlers/selfHostedHandler.ts
@@ -120,6 +120,7 @@ export default async function handler(body: Record<string, string>) {
             username: correctedUsername,
             emailVerified: new Date(Date.now()),
             identityProvider: IdentityProvider.CAL,
+            locale: language,
             password: {
               upsert: {
                 create: { hash: hashedPassword },
@@ -133,6 +134,7 @@ export default async function handler(body: Record<string, string>) {
             email: userEmail,
             emailVerified: new Date(Date.now()),
             identityProvider: IdentityProvider.CAL,
+            locale: language,
             password: { create: { hash: hashedPassword } },
             organizationId,
           },
@@ -178,6 +180,7 @@ export default async function handler(body: Record<string, string>) {
         data: {
           username: correctedUsername,
           email: userEmail,
+          locale: language,
           password: { create: { hash: hashedPassword } },
           identityProvider: IdentityProvider.CAL,
         },


### PR DESCRIPTION
## What does this PR do?

Fixes #19646

The `language` field sent by the signup form is validated by `signupSchema` and forwarded correctly by the client, but was **never written to `User.locale`** in any Prisma create/upsert call. Newly registered users always ended up with a null locale, causing the UI to fall back to browser-detected language rather than the language they actually signed up with.

**Root cause:**
```
signup-view.tsx  →  language: i18n.language         ✓ sent
signupSchema     →  language: z.string().optional()  ✓ validated
handlers         →  prisma.user.create({ data: … })  ✗ locale never set
```

In `calcomSignupHandler.ts`, `language` was not even included in the `signupSchema.pick()` call, so it was silently dropped before reaching the Prisma query.

**What's fixed:**
- **`calcomSignupHandler`**: adds `language` to the `pick()`, then passes `locale: language` to the team-invite `upsert` (both `update` and `create` branches) and the regular `user.create`
- **`selfHostedHandler`**: `language` was already destructured but missing from both branches of the team-invite `upsert` and the regular `user.create`

The `update` branch of each upsert is now covered — this is the path that runs when an **existing user accepts a team invite**. This was the specific gap flagged in the review of PR #27966.

No schema changes needed — `locale String?` already exists on the `User` model. Total diff: 8 lines across 2 files.

## Visual Demo (For contributors especially)

N/A — backend-only change. Verified via Prisma Studio: `User.locale` is now populated after signup.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A — no public API or doc surface changed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Environment variables needed:** Standard `.env` setup, no extras required.

**Minimal test data:** A new user signup with browser language set to a non-English locale (e.g. `fr`).

**Happy path (input → output):**
1. Set browser language to `fr`
2. Sign up for a new account via `/signup`
3. Query the DB: `SELECT locale FROM User WHERE email = '<your email>'`
4. Expected: `locale = 'fr'`

**Team-invite path (update branch):**
1. Invite an existing user to a team
2. The existing user accepts the invite (triggers the `upsert update` branch)
3. Verify `User.locale` is set/updated to their current browser language

**CI checks:** `yarn type-check` and `yarn lint` pass with no new errors.

## Checklist

- ~~I haven't read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)~~
- ~~My code doesn't follow the style guidelines of this project~~
- ~~My PR is too large (>500 lines or >10 files) and should be split into smaller PRs~~