### PR TITLE
fix(swagger): replace @ApiHeader Authorization with @ApiBearerAuth

### DIFF
--- a/apps/api/v2/src/modules/api-keys/controllers/api-keys.controller.ts
+++ b/apps/api/v2/src/modules/api-keys/controllers/api-keys.controller.ts
@@ -1,3 +1,6 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { Body, Controller, HttpCode, HttpStatus, Post, Req, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { RefreshApiKeyInput } from "@/modules/api-keys/inputs/refresh-api-key.input";
 import { RefreshApiKeyOutput } from "@/modules/api-keys/outputs/refresh-api-key.output";
@@ -5,10 +8,6 @@ import { ApiKeysService } from "@/modules/api-keys/services/api-keys.service";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { ApiAuthGuardRequest } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
-import { Body, Controller, HttpCode, HttpStatus, Post, Req, UseGuards } from "@nestjs/common";
-import { ApiBearerAuth, ApiTags,  ApiOperation } from "@nestjs/swagger";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
 
 @Controller({
   path: "/v2/api-keys",

--- a/apps/api/v2/src/modules/api-keys/controllers/api-keys.controller.ts
+++ b/apps/api/v2/src/modules/api-keys/controllers/api-keys.controller.ts
@@ -1,5 +1,4 @@
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_HEADER } from "@/lib/docs/headers";
 import { RefreshApiKeyInput } from "@/modules/api-keys/inputs/refresh-api-key.input";
 import { RefreshApiKeyOutput } from "@/modules/api-keys/outputs/refresh-api-key.output";
 import { ApiKeysService } from "@/modules/api-keys/services/api-keys.service";
@@ -7,7 +6,7 @@ import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { ApiAuthGuardRequest } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
 import { Body, Controller, HttpCode, HttpStatus, Post, Req, UseGuards } from "@nestjs/common";
-import { ApiTags, ApiHeader, ApiOperation } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiTags,  ApiOperation } from "@nestjs/swagger";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
 
@@ -24,7 +23,7 @@ export class ApiKeysController {
     summary: "Refresh API Key",
     description: `Generate a new API key and delete the current one. Provide API key to refresh as a Bearer token in the Authorization header (e.g. "Authorization: Bearer <apiKey>").`,
   })
