### PR TITLE
fix(cron): reject "Bearer undefined" when CRON_SECRET is unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,10 @@ CALCOM_TELEMETRY_DISABLED=
 # ApiKey for cronjobs
 CRON_API_KEY='0cc0e6c35519bba620c9360cfe3e68d0'
 
+# Bearer token used to authorize the tasker and calendar-subscription cron routes.
+# Leave unset to keep those endpoints closed; when unset they reject every request.
+CRON_SECRET=
+
 # Whether to automatically keep app metadata in the database in sync with the metadata/config files. When disabled, the
 # sync runs in a reporting-only dry-run mode.
 CRON_ENABLE_APP_SYNC=false

--- a/apps/web/app/api/cron/calendar-subscriptions-cleanup/__tests__/route.test.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions-cleanup/__tests__/route.test.ts
@@ -101,6 +101,20 @@ describe("/api/cron/calendar-subscriptions-cleanup", () => {
       expect(body.message).toBe("Forbidden");
     });
 
+    test("should return 403 for 'Bearer undefined' when CRON_SECRET is unset", async () => {
+      vi.stubEnv("CRON_API_KEY", undefined);
+      vi.stubEnv("CRON_SECRET", undefined);
+      const request = new NextRequest("http://localhost/api/cron/calendar-subscriptions-cleanup");
+      request.headers.set("authorization", "Bearer undefined");
+
+      const { GET } = await import("../route");
+      const response = await GET(request, { params: Promise.resolve({}) });
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.message).toBe("Forbidden");
+    });
+
     test("should accept CRON_API_KEY in authorization header", async () => {
       const request = new NextRequest("http://localhost/api/cron/calendar-subscriptions-cleanup");
       request.headers.set("authorization", "test-cron-key");

--- a/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
@@ -16,7 +16,12 @@ import { defaultResponderForAppDir } from "@calcom/web/app/api/defaultResponderF
 async function getHandler(request: NextRequest) {
   const apiKey = request.headers.get("authorization") || request.nextUrl.searchParams.get("apiKey");
 
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
+  const validApiKeys = [
+    process.env.CRON_API_KEY,
+    process.env.CRON_SECRET && `Bearer ${process.env.CRON_SECRET}`,
+  ].filter(Boolean);
+
+  if (!apiKey || !validApiKeys.includes(apiKey)) {
     return NextResponse.json({ message: "Forbidden" }, { status: 403 });
   }
 

--- a/apps/web/app/api/cron/calendar-subscriptions/__tests__/route.test.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions/__tests__/route.test.ts
@@ -59,7 +59,7 @@ describe("/api/cron/calendar-subscriptions", () => {
 
       expect(response.status).toBe(403);
       const body = await response.json();
-      expect(body.message).toBe("Forbiden");
+      expect(body.message).toBe("Forbidden");
     }, 10000);
 
     test("should return 403 when invalid API key is provided", async () => {
@@ -71,7 +71,7 @@ describe("/api/cron/calendar-subscriptions", () => {
 
       expect(response.status).toBe(403);
       const body = await response.json();
-      expect(body.message).toBe("Forbiden");
+      expect(body.message).toBe("Forbidden");
     });
 
     test("should accept valid API key", async () => {

--- a/apps/web/app/api/cron/calendar-subscriptions/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions/route.ts
@@ -30,7 +30,7 @@ async function getHandler(request: NextRequest) {
   ].filter(Boolean);
 
   if (!apiKey || !validApiKeys.includes(apiKey)) {
-    return NextResponse.json({ message: "Forbiden" }, { status: 403 });
+    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
   }
 
   // instantiate dependencies

--- a/apps/web/app/api/cron/calendar-subscriptions/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions/route.ts
@@ -24,7 +24,12 @@ import { NextResponse } from "next/server";
 async function getHandler(request: NextRequest) {
   const apiKey = request.headers.get("authorization") || request.nextUrl.searchParams.get("apiKey");
 
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
+  const validApiKeys = [
+    process.env.CRON_API_KEY,
+    process.env.CRON_SECRET && `Bearer ${process.env.CRON_SECRET}`,
+  ].filter(Boolean);
+
+  if (!apiKey || !validApiKeys.includes(apiKey)) {
     return NextResponse.json({ message: "Forbiden" }, { status: 403 });
   }
 

--- a/apps/web/app/api/cron/selected-calendars/route.ts
+++ b/apps/web/app/api/cron/selected-calendars/route.ts
@@ -27,7 +27,11 @@ const log = logger.getSubLogger({ prefix: ["[api]", "[delegation]", "[selected-c
 const validateRequest = (req: NextRequest) => {
   const url = new URL(req.url);
   const apiKey = req.headers.get("authorization") || url.searchParams.get("apiKey");
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
+  const validApiKeys = [
+    process.env.CRON_API_KEY,
+    process.env.CRON_SECRET && `Bearer ${process.env.CRON_SECRET}`,
+  ].filter(Boolean);
+  if (!apiKey || !validApiKeys.includes(apiKey)) {
     throw new HttpError({ statusCode: 401, message: "Unauthorized" });
   }
 };

--- a/packages/features/tasker/api/__tests__/auth.test.ts
+++ b/packages/features/tasker/api/__tests__/auth.test.ts
@@ -1,0 +1,136 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const cleanupMock = vi.fn();
+const processQueueMock = vi.fn();
+
+vi.mock("next/server", () => ({
+  NextRequest: class MockNextRequest {
+    url: string;
+    private _headers: Map<string, string>;
+
+    constructor(url: string) {
+      this.url = url;
+      this._headers = new Map();
+    }
+
+    headers = {
+      get: (key: string): string | null => this._headers.get(key.toLowerCase()) ?? null,
+      set: (key: string, value: string): void => {
+        this._headers.set(key.toLowerCase(), value);
+      },
+    };
+  },
+  NextResponse: {
+    json: vi.fn((body, init) => ({
+      json: vi.fn().mockResolvedValue(body),
+      status: init?.status ?? 200,
+    })),
+  },
+}));
+
+// The routes under test import from "..", which resolves to packages/features/tasker
+// relative to those files. From this test file that module is "../../index".
+vi.mock("../../index", () => ({
+  default: {
+    cleanup: cleanupMock,
+  },
+}));
+
+vi.mock("../../task-processor", () => ({
+  TaskProcessor: class {
+    processQueue = processQueueMock;
+  },
+}));
+
+const buildRequest = (authorization?: string) => {
+  const request = new NextRequest("http://localhost/api/tasks");
+  if (authorization !== undefined) {
+    request.headers.set("authorization", authorization);
+  }
+  return request;
+};
+
+describe("tasker api auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("cleanup route", () => {
+    test("rejects 'Bearer undefined' when CRON_SECRET is unset", async () => {
+      vi.stubEnv("CRON_SECRET", undefined);
+      const { GET } = await import("../cleanup");
+
+      const response = await GET(buildRequest("Bearer undefined"));
+
+      expect(response.status).toBe(401);
+      expect(cleanupMock).not.toHaveBeenCalled();
+    });
+
+    test("rejects a request with no authorization header when CRON_SECRET is unset", async () => {
+      vi.stubEnv("CRON_SECRET", undefined);
+      const { GET } = await import("../cleanup");
+
+      const response = await GET(buildRequest());
+
+      expect(response.status).toBe(401);
+      expect(cleanupMock).not.toHaveBeenCalled();
+    });
+
+    test("accepts the correct Bearer token when CRON_SECRET is set", async () => {
+      vi.stubEnv("CRON_SECRET", "super-secret");
+      const { GET } = await import("../cleanup");
+
+      const response = await GET(buildRequest("Bearer super-secret"));
+
+      expect(response.status).toBe(200);
+      expect(cleanupMock).toHaveBeenCalledOnce();
+    });
+
+    test("rejects an incorrect Bearer token when CRON_SECRET is set", async () => {
+      vi.stubEnv("CRON_SECRET", "super-secret");
+      const { GET } = await import("../cleanup");
+
+      const response = await GET(buildRequest("Bearer wrong"));
+
+      expect(response.status).toBe(401);
+      expect(cleanupMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cron route", () => {
+    test("rejects 'Bearer undefined' when CRON_SECRET is unset", async () => {
+      vi.stubEnv("CRON_SECRET", undefined);
+      const { GET } = await import("../cron");
+
+      const response = await GET(buildRequest("Bearer undefined"));
+
+      expect(response.status).toBe(401);
+      expect(processQueueMock).not.toHaveBeenCalled();
+    });
+
+    test("accepts the correct Bearer token via POST when CRON_SECRET is set", async () => {
+      vi.stubEnv("CRON_SECRET", "super-secret");
+      const { POST } = await import("../cron");
+
+      const response = await POST(buildRequest("Bearer super-secret"));
+
+      expect(response.status).toBe(200);
+      expect(processQueueMock).toHaveBeenCalledOnce();
+    });
+
+    test("rejects an incorrect Bearer token when CRON_SECRET is set", async () => {
+      vi.stubEnv("CRON_SECRET", "super-secret");
+      const { GET } = await import("../cron");
+
+      const response = await GET(buildRequest("Bearer wrong"));
+
+      expect(response.status).toBe(401);
+      expect(processQueueMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/features/tasker/api/__tests__/auth.test.ts
+++ b/packages/features/tasker/api/__tests__/auth.test.ts
@@ -113,6 +113,16 @@ describe("tasker api auth", () => {
       expect(processQueueMock).not.toHaveBeenCalled();
     });
 
+    test("rejects a request with no authorization header when CRON_SECRET is unset", async () => {
+      vi.stubEnv("CRON_SECRET", undefined);
+      const { GET } = await import("../cron");
+
+      const response = await GET(buildRequest());
+
+      expect(response.status).toBe(401);
+      expect(processQueueMock).not.toHaveBeenCalled();
+    });
+
     test("accepts the correct Bearer token via POST when CRON_SECRET is set", async () => {
       vi.stubEnv("CRON_SECRET", "super-secret");
       const { POST } = await import("../cron");

--- a/packages/features/tasker/api/cleanup.ts
+++ b/packages/features/tasker/api/cleanup.ts
@@ -5,7 +5,7 @@ import tasker from "..";
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new Response("Unauthorized", { status: 401 });
   }
   await tasker.cleanup();

--- a/packages/features/tasker/api/cron.ts
+++ b/packages/features/tasker/api/cron.ts
@@ -5,7 +5,7 @@ import { TaskProcessor } from "../task-processor";
 
 async function handler(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new Response("Unauthorized", { status: 401 });
   }
   const processor = new TaskProcessor();

--- a/packages/types/environment.d.ts
+++ b/packages/types/environment.d.ts
@@ -25,6 +25,7 @@ declare namespace NodeJS {
     readonly EMAIL_SERVER_USER: string | undefined;
     readonly EMAIL_SERVER_PASSWORD: string | undefined;
     readonly CRON_API_KEY: string | undefined;
+    readonly CRON_SECRET: string | undefined;
     readonly CRON_ENABLE_APP_SYNC: string | undefined;
     readonly NEXT_PUBLIC_STRIPE_PUBLIC_KEY: string | undefined;
     readonly STRIPE_PRIVATE_KEY: string | undefined;


### PR DESCRIPTION
Fixes #29565.

## Summary

Several cron/tasker route handlers authorize by comparing the `Authorization` header to `` `Bearer ${process.env.CRON_SECRET}` ``. When `CRON_SECRET` is unset (it is not in `.env.example`), that literal becomes the string `"Bearer undefined"`, so a request with `Authorization: Bearer undefined` is accepted. The array-based routes had the same issue via `[CRON_API_KEY, \`Bearer ${CRON_SECRET}\`].includes(...)`.

This makes the checks fail-closed:
- reject when the configured secret is unset (no more `"Bearer undefined"` match)
- build the allow-list from defined values only (`.filter(Boolean)`) and reject a missing `apiKey`
- document `CRON_SECRET` in `.env.example` and `packages/types/environment.d.ts`

Existing status codes / messages are preserved to keep the diff focused.

## Tests

- Added the tasker routes' first auth tests + a `Bearer undefined` regression test
- `auth.test.ts` 7/7, `calendar-subscriptions(-cleanup)` 19/19, `biome lint` clean, `tsc` clean on changed files

## Note

A review surfaced a related but separate misconfiguration class: four other cron routes can be bypassed if an operator explicitly sets `CRON_API_KEY=""`. That is outside this issue's scope — happy to follow up in a separate PR if useful.