### PR TITLE
fix: include buffer-overlapping bookings when prefetching bookings for slots

### DIFF
--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -1422,6 +1422,88 @@ describe("getSchedule", () => {
       );
     });
 
+    test("does not offer slots inside the after-event buffer of a booking ending just before the requested range", async () => {
+      const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
+
+      CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
+
+      const scenarioData = {
+        eventTypes: [
+          {
+            id: 1,
+            length: 45,
+            afterEventBuffer: 60,
+            users: [
+              {
+                id: 101,
+              },
+            ],
+          },
+          {
+            id: 2,
+            length: 60,
+            users: [
+              {
+                id: 101,
+              },
+            ],
+          },
+        ],
+        users: [
+          {
+            ...TestData.users.example,
+            id: 101,
+            schedules: [TestData.schedules.IstWorkHours],
+            credentials: [getGoogleCalendarCredential()],
+            selectedCalendars: [TestData.selectedCalendars.google],
+          },
+        ],
+        bookings: [
+          {
+            userId: 101,
+            eventTypeId: 1,
+            startTime: `${plus2DateString}T04:00:00.000Z`,
+            endTime: `${plus2DateString}T04:45:00.000Z`,
+            status: "ACCEPTED" as BookingStatus,
+          },
+        ],
+        apps: [TestData.apps["google-calendar"]],
+      };
+
+      await createBookingScenario(scenarioData);
+
+      // The booking ends at 04:45, before the requested range starts at 04:55, so the
+      // bookings prefetch misses it unless the query window is widened by the max buffer.
+      // Its 60-minute after-event buffer keeps the host busy until 05:45.
+      const scheduleForRangeStartingInsideBuffer = await availableSlotsService.getAvailableSlots({
+        input: {
+          eventTypeId: 2,
+          eventTypeSlug: "",
+          startTime: `${plus2DateString}T04:55:00.000Z`,
+          endTime: `${plus2DateString}T18:29:59.999Z`,
+          timeZone: Timezones["+5:30"],
+          isTeamEvent: false,
+          orgSlug: null,
+        },
+      });
+
+      expect(scheduleForRangeStartingInsideBuffer).toHaveTimeSlots(
+        [
+          // `05:30:00.000Z` is not available: 05:30-06:30 overlaps the booking's after-event buffer (04:45-05:45)
+          `06:30:00.000Z`,
+          `07:30:00.000Z`,
+          `08:30:00.000Z`,
+          `09:30:00.000Z`,
+          `10:30:00.000Z`,
+          `11:30:00.000Z`,
+        ],
+        {
+          dateString: plus2DateString,
+          doExactMatch: true,
+        }
+      );
+    });
+
     test("Start times are offset (offsetStart)", async () => {
       const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
       const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -37,6 +37,7 @@ import type { BookingRepository } from "@calcom/features/bookings/repositories/B
 import type { BusyTimesService } from "@calcom/features/busyTimes/services/getBusyTimes";
 import type { getBusyTimesService } from "@calcom/features/di/containers/BusyTimes";
 import { getDefaultEvent } from "@calcom/features/eventtypes/lib/defaultEvents";
+import { getDefinedBufferTimes } from "@calcom/features/eventtypes/lib/getDefinedBufferTimes";
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import type { PrismaOOORepository } from "@calcom/features/ooo/repositories/PrismaOOORepository";
 import type { IRedisService } from "@calcom/features/redis/IRedisService";
@@ -725,11 +726,19 @@ export class AvailableSlotsService {
     const userIdAndEmailMap = new Map(usersWithCredentials.map((user) => [user.id, user.email]));
     const allUserIds = Array.from(userIdAndEmailMap.keys());
 
+    // Widen the prefetch window by the largest configurable buffer so bookings outside the
+    // requested range whose buffers overlap it are included, the same way getBusyTimes widens
+    // its own query. Otherwise their buffers are never applied and unbookable slots are offered.
+    const definedBufferTimes = getDefinedBufferTimes();
+    const maxBufferMs = definedBufferTimes[definedBufferTimes.length - 1] * 60 * 1000;
+    const startTimeAdjustedWithMaxBuffer = new Date(startTimeDate.valueOf() - maxBufferMs);
+    const endTimeAdjustedWithMaxBuffer = new Date(endTimeDate.valueOf() + maxBufferMs);
+
     const bookingRepo = this.dependencies.bookingRepo;
     const [currentBookingsAllUsers, outOfOfficeDaysAllUsers] = await Promise.all([
       bookingRepo.findAllExistingBookingsForEventTypeBetween({
-        startDate: startTimeDate,
-        endDate: endTimeDate,
+        startDate: startTimeAdjustedWithMaxBuffer,
+        endDate: endTimeAdjustedWithMaxBuffer,
         eventTypeId: eventType.id,
         seatedEvent: Boolean(eventType.seatsPerTimeSlot),
         userIdAndEmailMap,


### PR DESCRIPTION
## What does this PR do?

Fixes #29532

The slots endpoint can offer a time that booking validation will always reject. When a booking ends just before the requested slot range but its after-event buffer extends into it, the slot listing prefetch misses that booking entirely, so the buffer is never applied and the in-buffer slot shows as available. Picking it then fails with a 500 `no_available_users_found_error`.

The two paths diverge:

- Booking validation goes through `getBusyTimes`, which widens its bookings query by the largest configurable buffer (`getDefinedBufferTimes()`, currently 120 min) on both sides, precisely to catch bookings outside the range whose buffers fall inside it.
- Slot listing prefetches bookings itself in `AvailableSlotsService` via `findAllExistingBookingsForEventTypeBetween` using the raw requested range, and hands the result to `getBusyTimes` as `currentBookings` — which skips the widened query.

This PR applies the same max-buffer widening to the slot-listing prefetch, so both paths see the same bookings. The rest of the busy-time math already handles these bookings correctly once they are in the list (as @jckw noted in the issue, and confirmed by @GAURAV07C's analysis).

## How it is tested

Added a `getSchedule` test reproducing the issue:

- Event type 1: 45 min with a 60-minute after-event buffer, booked at 04:00–04:45 UTC, making the host busy until 05:45.
- Event type 2: 60 min, no buffers. Slots requested with a range starting at 04:55 — after the booking ends, but inside its buffer.

Before the fix, the prefetch query (`endTime: { gte: startDate }`) excludes the 04:00–04:45 booking and the 05:30 slot is wrongly offered. With the fix it is hidden, matching what booking validation enforces. The test fails on `main` and passes with this change.

Also ran the full `getSchedule.test.ts` suite (37 passed), the slots router tests, and `getBusyTimes` tests — no regressions. Type checks pass for `packages/trpc` and `apps/web`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A — bug fix, no behavior contract change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
