### PR TITLE
fix(api-v2): rethrow unexpected errors in deleteSelectedCalendar catch block

### DIFF
--- a/apps/api/v2/src/modules/selected-calendars/services/selected-calendars.service.ts
+++ b/apps/api/v2/src/modules/selected-calendars/services/selected-calendars.service.ts
@@ -11,6 +11,7 @@ import {
   SelectedCalendarsRepository,
 } from "@/modules/selected-calendars/selected-calendars.repository";
 import { UserWithProfile } from "@/modules/users/users.repository";
+
 @Injectable()
 export class SelectedCalendarsService {
   constructor(
@@ -18,24 +19,30 @@ export class SelectedCalendarsService {
     private readonly calendarsCacheService: CalendarsCacheService,
     private readonly selectedCalendarsRepository: SelectedCalendarsRepository
   ) {}
+
   async addSelectedCalendar(user: UserWithProfile, input: SelectedCalendarsInputDto) {
     const { integration, externalId, credentialId } = input;
     await this.calendarsService.checkCalendarCredentials(Number(credentialId), user.id);
+
     const userSelectedCalendar = await this.selectedCalendarsRepository.addUserSelectedCalendar(
       user.id,
       integration,
       externalId,
       credentialId
     );
+
     await this.calendarsCacheService.deleteConnectedAndDestinationCalendarsCache(user.id);
+
     return userSelectedCalendar;
   }
+
   async deleteSelectedCalendar(
     selectedCalendar: SelectedCalendarsQueryParamsInputDto,
     user: UserWithProfile
   ) {
     const { integration, externalId, credentialId } = selectedCalendar;
     await this.calendarsService.checkCalendarCredentials(Number(credentialId), user.id);
+
     try {
       const removedCalendarEntry = await this.selectedCalendarsRepository.removeUserSelectedCalendar(
         user.id,
@@ -51,10 +58,12 @@ export class SelectedCalendarsService {
           throw new NotFoundException(NO_SELECTED_CALENDAR_FOUND);
         } else if (error.message === MULTIPLE_SELECTED_CALENDARS_FOUND) {
           throw new BadRequestException(MULTIPLE_SELECTED_CALENDARS_FOUND);
+        } else {
+          throw new InternalServerErrorException(error.message);
         }
-      }     
+      }
       throw new InternalServerErrorException(
-        error instanceof Error ? error.message : "An unexpected error occurred while deleting the selected calendar"
+        "An unexpected error occurred while deleting the selected calendar"
       );
     }
   }

--- a/apps/api/v2/src/modules/selected-calendars/services/selected-calendars.service.ts
+++ b/apps/api/v2/src/modules/selected-calendars/services/selected-calendars.service.ts
@@ -58,12 +58,14 @@ export class SelectedCalendarsService {
           throw new NotFoundException(NO_SELECTED_CALENDAR_FOUND);
         } else if (error.message === MULTIPLE_SELECTED_CALENDARS_FOUND) {
           throw new BadRequestException(MULTIPLE_SELECTED_CALENDARS_FOUND);
+        } else {
+          throw error;
         }
       }
+
+      
       throw new InternalServerErrorException(
-        error instanceof Error
-          ? error.message
-          : "An unexpected error occurred while deleting the selected calendar"
+        "An unexpected error occurred while deleting the selected calendar"
       );
     }
   }

--- a/apps/api/v2/src/modules/selected-calendars/services/selected-calendars.service.ts
+++ b/apps/api/v2/src/modules/selected-calendars/services/selected-calendars.service.ts
@@ -11,7 +11,6 @@ import {
   SelectedCalendarsRepository,
 } from "@/modules/selected-calendars/selected-calendars.repository";
 import { UserWithProfile } from "@/modules/users/users.repository";
