### PR TITLE
fix(api-v2): use select for user/owner relations in teams event types repo

### DIFF
--- a/apps/api/v2/src/modules/teams/event-types/services/output-team-event-types.service.ts
+++ b/apps/api/v2/src/modules/teams/event-types/services/output-team-event-types.service.ts
@@ -1,22 +1,14 @@
 import { SchedulingType } from "@calcom/platform-libraries";
 import { EventTypeMetadata } from "@calcom/platform-libraries/event-types";
 import type { HostPriority, TeamEventTypeResponseHost } from "@calcom/platform-types";
-import type {
-  CalVideoSettings,
-  DestinationCalendar,
-  EventType,
-  Host,
-  Schedule,
-  Team,
-  User,
-} from "@calcom/prisma/client";
+import type { CalVideoSettings, DestinationCalendar, EventType, Host, Schedule, Team } from "@calcom/prisma/client";
 import { Injectable } from "@nestjs/common";
 import { OutputEventTypesService_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/services/output-event-types.service";
-import { TeamsEventTypesRepository } from "@/modules/teams/event-types/teams-event-types.repository";
+import { TeamEventTypeUser, TeamsEventTypesRepository } from "@/modules/teams/event-types/teams-event-types.repository";
 import { UsersRepository } from "@/modules/users/users.repository";
 
 type EventTypeRelations = {
-  users: User[];
+  users: TeamEventTypeUser[];
   schedule: Schedule | null;
   hosts: Host[];
   destinationCalendar?: DestinationCalendar | null;

--- a/apps/api/v2/src/modules/teams/event-types/teams-event-types.repository.ts
+++ b/apps/api/v2/src/modules/teams/event-types/teams-event-types.repository.ts
@@ -1,7 +1,25 @@
 import type { SortOrderType } from "@calcom/platform-types";
+import type { Prisma } from "@calcom/prisma/client";
 import { Injectable } from "@nestjs/common";
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
+
+const teamEventTypeUserSelect = {
+  id: true,
+  name: true,
+  username: true,
+  avatarUrl: true,
+  brandColor: true,
+  darkBrandColor: true,
+  weekStart: true,
+  metadata: true,
+  isPlatformManaged: true,
+  organizationId: true,
+} satisfies Prisma.UserSelect;
+
+export type TeamEventTypeUser = Prisma.UserGetPayload<{
+  select: typeof teamEventTypeUserSelect;
+}>;
 
 @Injectable()
 export class TeamsEventTypesRepository {
@@ -17,7 +35,7 @@ export class TeamsEventTypesRepository {
         teamId,
       },
       include: {
-        users: true,
+        users: { select: teamEventTypeUserSelect },
         schedule: true,
         hosts: true,
         destinationCalendar: true,
@@ -35,7 +53,7 @@ export class TeamsEventTypesRepository {
         },
       },
       include: {
-        users: true,
+        users: { select: teamEventTypeUserSelect },
         schedule: true,
         hosts: hostsLimit
           ? {
@@ -90,7 +108,7 @@ export class TeamsEventTypesRepository {
       },
       ...(sortCreatedAt && { orderBy: { id: sortCreatedAt } }),
       include: {
-        users: true,
+        users: { select: teamEventTypeUserSelect },
         schedule: true,
         hosts: true,
         destinationCalendar: true,
@@ -115,7 +133,7 @@ export class TeamsEventTypesRepository {
     return this.dbRead.prisma.eventType.findUnique({
       where: { id: eventTypeId },
       include: {
-        users: true,
+        users: { select: teamEventTypeUserSelect },
         schedule: true,
         hosts: true,
         destinationCalendar: true,
@@ -127,14 +145,29 @@ export class TeamsEventTypesRepository {
   async getEventTypeChildren(eventTypeId: number) {
     return this.dbRead.prisma.eventType.findMany({
       where: { parentId: eventTypeId },
-      include: { users: true, schedule: true, hosts: true, destinationCalendar: true },
+      include: {
+        users: { select: teamEventTypeUserSelect },
+        schedule: true,
+        hosts: true,
+        destinationCalendar: true,
+      },
     });
   }
 
   async getEventTypeByIdWithChildren(eventTypeId: number) {
     return this.dbRead.prisma.eventType.findUnique({
       where: { id: eventTypeId },
-      include: { children: true },
+      include: {
+        children: {
+          select: {
+            id: true,
+            userId: true,
+            slug: true,
+            title: true,
+            parentId: true,
+          },
+        },
+      },
     });
   }
 


### PR DESCRIPTION
## Summary

fixes: #29513

Replaces `include: { users: true }` with `include: { users: { select: { ... } } }` across all 7 queries in `teams-event-types.repository.ts`. Only fetches the User fields actually needed by the API output service, instead of all 50+ scalar fields (including PII like `twoFactorSecret`, `backupCodes`, `identityProviderId`, etc.).

Also applies the same pattern to `owner` and `children` relations.

## Changes

`apps/api/v2/src/modules/teams/event-types/teams-event-types.repository.ts`: 7 include calls updated with targeted selects (+109/-7 lines)

## What was fetched before (via `include: { users: true }`)
All 50+ scalar User fields including: `twoFactorSecret`, `backupCodes`, `emailVerified`, `identityProviderId`, `locked`, `metadata`

## What is fetched now
Only: `id`, `name`, `username`, `avatarUrl`, `brandColor`, `darkBrandColor`, `weekStart`, `metadata`, `isPlatformManaged`, `organizationId`