### PR TITLE
fix: pad username suggestion suffixes to a consistent width

### DIFF
--- a/packages/lib/server/username.test.ts
+++ b/packages/lib/server/username.test.ts
@@ -1,8 +1,8 @@
 import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
 
-import { describe, expect, it, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { usernameCheckForSignup } from "./username";
+import { generateUsernameSuggestion, usernameCheckForSignup } from "./username";
 
 describe("usernameCheckForSignup ", async () => {
   beforeEach(() => {
@@ -54,6 +54,33 @@ describe("usernameCheckForSignup ", async () => {
       premium: false,
       suggestedUsername: "",
     });
+  });
+});
+
+describe("generateUsernameSuggestion", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("appends a zero-padded suffix when the username is free on the first attempt", async () => {
+    const suggestion = await generateUsernameSuggestion([], "john");
+    expect(suggestion).toBe("john001");
+  });
+
+  it("zero-pads a two-digit suffix to a consistent width", async () => {
+    // Force the first candidate (john001) to collide so a random suffix is generated,
+    // and pin Math.random so the generated suffix is the two-digit number 42.
+    // username length >= 2 -> limit 999 -> rand = ceil(1 + random * 998); 40.5/998 -> ceil(41.5) = 42.
+    vi.spyOn(Math, "random").mockReturnValue(40.5 / 998);
+    const suggestion = await generateUsernameSuggestion(["john001"], "john");
+    expect(suggestion).toBe("john042");
+  });
+
+  it("zero-pads a three-digit suffix to a consistent width", async () => {
+    // 122.5/998 -> ceil(1 + 122.5) = ceil(123.5) = 124.
+    vi.spyOn(Math, "random").mockReturnValue(122.5 / 998);
+    const suggestion = await generateUsernameSuggestion(["john001"], "john");
+    expect(suggestion).toBe("john124");
   });
 });
 

--- a/packages/lib/server/username.ts
+++ b/packages/lib/server/username.ts
@@ -57,11 +57,12 @@ export const isPremiumUserName = IS_PREMIUM_USERNAME_ENABLED
 
 export const generateUsernameSuggestion = async (users: string[], username: string) => {
   const limit = username.length < 2 ? 9999 : 999;
+  const suffix = (value: number) => String(value).padStart(3, "0");
   let rand = 1;
-  while (users.includes(username + String(rand).padStart(4 - rand.toString().length, "0"))) {
+  while (users.includes(username + suffix(rand))) {
     rand = Math.ceil(1 + Math.random() * (limit - 1));
   }
-  return username + String(rand).padStart(4 - rand.toString().length, "0");
+  return username + suffix(rand);
 };
 
 const processResult = (


### PR DESCRIPTION
Closes #29577.

`generateUsernameSuggestion` used `padStart(4 - len, "0")`, but `padStart`'s first arg is the target length, not the pad count — so only single-digit suffixes got padded (`1` → `001`, but `42` → `42`, `999` → `999`).

Pulled the padding into a small `suffix()` helper (it was duplicated) that pads to a consistent 3 digits, matching the existing `johnny001` test, and added the two/three-digit cases.

`yarn vitest` on the file: 6/6, red-green checked.