### PR TITLE
fix(api-v2): call phone lookup in getUserVerifiedPhoneNumber

### DIFF
--- a/apps/api/v2/src/modules/verified-resources/services/verified-resources.service.ts
+++ b/apps/api/v2/src/modules/verified-resources/services/verified-resources.service.ts
@@ -102,7 +102,7 @@ export class VerifiedResourcesService {
   }
 
   async getUserVerifiedPhoneNumber(userId: number, phoneNumber: string) {
-    return this.usersVerifiedResourcesRepository.getUserVerifiedEmail(userId, phoneNumber);
+    return this.usersVerifiedResourcesRepository.getUserVerifiedPhoneNumber(userId, phoneNumber);
   }
 
   async getTeamVerifiedPhoneNumber(userId: number, phoneNumber: string, teamId: number) {


### PR DESCRIPTION
getUserVerifiedPhoneNumber in erified-resources.service.ts was calling getUserVerifiedEmail on the repository, so every phone number verification silently searched the erifiedEmail table instead of erifiedNumber. Verified phone numbers were never found even when they existed.

**Before:**
``typescript
async getUserVerifiedPhoneNumber(userId: number, phoneNumber: string) {
  return this.usersVerifiedResourcesRepository.getUserVerifiedEmail(userId, phoneNumber);
}
``

**After:**
``typescript
async getUserVerifiedPhoneNumber(userId: number, phoneNumber: string) {
  return this.usersVerifiedResourcesRepository.getUserVerifiedPhoneNumber(userId, phoneNumber);
}
``

The correct getUserVerifiedPhoneNumber method already exists on UsersVerifiedResourcesRepository (line 19) and queries prisma.verifiedNumber - it was just never wired up.

Fixes #29450