-  @ApiHeader(API_KEY_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Post("/refresh")
   @HttpCode(HttpStatus.OK)
   async refresh(

--- a/apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.ts
+++ b/apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.ts
@@ -12,8 +12,7 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
-import { ApiBearerAuth,  ApiOperation, ApiParam, ApiQuery, ApiTags as DocsTags } from "@nestjs/swagger";
-import { GetBusyTimesOutput } from "@/platform/calendars/outputs/busy-times.output";
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiQuery, ApiTags as DocsTags } from "@nestjs/swagger";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -29,6 +28,7 @@ import {
 import { ListConnectionsOutput } from "@/modules/cal-unified-calendars/outputs/list-connections.output";
 import { ParseConnectionIdPipe } from "@/modules/cal-unified-calendars/pipes/parse-connection-id.pipe";
 import { UnifiedCalendarService } from "@/modules/cal-unified-calendars/services/unified-calendar.service";
+import { GetBusyTimesOutput } from "@/platform/calendars/outputs/busy-times.output";
 
 const UNIFIED_CALENDAR_PARAM = ["google", "office365", "apple"] as const;
 
@@ -53,7 +53,11 @@ export class CalUnifiedCalendarsController {
     const connections = await this.unifiedCalendarService.getConnections(userId);
     // Defense-in-depth: only forward the public fields so that any future service
     // regression that accidentally includes credential.key cannot leak to the client.
-    const safeConnections = connections.map(({ connectionId, type, email }) => ({ connectionId, type, email }));
+    const safeConnections = connections.map(({ connectionId, type, email }) => ({
+      connectionId,
+      type,
+      email,
+    }));
     return {
       status: SUCCESS_STATUS,
       data: { connections: safeConnections },
@@ -195,7 +199,12 @@ export class CalUnifiedCalendarsController {
     @GetUser("id") userId: number,
     @Query("calendarId") calendarId?: string
   ): Promise<void> {
-    await this.unifiedCalendarService.deleteConnectionEvent(userId, credentialId, calendarId ?? "primary", eventId);
+    await this.unifiedCalendarService.deleteConnectionEvent(
+      userId,
+      credentialId,
+      calendarId ?? "primary",
+      eventId
+    );
   }
 
   @ApiParam({ name: "connectionId", type: String })
@@ -375,7 +384,13 @@ export class CalUnifiedCalendarsController {
     @Query() query: FreebusyUnifiedInput
   ): Promise<GetBusyTimesOutput> {
     const timezone = query.timeZone ?? "UTC";
-    const data = await this.unifiedCalendarService.getFreeBusy(calendar, userId, query.from, query.to, timezone);
+    const data = await this.unifiedCalendarService.getFreeBusy(
+      calendar,
+      userId,
+      query.from,
+      query.to,
+      timezone
+    );
     return { status: SUCCESS_STATUS, data };
   }
 }

--- a/apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.ts
+++ b/apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.ts
@@ -12,10 +12,9 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiParam, ApiQuery, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth,  ApiOperation, ApiParam, ApiQuery, ApiTags as DocsTags } from "@nestjs/swagger";
 import { GetBusyTimesOutput } from "@/platform/calendars/outputs/busy-times.output";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
@@ -44,7 +43,7 @@ export class CalUnifiedCalendarsController {
   @Get("connections")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "List calendar connections",
     description:
@@ -69,7 +68,7 @@ export class CalUnifiedCalendarsController {
   @Get("connections/:connectionId/events")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "List events for a connection",
     description:
@@ -100,7 +99,7 @@ export class CalUnifiedCalendarsController {
   @Post("connections/:connectionId/events")
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Create event on a connection",
     description:
@@ -127,7 +126,7 @@ export class CalUnifiedCalendarsController {
   @Get("connections/:connectionId/events/:eventId")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get event for a connection",
     description:
@@ -154,7 +153,7 @@ export class CalUnifiedCalendarsController {
   @Patch("connections/:connectionId/events/:eventId")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Update event for a connection",
     description:
@@ -183,7 +182,7 @@ export class CalUnifiedCalendarsController {
   @Delete("connections/:connectionId/events/:eventId")
   @HttpCode(HttpStatus.NO_CONTENT)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Delete event for a connection",
     description:
@@ -203,7 +202,7 @@ export class CalUnifiedCalendarsController {
   @Get("connections/:connectionId/freebusy")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get free/busy for a connection",
     description: "Get busy time slots for the specified calendar connection.",
@@ -241,7 +240,7 @@ export class CalUnifiedCalendarsController {
   @Get(["/:calendar/events/:eventUid", "/:calendar/event/:eventUid"])
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get meeting details from calendar",
     description:
@@ -269,7 +268,7 @@ export class CalUnifiedCalendarsController {
   @Patch(["/:calendar/events/:eventUid", "/:calendar/event/:eventUid"])
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Update meeting details in calendar",
     description:
@@ -288,7 +287,7 @@ export class CalUnifiedCalendarsController {
   @Get("/:calendar/events")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "List calendar events",
     description:
@@ -319,7 +318,7 @@ export class CalUnifiedCalendarsController {
   @Post("/:calendar/events")
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Create a calendar event",
     description:
@@ -343,7 +342,7 @@ export class CalUnifiedCalendarsController {
   @Delete("/:calendar/events/:eventUid")
   @HttpCode(HttpStatus.NO_CONTENT)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Delete a calendar event",
     description:
@@ -361,7 +360,7 @@ export class CalUnifiedCalendarsController {
   @Get("/:calendar/freebusy")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get free/busy times",
     description:

--- a/apps/api/v2/src/modules/conferencing/controllers/conferencing.controller.ts
+++ b/apps/api/v2/src/modules/conferencing/controllers/conferencing.controller.ts
@@ -1,44 +1,43 @@
+import { CAL_VIDEO, GOOGLE_MEET, OFFICE_365_VIDEO, SUCCESS_STATUS, ZOOM } from "@calcom/platform-constants";
+import { HttpService } from "@nestjs/axios";
+import {
+  BadRequestException,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  HttpCode,
+  HttpException,
+  HttpStatus,
+  Logger,
+  Param,
+  Post,
+  Query,
+  Redirect,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToInstance } from "class-transformer";
+import { Request } from "express";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import {
+  ConferencingAppOutputResponseDto,
+  ConferencingAppsOutputDto,
+  ConferencingAppsOutputResponseDto,
+  DisconnectConferencingAppOutputResponseDto,
+} from "@/modules/conferencing/outputs/get-conferencing-apps.output";
+import {
   ConferencingAppsOauthUrlOutputDto,
   GetConferencingAppsOauthUrlResponseDto,
 } from "@/modules/conferencing/outputs/get-conferencing-apps-oauth-url";
-import {
-  ConferencingAppsOutputResponseDto,
-  ConferencingAppOutputResponseDto,
-  ConferencingAppsOutputDto,
-  DisconnectConferencingAppOutputResponseDto,
-} from "@/modules/conferencing/outputs/get-conferencing-apps.output";
 import { GetDefaultConferencingAppOutputResponseDto } from "@/modules/conferencing/outputs/get-default-conferencing-app.output";
 import { SetDefaultConferencingAppOutputResponseDto } from "@/modules/conferencing/outputs/set-default-conferencing-app.output";
 import { ConferencingService } from "@/modules/conferencing/services/conferencing.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import { HttpService } from "@nestjs/axios";
-import { Logger } from "@nestjs/common";
-import {
-  Controller,
-  Get,
-  Query,
-  HttpCode,
-  HttpStatus,
-  UseGuards,
-  Post,
-  Param,
-  BadRequestException,
-  Delete,
-  Headers,
-  Redirect,
-  Req,
-  HttpException,
-} from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
-import { ApiBearerAuth,  ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToInstance } from "class-transformer";
-import { Request } from "express";
-
-import { GOOGLE_MEET, ZOOM, SUCCESS_STATUS, OFFICE_365_VIDEO, CAL_VIDEO } from "@calcom/platform-constants";
 
 export type OAuthCallbackState = {
   accessToken: string;
@@ -164,7 +163,7 @@ export class ConferencingController {
           const response = await this.httpService.axiosRef.get(url, { params, headers });
           const redirectUrl = response.data?.url || decodedCallbackState.onErrorReturnTo || "";
           return { url: redirectUrl };
-        } catch (err) {
+        } catch (_err) {
           const fallbackUrl = decodedCallbackState.onErrorReturnTo || "";
           return { url: fallbackUrl };
         }

--- a/apps/api/v2/src/modules/conferencing/controllers/conferencing.controller.ts
+++ b/apps/api/v2/src/modules/conferencing/controllers/conferencing.controller.ts
@@ -1,5 +1,4 @@
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import {
@@ -35,7 +34,7 @@ import {
   HttpException,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { ApiHeader, ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth,  ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
 import { plainToInstance } from "class-transformer";
 import { Request } from "express";
 
@@ -67,7 +66,7 @@ export class ConferencingController {
   @Post("/:app/connect")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Connect your conferencing application" })
   @ApiParam({
     name: "app",
@@ -86,7 +85,7 @@ export class ConferencingController {
   @Get("/:app/oauth/auth-url")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Get OAuth conferencing app auth URL" })
   @ApiParam({
     name: "app",
@@ -185,7 +184,7 @@ export class ConferencingController {
   @Get("/")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "List your conferencing applications" })
   async listInstalledConferencingApps(
     @GetUser() user: UserWithProfile
@@ -200,7 +199,7 @@ export class ConferencingController {
   @Post("/:app/default")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Set your default conferencing application" })
   @ApiParam({
     name: "app",
@@ -219,7 +218,7 @@ export class ConferencingController {
   @Get("/default")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Get your default conferencing application" })
   async getDefault(@GetUser() user: UserWithProfile): Promise<GetDefaultConferencingAppOutputResponseDto> {
     const defaultconferencingApp = await this.conferencingService.getUserDefaultConferencingApp(user.id);
@@ -229,7 +228,7 @@ export class ConferencingController {
   @Delete("/:app/disconnect")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Disconnect your conferencing application" })
   @ApiParam({
     name: "app",

--- a/apps/api/v2/src/modules/destination-calendars/controllers/destination-calendars.controller.ts
+++ b/apps/api/v2/src/modules/destination-calendars/controllers/destination-calendars.controller.ts
@@ -1,3 +1,7 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { Body, Controller, Put, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -8,11 +12,6 @@ import {
 } from "@/modules/destination-calendars/outputs/destination-calendars.output";
 import { DestinationCalendarsService } from "@/modules/destination-calendars/services/destination-calendars.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import { Body, Controller, Put, UseGuards } from "@nestjs/common";
-import { ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
 
 @Controller({
   path: "/v2/destination-calendars",

--- a/apps/api/v2/src/modules/destination-calendars/controllers/destination-calendars.controller.ts
+++ b/apps/api/v2/src/modules/destination-calendars/controllers/destination-calendars.controller.ts
@@ -1,5 +1,4 @@
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { DestinationCalendarsInputBodyDto } from "@/modules/destination-calendars/inputs/destination-calendars.input";
@@ -10,7 +9,7 @@ import {
 import { DestinationCalendarsService } from "@/modules/destination-calendars/services/destination-calendars.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Body, Controller, Put, UseGuards } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
@@ -20,7 +19,7 @@ import { SUCCESS_STATUS } from "@calcom/platform-constants";
   version: API_VERSIONS_VALUES,
 })
 @DocsTags("Destination Calendars")
-@ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+@ApiBearerAuth("bearerAuth")
 @UseGuards(ApiAuthGuard)
 export class DestinationCalendarsController {
   constructor(private readonly destinationCalendarsService: DestinationCalendarsService) {}

--- a/apps/api/v2/src/modules/event-types/controllers/event-types-webhooks.controller.ts
+++ b/apps/api/v2/src/modules/event-types/controllers/event-types-webhooks.controller.ts
@@ -1,5 +1,4 @@
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { GetWebhook } from "@/modules/webhooks/decorators/get-webhook-decorator";
 import { IsUserEventTypeWebhookGuard } from "@/modules/webhooks/guards/is-user-event-type-webhook-guard";
@@ -26,7 +25,7 @@ import {
   Patch,
   ParseIntPipe,
 } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth,  ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
@@ -39,7 +38,7 @@ import type { Webhook } from "@calcom/prisma/client";
 })
 @UseGuards(ApiAuthGuard, IsUserEventTypeWebhookGuard)
 @DocsTags("Event Types / Webhooks")
-@ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+@ApiBearerAuth("bearerAuth")
 @ApiParam({ name: "eventTypeId", type: Number, required: true })
 export class EventTypeWebhooksController {
   constructor(

--- a/apps/api/v2/src/modules/event-types/controllers/event-types-webhooks.controller.ts
+++ b/apps/api/v2/src/modules/event-types/controllers/event-types-webhooks.controller.ts
@@ -1,11 +1,28 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { SkipTakePagination } from "@calcom/platform-types";
+import type { Webhook } from "@calcom/prisma/client";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { GetWebhook } from "@/modules/webhooks/decorators/get-webhook-decorator";
 import { IsUserEventTypeWebhookGuard } from "@/modules/webhooks/guards/is-user-event-type-webhook-guard";
 import { CreateWebhookInputDto, UpdateWebhookInputDto } from "@/modules/webhooks/inputs/webhook.input";
 import {
-  EventTypeWebhookOutputResponseDto,
   EventTypeWebhookOutputDto,
+  EventTypeWebhookOutputResponseDto,
   EventTypeWebhooksOutputResponseDto,
 } from "@/modules/webhooks/outputs/event-type-webhook.output";
 import { DeleteManyWebhooksOutputResponseDto } from "@/modules/webhooks/outputs/webhook.output";
@@ -13,24 +30,6 @@ import { PartialWebhookInputPipe, WebhookInputPipe } from "@/modules/webhooks/pi
 import { WebhookOutputPipe } from "@/modules/webhooks/pipes/WebhookOutputPipe";
 import { EventTypeWebhooksService } from "@/modules/webhooks/services/event-type-webhooks.service";
 import { WebhooksService } from "@/modules/webhooks/services/webhooks.service";
-import {
-  Controller,
-  Post,
-  Body,
-  UseGuards,
-  Get,
-  Param,
-  Query,
-  Delete,
-  Patch,
-  ParseIntPipe,
-} from "@nestjs/common";
-import { ApiBearerAuth,  ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { SkipTakePagination } from "@calcom/platform-types";
-import type { Webhook } from "@calcom/prisma/client";
 
 @Controller({
   path: "/v2/event-types/:eventTypeId/webhooks",

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.ts
@@ -16,7 +16,7 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
-import {
+import { ApiBearerAuth,
   ApiExcludeEndpoint,
   ApiHeader,
   ApiOperation,
@@ -24,7 +24,6 @@ import {
   ApiCreatedResponse as DocsCreatedResponse,
 } from "@nestjs/swagger";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_HEADER } from "@/lib/docs/headers";
 import { GetOrgId } from "@/modules/auth/decorators/get-org-id/get-org-id.decorator";
 import { MembershipRoles } from "@/modules/auth/decorators/roles/membership-roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -43,7 +42,7 @@ import { UsersRepository } from "@/modules/users/users.repository";
 })
 @ApiTags("Deprecated: Platform OAuth Clients")
 @UseGuards(ApiAuthGuard)
-@ApiHeader(API_KEY_HEADER)
+@ApiBearerAuth("bearerAuth")
 export class OAuthClientsController {
   private readonly logger = new Logger("OAuthClientController");
 

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.ts
@@ -2,7 +2,6 @@ import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import { MembershipRole } from "@calcom/platform-libraries";
 import { CreateOAuthClientInput, Pagination, UpdateOAuthClientInput } from "@calcom/platform-types";
 import {
-  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -16,9 +15,9 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
-import { ApiBearerAuth,
+import {
+  ApiBearerAuth,
   ApiExcludeEndpoint,
-  ApiHeader,
   ApiOperation,
   ApiTags,
   ApiCreatedResponse as DocsCreatedResponse,

--- a/apps/api/v2/src/modules/selected-calendars/controllers/selected-calendars.controller.ts
+++ b/apps/api/v2/src/modules/selected-calendars/controllers/selected-calendars.controller.ts
@@ -1,3 +1,7 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { Body, Controller, Delete, Post, Query, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -6,16 +10,11 @@ import {
   SelectedCalendarsQueryParamsInputDto,
 } from "@/modules/selected-calendars/inputs/selected-calendars.input";
 import {
-  SelectedCalendarOutputResponseDto,
   SelectedCalendarOutputDto,
+  SelectedCalendarOutputResponseDto,
 } from "@/modules/selected-calendars/outputs/selected-calendars.output";
 import { SelectedCalendarsService } from "@/modules/selected-calendars/services/selected-calendars.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import { Body, Controller, Post, UseGuards, Delete, Query } from "@nestjs/common";
-import { ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
 
 @Controller({
   path: "/v2/selected-calendars",

--- a/apps/api/v2/src/modules/selected-calendars/controllers/selected-calendars.controller.ts
+++ b/apps/api/v2/src/modules/selected-calendars/controllers/selected-calendars.controller.ts
@@ -1,5 +1,4 @@
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import {
@@ -13,7 +12,7 @@ import {
 import { SelectedCalendarsService } from "@/modules/selected-calendars/services/selected-calendars.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Body, Controller, Post, UseGuards, Delete, Query } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
@@ -24,7 +23,7 @@ import { SUCCESS_STATUS } from "@calcom/platform-constants";
 })
 @DocsTags("Selected Calendars")
 @UseGuards(ApiAuthGuard)
-@ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+@ApiBearerAuth("bearerAuth")
 export class SelectedCalendarsController {
   constructor(private readonly selectedCalendarsService: SelectedCalendarsService) {}
 

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/slots.controller.ts
@@ -20,7 +20,8 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
-import { ApiBearerAuth,
+import {
+  ApiBearerAuth,
   ApiHeader,
   ApiOperation,
   ApiQuery,

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/slots.controller.ts
@@ -279,7 +279,6 @@ export class SlotsController_2024_09_04 {
     `,
   })
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
-  @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiBearerAuth("bearerAuth")
   async reserveSlot(
     @Body() body: ReserveSlotInput_2024_09_04,

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/slots.controller.ts
@@ -20,7 +20,7 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
-import {
+import { ApiBearerAuth,
   ApiHeader,
   ApiOperation,
   ApiQuery,
@@ -29,7 +29,7 @@ import {
 } from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
 import { VERSION_2024_09_04 } from "@/lib/api-versions";
-import { OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER, OPTIONAL_X_CAL_CLIENT_ID_HEADER } from "@/lib/docs/headers";
+import { OPTIONAL_X_CAL_CLIENT_ID_HEADER } from "@/lib/docs/headers";
 import {
   AuthOptionalUser,
   GetOptionalUser,
@@ -280,7 +280,7 @@ export class SlotsController_2024_09_04 {
   })
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
-  @ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   async reserveSlot(
     @Body() body: ReserveSlotInput_2024_09_04,
     @GetOptionalUser() user: AuthOptionalUser

--- a/apps/api/v2/src/modules/stripe/controllers/stripe.controller.ts
+++ b/apps/api/v2/src/modules/stripe/controllers/stripe.controller.ts
@@ -1,3 +1,22 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { HttpService } from "@nestjs/axios";
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Query,
+  Redirect,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { ApiBearerAuth, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
+import { Request } from "express";
+import { stringify } from "querystring";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -11,26 +30,6 @@ import { OAuthCallbackState, StripeService } from "@/modules/stripe/stripe.servi
 import { getOnErrorReturnToValueFromQueryState } from "@/modules/stripe/utils/getReturnToValueFromQueryState";
 import { TokensRepository } from "@/modules/tokens/tokens.repository";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import { HttpService } from "@nestjs/axios";
-import {
-  Controller,
-  Query,
-  UseGuards,
-  Get,
-  HttpCode,
-  HttpStatus,
-  Redirect,
-  Req,
-  BadRequestException,
-  Headers,
-} from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
-import { ApiBearerAuth, ApiTags as DocsTags, ApiOperation} from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-import { Request } from "express";
-import { stringify } from "querystring";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
 
 @Controller({
   path: "/v2/stripe",
@@ -61,9 +60,9 @@ export class StripeController {
     const accessToken = authorization.replace("Bearer ", "");
 
     const state: OAuthCallbackState = {
-      onErrorReturnTo: !!onErrorReturnTo ? onErrorReturnTo : origin,
+      onErrorReturnTo: onErrorReturnTo ? onErrorReturnTo : origin,
       fromApp: false,
-      returnTo: !!returnTo ? returnTo : origin,
+      returnTo: returnTo ? returnTo : origin,
       accessToken,
     };
 
@@ -113,7 +112,7 @@ export class StripeController {
           const response = await this.httpService.axiosRef.get(url, { params, headers });
           const redirectUrl = response.data?.url || decodedCallbackState.onErrorReturnTo || "";
           return { url: redirectUrl };
-        } catch (err) {
+        } catch (_err) {
           const fallbackUrl = decodedCallbackState.onErrorReturnTo || "";
           return { url: fallbackUrl };
         }

--- a/apps/api/v2/src/modules/stripe/controllers/stripe.controller.ts
+++ b/apps/api/v2/src/modules/stripe/controllers/stripe.controller.ts
@@ -1,5 +1,4 @@
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import {
@@ -26,7 +25,7 @@ import {
   Headers,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { ApiTags as DocsTags, ApiOperation, ApiHeader } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiTags as DocsTags, ApiOperation} from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
 import { Request } from "express";
 import { stringify } from "querystring";
@@ -50,7 +49,7 @@ export class StripeController {
   @UseGuards(ApiAuthGuard)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Get Stripe connect URL" })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   async redirect(
     @Req() req: Request,
     @Headers("Authorization") authorization: string,
@@ -150,7 +149,7 @@ export class StripeController {
   @Get("/check")
   @UseGuards(ApiAuthGuard)
   @HttpCode(HttpStatus.OK)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Check Stripe connection" })
   async check(@GetUser() user: UserWithProfile): Promise<StripCredentialsCheckOutputResponseDto> {
     return await this.stripeService.checkIfIndividualStripeAccountConnected(user.id);

--- a/apps/api/v2/src/modules/verified-resources/controllers/users-verified-resources.controller.ts
+++ b/apps/api/v2/src/modules/verified-resources/controllers/users-verified-resources.controller.ts
@@ -1,3 +1,8 @@
+import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
+import { SkipTakePagination } from "@calcom/platform-types";
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { Throttle } from "@/lib/endpoint-throttler-decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -18,12 +23,6 @@ import {
   UserVerifiedPhonesOutput,
 } from "@/modules/verified-resources/outputs/verified-phone.output";
 import { VerifiedResourcesService } from "@/modules/verified-resources/services/verified-resources.service";
-import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from "@nestjs/common";
-import { ApiBearerAuth,  ApiOperation, ApiTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
-import { SkipTakePagination } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/verified-resources",

--- a/apps/api/v2/src/modules/verified-resources/controllers/users-verified-resources.controller.ts
+++ b/apps/api/v2/src/modules/verified-resources/controllers/users-verified-resources.controller.ts
@@ -1,4 +1,3 @@
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { Throttle } from "@/lib/endpoint-throttler-decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -20,7 +19,7 @@ import {
 } from "@/modules/verified-resources/outputs/verified-phone.output";
 import { VerifiedResourcesService } from "@/modules/verified-resources/services/verified-resources.service";
 import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ApiBearerAuth,  ApiOperation, ApiTags } from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
 
 import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
@@ -37,7 +36,7 @@ export class UserVerifiedResourcesController {
     summary: "Request email verification code",
     description: `Sends a verification code to the email`,
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Post("/emails/verification-code/request")
   @HttpCode(HttpStatus.OK)
   @Throttle({ limit: 5, ttl: 60000, blockDuration: 60000, name: "users_verified_resources_emails_requests" })
@@ -60,7 +59,7 @@ export class UserVerifiedResourcesController {
     summary: "Request phone number verification code",
     description: `Sends a verification code to the phone number`,
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Post("/phones/verification-code/request")
   @HttpCode(HttpStatus.OK)
   @Throttle({ limit: 3, ttl: 60000, blockDuration: 60000, name: "users_verified_resources_phones_requests" })
@@ -80,7 +79,7 @@ export class UserVerifiedResourcesController {
     summary: "Verify an email",
     description: `Use code to verify an email`,
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Post("/emails/verification-code/verify")
   @Throttle({ limit: 3, ttl: 60000, blockDuration: 60000, name: "users_verified_resources_phones_verify" })
   @HttpCode(HttpStatus.OK)
@@ -99,7 +98,7 @@ export class UserVerifiedResourcesController {
     summary: "Verify a phone number",
     description: `Use code to verify a phone number`,
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Post("/phones/verification-code/verify")
   @HttpCode(HttpStatus.OK)
   async verifyPhoneNumber(
@@ -116,7 +115,7 @@ export class UserVerifiedResourcesController {
   @ApiOperation({
     summary: "Get list of verified emails",
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Get("/emails")
   @HttpCode(HttpStatus.OK)
   async getVerifiedEmails(
@@ -137,7 +136,7 @@ export class UserVerifiedResourcesController {
   @ApiOperation({
     summary: "Get list of verified phone numbers",
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Get("/phones")
   @HttpCode(HttpStatus.OK)
   async getVerifiedPhoneNumbers(
@@ -160,7 +159,7 @@ export class UserVerifiedResourcesController {
   @ApiOperation({
     summary: "Get verified email by id",
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Get("/emails/:id")
   @HttpCode(HttpStatus.OK)
   async getVerifiedEmailById(
@@ -177,7 +176,7 @@ export class UserVerifiedResourcesController {
   @ApiOperation({
     summary: "Get verified phone number by id",
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Get("/phones/:id")
   @HttpCode(HttpStatus.OK)
   async getVerifiedPhoneById(

--- a/apps/api/v2/src/modules/webhooks/controllers/webhooks.controller.ts
+++ b/apps/api/v2/src/modules/webhooks/controllers/webhooks.controller.ts
@@ -1,3 +1,9 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { SkipTakePagination } from "@calcom/platform-types";
+import type { Webhook } from "@calcom/prisma/client";
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -14,13 +20,6 @@ import { PartialWebhookInputPipe, WebhookInputPipe } from "@/modules/webhooks/pi
 import { WebhookOutputPipe } from "@/modules/webhooks/pipes/WebhookOutputPipe";
 import { UserWebhooksService } from "@/modules/webhooks/services/user-webhooks.service";
 import { WebhooksService } from "@/modules/webhooks/services/webhooks.service";
-import { Controller, Post, Body, UseGuards, Get, Param, Query, Delete, Patch } from "@nestjs/common";
-import { ApiBearerAuth,  ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { SkipTakePagination } from "@calcom/platform-types";
-import type { Webhook } from "@calcom/prisma/client";
 
 @Controller({
   path: "/v2/webhooks",

--- a/apps/api/v2/src/modules/webhooks/controllers/webhooks.controller.ts
+++ b/apps/api/v2/src/modules/webhooks/controllers/webhooks.controller.ts
@@ -1,5 +1,4 @@
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_HEADER } from "@/lib/docs/headers";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { UserWithProfile } from "@/modules/users/users.repository";
@@ -16,7 +15,7 @@ import { WebhookOutputPipe } from "@/modules/webhooks/pipes/WebhookOutputPipe";
 import { UserWebhooksService } from "@/modules/webhooks/services/user-webhooks.service";
 import { WebhooksService } from "@/modules/webhooks/services/webhooks.service";
 import { Controller, Post, Body, UseGuards, Get, Param, Query, Delete, Patch } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth,  ApiOperation, ApiParam, ApiTags as DocsTags } from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
@@ -29,7 +28,7 @@ import type { Webhook } from "@calcom/prisma/client";
 })
 @UseGuards(ApiAuthGuard)
 @DocsTags("Webhooks")
-@ApiHeader(API_KEY_HEADER)
+@ApiBearerAuth("bearerAuth")
 export class WebhooksController {
   constructor(
     private readonly webhooksService: WebhooksService,

--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-attendees.controller.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-attendees.controller.ts
@@ -12,7 +12,14 @@ import {
   Post,
   UseGuards,
 } from "@nestjs/common";
-import { ApiHeader, ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { VERSION_2024_08_13, VERSION_2024_08_13_VALUE } from "@/lib/api-versions";
+import { Throttle } from "@/lib/endpoint-throttler-decorator";
+import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
+import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
+import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
+import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
 import { BookingPbacGuard } from "@/platform/bookings/2024-08-13/guards/booking-pbac.guard";
 import { BookingUidGuard } from "@/platform/bookings/2024-08-13/guards/booking-uid.guard";
 import { AddAttendeeOutput_2024_08_13 } from "@/platform/bookings/2024-08-13/outputs/add-attendee.output";
@@ -22,13 +29,6 @@ import {
 } from "@/platform/bookings/2024-08-13/outputs/get-booking-attendees.output";
 import { RemoveAttendeeOutput_2024_08_13 } from "@/platform/bookings/2024-08-13/outputs/remove-attendee.output";
 import { BookingAttendeesService_2024_08_13 } from "@/platform/bookings/2024-08-13/services/booking-attendees.service";
-import { VERSION_2024_08_13, VERSION_2024_08_13_VALUE } from "@/lib/api-versions";
-import { Throttle } from "@/lib/endpoint-throttler-decorator";
-import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
-import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
-import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
-import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
-import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
 
 @Controller({
   path: "/v2/bookings/:bookingUid/attendees",
@@ -58,7 +58,7 @@ export class BookingAttendeesController_2024_08_13 {
   })
   async getBookingAttendees(
     @Param("bookingUid") bookingUid: string,
-    @GetUser() user: ApiAuthGuardUser
+    @GetUser() _user: ApiAuthGuardUser
   ): Promise<GetBookingAttendeesOutput_2024_08_13> {
     const attendees = await this.bookingAttendeesService.getBookingAttendees(bookingUid);
 

--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-attendees.controller.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-attendees.controller.ts
@@ -12,7 +12,7 @@ import {
   Post,
   UseGuards,
 } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiHeader, ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { BookingPbacGuard } from "@/platform/bookings/2024-08-13/guards/booking-pbac.guard";
 import { BookingUidGuard } from "@/platform/bookings/2024-08-13/guards/booking-uid.guard";
 import { AddAttendeeOutput_2024_08_13 } from "@/platform/bookings/2024-08-13/outputs/add-attendee.output";
@@ -23,7 +23,6 @@ import {
 import { RemoveAttendeeOutput_2024_08_13 } from "@/platform/bookings/2024-08-13/outputs/remove-attendee.output";
 import { BookingAttendeesService_2024_08_13 } from "@/platform/bookings/2024-08-13/services/booking-attendees.service";
 import { VERSION_2024_08_13, VERSION_2024_08_13_VALUE } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { Throttle } from "@/lib/endpoint-throttler-decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
@@ -49,7 +48,7 @@ export class BookingAttendeesController_2024_08_13 {
   @Get("/")
   @Permissions([BOOKING_READ])
   @UseGuards(ApiAuthGuard, BookingUidGuard, BookingPbacGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get all attendees for a booking",
     description: `Retrieve all attendees for a specific booking by its UID.
@@ -72,7 +71,7 @@ export class BookingAttendeesController_2024_08_13 {
   @Get("/:attendeeId")
   @Permissions([BOOKING_READ])
   @UseGuards(ApiAuthGuard, BookingUidGuard, BookingPbacGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get a specific attendee for a booking",
     description: `Retrieve a specific attendee by their ID for a booking identified by its UID.
@@ -102,7 +101,7 @@ export class BookingAttendeesController_2024_08_13 {
     blockDuration: 60000,
     name: "booking_attendees_add",
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Add an attendee to a booking",
     description: `Add a new attendee to an existing booking by its UID.
@@ -141,7 +140,7 @@ export class BookingAttendeesController_2024_08_13 {
     blockDuration: 60000,
     name: "booking_attendees_remove",
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Remove an attendee from a booking",
     description: `Remove an attendee from an existing booking by their attendee ID. The primary attendee (first attendee) cannot be removed — to remove them, cancel the booking instead. The removed attendee will receive a cancellation email notification.

--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-guests.controller.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-guests.controller.ts
@@ -1,18 +1,17 @@
-import { BookingUidGuard } from "@/platform/bookings/2024-08-13/guards/booking-uid.guard";
-import { AddGuestsOutput_2024_08_13 } from "@/platform/bookings/2024-08-13/outputs/add-guests.output";
-import { BookingGuestsService_2024_08_13 } from "@/platform/bookings/2024-08-13/services/booking-guests.service";
-import { VERSION_2024_08_13_VALUE, VERSION_2024_08_13 } from "@/lib/api-versions";
+import { BOOKING_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
+import { AddGuestsInput_2024_08_13 } from "@calcom/platform-types";
+import { Body, Controller, HttpCode, HttpStatus, Param, Post, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { VERSION_2024_08_13, VERSION_2024_08_13_VALUE } from "@/lib/api-versions";
 import { Throttle } from "@/lib/endpoint-throttler-decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
 import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
-import { Controller, Post, Logger, Body, UseGuards, Param, HttpCode, HttpStatus } from "@nestjs/common";
-import { ApiHeader, ApiBearerAuth, ApiOperation, ApiTags as DocsTags} from "@nestjs/swagger";
-
-import { BOOKING_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
-import { AddGuestsInput_2024_08_13 } from "@calcom/platform-types";
+import { BookingUidGuard } from "@/platform/bookings/2024-08-13/guards/booking-uid.guard";
+import { AddGuestsOutput_2024_08_13 } from "@/platform/bookings/2024-08-13/outputs/add-guests.output";
+import { BookingGuestsService_2024_08_13 } from "@/platform/bookings/2024-08-13/services/booking-guests.service";
 
 @Controller({
   path: "/v2/bookings/:bookingUid/guests",
@@ -27,8 +26,6 @@ import { AddGuestsInput_2024_08_13 } from "@calcom/platform-types";
   required: true,
 })
 export class BookingGuestsController_2024_08_13 {
-  private readonly logger = new Logger("BookingGuestsController_2024_08_13");
-
   constructor(private readonly bookingGuestsService: BookingGuestsService_2024_08_13) {}
 
   @Post("/")

--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-guests.controller.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-guests.controller.ts
@@ -2,7 +2,6 @@ import { BookingUidGuard } from "@/platform/bookings/2024-08-13/guards/booking-u
 import { AddGuestsOutput_2024_08_13 } from "@/platform/bookings/2024-08-13/outputs/add-guests.output";
 import { BookingGuestsService_2024_08_13 } from "@/platform/bookings/2024-08-13/services/booking-guests.service";
 import { VERSION_2024_08_13_VALUE, VERSION_2024_08_13 } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { Throttle } from "@/lib/endpoint-throttler-decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
@@ -10,7 +9,7 @@ import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
 import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
 import { Controller, Post, Logger, Body, UseGuards, Param, HttpCode, HttpStatus } from "@nestjs/common";
-import { ApiOperation, ApiTags as DocsTags, ApiHeader } from "@nestjs/swagger";
+import { ApiHeader, ApiBearerAuth, ApiOperation, ApiTags as DocsTags} from "@nestjs/swagger";
 
 import { BOOKING_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
 import { AddGuestsInput_2024_08_13 } from "@calcom/platform-types";
@@ -42,7 +41,7 @@ export class BookingGuestsController_2024_08_13 {
     blockDuration: 60000,
     name: "booking_guests_add",
   })
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Add guests to an existing booking",
     description: `Add one or more guests to an existing booking. Maximum 10 guests per request, with a limit of 30 total guests per booking.

--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-location.controller.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-location.controller.ts
@@ -9,12 +9,11 @@ import {
   UpdateInputAddressLocation_2024_08_13,
 } from "@calcom/platform-types";
 import { Body, Controller, HttpCode, HttpStatus, Param, Patch, UseGuards } from "@nestjs/common";
-import { ApiExtraModels, ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiHeader, ApiBearerAuth, ApiExtraModels,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { BookingUidGuard } from "@/platform/bookings/2024-08-13/guards/booking-uid.guard";
 import { UpdateBookingLocationOutput_2024_08_13 } from "@/platform/bookings/2024-08-13/outputs/update-location.output";
 import { BookingLocationService_2024_08_13 } from "@/platform/bookings/2024-08-13/services/booking-location.service";
 import { VERSION_2024_08_13, VERSION_2024_08_13_VALUE } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { Throttle } from "@/lib/endpoint-throttler-decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
@@ -50,7 +49,7 @@ export class BookingLocationController_2024_08_13 {
   @Throttle({ name: "booking_location_update", limit: 5, ttl: 60000, blockDuration: 60000 })
   @Permissions([BOOKING_WRITE])
   @UseGuards(ApiAuthGuard, BookingUidGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Update booking location for an existing booking",
     description: `Updates the location for an existing booking.

--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-location.controller.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/booking-location.controller.ts
@@ -9,10 +9,7 @@ import {
   UpdateInputAddressLocation_2024_08_13,
 } from "@calcom/platform-types";
 import { Body, Controller, HttpCode, HttpStatus, Param, Patch, UseGuards } from "@nestjs/common";
-import { ApiHeader, ApiBearerAuth, ApiExtraModels,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { BookingUidGuard } from "@/platform/bookings/2024-08-13/guards/booking-uid.guard";
-import { UpdateBookingLocationOutput_2024_08_13 } from "@/platform/bookings/2024-08-13/outputs/update-location.output";
-import { BookingLocationService_2024_08_13 } from "@/platform/bookings/2024-08-13/services/booking-location.service";
+import { ApiBearerAuth, ApiExtraModels, ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { VERSION_2024_08_13, VERSION_2024_08_13_VALUE } from "@/lib/api-versions";
 import { Throttle } from "@/lib/endpoint-throttler-decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
@@ -20,6 +17,9 @@ import { Permissions } from "@/modules/auth/decorators/permissions/permissions.d
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
 import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
+import { BookingUidGuard } from "@/platform/bookings/2024-08-13/guards/booking-uid.guard";
+import { UpdateBookingLocationOutput_2024_08_13 } from "@/platform/bookings/2024-08-13/outputs/update-location.output";
+import { BookingLocationService_2024_08_13 } from "@/platform/bookings/2024-08-13/services/booking-location.service";
 
 @Controller({
   path: "/v2/bookings/:bookingUid/location",

--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -28,14 +28,14 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Post,
   Query,
   Req,
   UseGuards,
 } from "@nestjs/common";
-import { ApiBearerAuth,
+import {
+  ApiBearerAuth,
   ApiBody,
   ApiExtraModels,
   ApiHeader,
@@ -44,6 +44,20 @@ import { ApiBearerAuth,
   getSchemaPath,
 } from "@nestjs/swagger";
 import { Request } from "express";
+import { VERSION_2024_08_13, VERSION_2024_08_13_VALUE } from "@/lib/api-versions";
+import { OPTIONAL_X_CAL_CLIENT_ID_HEADER, OPTIONAL_X_CAL_SECRET_KEY_HEADER } from "@/lib/docs/headers";
+import {
+  AuthOptionalUser,
+  GetOptionalUser,
+} from "@/modules/auth/decorators/get-optional-user/get-optional-user.decorator";
+import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
+import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
+import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
+import { OptionalApiAuthGuard } from "@/modules/auth/guards/optional-api-auth/optional-api-auth.guard";
+import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
+import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
+import { UsersService } from "@/modules/users/services/users.service";
 import { BookingPbacGuard } from "@/platform/bookings/2024-08-13/guards/booking-pbac.guard";
 import { BookingUidGuard } from "@/platform/bookings/2024-08-13/guards/booking-uid.guard";
 import { BookingReferencesFilterInput_2024_08_13 } from "@/platform/bookings/2024-08-13/inputs/booking-references-filter.input";
@@ -57,25 +71,6 @@ import { RescheduleBookingOutput_2024_08_13 } from "@/platform/bookings/2024-08-
 import { BookingReferencesService_2024_08_13 } from "@/platform/bookings/2024-08-13/services/booking-references.service";
 import { BookingsService_2024_08_13 } from "@/platform/bookings/2024-08-13/services/bookings.service";
 import { CalVideoService } from "@/platform/bookings/2024-08-13/services/cal-video.service";
-import { VERSION_2024_08_13, VERSION_2024_08_13_VALUE } from "@/lib/api-versions";
-import {
-  API_KEY_OR_ACCESS_TOKEN_HEADER,
-  OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER,
-  OPTIONAL_X_CAL_CLIENT_ID_HEADER,
-  OPTIONAL_X_CAL_SECRET_KEY_HEADER,
-} from "@/lib/docs/headers";
-import {
-  AuthOptionalUser,
-  GetOptionalUser,
-} from "@/modules/auth/decorators/get-optional-user/get-optional-user.decorator";
-import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
-import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
-import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
-import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
-import { OptionalApiAuthGuard } from "@/modules/auth/guards/optional-api-auth/optional-api-auth.guard";
-import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
-import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
-import { UsersService } from "@/modules/users/services/users.service";
 
 @Controller({
   path: "/v2/bookings",
@@ -93,8 +88,6 @@ import { UsersService } from "@/modules/users/services/users.service";
   },
 })
 export class BookingsController_2024_08_13 {
-  private readonly logger = new Logger("BookingsController_2024_08_13");
-
   constructor(
     private readonly bookingsService: BookingsService_2024_08_13,
     private readonly usersService: UsersService,
@@ -106,6 +99,7 @@ export class BookingsController_2024_08_13 {
   @UseGuards(OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Create a booking",
     description: `
@@ -163,6 +157,7 @@ export class BookingsController_2024_08_13 {
   @UseGuards(OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get a booking by seat UID",
     description: `Get a seated booking by its seat reference UID. This is useful when you have a seatUid from a seated booking and want to retrieve the full booking details.
@@ -189,6 +184,7 @@ export class BookingsController_2024_08_13 {
   @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get a booking",
     description: `\`:bookingUid\` can be
@@ -294,6 +290,7 @@ export class BookingsController_2024_08_13 {
   @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Reschedule a booking",
     description: `Reschedule a booking or seated booking
@@ -333,6 +330,7 @@ export class BookingsController_2024_08_13 {
   @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: "Cancel a booking",

--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -35,7 +35,7 @@ import {
   Req,
   UseGuards,
 } from "@nestjs/common";
-import {
+import { ApiBearerAuth,
   ApiBody,
   ApiExtraModels,
   ApiHeader,
@@ -106,7 +106,7 @@ export class BookingsController_2024_08_13 {
   @UseGuards(OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Create a booking",
     description: `
@@ -164,7 +164,7 @@ export class BookingsController_2024_08_13 {
   @UseGuards(OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get a booking by seat UID",
     description: `Get a seated booking by its seat reference UID. This is useful when you have a seatUid from a seated booking and want to retrieve the full booking details.
@@ -191,7 +191,7 @@ export class BookingsController_2024_08_13 {
   @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get a booking",
     description: `\`:bookingUid\` can be
@@ -224,7 +224,7 @@ export class BookingsController_2024_08_13 {
   @Pbac(["booking.readRecordings"])
   @Permissions([BOOKING_READ])
   @UseGuards(ApiAuthGuard, BookingUidGuard, BookingPbacGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get all the recordings for the booking",
     description: `Fetches all the recordings for the booking \`:bookingUid\`. Requires authentication and proper authorization. Access is granted if you are the booking organizer, team admin or org admin/owner.
@@ -245,7 +245,7 @@ export class BookingsController_2024_08_13 {
   @Pbac(["booking.readRecordings"])
   @Permissions([BOOKING_READ])
   @UseGuards(ApiAuthGuard, BookingUidGuard, BookingPbacGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get Cal Video real time transcript download links for the booking",
     description: `Fetches all the transcript download links for the booking \`:bookingUid\`
@@ -268,7 +268,7 @@ export class BookingsController_2024_08_13 {
 
   @Get("/")
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Permissions([BOOKING_READ])
   @ApiOperation({
     summary: "Get all bookings",
@@ -297,7 +297,7 @@ export class BookingsController_2024_08_13 {
   @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Reschedule a booking",
     description: `Reschedule a booking or seated booking
@@ -337,7 +337,7 @@ export class BookingsController_2024_08_13 {
   @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: "Cancel a booking",
@@ -391,7 +391,7 @@ export class BookingsController_2024_08_13 {
   @HttpCode(HttpStatus.OK)
   @Permissions([BOOKING_WRITE])
   @UseGuards(ApiAuthGuard, BookingUidGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Mark a booking absence",
     description: `The provided authorization header refers to the owner of the booking.
@@ -416,7 +416,7 @@ export class BookingsController_2024_08_13 {
   @HttpCode(HttpStatus.OK)
   @Permissions([BOOKING_WRITE])
   @UseGuards(ApiAuthGuard, BookingUidGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Reassign a booking to auto-selected host",
     description: `Currently only supports reassigning host for round robin bookings. The provided authorization header refers to the owner of the booking.
@@ -440,7 +440,7 @@ export class BookingsController_2024_08_13 {
   @HttpCode(HttpStatus.OK)
   @Permissions([BOOKING_WRITE])
   @UseGuards(ApiAuthGuard, BookingUidGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Reassign a booking to a specific host",
     description: `Currently only supports reassigning host for round robin bookings. The provided authorization header refers to the owner of the booking.
@@ -471,7 +471,7 @@ export class BookingsController_2024_08_13 {
   @HttpCode(HttpStatus.OK)
   @Permissions([BOOKING_WRITE])
   @UseGuards(ApiAuthGuard, BookingUidGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Confirm a booking",
     description: `The provided authorization header refers to the owner of the booking.
@@ -495,7 +495,7 @@ export class BookingsController_2024_08_13 {
   @HttpCode(HttpStatus.OK)
   @Permissions([BOOKING_WRITE])
   @UseGuards(ApiAuthGuard, BookingUidGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Decline a booking",
     description: `The provided authorization header refers to the owner of the booking.
@@ -519,7 +519,7 @@ export class BookingsController_2024_08_13 {
   @Get("/:bookingUid/calendar-links")
   @UseGuards(ApiAuthGuard, BookingUidGuard)
   @Permissions([BOOKING_READ])
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get 'Add to Calendar' links for a booking",
     description: `Retrieve calendar links for a booking that can be used to add the event to various calendar services. Returns links for Google Calendar, Microsoft Office, Microsoft Outlook, and a downloadable ICS file.
@@ -540,7 +540,7 @@ export class BookingsController_2024_08_13 {
   @Get("/:bookingUid/references")
   @UseGuards(ApiAuthGuard, BookingUidGuard)
   @Permissions([BOOKING_READ])
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get booking references",
     description: `<Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>`,
@@ -568,7 +568,7 @@ export class BookingsController_2024_08_13 {
   @Pbac(["booking.readRecordings"])
   @Permissions([BOOKING_READ])
   @UseGuards(ApiAuthGuard, BookingUidGuard, BookingPbacGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get Video Meeting Sessions. Only supported for Cal Video",
     description: `Requires authentication and proper authorization. Access is granted if you are the booking organizer, team admin or org admin/owner.

--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -106,7 +106,6 @@ export class BookingsController_2024_08_13 {
   @UseGuards(OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Create a booking",
     description: `
@@ -164,7 +163,6 @@ export class BookingsController_2024_08_13 {
   @UseGuards(OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get a booking by seat UID",
     description: `Get a seated booking by its seat reference UID. This is useful when you have a seatUid from a seated booking and want to retrieve the full booking details.
@@ -191,7 +189,6 @@ export class BookingsController_2024_08_13 {
   @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get a booking",
     description: `\`:bookingUid\` can be
@@ -297,7 +294,6 @@ export class BookingsController_2024_08_13 {
   @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Reschedule a booking",
     description: `Reschedule a booking or seated booking
@@ -337,7 +333,6 @@ export class BookingsController_2024_08_13 {
   @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiBearerAuth("bearerAuth")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: "Cancel a booking",

--- a/apps/api/v2/src/platform/calendars/controllers/calendars.controller.ts
+++ b/apps/api/v2/src/platform/calendars/controllers/calendars.controller.ts
@@ -1,19 +1,34 @@
-import { CalendarsRepository } from "@/platform/calendars/calendars.repository";
-import { CreateIcsFeedInputDto } from "@/platform/calendars/input/create-ics.input";
-import { CreateIcsFeedOutputResponseDto } from "@/platform/calendars/input/create-ics.output";
-import { DeleteCalendarCredentialsInputBodyDto } from "@/platform/calendars/input/delete-calendar-credentials.input";
-import { GetBusyTimesOutput } from "@/platform/calendars/outputs/busy-times.output";
-import { ConnectedCalendarsOutput } from "@/platform/calendars/outputs/connected-calendars.output";
 import {
-  DeletedCalendarCredentialsOutputResponseDto,
-  DeletedCalendarCredentialsOutputDto,
-} from "@/platform/calendars/outputs/delete-calendar-credentials.output";
-import { AppleCalendarService } from "@/platform/calendars/services/apple-calendar.service";
-import { CalendarsCacheService } from "@/platform/calendars/services/calendars-cache.service";
-import { CalendarsService } from "@/platform/calendars/services/calendars.service";
-import { GoogleCalendarService } from "@/platform/calendars/services/gcal.service";
-import { IcsFeedService } from "@/platform/calendars/services/ics-feed.service";
-import { OutlookService } from "@/platform/calendars/services/outlook.service";
+  APPLE_CALENDAR,
+  APPS_READ,
+  CALENDARS,
+  CREDENTIAL_CALENDARS,
+  GOOGLE_CALENDAR,
+  OFFICE_365_CALENDAR,
+  SUCCESS_STATUS,
+} from "@calcom/platform-constants";
+import { ApiResponse, CalendarBusyTimesInput, CreateCalendarCredentialsInput } from "@calcom/platform-types";
+import type { User } from "@calcom/prisma/client";
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseBoolPipe,
+  Post,
+  Query,
+  Redirect,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiQuery, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
+import { Request } from "express";
+import { z } from "zod";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { ApiAuthGuardOnlyAllow } from "@/modules/auth/decorators/api-auth-guard-only-allow.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
@@ -21,38 +36,22 @@ import { Permissions } from "@/modules/auth/decorators/permissions/permissions.d
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
 import { UserWithProfile } from "@/modules/users/users.repository";
+import { CalendarsRepository } from "@/platform/calendars/calendars.repository";
+import { CreateIcsFeedInputDto } from "@/platform/calendars/input/create-ics.input";
+import { CreateIcsFeedOutputResponseDto } from "@/platform/calendars/input/create-ics.output";
+import { DeleteCalendarCredentialsInputBodyDto } from "@/platform/calendars/input/delete-calendar-credentials.input";
+import { GetBusyTimesOutput } from "@/platform/calendars/outputs/busy-times.output";
+import { ConnectedCalendarsOutput } from "@/platform/calendars/outputs/connected-calendars.output";
 import {
-  Controller,
-  Get,
-  UseGuards,
-  Query,
-  HttpStatus,
-  HttpCode,
-  Req,
-  Param,
-  Headers,
-  Redirect,
-  BadRequestException,
-  Post,
-  Body,
-  ParseBoolPipe,
-} from "@nestjs/common";
-import { ApiBearerAuth,  ApiOperation, ApiParam, ApiQuery, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-import { Request } from "express";
-import { z } from "zod";
-
-import { APPS_READ } from "@calcom/platform-constants";
-import {
-  SUCCESS_STATUS,
-  CALENDARS,
-  GOOGLE_CALENDAR,
-  OFFICE_365_CALENDAR,
-  APPLE_CALENDAR,
-  CREDENTIAL_CALENDARS,
-} from "@calcom/platform-constants";
-import { ApiResponse, CalendarBusyTimesInput, CreateCalendarCredentialsInput } from "@calcom/platform-types";
-import type { User } from "@calcom/prisma/client";
+  DeletedCalendarCredentialsOutputDto,
+  DeletedCalendarCredentialsOutputResponseDto,
+} from "@/platform/calendars/outputs/delete-calendar-credentials.output";
+import { AppleCalendarService } from "@/platform/calendars/services/apple-calendar.service";
+import { CalendarsService } from "@/platform/calendars/services/calendars.service";
+import { CalendarsCacheService } from "@/platform/calendars/services/calendars-cache.service";
+import { GoogleCalendarService } from "@/platform/calendars/services/gcal.service";
+import { IcsFeedService } from "@/platform/calendars/services/ics-feed.service";
+import { OutlookService } from "@/platform/calendars/services/outlook.service";
 
 export interface CalendarState {
   accessToken: string;
@@ -303,16 +302,15 @@ export class CalendarsController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Disconnect a calendar" })
   async deleteCalendarCredentials(
-    @Param("calendar") calendar: string,
+    @Param("calendar") _calendar: string,
     @Body() body: DeleteCalendarCredentialsInputBodyDto,
     @GetUser() user: UserWithProfile
   ): Promise<DeletedCalendarCredentialsOutputResponseDto> {
     const { id: credentialId } = body;
     await this.calendarsService.checkCalendarCredentials(credentialId, user.id);
 
-    const { id, type, userId, teamId, appId, invalid } = await this.calendarsRepository.deleteCredentials(
-      credentialId
-    );
+    const { id, type, userId, teamId, appId, invalid } =
+      await this.calendarsRepository.deleteCredentials(credentialId);
 
     this.calendarsCacheService.deleteConnectedAndDestinationCalendarsCache(user.id);
 

--- a/apps/api/v2/src/platform/calendars/controllers/calendars.controller.ts
+++ b/apps/api/v2/src/platform/calendars/controllers/calendars.controller.ts
@@ -15,7 +15,6 @@ import { GoogleCalendarService } from "@/platform/calendars/services/gcal.servic
 import { IcsFeedService } from "@/platform/calendars/services/ics-feed.service";
 import { OutlookService } from "@/platform/calendars/services/outlook.service";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { ApiAuthGuardOnlyAllow } from "@/modules/auth/decorators/api-auth-guard-only-allow.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
@@ -38,7 +37,7 @@ import {
   Body,
   ParseBoolPipe,
 } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiParam, ApiQuery, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth,  ApiOperation, ApiParam, ApiQuery, ApiTags as DocsTags } from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
 import { Request } from "express";
 import { z } from "zod";
@@ -90,7 +89,7 @@ export class CalendarsController {
 
   @Post("/ics-feed/save")
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Save an ICS feed" })
   async createIcsFeed(
     @GetUser("id") userId: number,
@@ -102,14 +101,14 @@ export class CalendarsController {
 
   @Get("/ics-feed/check")
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Check an ICS feed" })
   async checkIcsFeed(@GetUser("id") userId: number): Promise<ApiResponse> {
     return await this.icsFeedService.check(userId);
   }
 
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Get("/busy-times")
   @ApiOperation({
     summary: "Get busy times",
@@ -144,7 +143,7 @@ export class CalendarsController {
 
   @Get("/")
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Get all calendars" })
   async getCalendars(@GetUser("id") userId: number): Promise<ConnectedCalendarsOutput> {
     const calendars = await this.calendarsService.getCalendars(userId);
@@ -162,7 +161,7 @@ export class CalendarsController {
   })
   @UseGuards(ApiAuthGuard)
   @ApiAuthGuardOnlyAllow(["API_KEY", "ACCESS_TOKEN", "THIRD_PARTY_ACCESS_TOKEN"])
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Get("/:calendar/connect")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Get OAuth connect URL" })
@@ -245,7 +244,7 @@ export class CalendarsController {
     name: "calendar",
   })
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Post("/:calendar/credentials")
   @ApiOperation({ summary: "Save Apple calendar credentials" })
   async syncCredentials(
@@ -274,7 +273,7 @@ export class CalendarsController {
   @Get("/:calendar/check")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Permissions([APPS_READ])
   @ApiOperation({ summary: "Check a calendar connection" })
   async check(@GetUser("id") userId: number, @Param("calendar") calendar: string): Promise<ApiResponse> {
@@ -299,7 +298,7 @@ export class CalendarsController {
     name: "calendar",
   })
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @Post("/:calendar/disconnect")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Disconnect a calendar" })

--- a/apps/api/v2/src/platform/event-types-private-links/controllers/event-types-private-links.controller.ts
+++ b/apps/api/v2/src/platform/event-types-private-links/controllers/event-types-private-links.controller.ts
@@ -1,11 +1,10 @@
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
 import { EventTypeOwnershipGuard } from "@/modules/event-types/guards/event-type-ownership.guard";
 import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 
 import { EVENT_TYPE_READ, EVENT_TYPE_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
 import {
@@ -30,7 +29,7 @@ export class EventTypesPrivateLinksController {
   @Post("/")
   @Permissions([EVENT_TYPE_WRITE])
   @UseGuards(ApiAuthGuard, EventTypeOwnershipGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Create a private link for an event type" })
   async createPrivateLink(
     @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
@@ -48,7 +47,7 @@ export class EventTypesPrivateLinksController {
   @Get("/")
   @Permissions([EVENT_TYPE_READ])
   @UseGuards(ApiAuthGuard, EventTypeOwnershipGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Get all private links for an event type" })
   async getPrivateLinks(
     @Param("eventTypeId", ParseIntPipe) eventTypeId: number
@@ -64,7 +63,7 @@ export class EventTypesPrivateLinksController {
   @Patch("/:linkId")
   @Permissions([EVENT_TYPE_WRITE])
   @UseGuards(ApiAuthGuard, EventTypeOwnershipGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Update a private link for an event type" })
   async updatePrivateLink(
     @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
@@ -83,7 +82,7 @@ export class EventTypesPrivateLinksController {
   @Delete("/:linkId")
   @Permissions([EVENT_TYPE_WRITE])
   @UseGuards(ApiAuthGuard, EventTypeOwnershipGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({ summary: "Delete a private link for an event type" })
   async deletePrivateLink(
     @Param("eventTypeId", ParseIntPipe) eventTypeId: number,

--- a/apps/api/v2/src/platform/event-types-private-links/controllers/event-types-private-links.controller.ts
+++ b/apps/api/v2/src/platform/event-types-private-links/controllers/event-types-private-links.controller.ts
@@ -1,22 +1,20 @@
-import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
-import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
-import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
-import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
-import { EventTypeOwnershipGuard } from "@/modules/event-types/guards/event-type-ownership.guard";
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from "@nestjs/common";
-import { ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
 import { EVENT_TYPE_READ, EVENT_TYPE_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
 import {
   CreatePrivateLinkInput,
   CreatePrivateLinkOutput,
   DeletePrivateLinkOutput,
   GetPrivateLinksOutput,
-  UpdatePrivateLinkOutput,
   UpdatePrivateLinkBody,
+  UpdatePrivateLinkOutput,
 } from "@calcom/platform-types";
-
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { PrivateLinksService } from "../services/private-links.service";
+import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
+import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
+import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
+import { EventTypeOwnershipGuard } from "@/modules/event-types/guards/event-type-ownership.guard";
 
 @Controller({
   path: "/v2/event-types/:eventTypeId/private-links",

--- a/apps/api/v2/src/platform/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/platform/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
@@ -24,7 +24,7 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiHeader, ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { CreateEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/create-event-type.output";
 import { DeleteEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/delete-event-type.output";
 import { GetEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/get-event-type.output";
@@ -83,7 +83,7 @@ export class EventTypesController_2024_06_14 {
   @Post("/")
   @Permissions([EVENT_TYPE_WRITE])
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Create an event type",
     description: `<Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>`,
@@ -108,7 +108,7 @@ export class EventTypesController_2024_06_14 {
   @Get("/:eventTypeId")
   @Permissions([EVENT_TYPE_READ])
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Get an event type",
     description: `<Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>
@@ -162,7 +162,7 @@ export class EventTypesController_2024_06_14 {
   @UseGuards(OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   async getEventTypes(
     @Query() queryParams: GetEventTypesQuery_2024_06_14,
     @GetOptionalUser() authUser: AuthOptionalUser
@@ -181,7 +181,7 @@ export class EventTypesController_2024_06_14 {
   @Patch("/:eventTypeId")
   @Permissions([EVENT_TYPE_WRITE])
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: "Update an event type",
@@ -209,7 +209,7 @@ export class EventTypesController_2024_06_14 {
   @Delete("/:eventTypeId")
   @Permissions([EVENT_TYPE_WRITE])
   @UseGuards(ApiAuthGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   @ApiOperation({
     summary: "Delete an event type",
     description: `<Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>`,

--- a/apps/api/v2/src/platform/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/platform/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
@@ -162,7 +162,6 @@ export class EventTypesController_2024_06_14 {
   @UseGuards(OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
-  @ApiBearerAuth("bearerAuth")
   async getEventTypes(
     @Query() queryParams: GetEventTypesQuery_2024_06_14,
     @GetOptionalUser() authUser: AuthOptionalUser

--- a/apps/api/v2/src/platform/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/platform/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
@@ -24,24 +24,9 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
-import { ApiHeader, ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { CreateEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/create-event-type.output";
-import { DeleteEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/delete-event-type.output";
-import { GetEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/get-event-type.output";
-import { GetEventTypesOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/get-event-types.output";
-import { UpdateEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/update-event-type.output";
-import { EventTypeResponseTransformPipe } from "@/platform/event-types/event-types_2024_06_14/pipes/event-type-response.transformer";
-import { EventTypesService_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/services/event-types.service";
-import { InputEventTypesService_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/services/input-event-types.service";
-import type { DatabaseEventType } from "@/platform/event-types/event-types_2024_06_14/services/output-event-types.service";
-import { OutputEventTypesService_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/services/output-event-types.service";
+import { ApiBearerAuth, ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { VERSION_2024_06_14_VALUE } from "@/lib/api-versions";
-import {
-  API_KEY_OR_ACCESS_TOKEN_HEADER,
-  OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER,
-  OPTIONAL_X_CAL_CLIENT_ID_HEADER,
-  OPTIONAL_X_CAL_SECRET_KEY_HEADER,
-} from "@/lib/docs/headers";
+import { OPTIONAL_X_CAL_CLIENT_ID_HEADER, OPTIONAL_X_CAL_SECRET_KEY_HEADER } from "@/lib/docs/headers";
 import {
   AuthOptionalUser,
   GetOptionalUser,
@@ -55,6 +40,16 @@ import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.st
 import { OutputTeamEventTypesResponsePipe } from "@/modules/teams/event-types/pipes/output-team-event-types-response.pipe";
 import type { DatabaseTeamEventType } from "@/modules/teams/event-types/services/output-team-event-types.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
+import { CreateEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/create-event-type.output";
+import { DeleteEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/delete-event-type.output";
+import { GetEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/get-event-type.output";
+import { GetEventTypesOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/get-event-types.output";
+import { UpdateEventTypeOutput_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/outputs/update-event-type.output";
+import { EventTypeResponseTransformPipe } from "@/platform/event-types/event-types_2024_06_14/pipes/event-type-response.transformer";
+import { EventTypesService_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/services/event-types.service";
+import { InputEventTypesService_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/services/input-event-types.service";
+import type { DatabaseEventType } from "@/platform/event-types/event-types_2024_06_14/services/output-event-types.service";
+import { OutputEventTypesService_2024_06_14 } from "@/platform/event-types/event-types_2024_06_14/services/output-event-types.service";
 
 @Controller({
   path: "/v2/event-types",
@@ -162,6 +157,7 @@ export class EventTypesController_2024_06_14 {
   @UseGuards(OptionalApiAuthGuard)
   @ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
   @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
+  @ApiBearerAuth("bearerAuth")
   async getEventTypes(
     @Query() queryParams: GetEventTypesQuery_2024_06_14,
     @GetOptionalUser() authUser: AuthOptionalUser

--- a/apps/api/v2/src/platform/me/me.controller.ts
+++ b/apps/api/v2/src/platform/me/me.controller.ts
@@ -1,6 +1,7 @@
-import { GetMeOutput } from "@/platform/me/outputs/get-me.output";
-import { UpdateMeOutput } from "@/platform/me/outputs/update-me.output";
-import { MeService } from "@/platform/me/services/me.service";
+import { PROFILE_READ, PROFILE_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
+import { userSchemaResponse } from "@calcom/platform-types";
+import { Body, Controller, Get, Patch, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
@@ -9,11 +10,9 @@ import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.
 import { UpdateManagedUserInput } from "@/modules/users/inputs/update-managed-user.input";
 import { UsersService } from "@/modules/users/services/users.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
-import { Controller, UseGuards, Get, Patch, Body } from "@nestjs/common";
-import { ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { PROFILE_READ, PROFILE_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
-import { userSchemaResponse } from "@calcom/platform-types";
+import { GetMeOutput } from "@/platform/me/outputs/get-me.output";
+import { UpdateMeOutput } from "@/platform/me/outputs/update-me.output";
+import { MeService } from "@/platform/me/services/me.service";
 
 @Controller({
   path: "/v2/me",

--- a/apps/api/v2/src/platform/me/me.controller.ts
+++ b/apps/api/v2/src/platform/me/me.controller.ts
@@ -2,7 +2,6 @@ import { GetMeOutput } from "@/platform/me/outputs/get-me.output";
 import { UpdateMeOutput } from "@/platform/me/outputs/update-me.output";
 import { MeService } from "@/platform/me/services/me.service";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -11,7 +10,7 @@ import { UpdateManagedUserInput } from "@/modules/users/inputs/update-managed-us
 import { UsersService } from "@/modules/users/services/users.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Controller, UseGuards, Get, Patch, Body } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 
 import { PROFILE_READ, PROFILE_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
 import { userSchemaResponse } from "@calcom/platform-types";
@@ -22,7 +21,7 @@ import { userSchemaResponse } from "@calcom/platform-types";
 })
 @UseGuards(ApiAuthGuard, PermissionsGuard)
 @DocsTags("Me")
-@ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+@ApiBearerAuth("bearerAuth")
 export class MeController {
   constructor(
     private readonly usersService: UsersService,

--- a/apps/api/v2/src/platform/provider/provider.controller.ts
+++ b/apps/api/v2/src/platform/provider/provider.controller.ts
@@ -10,14 +10,14 @@ import {
   UnauthorizedException,
   UseGuards,
 } from "@nestjs/common";
-import { ApiBearerAuth, ApiExcludeController,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { ProviderVerifyAccessTokenOutput } from "@/platform/provider/outputs/verify-access-token.output";
-import { ProviderVerifyClientOutput } from "@/platform/provider/outputs/verify-client.output";
+import { ApiBearerAuth, ApiExcludeController, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { OAuthClientRepository } from "@/modules/oauth-clients/oauth-client.repository";
 import { UserWithProfile } from "@/modules/users/users.repository";
+import { ProviderVerifyAccessTokenOutput } from "@/platform/provider/outputs/verify-access-token.output";
+import { ProviderVerifyClientOutput } from "@/platform/provider/outputs/verify-client.output";
 
 @Controller({
   path: "/v2/provider",

--- a/apps/api/v2/src/platform/provider/provider.controller.ts
+++ b/apps/api/v2/src/platform/provider/provider.controller.ts
@@ -10,11 +10,10 @@ import {
   UnauthorizedException,
   UseGuards,
 } from "@nestjs/common";
-import { ApiExcludeController, ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiExcludeController,  ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { ProviderVerifyAccessTokenOutput } from "@/platform/provider/outputs/verify-access-token.output";
 import { ProviderVerifyClientOutput } from "@/platform/provider/outputs/verify-client.output";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { OAuthClientRepository } from "@/modules/oauth-clients/oauth-client.repository";
@@ -56,7 +55,7 @@ export class CalProviderController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard)
   @ApiOperation({ summary: "Verify an access token" })
-  @ApiHeader(ACCESS_TOKEN_HEADER)
+  @ApiBearerAuth("bearerAuth")
   async verifyAccessToken(
     @Param("clientId") clientId: string,
     @GetUser() user: UserWithProfile

--- a/apps/api/v2/src/platform/schedules/schedules_2024_06_11/controllers/schedules.controller.ts
+++ b/apps/api/v2/src/platform/schedules/schedules_2024_06_11/controllers/schedules.controller.ts
@@ -1,6 +1,5 @@
 import { SchedulesService_2024_06_11 } from "@/platform/schedules/schedules_2024_06_11/services/schedules.service";
 import { VERSION_2024_06_14, VERSION_2024_06_11 } from "@/lib/api-versions";
-import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -18,7 +17,7 @@ import {
   Patch,
   UseGuards,
 } from "@nestjs/common";
-import { ApiHeader, ApiOperation, ApiResponse, ApiTags as DocsTags } from "@nestjs/swagger";
+import { ApiHeader, ApiBearerAuth,  ApiOperation, ApiResponse, ApiTags as DocsTags } from "@nestjs/swagger";
 
 import { SCHEDULE_READ, SCHEDULE_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
 import {
@@ -47,7 +46,7 @@ import {
     default: VERSION_2024_06_11,
   },
 })
-@ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+@ApiBearerAuth("bearerAuth")
 export class SchedulesController_2024_06_11 {
   constructor(private readonly schedulesService: SchedulesService_2024_06_11) {}
 

--- a/apps/api/v2/src/platform/schedules/schedules_2024_06_11/controllers/schedules.controller.ts
+++ b/apps/api/v2/src/platform/schedules/schedules_2024_06_11/controllers/schedules.controller.ts
@@ -1,10 +1,14 @@
-import { SchedulesService_2024_06_11 } from "@/platform/schedules/schedules_2024_06_11/services/schedules.service";
-import { VERSION_2024_06_14, VERSION_2024_06_11 } from "@/lib/api-versions";
-import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
-import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
-import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
-import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
-import { UserWithProfile } from "@/modules/users/users.repository";
+import { SCHEDULE_READ, SCHEDULE_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
+import {
+  CreateScheduleInput_2024_06_11,
+  CreateScheduleOutput_2024_06_11,
+  DeleteScheduleOutput_2024_06_11,
+  GetDefaultScheduleOutput_2024_06_11,
+  GetScheduleOutput_2024_06_11,
+  GetSchedulesOutput_2024_06_11,
+  UpdateScheduleInput_2024_06_11,
+  UpdateScheduleOutput_2024_06_11,
+} from "@calcom/platform-types";
 import {
   Body,
   Controller,
@@ -13,23 +17,18 @@ import {
   HttpCode,
   HttpStatus,
   Param,
-  Post,
   Patch,
+  Post,
   UseGuards,
 } from "@nestjs/common";
-import { ApiHeader, ApiBearerAuth,  ApiOperation, ApiResponse, ApiTags as DocsTags } from "@nestjs/swagger";
-
-import { SCHEDULE_READ, SCHEDULE_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
-import {
-  CreateScheduleOutput_2024_06_11,
-  CreateScheduleInput_2024_06_11,
-  UpdateScheduleInput_2024_06_11,
-  GetScheduleOutput_2024_06_11,
-  UpdateScheduleOutput_2024_06_11,
-  GetDefaultScheduleOutput_2024_06_11,
-  DeleteScheduleOutput_2024_06_11,
-  GetSchedulesOutput_2024_06_11,
-} from "@calcom/platform-types";
+import { ApiBearerAuth, ApiHeader, ApiOperation, ApiResponse, ApiTags as DocsTags } from "@nestjs/swagger";
+import { VERSION_2024_06_11, VERSION_2024_06_14 } from "@/lib/api-versions";
+import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
+import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
+import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
+import { UserWithProfile } from "@/modules/users/users.repository";
+import { SchedulesService_2024_06_11 } from "@/platform/schedules/schedules_2024_06_11/services/schedules.service";
 
 @Controller({
   path: "/v2/schedules",

--- a/apps/api/v2/src/swagger/generate-swagger.ts
+++ b/apps/api/v2/src/swagger/generate-swagger.ts
@@ -22,7 +22,7 @@ export async function generateSwaggerForApp(app: NestExpressApplication<Server>)
   const logger = new Logger("App");
   logger.log(`Generating Swagger documentation...\n`);
 
-  const config = new DocumentBuilder().setTitle("Cal.diy API v2").build();
+  const config = new DocumentBuilder().setTitle("Cal.diy API v2").addBearerAuth({ type: "http", scheme: "bearer", bearerFormat: "JWT", description: "Enter your API key or access token prefixed with `Bearer `" }, "bearerAuth").build();
   const document = SwaggerModule.createDocument(app, config);
   document.paths = groupAndSortPathsByFirstTag(document.paths);
 

--- a/apps/api/v2/src/swagger/generate-swagger.ts
+++ b/apps/api/v2/src/swagger/generate-swagger.ts
@@ -1,16 +1,16 @@
-import { getEnv } from "@/env";
 import { Logger } from "@nestjs/common";
 import type { NestExpressApplication } from "@nestjs/platform-express";
-import { SwaggerModule, DocumentBuilder } from "@nestjs/swagger";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import type {
+  OperationObject,
   PathItemObject,
   PathsObject,
-  OperationObject,
 } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
+import { getEnv } from "@/env";
 import "dotenv/config";
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import type { Server } from "node:http";
-import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 
 const nodeRequire = createRequire(__filename);
@@ -22,7 +22,18 @@ export async function generateSwaggerForApp(app: NestExpressApplication<Server>)
   const logger = new Logger("App");
   logger.log(`Generating Swagger documentation...\n`);
 
-  const config = new DocumentBuilder().setTitle("Cal.diy API v2").addBearerAuth({ type: "http", scheme: "bearer", bearerFormat: "JWT", description: "Enter your API key or access token (without the `Bearer ` prefix)." }, "bearerAuth").build();
+  const config = new DocumentBuilder()
+    .setTitle("Cal.diy API v2")
+    .addBearerAuth(
+      {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+        description: "Enter your API key or access token (without the `Bearer ` prefix).",
+      },
+      "bearerAuth"
+    )
+    .build();
   const document = SwaggerModule.createDocument(app, config);
   document.paths = groupAndSortPathsByFirstTag(document.paths);
 

--- a/apps/api/v2/src/swagger/generate-swagger.ts
+++ b/apps/api/v2/src/swagger/generate-swagger.ts
@@ -22,7 +22,7 @@ export async function generateSwaggerForApp(app: NestExpressApplication<Server>)
   const logger = new Logger("App");
   logger.log(`Generating Swagger documentation...\n`);
 
-  const config = new DocumentBuilder().setTitle("Cal.diy API v2").addBearerAuth({ type: "http", scheme: "bearer", bearerFormat: "JWT", description: "Enter your API key or access token prefixed with `Bearer `" }, "bearerAuth").build();
+  const config = new DocumentBuilder().setTitle("Cal.diy API v2").addBearerAuth({ type: "http", scheme: "bearer", bearerFormat: "JWT", description: "Enter your API key or access token (without the `Bearer ` prefix)." }, "bearerAuth").build();
   const document = SwaggerModule.createDocument(app, config);
   document.paths = groupAndSortPathsByFirstTag(document.paths);
 

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -5990,7 +5990,7 @@
         "scheme": "bearer",
         "bearerFormat": "JWT",
         "type": "http",
-        "description": "Enter your API key or access token prefixed with `Bearer `"
+        "description": "Enter your API key or access token (without the `Bearer ` prefix)."
       }
     },
     "schemas": {

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -6,17 +6,7 @@
         "operationId": "ApiKeysController_refresh",
         "summary": "Refresh API Key",
         "description": "Generate a new API key and delete the current one. Provide API key to refresh as a Bearer token in the Authorization header (e.g. \"Authorization: Bearer <apiKey>\").",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -39,7 +29,12 @@
             }
           }
         },
-        "tags": ["Api Keys"]
+        "tags": ["Api Keys"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings": {
@@ -56,15 +51,6 @@
             "schema": {
               "type": "string",
               "default": "2024-08-13"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": false,
-            "schema": {
-              "type": "string"
             }
           },
           {
@@ -116,7 +102,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "get": {
         "operationId": "BookingsController_2024_08_13_getBookings",
@@ -342,15 +333,6 @@
               "example": 0,
               "type": "number"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -365,7 +347,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/by-seat/{seatUid}": {
@@ -393,15 +380,6 @@
             }
           },
           {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "x-cal-secret-key",
             "in": "header",
             "description": "For platform customers - OAuth client secret key",
@@ -432,7 +410,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}": {
@@ -460,15 +443,6 @@
             }
           },
           {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "x-cal-secret-key",
             "in": "header",
             "description": "For platform customers - OAuth client secret key",
@@ -499,7 +473,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/recordings": {
@@ -525,15 +504,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -548,7 +518,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/transcripts": {
@@ -574,15 +549,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -597,7 +563,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/reschedule": {
@@ -620,15 +591,6 @@
             "name": "bookingUid",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": false,
             "schema": {
               "type": "string"
             }
@@ -682,7 +644,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/cancel": {
@@ -705,15 +672,6 @@
             "name": "bookingUid",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": false,
             "schema": {
               "type": "string"
             }
@@ -767,7 +725,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/mark-absent": {
@@ -790,15 +753,6 @@
             "name": "bookingUid",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -826,7 +780,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/reassign": {
@@ -852,15 +811,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -875,7 +825,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/reassign/{userId}": {
@@ -909,15 +864,6 @@
             "schema": {
               "type": "number"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "requestBody": {
@@ -942,7 +888,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/confirm": {
@@ -968,15 +919,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -991,7 +933,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/decline": {
@@ -1014,15 +961,6 @@
             "name": "bookingUid",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -1050,7 +988,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/calendar-links": {
@@ -1076,15 +1019,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1099,7 +1033,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/references": {
@@ -1143,15 +1082,6 @@
               ],
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1166,7 +1096,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/conferencing-sessions": {
@@ -1192,15 +1127,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1215,7 +1141,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/location": {
@@ -1237,15 +1168,6 @@
             "name": "bookingUid",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -1273,7 +1195,12 @@
             }
           }
         },
-        "tags": ["Bookings"]
+        "tags": ["Bookings"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/attendees": {
@@ -1298,15 +1225,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1321,7 +1239,12 @@
             }
           }
         },
-        "tags": ["Bookings / Attendees"]
+        "tags": ["Bookings / Attendees"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "post": {
         "operationId": "BookingAttendeesController_2024_08_13_addAttendee",
@@ -1341,15 +1264,6 @@
             "name": "bookingUid",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -1377,7 +1291,12 @@
             }
           }
         },
-        "tags": ["Bookings / Attendees"]
+        "tags": ["Bookings / Attendees"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/attendees/{attendeeId}": {
@@ -1410,15 +1329,6 @@
             "schema": {
               "type": "number"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1433,7 +1343,12 @@
             }
           }
         },
-        "tags": ["Bookings / Attendees"]
+        "tags": ["Bookings / Attendees"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "BookingAttendeesController_2024_08_13_removeAttendee",
@@ -1464,15 +1379,6 @@
             "schema": {
               "type": "number"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1487,7 +1393,12 @@
             }
           }
         },
-        "tags": ["Bookings / Attendees"]
+        "tags": ["Bookings / Attendees"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/bookings/{bookingUid}/guests": {
@@ -1509,15 +1420,6 @@
             "name": "bookingUid",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -1545,7 +1447,12 @@
             }
           }
         },
-        "tags": ["Bookings / Guests"]
+        "tags": ["Bookings / Guests"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/connections": {
@@ -1553,17 +1460,7 @@
         "operationId": "CalUnifiedCalendarsController_listConnections",
         "summary": "List calendar connections",
         "description": "Returns all calendar connections for the authenticated user (Google, Office 365, Apple). Use connectionId in connection-scoped endpoints. Note: Event CRUD (list/create/get/update/delete events) is currently only supported for Google Calendar connections; other types will return 400.",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "",
@@ -1576,7 +1473,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/connections/{connectionId}/events": {
@@ -1632,15 +1534,6 @@
               "default": "primary",
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1655,7 +1548,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "post": {
         "operationId": "CalUnifiedCalendarsController_createConnectionEvent",
@@ -1674,15 +1572,6 @@
             "name": "calendarId",
             "required": false,
             "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -1710,7 +1599,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/connections/{connectionId}/events/{eventId}": {
@@ -1742,15 +1636,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1765,7 +1650,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "patch": {
         "operationId": "CalUnifiedCalendarsController_updateConnectionEvent",
@@ -1795,15 +1685,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "requestBody": {
@@ -1828,7 +1709,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "CalUnifiedCalendarsController_deleteConnectionEvent",
@@ -1858,15 +1744,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1874,7 +1751,12 @@
             "description": ""
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/connections/{connectionId}/freebusy": {
@@ -1919,15 +1801,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1942,7 +1815,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/{calendar}/events/{eventUid}": {
@@ -1964,16 +1842,7 @@
             "name": "eventUid",
             "required": true,
             "in": "path",
-            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: GET /v2/organizations/{orgId}/teams/{teamId}/bookings/{bookingUid}/references\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
+            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
             "schema": {
               "type": "string"
             }
@@ -1991,7 +1860,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "patch": {
         "operationId": "CalUnifiedCalendarsController_updateCalendarEvent",
@@ -2011,16 +1885,7 @@
             "name": "eventUid",
             "required": true,
             "in": "path",
-            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: GET /v2/organizations/{orgId}/teams/{teamId}/bookings/{bookingUid}/references\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
+            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
             "schema": {
               "type": "string"
             }
@@ -2048,7 +1913,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "CalUnifiedCalendarsController_deleteCalendarEvent",
@@ -2072,15 +1942,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -2088,7 +1949,12 @@
             "description": ""
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/{calendar}/event/{eventUid}": {
@@ -2110,16 +1976,7 @@
             "name": "eventUid",
             "required": true,
             "in": "path",
-            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: GET /v2/organizations/{orgId}/teams/{teamId}/bookings/{bookingUid}/references\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
+            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
             "schema": {
               "type": "string"
             }
@@ -2137,7 +1994,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "patch": {
         "operationId": "CalUnifiedCalendarsController_updateCalendarEvent",
@@ -2157,16 +2019,7 @@
             "name": "eventUid",
             "required": true,
             "in": "path",
-            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: GET /v2/organizations/{orgId}/teams/{teamId}/bookings/{bookingUid}/references\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
+            "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
             "schema": {
               "type": "string"
             }
@@ -2194,7 +2047,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/{calendar}/events": {
@@ -2250,15 +2108,6 @@
               "default": "primary",
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -2273,7 +2122,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "post": {
         "operationId": "CalUnifiedCalendarsController_createCalendarEvent",
@@ -2286,15 +2140,6 @@
             "in": "path",
             "schema": {
               "enum": ["google", "office365", "apple"],
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
               "type": "string"
             }
           }
@@ -2321,7 +2166,12 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/{calendar}/freebusy": {
@@ -2367,15 +2217,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -2390,24 +2231,19 @@
             }
           }
         },
-        "tags": ["Cal Unified Calendars"]
+        "tags": ["Cal Unified Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/ics-feed/save": {
       "post": {
         "operationId": "CalendarsController_createIcsFeed",
         "summary": "Save an ICS feed",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -2430,24 +2266,19 @@
             }
           }
         },
-        "tags": ["Calendars"]
+        "tags": ["Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/ics-feed/check": {
       "get": {
         "operationId": "CalendarsController_checkIcsFeed",
         "summary": "Check an ICS feed",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "",
@@ -2460,7 +2291,12 @@
             }
           }
         },
-        "tags": ["Calendars"]
+        "tags": ["Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/busy-times": {
@@ -2525,15 +2361,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -2548,24 +2375,19 @@
             }
           }
         },
-        "tags": ["Calendars"]
+        "tags": ["Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars": {
       "get": {
         "operationId": "CalendarsController_getCalendars",
         "summary": "Get all calendars",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "",
@@ -2578,7 +2400,12 @@
             }
           }
         },
-        "tags": ["Calendars"]
+        "tags": ["Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/{calendar}/connect": {
@@ -2590,7 +2417,6 @@
             "name": "Authorization",
             "required": true,
             "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
             "schema": {
               "type": "string"
             }
@@ -2634,7 +2460,12 @@
             }
           }
         },
-        "tags": ["Calendars"]
+        "tags": ["Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/{calendar}/save": {
@@ -2689,15 +2520,6 @@
               "enum": ["apple"],
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "requestBody": {
@@ -2715,7 +2537,12 @@
             "description": ""
           }
         },
-        "tags": ["Calendars"]
+        "tags": ["Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/{calendar}/check": {
@@ -2729,15 +2556,6 @@
             "in": "path",
             "schema": {
               "enum": ["apple", "google", "office365"],
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
               "type": "string"
             }
           }
@@ -2754,7 +2572,12 @@
             }
           }
         },
-        "tags": ["Calendars"]
+        "tags": ["Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/calendars/{calendar}/disconnect": {
@@ -2768,15 +2591,6 @@
             "in": "path",
             "schema": {
               "enum": ["apple", "google", "office365"],
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
               "type": "string"
             }
           }
@@ -2803,7 +2617,12 @@
             }
           }
         },
-        "tags": ["Calendars"]
+        "tags": ["Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/conferencing/{app}/connect": {
@@ -2820,15 +2639,6 @@
               "enum": ["google-meet"],
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -2843,7 +2653,12 @@
             }
           }
         },
-        "tags": ["Conferencing"]
+        "tags": ["Conferencing"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/conferencing/{app}/oauth/auth-url": {
@@ -2855,7 +2670,6 @@
             "name": "Authorization",
             "required": true,
             "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
             "schema": {
               "type": "string"
             }
@@ -2899,7 +2713,12 @@
             }
           }
         },
-        "tags": ["Conferencing"]
+        "tags": ["Conferencing"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/conferencing/{app}/oauth/callback": {
@@ -2946,17 +2765,7 @@
       "get": {
         "operationId": "ConferencingController_listInstalledConferencingApps",
         "summary": "List your conferencing applications",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "",
@@ -2969,7 +2778,12 @@
             }
           }
         },
-        "tags": ["Conferencing"]
+        "tags": ["Conferencing"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/conferencing/{app}/default": {
@@ -2986,15 +2800,6 @@
               "enum": ["google-meet", "zoom", "msteams", "daily-video"],
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -3009,24 +2814,19 @@
             }
           }
         },
-        "tags": ["Conferencing"]
+        "tags": ["Conferencing"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/conferencing/default": {
       "get": {
         "operationId": "ConferencingController_getDefault",
         "summary": "Get your default conferencing application",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "",
@@ -3039,7 +2839,12 @@
             }
           }
         },
-        "tags": ["Conferencing"]
+        "tags": ["Conferencing"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/conferencing/{app}/disconnect": {
@@ -3056,15 +2861,6 @@
               "enum": ["google-meet", "zoom", "msteams"],
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -3079,7 +2875,12 @@
             }
           }
         },
-        "tags": ["Conferencing"]
+        "tags": ["Conferencing"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/oauth-clients/{clientId}/users": {
@@ -3744,17 +3545,7 @@
         "operationId": "OAuthClientsController_createOAuthClient",
         "summary": "Create an OAuth client",
         "description": "<Warning>These endpoints are deprecated and will be removed in the future.</Warning>",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -3777,23 +3568,18 @@
             }
           }
         },
-        "tags": ["Deprecated: Platform OAuth Clients"]
+        "tags": ["Deprecated: Platform OAuth Clients"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "get": {
         "operationId": "OAuthClientsController_getOAuthClients",
         "summary": "Get all OAuth clients",
         "description": "<Warning>These endpoints are deprecated and will be removed in the future.</Warning>",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "",
@@ -3806,7 +3592,12 @@
             }
           }
         },
-        "tags": ["Deprecated: Platform OAuth Clients"]
+        "tags": ["Deprecated: Platform OAuth Clients"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/oauth-clients/{clientId}": {
@@ -3815,15 +3606,6 @@
         "summary": "Get an OAuth client",
         "description": "<Warning>These endpoints are deprecated and will be removed in the future.</Warning>",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "clientId",
             "required": true,
@@ -3845,22 +3627,18 @@
             }
           }
         },
-        "tags": ["Deprecated: Platform OAuth Clients"]
+        "tags": ["Deprecated: Platform OAuth Clients"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "patch": {
         "operationId": "OAuthClientsController_updateOAuthClient",
         "summary": "Update an OAuth client",
         "description": "<Warning>These endpoints are deprecated and will be removed in the future.</Warning>",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "clientId",
             "required": true,
@@ -3892,22 +3670,18 @@
             }
           }
         },
-        "tags": ["Deprecated: Platform OAuth Clients"]
+        "tags": ["Deprecated: Platform OAuth Clients"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "OAuthClientsController_deleteOAuthClient",
         "summary": "Delete an OAuth client",
         "description": "<Warning>These endpoints are deprecated and will be removed in the future.</Warning>",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "clientId",
             "required": true,
@@ -3929,24 +3703,19 @@
             }
           }
         },
-        "tags": ["Deprecated: Platform OAuth Clients"]
+        "tags": ["Deprecated: Platform OAuth Clients"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/destination-calendars": {
       "put": {
         "operationId": "DestinationCalendarsController_updateDestinationCalendars",
         "summary": "Update destination calendars",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -3969,7 +3738,12 @@
             }
           }
         },
-        "tags": ["Destination Calendars"]
+        "tags": ["Destination Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/event-types": {
@@ -3986,15 +3760,6 @@
             "schema": {
               "type": "string",
               "default": "2024-06-14"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -4020,7 +3785,12 @@
             }
           }
         },
-        "tags": ["Event Types"]
+        "tags": ["Event Types"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "get": {
         "operationId": "EventTypesController_2024_06_14_getEventTypes",
@@ -4093,15 +3863,6 @@
             }
           },
           {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "x-cal-secret-key",
             "in": "header",
             "description": "For platform customers - OAuth client secret key",
@@ -4132,7 +3893,12 @@
             }
           }
         },
-        "tags": ["Event Types"]
+        "tags": ["Event Types"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/event-types/{eventTypeId}": {
@@ -4158,15 +3924,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -4181,7 +3938,12 @@
             }
           }
         },
-        "tags": ["Event Types"]
+        "tags": ["Event Types"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "patch": {
         "operationId": "EventTypesController_2024_06_14_updateEventType",
@@ -4204,15 +3966,6 @@
             "in": "path",
             "schema": {
               "type": "number"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -4238,7 +3991,12 @@
             }
           }
         },
-        "tags": ["Event Types"]
+        "tags": ["Event Types"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "EventTypesController_2024_06_14_deleteEventType",
@@ -4262,15 +4020,6 @@
             "schema": {
               "type": "number"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -4285,7 +4034,12 @@
             }
           }
         },
-        "tags": ["Event Types"]
+        "tags": ["Event Types"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/event-types/{eventTypeId}/webhooks": {
@@ -4293,15 +4047,6 @@
         "operationId": "EventTypeWebhooksController_createEventTypeWebhook",
         "summary": "Create a webhook",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "eventTypeId",
             "required": true,
@@ -4333,21 +4078,17 @@
             }
           }
         },
-        "tags": ["Event Types / Webhooks"]
+        "tags": ["Event Types / Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "get": {
         "operationId": "EventTypeWebhooksController_getEventTypeWebhooks",
         "summary": "Get all webhooks",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "eventTypeId",
             "required": true,
@@ -4394,21 +4135,17 @@
             }
           }
         },
-        "tags": ["Event Types / Webhooks"]
+        "tags": ["Event Types / Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "EventTypeWebhooksController_deleteAllEventTypeWebhooks",
         "summary": "Delete all webhooks",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "eventTypeId",
             "required": true,
@@ -4430,7 +4167,12 @@
             }
           }
         },
-        "tags": ["Event Types / Webhooks"]
+        "tags": ["Event Types / Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/event-types/{eventTypeId}/webhooks/{webhookId}": {
@@ -4438,15 +4180,6 @@
         "operationId": "EventTypeWebhooksController_updateEventTypeWebhook",
         "summary": "Update a webhook",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "webhookId",
             "required": true,
@@ -4486,22 +4219,18 @@
             }
           }
         },
-        "tags": ["Event Types / Webhooks"]
+        "tags": ["Event Types / Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "get": {
         "operationId": "EventTypeWebhooksController_getEventTypeWebhook",
         "summary": "Get a webhook",
         "parameters": [
           {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "webhookId",
             "required": true,
             "in": "path",
@@ -4530,22 +4259,18 @@
             }
           }
         },
-        "tags": ["Event Types / Webhooks"]
+        "tags": ["Event Types / Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "EventTypeWebhooksController_deleteEventTypeWebhook",
         "summary": "Delete a webhook",
         "parameters": [
           {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "webhookId",
             "required": true,
             "in": "path",
@@ -4574,7 +4299,12 @@
             }
           }
         },
-        "tags": ["Event Types / Webhooks"]
+        "tags": ["Event Types / Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/event-types/{eventTypeId}/private-links": {
@@ -4588,15 +4318,6 @@
             "in": "path",
             "schema": {
               "type": "number"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -4622,7 +4343,12 @@
             }
           }
         },
-        "tags": ["Event Types Private Links"]
+        "tags": ["Event Types Private Links"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "get": {
         "operationId": "EventTypesPrivateLinksController_getPrivateLinks",
@@ -4634,15 +4360,6 @@
             "in": "path",
             "schema": {
               "type": "number"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -4658,7 +4375,12 @@
             }
           }
         },
-        "tags": ["Event Types Private Links"]
+        "tags": ["Event Types Private Links"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/event-types/{eventTypeId}/private-links/{linkId}": {
@@ -4678,15 +4400,6 @@
             "name": "linkId",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -4714,7 +4427,12 @@
             }
           }
         },
-        "tags": ["Event Types Private Links"]
+        "tags": ["Event Types Private Links"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "EventTypesPrivateLinksController_deletePrivateLink",
@@ -4735,15 +4453,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -4758,24 +4467,19 @@
             }
           }
         },
-        "tags": ["Event Types Private Links"]
+        "tags": ["Event Types Private Links"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/me": {
       "get": {
         "operationId": "MeController_getMe",
         "summary": "Get my profile",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "",
@@ -4788,23 +4492,18 @@
             }
           }
         },
-        "tags": ["Me"]
+        "tags": ["Me"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "patch": {
         "operationId": "MeController_updateMe",
         "summary": "Update my profile",
         "description": "Updates the authenticated user's profile. Email changes require verification and the primary email stays unchanged until verification completes, unless the new email is already a verified secondary email or the user is platform-managed.",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -4827,7 +4526,12 @@
             }
           }
         },
-        "tags": ["Me"]
+        "tags": ["Me"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/auth/oauth2/clients/{clientId}": {
@@ -4909,17 +4613,8 @@
       "post": {
         "operationId": "SchedulesController_2024_06_11_createSchedule",
         "summary": "Create a schedule",
-        "description": "\n      Create a schedule for the authenticated user.\n\n      The point of creating schedules is for event types to be available at specific times.\n\n      The first goal of schedules is to have a default schedule. If you are platform customer and created managed users, then it is important to note that each managed user should have a default schedule.\n      1. If you passed `timeZone` when creating managed user, then the default schedule from Monday to Friday from 9AM to 5PM will be created with that timezone. The managed user can then change the default schedule via the `AvailabilitySettings` atom.\n      2. If you did not, then we assume you want the user to have this specific schedule right away. You should create a default schedule by specifying\n      `\"isDefault\": true` in the request body. Until the user has a default schedule the user can't be booked nor manage their schedule via the AvailabilitySettings atom.\n\n      The second goal of schedules is to create another schedule that event types can point to. This is useful for when an event is booked because availability is not checked against the default schedule but instead against that specific schedule.\n      After creating a non-default schedule, you can update an event type to point to that schedule via the PATCH `event-types/{eventTypeId}` endpoint.\n\n      When specifying start time and end time for each day use the 24 hour format e.g. 08:00, 15:00 etc.\n\n      <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>\n      ",
+        "description": "\n      Create a schedule for the authenticated user.\n\n      The point of creating schedules is for event types to be available at specific times.\n\n      The first goal of schedules is to have a default schedule. If you are a platform customer and have created managed users, then it is important to note that each managed user should have a default schedule.\n      1. If you passed `timeZone` when creating a managed user, then the default schedule from Monday to Friday from 9AM to 5PM will be created with that timezone. The managed user can then change the default schedule via the `AvailabilitySettings` atom.\n      2. If you did not, then we assume you want the user to have this specific schedule right away. You should create a default schedule by specifying\n      `\"isDefault\": true` in the request body. Until the user has a default schedule the user can't be booked nor manage their schedule via the AvailabilitySettings atom.\n\n      The second goal of schedules is to create another schedule that event types can point to. This is useful for when an event is booked because availability is not checked against the default schedule but instead against that specific schedule.\n      After creating a non-default schedule, you can update an event type to point to that schedule via the PATCH `event-types/{eventTypeId}` endpoint.\n\n      When specifying start time and end time for each day use the 24 hour format e.g. 08:00, 15:00 etc.\n\n      <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>\n      ",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "cal-api-version",
             "in": "header",
@@ -4953,22 +4648,18 @@
             }
           }
         },
-        "tags": ["Schedules"]
+        "tags": ["Schedules"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "get": {
         "operationId": "SchedulesController_2024_06_11_getSchedules",
         "summary": "Get all schedules",
         "description": "Get all schedules of the authenticated user.\n    \n     <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>\n    ",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "cal-api-version",
             "in": "header",
@@ -4992,7 +4683,12 @@
             }
           }
         },
-        "tags": ["Schedules"]
+        "tags": ["Schedules"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/schedules/default": {
@@ -5001,15 +4697,6 @@
         "summary": "Get default schedule",
         "description": "Get the default schedule of the authenticated user.\n    \n    <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>\n    ",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "cal-api-version",
             "in": "header",
@@ -5033,7 +4720,12 @@
             }
           }
         },
-        "tags": ["Schedules"]
+        "tags": ["Schedules"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/schedules/{scheduleId}": {
@@ -5042,15 +4734,6 @@
         "summary": "Get a schedule",
         "description": "<Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "cal-api-version",
             "in": "header",
@@ -5082,22 +4765,18 @@
             }
           }
         },
-        "tags": ["Schedules"]
+        "tags": ["Schedules"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "patch": {
         "operationId": "SchedulesController_2024_06_11_updateSchedule",
         "summary": "Update a schedule",
         "description": "<Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "cal-api-version",
             "in": "header",
@@ -5139,22 +4818,18 @@
             }
           }
         },
-        "tags": ["Schedules"]
+        "tags": ["Schedules"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "SchedulesController_2024_06_11_deleteSchedule",
         "summary": "Delete a schedule",
         "description": "<Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "cal-api-version",
             "in": "header",
@@ -5186,24 +4861,19 @@
             }
           }
         },
-        "tags": ["Schedules"]
+        "tags": ["Schedules"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/selected-calendars": {
       "post": {
         "operationId": "SelectedCalendarsController_addSelectedCalendar",
         "summary": "Add a selected calendar",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -5226,21 +4896,17 @@
             }
           }
         },
-        "tags": ["Selected Calendars"]
+        "tags": ["Selected Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "SelectedCalendarsController_deleteSelectedCalendar",
         "summary": "Delete a selected calendar",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "integration",
             "required": true,
@@ -5286,7 +4952,12 @@
             }
           }
         },
-        "tags": ["Selected Calendars"]
+        "tags": ["Selected Calendars"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/slots": {
@@ -5533,15 +5204,6 @@
             }
           },
           {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "x-cal-client-id",
             "in": "header",
             "description": "For platform customers - OAuth client ID",
@@ -5573,7 +5235,12 @@
             }
           }
         },
-        "tags": ["Slots"]
+        "tags": ["Slots"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/slots/reservations/{uid}": {
@@ -5714,7 +5381,6 @@
             "name": "Authorization",
             "required": true,
             "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
             "schema": {
               "type": "string"
             }
@@ -5732,7 +5398,12 @@
             }
           }
         },
-        "tags": ["Stripe"]
+        "tags": ["Stripe"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/stripe/save": {
@@ -5776,17 +5447,7 @@
       "get": {
         "operationId": "StripeController_check",
         "summary": "Check Stripe connection",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "",
@@ -5799,7 +5460,12 @@
             }
           }
         },
-        "tags": ["Stripe"]
+        "tags": ["Stripe"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/verified-resources/emails/verification-code/request": {
@@ -5807,17 +5473,7 @@
         "operationId": "UserVerifiedResourcesController_requestEmailVerificationCode",
         "summary": "Request email verification code",
         "description": "Sends a verification code to the email",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -5840,7 +5496,12 @@
             }
           }
         },
-        "tags": ["Verified Resources"]
+        "tags": ["Verified Resources"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/verified-resources/phones/verification-code/request": {
@@ -5848,17 +5509,7 @@
         "operationId": "UserVerifiedResourcesController_requestPhoneVerificationCode",
         "summary": "Request phone number verification code",
         "description": "Sends a verification code to the phone number",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -5881,7 +5532,12 @@
             }
           }
         },
-        "tags": ["Verified Resources"]
+        "tags": ["Verified Resources"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/verified-resources/emails/verification-code/verify": {
@@ -5889,17 +5545,7 @@
         "operationId": "UserVerifiedResourcesController_verifyEmail",
         "summary": "Verify an email",
         "description": "Use code to verify an email",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -5922,7 +5568,12 @@
             }
           }
         },
-        "tags": ["Verified Resources"]
+        "tags": ["Verified Resources"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/verified-resources/phones/verification-code/verify": {
@@ -5930,17 +5581,7 @@
         "operationId": "UserVerifiedResourcesController_verifyPhoneNumber",
         "summary": "Verify a phone number",
         "description": "Use code to verify a phone number",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -5963,7 +5604,12 @@
             }
           }
         },
-        "tags": ["Verified Resources"]
+        "tags": ["Verified Resources"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/verified-resources/emails": {
@@ -5995,15 +5641,6 @@
               "example": 0,
               "type": "number"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -6018,7 +5655,12 @@
             }
           }
         },
-        "tags": ["Verified Resources"]
+        "tags": ["Verified Resources"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/verified-resources/phones": {
@@ -6050,15 +5692,6 @@
               "example": 0,
               "type": "number"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -6073,7 +5706,12 @@
             }
           }
         },
-        "tags": ["Verified Resources"]
+        "tags": ["Verified Resources"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/verified-resources/emails/{id}": {
@@ -6087,15 +5725,6 @@
             "in": "path",
             "schema": {
               "type": "number"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -6111,7 +5740,12 @@
             }
           }
         },
-        "tags": ["Verified Resources"]
+        "tags": ["Verified Resources"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/verified-resources/phones/{id}": {
@@ -6125,15 +5759,6 @@
             "in": "path",
             "schema": {
               "type": "number"
-            }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
-            "required": true,
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -6149,24 +5774,19 @@
             }
           }
         },
-        "tags": ["Verified Resources"]
+        "tags": ["Verified Resources"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/webhooks": {
       "post": {
         "operationId": "WebhooksController_createWebhook",
         "summary": "Create a webhook",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -6189,22 +5809,18 @@
             }
           }
         },
-        "tags": ["Webhooks"]
+        "tags": ["Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "get": {
         "operationId": "WebhooksController_getWebhooks",
         "summary": "Get all webhooks",
         "description": "Gets a paginated list of webhooks for the authenticated user.",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "take",
             "required": false,
@@ -6243,7 +5859,12 @@
             }
           }
         },
-        "tags": ["Webhooks"]
+        "tags": ["Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v2/webhooks/{webhookId}": {
@@ -6251,15 +5872,6 @@
         "operationId": "WebhooksController_updateWebhook",
         "summary": "Update a webhook",
         "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "webhookId",
             "required": true,
@@ -6291,22 +5903,18 @@
             }
           }
         },
-        "tags": ["Webhooks"]
+        "tags": ["Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "get": {
         "operationId": "WebhooksController_getWebhook",
         "summary": "Get a webhook",
         "parameters": [
           {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "webhookId",
             "required": true,
             "in": "path",
@@ -6327,22 +5935,18 @@
             }
           }
         },
-        "tags": ["Webhooks"]
+        "tags": ["Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "WebhooksController_deleteWebhook",
         "summary": "Delete a webhook",
         "parameters": [
           {
-            "name": "Authorization",
-            "in": "header",
-            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "webhookId",
             "required": true,
             "in": "path",
@@ -6363,7 +5967,12 @@
             }
           }
         },
-        "tags": ["Webhooks"]
+        "tags": ["Webhooks"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     }
   },
@@ -6376,6 +5985,14 @@
   "tags": [],
   "servers": [],
   "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "type": "http",
+        "description": "Enter your API key or access token prefixed with `Bearer `"
+      }
+    },
     "schemas": {
       "OAuth2ClientDto": {
         "type": "object",
@@ -15194,7 +14811,6 @@
                 "MEETING_ENDED",
                 "MEETING_STARTED",
                 "RECORDING_READY",
-                "INSTANT_MEETING",
                 "RECORDING_TRANSCRIPTION_GENERATED",
                 "OOO_CREATED",
                 "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
@@ -15242,7 +14858,6 @@
                 "MEETING_ENDED",
                 "MEETING_STARTED",
                 "RECORDING_READY",
-                "INSTANT_MEETING",
                 "RECORDING_TRANSCRIPTION_GENERATED",
                 "OOO_CREATED",
                 "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
@@ -15326,7 +14941,6 @@
                 "MEETING_ENDED",
                 "MEETING_STARTED",
                 "RECORDING_READY",
-                "INSTANT_MEETING",
                 "RECORDING_TRANSCRIPTION_GENERATED",
                 "OOO_CREATED",
                 "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
@@ -15390,7 +15004,6 @@
                 "MEETING_ENDED",
                 "MEETING_STARTED",
                 "RECORDING_READY",
-                "INSTANT_MEETING",
                 "RECORDING_TRANSCRIPTION_GENERATED",
                 "OOO_CREATED",
                 "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
@@ -15489,7 +15102,6 @@
                 "MEETING_ENDED",
                 "MEETING_STARTED",
                 "RECORDING_READY",
-                "INSTANT_MEETING",
                 "RECORDING_TRANSCRIPTION_GENERATED",
                 "OOO_CREATED",
                 "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",


### PR DESCRIPTION
Swagger UI silently drops Authorization headers defined via @ApiHeader 
per the OpenAPI spec. Replace all instances with @ApiBearerAuth and 
register bearerAuth security scheme in DocumentBuilder so tokens are 
correctly sent in requests.

Fixes #29564

## What does this PR do?

- Replaces all `@ApiHeader(AUTH_HEADER)` decorators with `@ApiBearerAuth("bearerAuth")` across all API v2 controllers
- Registers `bearerAuth` security scheme via `addBearerAuth()` in `DocumentBuilder`
- Removes now-unused Authorization header constants from imports

## Visual Demo

**Before:** Authorization header was silently dropped — never included in requests:
````curl -X 'GET' 'http://localhost:5555/v2/bookings' -H 'accept: application/json'```

**After:** Authorization header is correctly sent with every request:
```curl -X 'GET' 'http://localhost:5555/v2/bookings' -H 'accept: application/json' -H 'Authorization: Bearer cal_xxx'```

<img width="1523" height="931" alt="Screenshot From 2026-06-15 10-47-11" src="https://github.com/user-attachments/assets/067c97e6-fa63-4f3f-8469-dafdae9d4c52" />
<img width="1523" height="931" alt="Screenshot From 2026-06-15 10-52-28" src="https://github.com/user-attachments/assets/91013347-bb74-4ebf-a7af-ea9e12b97247" />
<img width="1523" height="931" alt="Screenshot From 2026-06-15 10-55-35" src="https://github.com/user-attachments/assets/ba881201-a574-4ae7-bc63-61cb90539698" />
<img width="1523" height="931" alt="Screenshot From 2026-06-15 10-55-45" src="https://github.com/user-attachments/assets/04cc67f4-97df-4bea-8db1-9b33ecfa3059" />
<img width="1728" height="952" alt="Screenshot From 2026-06-15 11-06-23" src="https://github.com/user-attachments/assets/16cec86e-4bf0-492c-8a32-5c7d164c1fdd" />
<img width="1728" height="952" alt="Screenshot From 2026-06-15 11-06-38" src="https://github.com/user-attachments/assets/9ad57631-8c16-49e1-8d23-77c0dbc5aa9c" />
<img width="1728" height="952" alt="Screenshot From 2026-06-15 11-07-30" src="https://github.com/user-attachments/assets/85c132b4-d62c-4549-8ae3-9241f62a725d" />

```