### PR TITLE
fix(api): return 401 instead of 409 for unauthenticated /api/me requests

### DIFF
--- a/apps/web/app/api/me/route.ts
+++ b/apps/web/app/api/me/route.ts
@@ -1,11 +1,9 @@
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { performance } from "@calcom/lib/server/perfObserver";
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
 import { cookies, headers } from "next/headers";
 import { NextResponse } from "next/server";
-
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { performance } from "@calcom/lib/server/perfObserver";
-
-import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
 async function getHandler() {
   const prePrismaDate = performance.now();
@@ -17,7 +15,7 @@ async function getHandler() {
 
   const session = await getServerSession({ req: legacyReq });
   if (!session) {
-    return NextResponse.json({ message: "Unauthorized" }, { status: 409 });
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
   }
 
   const preUserDate = performance.now();

--- a/apps/web/app/api/me/route.ts
+++ b/apps/web/app/api/me/route.ts
@@ -1,9 +1,11 @@
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { performance } from "@calcom/lib/server/perfObserver";
-import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
 import { cookies, headers } from "next/headers";
 import { NextResponse } from "next/server";
+
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { performance } from "@calcom/lib/server/perfObserver";
+
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
 async function getHandler() {
   const prePrismaDate = performance.now();


### PR DESCRIPTION
## What does this PR do?

This PR fixes the HTTP status code returned by the `/api/me` endpoint when no valid session is present.

Currently, the endpoint returns `409 Conflict` for unauthenticated requests. This does not align with standard HTTP authentication semantics and is inconsistent with the OpenAPI specification defined in `calendso.yaml`, which expects authentication failures to be represented as `401 Unauthorized`.

Fixes #29537

## Visual Demo (For contributors especially)

### Image Demo

**Before**

Unauthenticated request to `/api/me` returns `409 Conflict`.

<img width="1561" height="359" alt="image" src="https://github.com/user-attachments/assets/564f5832-dd3a-4108-aec7-26aacd1385e0" />

**After**

Unauthenticated request to `/api/me` now returns `401 Unauthorized`.

<img width="1561" height="359" alt="image" src="https://github.com/user-attachments/assets/3028f3ef-3e5d-4cee-828f-dc407d4ad729" />

## Mandatory Tasks (DO NOT REMOVE)

* [x] I have self-reviewed the code.
* [x] I have updated the developer docs if this PR makes changes that would require a documentation change. (N/A)
* [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Start Cal.com locally.
2. Ensure no authenticated session is present.
3. Run:

```bash
curl -i http://localhost:3000/api/me
```

4. Verify the response status code is `401 Unauthorized`.

Expected behavior:

* Unauthenticated requests return `401 Unauthorized`.
* Authenticated requests continue to return the user information as before.

## Checklist

* [x] My changes are small and focused.
* [x] My changes do not exceed the recommended PR size limits.
* [x] I have checked that my changes generate no new warnings.



