### PR TITLE
fix: layout constraints and mobile viewport overflow in EventLimitsTab

### DIFF
--- a/packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx
+++ b/packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx
@@ -352,7 +352,7 @@ const MinimumBookingNoticeInput = function MinimumBookingNoticeInput({
   }, [minimumBookingNoticeDisplayValues, setValue, passThroughProps.name]);
 
   return (
-    <div className="flex flex-wrap items-end justify-end gap-2 sm:flex-nowrap">
+    <div className="flex flex-wrap items-end gap-2 sm:flex-nowrap">
       <div className="w-full min-w-[80px] flex-1">
         <InputField
           required
@@ -487,7 +487,7 @@ export const EventLimitsTab = ({ eventType, customClassNames }: EventLimitsTabPr
           "stack-y-6 rounded-lg border border-subtle p-6",
           customClassNames?.bufferAndNoticeSection?.container
         )}>
-        <div className="flex flex-wrap items-stretch gap-4 lg:flex-row lg:space-x-4 lg:gap-0">
+        <div className="flex flex-wrap items-stretch gap-4 lg:flex-row">
           <div
             className={classNames(
               "w-full",

--- a/packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx
+++ b/packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx
@@ -352,8 +352,8 @@ const MinimumBookingNoticeInput = function MinimumBookingNoticeInput({
   }, [minimumBookingNoticeDisplayValues, setValue, passThroughProps.name]);
 
   return (
-    <div className="flex items-end justify-end">
-      <div className="w-1/2 md:w-full">
+    <div className="flex flex-wrap items-end justify-end gap-2 sm:flex-nowrap">
+      <div className="w-full min-w-[80px] flex-1">
         <InputField
           required
           disabled={passThroughProps.disabled}
@@ -376,7 +376,7 @@ const MinimumBookingNoticeInput = function MinimumBookingNoticeInput({
         isSearchable={false}
         isDisabled={passThroughProps.disabled}
         className={classNames(
-          "mb-0 ml-2 w-full capitalize md:min-w-[150px] md:max-w-[200px]",
+          "mb-0 w-full min-w-[120px] shrink-0 capitalize sm:w-auto md:min-w-[150px] md:max-w-[200px]",
           customClassNames?.select
         )}
         innerClassNames={customClassNames?.innerClassNames}
@@ -456,7 +456,11 @@ export const EventLimitsTab = ({ eventType, customClassNames }: EventLimitsTabPr
   };
 
   const shouldLockIndicator = (_field: string): null => null;
-  const shouldLockDisableProps = (_field: string) => ({ disabled: false, LockedIcon: false as const, isLocked: false });
+  const shouldLockDisableProps = (_field: string) => ({
+    disabled: false,
+    LockedIcon: false as const,
+    isLocked: false,
+  });
 
   const bookingLimitsLocked = shouldLockDisableProps("bookingLimits");
   const durationLimitsLocked = shouldLockDisableProps("durationLimits");
@@ -483,7 +487,7 @@ export const EventLimitsTab = ({ eventType, customClassNames }: EventLimitsTabPr
           "stack-y-6 rounded-lg border border-subtle p-6",
           customClassNames?.bufferAndNoticeSection?.container
         )}>
-        <div className="stack-y-4 lg:stack-y-0 flex flex-col lg:flex-row lg:space-x-4">
+        <div className="flex flex-wrap items-stretch gap-4 lg:flex-row lg:space-x-4 lg:gap-0">
           <div
             className={classNames(
               "w-full",
@@ -577,7 +581,7 @@ export const EventLimitsTab = ({ eventType, customClassNames }: EventLimitsTabPr
             />
           </div>
         </div>
-        <div className="stack-y-4 lg:stack-y-0 flex flex-col lg:flex-row lg:space-x-4">
+        <div className="flex flex-wrap items-stretch gap-4 lg:flex-row lg:space-x-4 lg:gap-0">
           <div
             className={classNames(
               "w-full",


### PR DESCRIPTION
# Description

This Pull Request delivers critical layout fixes tailored exclusively for the Event Booking Limits and Buffers tab view (`EventLimitsTab.tsx`) on mobile viewports.

The primary objective is to resolve component layout breakage, clipping, and horizontal overflow inside the scheduling notice and buffer sections on smaller devices (micro mobile viewports).

---

# Detailed Code Changes

## 1. Structural Flex Wrap & Container Adaptability

### Vector / Problem

The container components handling scheduling rules and buffer layout elements used rigid layout behaviors (`flex-col lg:flex-row`).

On smaller viewports, internal form controls—such as the input fields and selection dropdowns—became squished, misaligned, or caused context clipping due to tight spatial limitations.

### Solution

* Refactored wrapper structures inside `MinimumBookingNoticeInput` and section boundaries from unyielding flex structures to fluid layout matrices leveraging `flex-wrap` and dynamic container boundaries.
* Replaced rigid margin assignments with adaptive `gap-2` and `gap-4` metrics to preserve structural vertical and horizontal spacing during screen downsizing.
* Standardized internal function signatures for property control definitions.

###  Code Comparison

#### Before

```ts
// 1. Rigid container bounds for notice input
<div className="w-1/2 md:w-full">

// 2. Rigid wrapper behavior for internal components layout
<div className="stack-y-4 lg:stack-y-0 flex flex-col lg:flex-row lg:space-x-4">
```

#### After

```tsx
// 1. Hardened responsive layout wrap with consistent fluid start-alignment
<div className="flex flex-wrap items-end gap-2 sm:flex-nowrap">

// 2. Pure gap-driven spacing strategy optimized across all breakpoint transitions
<div className="flex flex-wrap items-stretch gap-4 lg:flex-row">
```
### Visual Demo (Before / After)

#### Scenario 1: Layout broken and container overflow (Bug)
* Elements are crushed and truncated on the right side of the screen inside narrow viewports. (Reported in the issue: https://github.com/calcom/cal.diy/issues/29426)

<img width="490" height="911" alt="IMGCENARIO1" src="https://github.com/user-attachments/assets/3e7400ef-20fd-4158-a50d-aec752bce4eb" />

---

#### Scenario 2: Component resolution and adaptation (Responsive Wrapping)
* Inputs and dropdown controls cascade and stack fluidly, keeping all boundaries accessible.

<img width="352" height="802" alt="IMGCENARIO2" src="https://github.com/user-attachments/assets/8c42a761-480c-4745-8a6c-86b1f29141ce" />


# Testing Matrix & Compliance

## Layout & Viewport Validation

* Verified via browser layout simulation utilities that all configuration blocks cascade cleanly down to `< 360px`.
* Confirmed that layout rows break and adapt fluidly, keeping all numeric forms and select dropdowns accessible.

## Workspace & Pipeline Health

* Isolated to exactly 1 targeted file (`EventLimitsTab.tsx`) with 10 additions and 6 deletions.
* Entirely removed any automatic build file updates or environmental variables (`.env`).

---

# Note for Reviewers

This is a clean, targeted patch that replaces previous iterations.

The branch has been rebuilt from an updated upstream foundation to isolate exactly 1 file (`EventLimitsTab.tsx`).

All local build cache, autogenerated assets, and transient configuration tracking profiles have been completely extracted to align with the repository's strict upstream maintenance guidelines.
