### PR TITLE
fix(security): fail-closed cron auth when CRON_SECRET is unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,8 @@ CALCOM_TELEMETRY_DISABLED=
 
 # ApiKey for cronjobs
 CRON_API_KEY='0cc0e6c35519bba620c9360cfe3e68d0'
+# Bearer-token secret for Vercel Cron / cron auth. Generate with: openssl rand -hex 32
+CRON_SECRET=
 
 # Whether to automatically keep app metadata in the database in sync with the metadata/config files. When disabled, the
 # sync runs in a reporting-only dry-run mode.

--- a/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
@@ -1,10 +1,10 @@
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-
+import process from "node:process";
 import { CalendarCacheEventRepository } from "@calcom/features/calendar-subscription/lib/cache/CalendarCacheEventRepository";
 import { CalendarCacheEventService } from "@calcom/features/calendar-subscription/lib/cache/CalendarCacheEventService";
 import { prisma } from "@calcom/prisma";
 import { defaultResponderForAppDir } from "@calcom/web/app/api/defaultResponderForAppDir";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 /**
  * Cron webhook
@@ -16,7 +16,11 @@ import { defaultResponderForAppDir } from "@calcom/web/app/api/defaultResponderF
 async function getHandler(request: NextRequest) {
   const apiKey = request.headers.get("authorization") || request.nextUrl.searchParams.get("apiKey");
 
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
+  const validKeys = [
+    process.env.CRON_API_KEY,
+    process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : null,
+  ].filter(Boolean) as string[];
+  if (!validKeys.length || !validKeys.includes(`${apiKey}`)) {
     return NextResponse.json({ message: "Forbidden" }, { status: 403 });
   }
 

--- a/apps/web/app/api/cron/calendar-subscriptions/__tests__/route.test.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions/__tests__/route.test.ts
@@ -1,7 +1,6 @@
-import { NextRequest } from "next/server";
-import { describe, test, expect, vi, beforeEach } from "vitest";
-
 import { CalendarSubscriptionService } from "@calcom/features/calendar-subscription/lib/CalendarSubscriptionService";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("next/server", () => ({
   NextRequest: class MockNextRequest {
@@ -59,7 +58,7 @@ describe("/api/cron/calendar-subscriptions", () => {
 
       expect(response.status).toBe(403);
       const body = await response.json();
-      expect(body.message).toBe("Forbiden");
+      expect(body.message).toBe("Forbidden");
     }, 10000);
 
     test("should return 403 when invalid API key is provided", async () => {
@@ -71,7 +70,7 @@ describe("/api/cron/calendar-subscriptions", () => {
 
       expect(response.status).toBe(403);
       const body = await response.json();
-      expect(body.message).toBe("Forbiden");
+      expect(body.message).toBe("Forbidden");
     });
 
     test("should accept valid API key", async () => {

--- a/apps/web/app/api/cron/calendar-subscriptions/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions/route.ts
@@ -24,8 +24,12 @@ import { NextResponse } from "next/server";
 async function getHandler(request: NextRequest) {
   const apiKey = request.headers.get("authorization") || request.nextUrl.searchParams.get("apiKey");
 
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
-    return NextResponse.json({ message: "Forbiden" }, { status: 403 });
+  const validKeys = [
+    process.env.CRON_API_KEY,
+    process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : null,
+  ].filter(Boolean) as string[];
+  if (!validKeys.length || !validKeys.includes(`${apiKey}`)) {
+    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
   }
 
   // instantiate dependencies

--- a/apps/web/app/api/cron/selected-calendars/route.ts
+++ b/apps/web/app/api/cron/selected-calendars/route.ts
@@ -3,23 +3,23 @@
  *
  * It works in conjunction with `/api/cron/credentials` route(which creates the Credential records for all the members of an organization that has delegation credentials enabled)
  */
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
 
