### PR TITLE
fix(api): remove .ics suffix requirement from ICS feed URL validator

### DIFF
--- a/apps/api/v2/src/platform/calendars/input/create-ics.input.ts
+++ b/apps/api/v2/src/platform/calendars/input/create-ics.input.ts
@@ -15,27 +15,24 @@ export class IsICSUrlConstraint implements ValidatorConstraintInterface {
   validate(url: unknown) {
     if (typeof url !== "string") return false;
 
-    // Check if it's a valid URL and ends with .ics
+    // Check if it's a valid http/https URL — RFC 5545 imposes no .ics suffix requirement
     try {
       const urlObject = new URL(url);
-      return (
-        (urlObject.protocol === "http:" || urlObject.protocol === "https:") &&
-        urlObject.pathname.endsWith(".ics")
-      );
-    } catch (error) {
+      return urlObject.protocol === "http:" || urlObject.protocol === "https:";
+    } catch {
       return false;
     }
   }
 
   defaultMessage() {
-    return "The URL must be a valid ICS URL (ending with .ics)";
+    return "The URL must be a valid http or https URL";
   }
 }
 
 export class CreateIcsFeedInputDto {
   @ApiProperty({
-    example: ["https://cal.com/ics/feed.ics", "http://cal.com/ics/feed.ics"],
-    description: "An array of ICS URLs",
+    example: ["https://cal.com/ics/feed.ics", "https://calendar.example.com/feed?format=ics"],
+    description: "An array of ICS feed URLs (http or https)",
     type: "array",
     items: {
       type: "string",


### PR DESCRIPTION
## What does this PR do?

Fixes #29286

The ICS feed URL validator was enforcing a `.ics` suffix on all submitted URLs:

```ts
urlObject.pathname.endsWith(".ics")
```

RFC 5545 (iCalendar) has no requirement for a `.ics` file extension. Valid CalDAV feeds and dynamic export endpoints (e.g. `?format=ics`, `?export=ics`) were silently rejected even though they serve valid `text/calendar` content.

Removes the suffix check and keeps only the `http/https` protocol validation, which is the only meaningful constraint here. Also updates the `@ApiProperty` description and example to reflect the relaxed validation.

## Visual Demo (For contributors especially)

N/A — validator logic change, no UI.

**Before:** `POST /v2/calendars/ics` with `https://calendar.example.com/feed?format=ics` → 400 "must end with .ics"

**After:** same request → 201 accepted

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A — no public doc surface changed beyond the updated `@ApiProperty` description.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — covered by the existing integration test suite for the calendars endpoint.

## How should this be tested?

No extra environment variables needed.

**Happy path:**
1. `POST /v2/calendars/ics` with body `{ "urls": ["https://calendar.example.com/feed?format=ics"] }`
2. Expected: 201 — previously rejected with 400

**Still rejected (protocol guard still applies):**
- `ftp://example.com/feed.ics` → 400
- `not-a-url` → 400

## Checklist

- ~~I haven't read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)~~
- ~~My code doesn't follow the style guidelines of this project~~
- ~~My PR is too large (>500 lines or >10 files) and should be split into smaller PRs~~
