### PR TITLE
fix(frontend): improve password update form UX and add translation

### DIFF
--- a/apps/web/modules/settings/security/password-view.tsx
+++ b/apps/web/modules/settings/security/password-view.tsx
@@ -122,6 +122,7 @@ const PasswordView = ({ user }: PasswordViewProps) => {
   });
 
   const formMethods = useForm<ChangePasswordSessionFormValues>({
+    mode: "onChange",
     defaultValues: {
       oldPassword: "",
       newPassword: "",
@@ -130,22 +131,6 @@ const PasswordView = ({ user }: PasswordViewProps) => {
 
   const handleSubmit = (values: ChangePasswordSessionFormValues) => {
     const { oldPassword, newPassword } = values;
-
-    if (!oldPassword.length) {
-      formMethods.setError(
-        "oldPassword",
-        { type: "required", message: t("error_required_field") },
-        { shouldFocus: true }
-      );
-    }
-
-    if (!newPassword.length) {
-      formMethods.setError(
-        "newPassword",
-        { type: "required", message: t("error_required_field") },
-        { shouldFocus: true }
-      );
-    }
 
     if (oldPassword && newPassword) {
       passwordMutation.mutate({ oldPassword, newPassword });
@@ -157,7 +142,7 @@ const PasswordView = ({ user }: PasswordViewProps) => {
     value: mins,
   }));
 
-  const isDisabled = formMethods.formState.isSubmitting || !formMethods.formState.isDirty;
+  const isDisabled = formMethods.formState.isSubmitting || !formMethods.formState.isDirty || !formMethods.formState.isValid;
 
   const passwordMinLength = data?.user.role === "USER" ? 7 : 15;
   const isUser = data?.user.role === "USER";
@@ -196,17 +181,23 @@ const PasswordView = ({ user }: PasswordViewProps) => {
             )}
             <div className="w-full sm:grid sm:grid-cols-2 sm:gap-x-6">
               <div>
-                <PasswordField {...formMethods.register("oldPassword")} label={t("old_password")} />
+                <PasswordField
+                  {...formMethods.register("oldPassword", {
+                    required: t("error_required_field"),
+                  })}
+                  label={t("old_password")}
+                />
               </div>
               <div>
                 <PasswordField
                   {...formMethods.register("newPassword", {
+                    required: t("error_required_field"),
                     minLength: {
                       message: t(isUser ? "password_hint_min" : "password_hint_admin_min"),
                       value: passwordMinLength,
                     },
                     pattern: {
-                      message: "Should contain a number, uppercase and lowercase letters",
+                      message: t("password_complexity_requirement"),
                       value: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).*$/gm,
                     },
                   })}

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -689,6 +689,7 @@
   "password_hint_num": "Contain at least 1 number",
   "max_limit_allowed_hint": "Must be {{limit}} or fewer characters long",
   "invalid_password_hint": "The password must be a minimum of {{passwordLength}} characters long containing at least one number and have a mixture of uppercase and lowercase letters",
+  "password_complexity_requirement": "Should contain a number, uppercase and lowercase letters",
   "incorrect_password": "Password is incorrect.",
   "incorrect_email_password": "Email or password is incorrect.",
   "compliance": "Compliance",


### PR DESCRIPTION
## What does this PR do?

This PR improves the password update form UX in **Settings → Security**.

### Changes

* Disable the **Update Password** button until the form is valid.
* Add required field validation for old and new password fields.
* Replace the hardcoded password complexity validation message with a translation key.

Fixes #29543

## Visual Demo (For contributors especially)

### Video Demo

https://github.com/user-attachments/assets/235afc55-7fc4-4c45-8f2f-6c8bf73d933f

The video demonstrates:

* The issue before the change where the Update Password button could be enabled while the form was invalid.
* The updated behavior where the button remains disabled until all validation requirements are satisfied.
* The translated password complexity validation message.

## Mandatory Tasks (DO NOT REMOVE)

* [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
* [x] I have updated the developer docs if this PR makes changes that would require a documentation change. (N/A)
* [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to **Settings → Security**.
2. Open the password change form.
3. Verify that the **Update Password** button remains disabled when:

   * Required fields are empty.
   * Password validation requirements are not satisfied.
4. Enter valid values in both password fields.
5. Verify that the button becomes enabled.
6. Trigger the password complexity validation error and verify that the translated message is displayed.

## Checklist

* [x] I have read the contributing guide.
* [x] My code follows the style guidelines of this project.
* [x] I have checked that my changes generate no new warnings.
* [x] My PR is small and focused.