-
 @Injectable()
 export class SelectedCalendarsService {
   constructor(
@@ -19,30 +18,24 @@ export class SelectedCalendarsService {
     private readonly calendarsCacheService: CalendarsCacheService,
     private readonly selectedCalendarsRepository: SelectedCalendarsRepository
   ) {}
-
   async addSelectedCalendar(user: UserWithProfile, input: SelectedCalendarsInputDto) {
     const { integration, externalId, credentialId } = input;
     await this.calendarsService.checkCalendarCredentials(Number(credentialId), user.id);
-
     const userSelectedCalendar = await this.selectedCalendarsRepository.addUserSelectedCalendar(
       user.id,
       integration,
       externalId,
       credentialId
     );
-
     await this.calendarsCacheService.deleteConnectedAndDestinationCalendarsCache(user.id);
-
     return userSelectedCalendar;
   }
-
   async deleteSelectedCalendar(
     selectedCalendar: SelectedCalendarsQueryParamsInputDto,
     user: UserWithProfile
   ) {
     const { integration, externalId, credentialId } = selectedCalendar;
     await this.calendarsService.checkCalendarCredentials(Number(credentialId), user.id);
-
     try {
       const removedCalendarEntry = await this.selectedCalendarsRepository.removeUserSelectedCalendar(
         user.id,
@@ -58,14 +51,10 @@ export class SelectedCalendarsService {
           throw new NotFoundException(NO_SELECTED_CALENDAR_FOUND);
         } else if (error.message === MULTIPLE_SELECTED_CALENDARS_FOUND) {
           throw new BadRequestException(MULTIPLE_SELECTED_CALENDARS_FOUND);
-        } else {
-          throw error;
         }
-      }
-
-      
+      }     
       throw new InternalServerErrorException(
-        "An unexpected error occurred while deleting the selected calendar"
+        error instanceof Error ? error.message : "An unexpected error occurred while deleting the selected calendar"
       );
     }
   }

--- a/apps/api/v2/src/modules/selected-calendars/services/selected-calendars.service.ts
+++ b/apps/api/v2/src/modules/selected-calendars/services/selected-calendars.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from "@nestjs/common";
 import { CalendarsService } from "@/platform/calendars/services/calendars.service";
 import { CalendarsCacheService } from "@/platform/calendars/services/calendars-cache.service";
 import {
@@ -60,6 +60,11 @@ export class SelectedCalendarsService {
           throw new BadRequestException(MULTIPLE_SELECTED_CALENDARS_FOUND);
         }
       }
+      throw new InternalServerErrorException(
+        error instanceof Error
+          ? error.message
+          : "An unexpected error occurred while deleting the selected calendar"
+      );
     }
   }
 }


### PR DESCRIPTION
Fixes #29456 

## Summary

The `catch` block in `deleteSelectedCalendar` handles two known error messages (`NO_SELECTED_CALENDAR_FOUND` and `MULTIPLE_SELECTED_CALENDARS_FOUND`) correctly, but any other error exits the catch block silently, causing the function to implicitly return `undefined`.

## Before

```typescript
    } catch (error) {
      if (error instanceof Error) {
        if (error.message === NO_SELECTED_CALENDAR_FOUND) {
          throw new NotFoundException(NO_SELECTED_CALENDAR_FOUND);
        } else if (error.message === MULTIPLE_SELECTED_CALENDARS_FOUND) {
          throw new BadRequestException(MULTIPLE_SELECTED_CALENDARS_FOUND);
        }
      }
    }
```
Unrecognized errors (DB failures, runtime errors) fall through the if/else chain and exit the catch block, returning undefined silently. The caller has no way to know the deletion failed.

After
```
    } catch (error) {
      if (error instanceof Error) {
        if (error.message === NO_SELECTED_CALENDAR_FOUND) {
          throw new NotFoundException(NO_SELECTED_CALENDAR_FOUND);
        } else if (error.message === MULTIPLE_SELECTED_CALENDARS_FOUND) {
          throw new BadRequestException(MULTIPLE_SELECTED_CALENDARS_FOUND);
        }
      }
      throw new InternalServerErrorException(
        error instanceof Error
          ? error.message
          : "An unexpected error occurred while deleting the selected calendar"
      );
    }
```
Any unrecognized error is now rethrown as InternalServerErrorException so callers are aware of the failure.
Changes
- apps/api/v2/src/modules/selected-calendars/services/selected-calendars.service.ts — added InternalServerErrorException import and rethrow for unexpected errors

Closes #29456