### PR TITLE
fix(office365video): use PATCH for updateMeeting and implement deleteMeeting

### DIFF
--- a/packages/app-store/office365video/lib/VideoApiAdapter.test.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.test.ts
@@ -7,14 +7,21 @@ import { internalServerErrorResponse, successResponse } from "../../_utils/testU
 import config from "../config.json";
 import VideoApiAdapter from "./VideoApiAdapter";
 
+const FAKE_MEETING_ID = "FAKE_MEETING_ID";
+const FAKE_BOOKING_REF = { type: "office365_video", uid: "FAKE_UID", meetingId: FAKE_MEETING_ID };
+
 const URLS = {
   CREATE_MEETING: {
     url: "https://graph.microsoft.com/v1.0/me/onlineMeetings",
     method: "POST",
   },
   UPDATE_MEETING: {
-    url: "https://graph.microsoft.com/v1.0/me/onlineMeetings",
-    method: "POST",
+    url: `https://graph.microsoft.com/v1.0/me/onlineMeetings/${FAKE_MEETING_ID}`,
+    method: "PATCH",
+  },
+  DELETE_MEETING: {
+    url: `https://graph.microsoft.com/v1.0/me/onlineMeetings/${FAKE_MEETING_ID}`,
+    method: "DELETE",
   },
 };
 
