### PR TITLE
fix(api): missing trpc route added for the api keys

### DIFF
--- a/apps/web/pages/api/trpc/apiKeys/[trpc].ts
+++ b/apps/web/pages/api/trpc/apiKeys/[trpc].ts
@@ -1,0 +1,4 @@
+import { createNextApiHandler } from "@calcom/trpc/server/createNextApiHandler";
+import { apiKeysRouter } from "@calcom/trpc/server/routers/viewer/apiKeys/_router";
+
+export default createNextApiHandler(apiKeysRouter);


### PR DESCRIPTION
Fixes #29475 
## Summary

Fixes API key creation failure caused by a missing standalone tRPC endpoint.

## Problem

Creating API keys from `/settings/developer/api-keys` returned:

Unexpected token '<', "<!DOCTYPE "... is not valid JSON

because `/api/trpc/apiKeys/create` returned an HTML 404 page instead of a JSON tRPC response.

## Root Cause

The API keys router existed, but the Next API route exposing the standalone endpoint was missing.

## Fix

Added:

`apps/web/pages/api/trpc/apiKeys/[trpc].ts`

to expose the existing `apiKeysRouter` through `createNextApiHandler`.

## Before
<img width="2914" height="1887" alt="IMG_20260606_213625" src="https://github.com/user-attachments/assets/9e3dc605-fc6c-419e-b025-6281d0c0af7a" />


## After
<img width="2344" height="1497" alt="IMG_20260606_213614" src="https://github.com/user-attachments/assets/fa2e034f-f9ee-4ebc-b28b-401eaf1e477a" />

<img width="2884" height="2080" alt="IMG_20260606_213645" src="https://github.com/user-attachments/assets/03819571-98f1-4cea-ad66-1632a5e79c26" />


## Notes
The fix follows the same standalone endpoint pattern used by other tRPC routes in the repository.
