### PR TITLE
fix: allow name/email/phone fields to be editable during reschedule

### DIFF
--- a/apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx
+++ b/apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx
@@ -163,6 +163,19 @@ export const BookingFields = ({
           readOnly = false;
         }
 
+        // `name`, `email`, and `attendeePhoneNumber` must be editable during reschedule so that any
+        // participant (including the host rescheduling on behalf of an attendee) can update their contact
+        // information. Without this, email-verification flows fail because the pre-filled attendee email
+        // is locked and the rescheduling user never receives the verification code.
+        if (
+          rescheduleReadOnly &&
+          (field.name === SystemField.Enum.name ||
+            field.name === SystemField.Enum.email ||
+            field.name === SystemField.Enum.attendeePhoneNumber)
+        ) {
+          readOnly = false;
+        }
+
         if (field.name === SystemField.Enum.guests) {
           readOnly = false;
           // No matter what user configured for Guests field, we don't show it for dynamic group booking as that doesn't support guests


### PR DESCRIPTION
## What does this PR do?

Fixes the Reschedule flow being broken for any participant when email verification is enabled, or when the host reschedules on behalf of an attendee.

### Root Cause

In BookingFields.tsx, during rescheduling (when rescheduleUid is set and bookingData is not null), all system fields default to readOnly = true. This includes name, email, and attendeePhoneNumber.

When a host reschedules a booking, the form is pre-filled with the attendee's name and email, both fields are then greyed out and read-only. If email verification is enabled, the host cannot change the email field to their own address, so they never receive the verification code and the reschedule is completely blocked.

### Fix

Override readOnly = false for name, email, and attendeePhoneNumber system fields during the reschedule flow, following the exact same pattern already used for smsReminderNumber, guests, and location in the same file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have self-reviewed the code
- [x] PR is minimal (1 source file, ~10 lines added)
- [x] No new dependencies added
- [x] Follows the existing pattern used for smsReminderNumber, guests, and location in the same file

Closes #17523