### PR TITLE
fix: pin changesets/action to a commit SHA (supply-chain hardening)

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm install -g npm@11.5.1
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d  # v1
         with:
           version: yarn changesets-version
           publish: yarn changesets-release


### PR DESCRIPTION
## What does this PR do?

Pins `changesets/action` from the mutable `v1` tag to the exact commit that tag currently resolves to (`a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d`) in `.github/workflows/changesets.yml`. A `# v1` comment is kept so the version stays legible.

A mutable tag can be re-pointed by the upstream maintainer, or by an attacker who compromises that account, and the new code would then run in the release workflow, which here holds `contents: write` and `pull-requests: write`. Pinning to an immutable commit SHA is the [GitHub-recommended hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions.

- N/A (supply-chain hardening, no linked issue)

## Visual Demo (For contributors especially)

N/A. CI workflow configuration change with no user-facing or visual behavior.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] N/A. No developer docs are affected.
- [x] N/A. Ref-only workflow change; the pinned SHA is the exact commit `v1` resolves to today, so there is no runtime behavior to test.

## How should this be tested?

Verification level: **SHA-resolution + static**. I confirmed `a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d` is the commit the `v1` tag resolves to today, so behavior is unchanged. I have **not** run this repository's CI. No env vars or test data required.

## Checklist

- I have read the contributing guide and followed the project's conventions.

<sub>Prepared by [TaskBounty](https://task-bounty.com). The pinned SHA was verified against the upstream tag. Glad to adjust or close if this isn't useful.</sub>
