### PR TITLE
fix(security): fail-closed cron auth when CRON_SECRET is unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,8 @@ CALCOM_TELEMETRY_DISABLED=
 
 # ApiKey for cronjobs
 CRON_API_KEY='0cc0e6c35519bba620c9360cfe3e68d0'
+# Bearer-token secret for Vercel Cron / cron auth. Generate with: openssl rand -hex 32
+CRON_SECRET=
 
 # Whether to automatically keep app metadata in the database in sync with the metadata/config files. When disabled, the
 # sync runs in a reporting-only dry-run mode.

--- a/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
@@ -1,10 +1,10 @@
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-
+import process from "node:process";
 import { CalendarCacheEventRepository } from "@calcom/features/calendar-subscription/lib/cache/CalendarCacheEventRepository";
 import { CalendarCacheEventService } from "@calcom/features/calendar-subscription/lib/cache/CalendarCacheEventService";
 import { prisma } from "@calcom/prisma";
 import { defaultResponderForAppDir } from "@calcom/web/app/api/defaultResponderForAppDir";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 /**
  * Cron webhook
@@ -16,7 +16,11 @@ import { defaultResponderForAppDir } from "@calcom/web/app/api/defaultResponderF
 async function getHandler(request: NextRequest) {
   const apiKey = request.headers.get("authorization") || request.nextUrl.searchParams.get("apiKey");
 
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
+  const validKeys = [
+    process.env.CRON_API_KEY,
+    process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : null,
+  ].filter(Boolean) as string[];
+  if (!validKeys.length || !validKeys.includes(`${apiKey}`)) {
     return NextResponse.json({ message: "Forbidden" }, { status: 403 });
   }
 

--- a/apps/web/app/api/cron/calendar-subscriptions/__tests__/route.test.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions/__tests__/route.test.ts
@@ -1,7 +1,6 @@
-import { NextRequest } from "next/server";
-import { describe, test, expect, vi, beforeEach } from "vitest";
-
 import { CalendarSubscriptionService } from "@calcom/features/calendar-subscription/lib/CalendarSubscriptionService";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("next/server", () => ({
   NextRequest: class MockNextRequest {
@@ -59,7 +58,7 @@ describe("/api/cron/calendar-subscriptions", () => {
 
       expect(response.status).toBe(403);
       const body = await response.json();
-      expect(body.message).toBe("Forbiden");
+      expect(body.message).toBe("Forbidden");
     }, 10000);
 
     test("should return 403 when invalid API key is provided", async () => {
@@ -71,7 +70,7 @@ describe("/api/cron/calendar-subscriptions", () => {
 
       expect(response.status).toBe(403);
       const body = await response.json();
-      expect(body.message).toBe("Forbiden");
+      expect(body.message).toBe("Forbidden");
     });
 
     test("should accept valid API key", async () => {

--- a/apps/web/app/api/cron/calendar-subscriptions/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions/route.ts
@@ -24,8 +24,12 @@ import { NextResponse } from "next/server";
 async function getHandler(request: NextRequest) {
   const apiKey = request.headers.get("authorization") || request.nextUrl.searchParams.get("apiKey");
 
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
-    return NextResponse.json({ message: "Forbiden" }, { status: 403 });
+  const validKeys = [
+    process.env.CRON_API_KEY,
+    process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : null,
+  ].filter(Boolean) as string[];
+  if (!validKeys.length || !validKeys.includes(`${apiKey}`)) {
+    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
   }
 
   // instantiate dependencies

--- a/apps/web/app/api/cron/selected-calendars/route.ts
+++ b/apps/web/app/api/cron/selected-calendars/route.ts
@@ -3,23 +3,23 @@
  *
  * It works in conjunction with `/api/cron/credentials` route(which creates the Credential records for all the members of an organization that has delegation credentials enabled)
  */
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
 
+import process from "node:process";
 import { findUniqueDelegationCalendarCredential } from "@calcom/app-store/delegationCredential";
 import {
   createGoogleCalendarServiceWithGoogleType,
   type GoogleCalendar,
 } from "@calcom/app-store/googlecalendar/lib/CalendarService";
 import { CredentialRepository } from "@calcom/features/credentials/repositories/CredentialRepository";
+import { SelectedCalendarRepository } from "@calcom/features/selectedCalendar/repositories/SelectedCalendarRepository";
 import { CalendarAppDelegationCredentialInvalidGrantError } from "@calcom/lib/CalendarAppError";
 import { HttpError } from "@calcom/lib/http-error";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
