### PR TITLE
feat: lazy load app-store schemas and metadata; add office365_calendar subscription support

### DIFF
--- a/packages/app-store/appStoreMetaData.ts
+++ b/packages/app-store/appStoreMetaData.ts
@@ -1,14 +1,39 @@
 import type { AppMeta } from "@calcom/types/App";
 
-import { appStoreMetadata as rawAppStoreMetadata } from "./apps.metadata.generated";
 import { getNormalizedAppMetadata } from "./getNormalizedAppMetadata";
 
-type RawAppStoreMetaData = typeof rawAppStoreMetadata;
-type AppStoreMetaData = {
-  [key in keyof RawAppStoreMetaData]: Omit<AppMeta, "dirName"> & { dirName: string };
-};
+type AppStoreMetaData = Record<string, Omit<AppMeta, "dirName"> & { dirName: string }>;
 
-export const appStoreMetadata = {} as AppStoreMetaData;
-for (const [key, value] of Object.entries(rawAppStoreMetadata)) {
-  appStoreMetadata[key as keyof typeof appStoreMetadata] = getNormalizedAppMetadata(value);
+/**
+ * Lazy-loads app store metadata from the generated file.
+ * The raw metadata (config.json / _metadata.ts) is loaded on first access,
+ * avoiding eager loading of ~100+ metadata files at module import time.
+ */
+let _loaded = false;
+const _normalizedCache: AppStoreMetaData = {} as AppStoreMetaData;
+
+function ensureMetadataLoaded() {
+  if (_loaded) return;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { appStoreMetadata: raw } = require("./apps.metadata.generated");
+  for (const [key, value] of Object.entries(raw)) {
+    _normalizedCache[key] = getNormalizedAppMetadata(value) as AppStoreMetaData[string];
+  }
+  _loaded = true;
 }
+
+export const appStoreMetadata = new Proxy(_normalizedCache as AppStoreMetaData, {
+  get(target, key: string) {
+    if (key === "then" || key === "__esModule") return undefined;
+    ensureMetadataLoaded();
+    return target[key];
+  },
+  ownKeys() {
+    ensureMetadataLoaded();
+    return Reflect.ownKeys(_normalizedCache);
+  },
+  getOwnPropertyDescriptor(_target, key) {
+    ensureMetadataLoaded();
+    return Reflect.getOwnPropertyDescriptor(_normalizedCache, key);
+  },
+});

--- a/packages/app-store/zod-utils.ts
+++ b/packages/app-store/zod-utils.ts
@@ -2,16 +2,51 @@ import { z } from "zod";
 
 import { eventTypeMetaDataSchemaWithoutApps } from "@calcom/prisma/zod-utils";
 
-import { appDataSchemas } from "./apps.schemas.generated";
+/**
+ * Lazy-loads app data schemas from the generated file only when first accessed.
+ * This avoids eagerly loading ~50 app zod schemas (~650KB) at module import time.
+ */
+function loadAppDataSchemas() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { appDataSchemas } = require("./apps.schemas.generated");
+  const EventTypeAppMetadataSchema = z.object(appDataSchemas).partial();
+  const eventTypeAppMetadataOptionalSchema = EventTypeAppMetadataSchema.optional();
+  const eventTypeMetaDataSchemaWithTypedApps = eventTypeMetaDataSchemaWithoutApps
+    .unwrap()
+    .merge(
+      z.object({
+        apps: eventTypeAppMetadataOptionalSchema,
+      })
+    )
+    .nullable();
+  return {
+    EventTypeAppMetadataSchema,
+    eventTypeAppMetadataOptionalSchema,
+    eventTypeMetaDataSchemaWithTypedApps,
+  };
+}
 
-export const EventTypeAppMetadataSchema = z.object(appDataSchemas).partial();
-export const eventTypeAppMetadataOptionalSchema = EventTypeAppMetadataSchema.optional();
+type LazySchemas = ReturnType<typeof loadAppDataSchemas>;
 
