### PR TITLE
fix: correct CLAUDE.md symlink casing to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-agents.md
+AGENTS.md


### PR DESCRIPTION
## Summary

- Fixes broken `CLAUDE.md` symlink on Linux (case-sensitive filesystems)
- The symlink pointed to `agents.md` (lowercase) but the actual file is `AGENTS.md` (uppercase)
- On macOS the symlink worked by accident due to the case-insensitive filesystem

Closes #29555

## Test plan

- [ ] Verify on Linux: `cat CLAUDE.md` reads the file without error
- [ ] Verify symlink: `ls -la CLAUDE.md` shows `CLAUDE.md -> AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)