### PR TITLE
fix: use write service for membership creation

### DIFF
--- a/apps/api/v2/src/modules/memberships/memberships.repository.ts
+++ b/apps/api/v2/src/modules/memberships/memberships.repository.ts
@@ -1,11 +1,15 @@
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
+import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { Injectable } from "@nestjs/common";
 
 import { MembershipRole } from "@calcom/platform-libraries";
 
 @Injectable()
 export class MembershipsRepository {
-  constructor(private readonly dbRead: PrismaReadService) {}
+  constructor(
+    private readonly dbRead: PrismaReadService,
+    private readonly dbWrite: PrismaWriteService
+  ) {}
 
   async findOrgUserMembership(organizationId: number, userId: number) {
     const membership = await this.dbRead.prisma.membership.findUniqueOrThrow({
@@ -111,7 +115,7 @@ export class MembershipsRepository {
   }
 
   async createMembership(teamId: number, userId: number, role: MembershipRole, accepted: boolean) {
-    const membership = await this.dbRead.prisma.membership.create({
+    const membership = await this.dbWrite.prisma.membership.create({
       data: {
         createdAt: new Date(),
         role,


### PR DESCRIPTION
What does this PR do?
Fixes #29446

MembershipsRepository only injected PrismaReadService, but createMembership was calling this.dbRead.prisma.membership.create(...) — routing a write operation through the read service. In a production read-replica setup where the read and write database URLs point to different instances, this would either fail (replica is read-only) or silently misroute the write.

Changes:

Inject PrismaWriteService alongside PrismaReadService in MembershipsRepository
Change createMembership to use this.dbWrite.prisma.membership.create(...) instead of this.dbRead
All read operations (findFirst, findMany, findUnique, findUniqueOrThrow) are left unchanged on dbRead
No module-level changes are required — MembershipsModule already imports PrismaModule, which exports both PrismaReadService and PrismaWriteService.

Mandatory Tasks (DO NOT REMOVE)

 I have self-reviewed the code (A decent size PR without self-review might be rejected).

 I have updated the developer docs if this PR makes changes that would require a documentation change. N/A

 I confirm automated tests are in place that prove my fix is effective or that my feature works.
How should this be tested?
Environment:

Requires a read-replica database setup where DATABASE_READ_URL and DATABASE_WRITE_URL point to different instances (the bug is invisible when both point to the same database).
Steps to reproduce the bug (before fix):

Configure a read-replica DB with separate read/write URLs
Invite a user to a team (or trigger any flow that calls createMembership)
Observe the write being routed to the read replica — it will fail or be silently misrouted
Expected after fix:

createMembership routes the prisma.membership.create(...) call through PrismaWriteService (the write DB)
All find* calls continue to use PrismaReadService (the read replica)
Local verification (single DB setup):

Invite a user to a team via the API
Confirm the membership row is created successfully — this verifies the write service injection is wired correctly by NestJS
Checklist
My code follows the style guidelines of this project
I have checked that my changes generate no new warnings
This PR is small and focused (2 files changed, ~6 lines)