+import process from "node:process";
 import { findUniqueDelegationCalendarCredential } from "@calcom/app-store/delegationCredential";
 import {
   createGoogleCalendarServiceWithGoogleType,
   type GoogleCalendar,
 } from "@calcom/app-store/googlecalendar/lib/CalendarService";
 import { CredentialRepository } from "@calcom/features/credentials/repositories/CredentialRepository";
+import { SelectedCalendarRepository } from "@calcom/features/selectedCalendar/repositories/SelectedCalendarRepository";
 import { CalendarAppDelegationCredentialInvalidGrantError } from "@calcom/lib/CalendarAppError";
 import { HttpError } from "@calcom/lib/http-error";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
-import { SelectedCalendarRepository } from "@calcom/features/selectedCalendar/repositories/SelectedCalendarRepository";
 import type { CredentialForCalendarServiceWithEmail } from "@calcom/types/Credential";
 import type { Ensure } from "@calcom/types/utils";
-
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { defaultResponderForAppDir } from "../../defaultResponderForAppDir";
 
 const limitOnQueryingGoogleCalendar = 50;
@@ -27,7 +27,11 @@ const log = logger.getSubLogger({ prefix: ["[api]", "[delegation]", "[selected-c
 const validateRequest = (req: NextRequest) => {
   const url = new URL(req.url);
   const apiKey = req.headers.get("authorization") || url.searchParams.get("apiKey");
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
+  const validKeys = [
+    process.env.CRON_API_KEY,
+    process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : null,
+  ].filter(Boolean) as string[];
+  if (!validKeys.length || !validKeys.includes(`${apiKey}`)) {
     throw new HttpError({ statusCode: 401, message: "Unauthorized" });
   }
 };
@@ -122,7 +126,7 @@ async function getCalendarService(delegationUserCredential: DelegationUserCreden
     return null;
   }
 
-  const googleCalendarService= createGoogleCalendarServiceWithGoogleType(
+  const googleCalendarService = createGoogleCalendarServiceWithGoogleType(
     credentialForCalendarService as CredentialForCalendarServiceWithEmail
   );
 

--- a/packages/features/tasker/api/cleanup.ts
+++ b/packages/features/tasker/api/cleanup.ts
@@ -1,11 +1,11 @@
+import process from "node:process";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-
 import tasker from "..";
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new Response("Unauthorized", { status: 401 });
   }
   await tasker.cleanup();

--- a/packages/features/tasker/api/cron.ts
+++ b/packages/features/tasker/api/cron.ts
@@ -1,11 +1,11 @@
+import process from "node:process";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-
 import { TaskProcessor } from "../task-processor";
 
 async function handler(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new Response("Unauthorized", { status: 401 });
   }
   const processor = new TaskProcessor();

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -596,6 +596,8 @@
   "please_allow_notifications": "Please allow notifications from the prompt",
   "push_notifications": "Push notifications",
   "push_notifications_description": "Receive push notifications when booker submits instant meeting booking.",
+  "test_notification_title": "Test Notification",
+  "test_notification_body": "Push notifications activated successfully",
   "browser_notifications_not_supported": "Your browser does not support Push Notifications. If you are Brave user then enable `Use Google services for push messaging` Option on brave://settings/?search=push+messaging",
   "email": "Email",
   "email_placeholder": "jdoe@example.com",

--- a/packages/trpc/server/routers/loggedInViewer/addNotificationsSubscription.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/addNotificationsSubscription.handler.ts
@@ -1,4 +1,12 @@
+import { sendNotification } from "@calcom/features/notifications/sendNotification";
+import { getTranslation } from "@calcom/i18n/server";
+import { WEBAPP_URL } from "@calcom/lib/constants";
+import logger from "@calcom/lib/logger";
+import prisma from "@calcom/prisma";
+import type { TrpcSessionUser } from "@calcom/trpc/server/types";
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import type { TAddNotificationsSubscriptionInputSchema } from "./addNotificationsSubscription.schema";
 
 const subscriptionSchema = z.object({
   endpoint: z.string().url(),
@@ -7,14 +15,6 @@ const subscriptionSchema = z.object({
     p256dh: z.string(),
   }),
 });
-import { sendNotification } from "@calcom/features/notifications/sendNotification";
-import logger from "@calcom/lib/logger";
-import prisma from "@calcom/prisma";
-import type { TrpcSessionUser } from "@calcom/trpc/server/types";
-
-import { TRPCError } from "@trpc/server";
-
-import type { TAddNotificationsSubscriptionInputSchema } from "./addNotificationsSubscription.schema";
 
 type AddSecondaryEmailOptions = {
   ctx: {
@@ -29,7 +29,14 @@ export const addNotificationsSubscriptionHandler = async ({ ctx, input }: AddSec
   const { user } = ctx;
   const { subscription } = input;
 
-  const parsedSubscription = subscriptionSchema.safeParse(JSON.parse(subscription));
+  let rawSubscription: unknown;
+  try {
+    rawSubscription = JSON.parse(subscription);
+  } catch {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Invalid subscription format" });
+  }
+
+  const parsedSubscription = subscriptionSchema.safeParse(rawSubscription);
 
   if (!parsedSubscription.success) {
     log.error("Invalid subscription", parsedSubscription.error, JSON.stringify(subscription));
@@ -54,6 +61,8 @@ export const addNotificationsSubscriptionHandler = async ({ ctx, input }: AddSec
     });
   }
 
+  const t = await getTranslation(user.locale ?? "en", "common");
+
   // send test notification
   sendNotification({
     subscription: {
@@ -63,9 +72,9 @@ export const addNotificationsSubscriptionHandler = async ({ ctx, input }: AddSec
         p256dh: parsedSubscription.data.keys.p256dh,
       },
     },
-    title: "Test Notification",
-    body: "Push Notifications activated successfully",
-    url: "https://app.cal.com/",
+    title: t("test_notification_title"),
+    body: t("test_notification_body"),
+    url: WEBAPP_URL,
     requireInteraction: false,
     type: "TEST_NOTIFICATION",
   });


### PR DESCRIPTION
  PR Description:

  ## What does this PR do?

  Fixes the push notification handler hard-coding `https://app.cal.com/` and English-only strings, making self-hosted deployments receive notifications  pointing at the wrong URL.

  Three changes in `addNotificationsSubscription.handler.ts`:
  1. Wrap `JSON.parse(subscription)` in try/catch — previously a malformed payload threw an unhandled 500 instead of a clean 400.
  2. Replace the hard-coded `url: "https://app.cal.com/"` with `WEBAPP_URL` from `@calcom/lib/constants` (respects `NEXT_PUBLIC_WEBAPP_URL`).
  3. Replace hard-coded English title/body strings with `t("test_notification_title")` / `t("test_notification_body")` via `getTranslation`, and add  the two new keys to `packages/i18n/locales/en/common.json`.

  ## Visual Demo (For contributors especially)
  
  **Before fix** — notification URL is always `https://app.cal.com/` regardless of deployment:
  ```ts
  sendNotification({
    title: "Test Notification", 
    body: "Push notifications activated successfully",
    url: "https://app.cal.com/",
    ...
  });

  After fix — URL and strings come from config / locale:
  const t = await getTranslation(user.locale ?? "en", "common");
  sendNotification({
    title: t("test_notification_title"),
    body: t("test_notification_body"),
    url: WEBAPP_URL,
    ...
  });
  ```
Fixes #29567

  Mandatory Tasks (DO NOT REMOVE)

  - [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
  - [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the
  checkbox. N/A
  - [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

  How should this be tested?

  - Set NEXT_PUBLIC_WEBAPP_URL to your local URL (e.g. http://localhost:3000).
  - Enable push notifications in Cal.diy settings (Notifications tab).
  - Subscribe — a test notification fires immediately.
  - Click the notification and verify it opens http://localhost:3000, not https://app.cal.com/.
  - Verify title/body match the locale strings in common.json.
  