### PR TITLE
fix: shell-quote update to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "axios": "1.15.0",
     "follow-redirects": "1.16.0",
     "protobufjs": "7.5.5",
+    "shell-quote": "1.8.4",
     "jws": "4.0.1",
     "jsonwebtoken": "9.0.0",
     "sha.js": "2.4.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -37379,10 +37379,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1":
-  version: 1.8.2
-  resolution: "shell-quote@npm:1.8.2"
-  checksum: 10/3ae4804fd80a12ba07650d0262804ae3b479a62a6b6971a6dc5fa12995507aa63d3de3e6a8b7a8d18f4ce6eb118b7d75db7fcb2c0acbf016f210f746b10cfe02
+"shell-quote@npm:1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10/a3e3796385f2cd5cf0b78207a4439f0c7395c0833fc75b2473084b5d298c109c5c0fa687fcd1c04e4b4484866e5bb8eaae7efae443b80fff71ea7e29baf11f0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
updates shell-quote to patched version 1.8.4 to prevent ci audit check from failing

context: https://github.com/advisories/GHSA-w7jw-789q-3m8p

<img width="669" height="354" alt="image" src="https://github.com/user-attachments/assets/e26a1698-ecc2-4f21-8906-516b82ef4b37" />