-export const eventTypeMetaDataSchemaWithTypedApps = eventTypeMetaDataSchemaWithoutApps
-  .unwrap()
-  .merge(
-    z.object({
-      apps: eventTypeAppMetadataOptionalSchema,
-    })
-  )
-  .nullable();
+/** Creates a Proxy that lazily initializes an object on first property access. */
+function lazyProxy<T extends object>(init: () => T): T {
+  let instance: T | null = null;
+  return new Proxy({} as T, {
+    get(_target, key: string) {
+      if (key === "then" || key === "__esModule") return undefined;
+      if (!instance) instance = init();
+      const value = (instance as Record<string, unknown>)[key];
+      return typeof value === "function" ? value.bind(instance) : value;
+    },
+  });
+}
+
+export const EventTypeAppMetadataSchema: LazySchemas["EventTypeAppMetadataSchema"] = lazyProxy(
+  () => loadAppDataSchemas().EventTypeAppMetadataSchema
+);
+export const eventTypeAppMetadataOptionalSchema: LazySchemas["eventTypeAppMetadataOptionalSchema"] = lazyProxy(
+  () => loadAppDataSchemas().eventTypeAppMetadataOptionalSchema
+);
+export const eventTypeMetaDataSchemaWithTypedApps: LazySchemas["eventTypeMetaDataSchemaWithTypedApps"] = lazyProxy(
+  () => loadAppDataSchemas().eventTypeMetaDataSchemaWithTypedApps
+);

--- a/packages/features/calendar-subscription/adapters/AdaptersFactory.ts
+++ b/packages/features/calendar-subscription/adapters/AdaptersFactory.ts
@@ -54,7 +54,7 @@ export class DefaultAdapterFactory implements AdapterFactory {
    * @returns
    */
   getProviders(): CalendarSubscriptionProvider[] {
-    const providers: CalendarSubscriptionProvider[] = ["google_calendar"];
+    const providers: CalendarSubscriptionProvider[] = ["google_calendar", "office365_calendar"];
     return providers;
   }
 

--- a/packages/features/calendar-subscription/adapters/__tests__/AdaptersFactory.test.ts
+++ b/packages/features/calendar-subscription/adapters/__tests__/AdaptersFactory.test.ts
@@ -48,7 +48,7 @@ describe("DefaultAdapterFactory", () => {
     test("should return array with correct length", () => {
       const providers = factory.getProviders();
 
-      expect(providers).toHaveLength(1);
+      expect(providers).toHaveLength(2);
     });
   });
 });

--- a/packages/features/calendar-subscription/lib/cache/CalendarCacheEventService.ts
+++ b/packages/features/calendar-subscription/lib/cache/CalendarCacheEventService.ts
@@ -94,7 +94,6 @@ export class CalendarCacheEventService {
    */
   static isCalendarTypeSupported(type: string | null): boolean {
     if (!type) return false;
-    // return ["google_calendar", "office365_calendar"].includes(type);
-    return ["google_calendar"].includes(type);
+    return ["google_calendar", "office365_calendar"].includes(type);
   }
 }

--- a/packages/features/calendar-subscription/lib/cache/__tests__/CalendarCacheEventService.test.ts
+++ b/packages/features/calendar-subscription/lib/cache/__tests__/CalendarCacheEventService.test.ts
@@ -340,8 +340,11 @@ describe("CalendarCacheEventService", () => {
       expect(CalendarCacheEventService.isCalendarTypeSupported("google_calendar")).toBe(true);
     });
 
+    test("should return true for office365_calendar (now supported)", () => {
+      expect(CalendarCacheEventService.isCalendarTypeSupported("office365_calendar")).toBe(true);
+    });
+
     test("should return false for unsupported calendar types", () => {
-      expect(CalendarCacheEventService.isCalendarTypeSupported("office365_calendar")).toBe(false);
       expect(CalendarCacheEventService.isCalendarTypeSupported("outlook_calendar")).toBe(false);
       expect(CalendarCacheEventService.isCalendarTypeSupported("apple_calendar")).toBe(false);
       expect(CalendarCacheEventService.isCalendarTypeSupported("unknown_calendar")).toBe(false);


### PR DESCRIPTION
feat: lazy load app-store schemas and metadata; add office365_calendar subscription support

- Replace static imports in appStoreMetaData.ts and zod-utils.ts with Proxy-based lazy loading, deferring the load of ~50 app zod schemas and ~100+ metadata configs until first access
- Add office365_calendar to supported calendar subscription providers and cache service
- Update corresponding tests for the new provider

/claim #29570