@@ -199,11 +206,11 @@ describe("updateMeeting", () => {
     const videoApi = VideoApiAdapter(testCredential);
 
     mockRequestRaw.mockImplementation(({ url }) => {
-      if (url === URLS.CREATE_MEETING.url) {
+      if (url === URLS.UPDATE_MEETING.url) {
         return Promise.resolve(
           successResponse({
             json: {
-              id: 1,
+              id: FAKE_MEETING_ID,
               joinWebUrl: "https://join_web_url.example.com",
               joinUrl: "https://join_url.example.com",
             },
@@ -220,12 +227,12 @@ describe("updateMeeting", () => {
       endTime: new Date(),
     };
 
-    const updatedMeeting = await videoApi?.updateMeeting(null, event);
+    const updatedMeeting = await videoApi?.updateMeeting(FAKE_BOOKING_REF, event);
     expect(OAuthManager).toHaveBeenCalled();
     expect(mockRequestRaw).toHaveBeenCalledWith({
-      url: URLS.CREATE_MEETING.url,
+      url: URLS.UPDATE_MEETING.url,
       options: {
-        method: "POST",
+        method: "PATCH",
         body: JSON.stringify({
           startDateTime: event.startTime,
           endDateTime: event.endTime,
@@ -234,7 +241,7 @@ describe("updateMeeting", () => {
       },
     });
     expect(updatedMeeting).toEqual({
-      id: 1,
+      id: FAKE_MEETING_ID,
       password: "",
       type: config.type,
       url: "https://join_web_url.example.com",
@@ -245,11 +252,11 @@ describe("updateMeeting", () => {
     const videoApi = VideoApiAdapter(testCredential);
 
     mockRequestRaw.mockImplementation(({ url }) => {
-      if (url === URLS.CREATE_MEETING.url) {
+      if (url === URLS.UPDATE_MEETING.url) {
         return Promise.resolve(
           internalServerErrorResponse({
             json: {
-              id: 1,
+              id: FAKE_MEETING_ID,
               joinWebUrl: "https://join_web_url.example.com",
               joinUrl: "https://join_url.example.com",
             },
@@ -266,12 +273,14 @@ describe("updateMeeting", () => {
       endTime: new Date(),
     };
 
-    await expect(() => videoApi?.updateMeeting(null, event)).rejects.toThrowError("Internal Server Error");
+    await expect(() => videoApi?.updateMeeting(FAKE_BOOKING_REF, event)).rejects.toThrowError(
+      "Internal Server Error"
+    );
     expect(OAuthManager).toHaveBeenCalled();
     expect(mockRequestRaw).toHaveBeenCalledWith({
-      url: URLS.CREATE_MEETING.url,
+      url: URLS.UPDATE_MEETING.url,
       options: {
-        method: "POST",
+        method: "PATCH",
         body: JSON.stringify({
           startDateTime: event.startTime,
           endDateTime: event.endTime,
@@ -279,5 +288,62 @@ describe("updateMeeting", () => {
         }),
       },
     });
+  });
+
+  test("`updateMeeting` throws when meetingId is missing", async () => {
+    const videoApi = VideoApiAdapter(testCredential);
+    const event = {
+      title: "Test Meeting",
+      description: "Test Description",
+      startTime: new Date(),
+      endTime: new Date(),
+    };
+    await expect(() =>
+      videoApi?.updateMeeting({ type: "office365_video", uid: "uid", meetingId: null }, event)
+    ).rejects.toThrowError("Meeting ID is required");
+  });
+});
+
+describe("deleteMeeting", () => {
+  test("Successful `deleteMeeting` call", async () => {
+    const videoApi = VideoApiAdapter(testCredential);
+
+    mockRequestRaw.mockImplementation(({ url }) => {
+      if (url === URLS.DELETE_MEETING.url) {
+        return Promise.resolve(successResponse({ json: {} }));
+      }
+      throw new Error("Unexpected URL");
+    });
+
+    await expect(videoApi?.deleteMeeting(FAKE_MEETING_ID)).resolves.toBeDefined();
+    expect(mockRequestRaw).toHaveBeenCalledWith({
+      url: URLS.DELETE_MEETING.url,
+      options: { method: "DELETE" },
+    });
+  });
+
+  test("`deleteMeeting` is idempotent on 404", async () => {
+    const videoApi = VideoApiAdapter(testCredential);
+
+    mockRequestRaw.mockImplementation(() =>
+      Promise.resolve({ ok: false, status: 404, statusText: "Not Found", text: async () => "" })
+    );
+
+    await expect(videoApi?.deleteMeeting(FAKE_MEETING_ID)).resolves.toBeDefined();
+  });
+
+  test("Failing `deleteMeeting` call", async () => {
+    const videoApi = VideoApiAdapter(testCredential);
+
+    mockRequestRaw.mockImplementation(({ url }) => {
+      if (url === URLS.DELETE_MEETING.url) {
+        return Promise.resolve(internalServerErrorResponse({ json: {} }));
+      }
+      throw new Error("Unexpected URL");
+    });
+
+    await expect(() => videoApi?.deleteMeeting(FAKE_MEETING_ID)).rejects.toThrowError(
+      "Internal Server Error"
+    );
   });
 });

--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -228,11 +228,18 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
       return Promise.resolve([]);
     },
     updateMeeting: async (bookingRef: PartialReference, event: CalendarEvent) => {
+      const meetingId = bookingRef?.meetingId;
+      if (!meetingId) {
+        throw new HttpError({
+          statusCode: 400,
+          message: "Meeting ID is required to update a Teams meeting",
+        });
+      }
       try {
         const response = await auth.requestRaw({
-          url: `${await getUserEndpoint()}/onlineMeetings`,
+          url: `${await getUserEndpoint()}/onlineMeetings/${meetingId}`,
           options: {
-            method: "POST",
+            method: "PATCH",
             body: JSON.stringify(translateEvent(event)),
           },
         });
@@ -244,12 +251,11 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
           });
         }
 
-        const resultString = await response.text();
-        const resultObject = JSON.parse(resultString);
+        const resultObject = JSON.parse(await response.text());
 
         return Promise.resolve({
           type: "office365_video",
-          id: resultObject.id,
+          id: resultObject.id ?? meetingId,
           password: "",
           url: resultObject.joinWebUrl || resultObject.joinUrl,
         });
@@ -264,8 +270,29 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         });
       }
     },
-    deleteMeeting:() => {
-      return Promise.resolve([]);
+    deleteMeeting: async (uid: string) => {
+      try {
+        const response = await auth.requestRaw({
+          url: `${await getUserEndpoint()}/onlineMeetings/${uid}`,
+          options: { method: "DELETE" },
+        });
+        if (!response.ok && response.status !== 404) {
+          throw new HttpError({
+            statusCode: response.status,
+            message: response.statusText,
+          });
+        }
+        return Promise.resolve([]);
+      } catch (error) {
+        log.error(`Error deleting MS Teams meeting ${uid}`, error);
+        if (error instanceof HttpError) {
+          throw error;
+        }
+        throw new HttpError({
+          statusCode: 500,
+          message: `Error deleting MS Teams meeting ${uid}`,
+        });
+      }
     },
     createMeeting: async (event: CalendarEvent): Promise<VideoCallData> => {
       const url = `${await getUserEndpoint()}/onlineMeetings`;


### PR DESCRIPTION
## What does this PR do?

Fixes #29498

The Office 365 Video (MS Teams) adapter had two broken methods:

**1. `updateMeeting` created duplicates on every reschedule**

It was calling `POST /onlineMeetings` (which creates a new meeting) instead of `PATCH /onlineMeetings/{meetingId}` (which updates the existing one). Every time a user rescheduled a booking, a brand-new Teams meeting was created and the old one was left orphaned.

**2. `deleteMeeting` was a no-op**

The implementation was `return Promise.resolve([])` — it never made an HTTP request, so the remote Teams meeting stayed alive after the booking was deleted on the Cal side.

Both methods now call the correct Microsoft Graph API endpoints using the meeting ID that's already stored in the booking reference.

## Visual Demo (For contributors especially)

N/A — backend adapter fix.

**Before reschedule:** two Teams meetings visible in the organizer's Teams calendar (original + duplicate).

**After:** only one meeting, updated with the new time.

**Before cancel:** Teams meeting stays active after booking is deleted.

**After:** Teams meeting is removed via `DELETE /onlineMeetings/{id}`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. Updated existing `updateMeeting` tests (they were asserting the broken POST behavior) and added a full `deleteMeeting` test suite.

## How should this be tested?

Requires an Office 365 / MS Teams account connected to Cal.

**Reschedule path:**
1. Create a booking with MS Teams as the conferencing provider
2. Reschedule the booking to a different time
3. Expected: the existing Teams meeting is updated (single meeting in Teams calendar); before this fix a second meeting was created

**Cancellation path:**
1. Cancel a booking with a Teams meeting attached
2. Expected: the Teams meeting is deleted from the calendar; before this fix it remained active

**Unit tests:**
- `yarn vitest packages/app-store/office365video` — all tests pass

## Checklist

- ~~I haven't read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)~~
- ~~My code doesn't follow the style guidelines of this project~~
- ~~My PR is too large (>500 lines or >10 files) and should be split into smaller PRs~~