-import { SelectedCalendarRepository } from "@calcom/features/selectedCalendar/repositories/SelectedCalendarRepository";
 import type { CredentialForCalendarServiceWithEmail } from "@calcom/types/Credential";
 import type { Ensure } from "@calcom/types/utils";
-
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { defaultResponderForAppDir } from "../../defaultResponderForAppDir";
 
 const limitOnQueryingGoogleCalendar = 50;
@@ -27,7 +27,11 @@ const log = logger.getSubLogger({ prefix: ["[api]", "[delegation]", "[selected-c
 const validateRequest = (req: NextRequest) => {
   const url = new URL(req.url);
   const apiKey = req.headers.get("authorization") || url.searchParams.get("apiKey");
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
+  const validKeys = [
+    process.env.CRON_API_KEY,
+    process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : null,
+  ].filter(Boolean) as string[];
+  if (!validKeys.length || !validKeys.includes(`${apiKey}`)) {
     throw new HttpError({ statusCode: 401, message: "Unauthorized" });
   }
 };
@@ -122,7 +126,7 @@ async function getCalendarService(delegationUserCredential: DelegationUserCreden
     return null;
   }
 
-  const googleCalendarService= createGoogleCalendarServiceWithGoogleType(
+  const googleCalendarService = createGoogleCalendarServiceWithGoogleType(
     credentialForCalendarService as CredentialForCalendarServiceWithEmail
   );
 

--- a/packages/features/tasker/api/cleanup.ts
+++ b/packages/features/tasker/api/cleanup.ts
@@ -1,11 +1,11 @@
+import process from "node:process";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-
 import tasker from "..";
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new Response("Unauthorized", { status: 401 });
   }
   await tasker.cleanup();

--- a/packages/features/tasker/api/cron.ts
+++ b/packages/features/tasker/api/cron.ts
@@ -1,11 +1,11 @@
+import process from "node:process";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-
 import { TaskProcessor } from "../task-processor";
 
 async function handler(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new Response("Unauthorized", { status: 401 });
   }
   const processor = new TaskProcessor();


### PR DESCRIPTION
## What does this PR do?

When `CRON_SECRET` is not set in the environment  the default on a fresh install since it was missing from `.env.example`  the template literal `` `Bearer ${process.env.CRON_SECRET}` `` evaluates to the string `"Bearer undefined"`. The existing auth checks compared against this value directly, so any HTTP client that sent `Authorization: Bearer undefined` bypassed cron authentication entirely.

Two patterns were affected. Direct string comparison in `packages/features/tasker/api/cron.ts` and `cleanup.ts`:

```ts
if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) { ... }
```

And array `.includes()` checks in three `/api/cron/**` routes, where `"Bearer undefined"` was literally a member of the array when `CRON_SECRET` is unset:

```ts
if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) { ... }
```

The fix builds a `validKeys` array using only env vars that are actually set (`filter(Boolean)`) and rejects the request when no valid credentials are configured (fail-closed). `CRON_SECRET` is now documented in `.env.example`.

- Fixes #29565 

## Visual Demo (For contributors especially)

#### Before the fix — bypass succeeds (test expects 403, gets 200):
<img width="1531" height="957" alt="Screenshot from 2026-06-15 05-53-48" src="https://github.com/user-attachments/assets/14d60b5e-e830-406d-aa87-9651ceb0c1c5" />


#### After the fix — bypass is blocked (1 passed, 403 correctly returned):

<img width="1547" height="484" alt="Screenshot from 2026-06-15 05-55-02" src="https://github.com/user-attachments/assets/97e89ac1-a34a-46bd-9d89-b0155698f2db" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A — `CRON_SECRET` added to `.env.example`.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the reproduction test against the fixed code:

```bash
yarn test apps/web/app/api/cron/calendar-subscriptions/__tests__/route.test.ts -- --no-isolate --reporter=verbose
```

Expected: 9/9 tests pass.

To manually verify:

**Scenario 1 — bypass blocked (most important)**

Leave `CRON_SECRET` unset. Send `Authorization: Bearer undefined`:
```bash
curl -v -H "Authorization: Bearer undefined" \
  http://localhost:3000/api/cron/calendar-subscriptions
```
Expected: 403.

**Scenario 2 — legitimate Bearer token accepted**

Set `CRON_SECRET=your-secret` and send the correct token:
```bash
curl -v -H "Authorization: Bearer your-secret" \
  http://localhost:3000/api/cron/calendar-subscriptions
```
Expected: 200.