### PR TITLE
 feat(calendar): autoscroll week view to first available slot

### DIFF
--- a/apps/web/modules/calendars/weeklyview/components/Calendar.tsx
+++ b/apps/web/modules/calendars/weeklyview/components/Calendar.tsx
@@ -1,3 +1,4 @@
+import dayjs from "@calcom/dayjs";
 import {
   CalendarStoreContext,
   createCalendarStore,
@@ -5,7 +6,7 @@ import {
 } from "@calcom/features/calendars/weeklyview/state/store";
 import classNames from "@calcom/ui/classNames";
 import type React from "react";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import "@calcom/features/calendars/weeklyview/styles/styles.css";
 import type { CalendarComponentProps } from "@calcom/features/calendars/weeklyview/types/state";
 import { getDaysBetweenDates, getHoursToDisplay } from "@calcom/features/calendars/weeklyview/utils";
@@ -40,6 +41,26 @@ function CalendarInner(props: CalendarComponentProps) {
   const scrollToCurrentTime = useCalendarStore((state) => state.scrollToCurrentTime ?? true);
   const updateCurrentTimeOnFocus = useCalendarStore((state) => state.updateCurrentTimeOnFocus ?? false);
 
+  const firstAvailableSlot = useMemo(() => {
+    if (!availableTimeslots || Object.keys(availableTimeslots).length === 0) return null;
+    let earliestTime: number | null = null;
+    for (const day in availableTimeslots) {
+      const slots = availableTimeslots[day];
+      if (slots && slots.length > 0) {
+        const earliestInDay = Math.min(
+          ...slots.map((slot) => {
+            const time = dayjs(slot.start).tz(timezone);
+            return time.hour() * 60 + time.minute();
+          })
+        );
+        if (earliestTime === null || earliestInDay < earliestTime) {
+          earliestTime = earliestInDay;
+        }
+      }
+    }
+    return earliestTime;
+  }, [availableTimeslots, timezone]);
+
   const days = useMemo(() => getDaysBetweenDates(startDate, endDate), [startDate, endDate]);
 
   const hours = useMemo(
@@ -49,10 +70,26 @@ function CalendarInner(props: CalendarComponentProps) {
   const numberOfGridStopsPerDay = hours.length * usersCellsStopsPerHour;
   const hourSize = 58;
 
+  const [hasScrolledToAvailableSlot, setHasScrolledToAvailableSlot] = useState(false);
+
+  const dummyScrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (firstAvailableSlot !== null && dummyScrollRef.current && !hasScrolledToAvailableSlot) {
+      setTimeout(() => {
+        dummyScrollRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+        setHasScrolledToAvailableSlot(true);
+      }, 100);
+    }
+  }, [firstAvailableSlot, hasScrolledToAvailableSlot]);
+
   // Initalise State on initial mount and when props change
   useEffect(() => {
     initialState(props);
   }, [props, initialState]);
+
+  const hasAvailableTimeslots = availableTimeslots && Object.keys(availableTimeslots).length > 0;
+  const shouldScrollToCurrentTime = scrollToCurrentTime && !hasAvailableTimeslots;
 
   return (
     <MobileNotSupported>
@@ -81,9 +118,19 @@ function CalendarInner(props: CalendarComponentProps) {
             <div className="relative flex flex-auto">
               <CurrentTime
                 timezone={timezone}
-                scrollToCurrentTime={scrollToCurrentTime}
+                scrollToCurrentTime={shouldScrollToCurrentTime}
                 updateOnFocus={updateCurrentTimeOnFocus}
               />
+              {firstAvailableSlot !== null && (
+                <div
+                  ref={dummyScrollRef}
+                  style={{
+                    position: "absolute",
+                    top: `calc(${Math.max(0, firstAvailableSlot - startHour * 60 - 150)} * var(--one-minute-height) + var(--calendar-offset-top))`,
+                    visibility: "hidden",
+                  }}
+                />
+              )}
               <div
                 className={classNames(
                   "bg-default dark:bg-cal-muted ring-muted sticky left-0 z-10 w-16 flex-none ring-1",


### PR DESCRIPTION

# feat(calendar): autoscroll week view to first available slot #29551 
## Description

Currently, on the week layout booking page, the time grid loads showing times starting from midnight. If a host's availability starts later in the day (e.g., 09:00), the booker has to manually scroll down to see the bookable times. This PR improves the UX by anchoring the initial view to the host's first available slot, matching the auto-scroll behavior on mobile.

### Changes Made
- Added logic in `Calendar.tsx` to calculate the `firstAvailableSlot` for the displayed week.
- Used `scrollIntoView({ block: "start", behavior: "smooth" })` on an invisible anchor element positioned `150 minutes` prior to the `firstAvailableSlot`.
- The 150-minute offset provides clean visual breathing room and ensures the time slot isn't hidden under the sticky days-of-the-week header.
- Maintained the native DOM traversal for scrolling because the time grid itself is not an internally scrollable container (the browser window/main layout handles the scroll). This exactly mimics the existing and stable `CurrentTime` marker auto-scroll behavior without yanking the parent browser window layout.

## Before and After

### Before
*(Grid opens showing 00:00 to 12:00, requiring manual scrolling to find availability)*

https://github.com/user-attachments/assets/ccede260-d271-4401-89e7-92ea0fc0b54b



### After
*(Grid elegantly auto-scrolls to display the first available slot perfectly below the sticky header)*

https://github.com/user-attachments/assets/e37474fa-a6aa-45c3-bc36-2709e9c7021e



## Type of Change
- [ ] Bug fix
- [x] New feature / UX Improvement
- [ ] Refactoring

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested the changes locally