### PR TITLE
fix: send test push notification to configured WEBAPP_URL

### DIFF
--- a/packages/trpc/server/routers/loggedInViewer/addNotificationsSubscription.handler.test.ts
+++ b/packages/trpc/server/routers/loggedInViewer/addNotificationsSubscription.handler.test.ts
@@ -1,0 +1,63 @@
+import { prisma } from "@calcom/prisma/__mocks__/prisma";
+import type { TrpcSessionUser } from "@calcom/trpc/server/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addNotificationsSubscriptionHandler } from "./addNotificationsSubscription.handler";
+
+vi.mock("@calcom/prisma", () => ({
+  default: prisma,
+  prisma,
+}));
+
+const { SELF_HOSTED_URL, sendNotificationMock } = vi.hoisted(() => ({
+  SELF_HOSTED_URL: "https://cal.example.com",
+  sendNotificationMock: vi.fn(),
+}));
+
+vi.mock("@calcom/features/notifications/sendNotification", () => ({
+  sendNotification: (...args: unknown[]) => sendNotificationMock(...args),
+}));
+
+vi.mock("@calcom/lib/constants", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@calcom/lib/constants")>();
+  return { ...actual, WEBAPP_URL: SELF_HOSTED_URL };
+});
+
+const VALID_SUBSCRIPTION = JSON.stringify({
+  endpoint: "https://push.example.com/sub-1",
+  keys: { auth: "auth-key", p256dh: "p256dh-key" },
+});
+
+function createMockUser() {
+  return { id: 1 } as unknown as NonNullable<TrpcSessionUser>;
+}
+
+describe("addNotificationsSubscription.handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.notificationsSubscriptions.findFirst.mockResolvedValue(null);
+    prisma.notificationsSubscriptions.create.mockResolvedValue({} as never);
+  });
+
+  it("sends the test notification to the configured WEBAPP_URL, not a hardcoded cal.com URL", async () => {
+    await addNotificationsSubscriptionHandler({
+      ctx: { user: createMockUser() },
+      input: { subscription: VALID_SUBSCRIPTION },
+    });
+
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    const payload = sendNotificationMock.mock.calls[0][0];
+    expect(payload.url).toBe(SELF_HOSTED_URL);
+    expect(payload.url).not.toBe("https://app.cal.com/");
+  });
+
+  it("throws a BAD_REQUEST instead of an uncaught error when the subscription is not valid JSON", async () => {
+    await expect(
+      addNotificationsSubscriptionHandler({
+        ctx: { user: createMockUser() },
+        input: { subscription: "not-json{" },
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/trpc/server/routers/loggedInViewer/addNotificationsSubscription.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/addNotificationsSubscription.handler.ts
@@ -7,13 +7,13 @@ const subscriptionSchema = z.object({
     p256dh: z.string(),
   }),
 });
+
 import { sendNotification } from "@calcom/features/notifications/sendNotification";
+import { WEBAPP_URL } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
 import prisma from "@calcom/prisma";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
-
 import { TRPCError } from "@trpc/server";
-
 import type { TAddNotificationsSubscriptionInputSchema } from "./addNotificationsSubscription.schema";
 
 type AddSecondaryEmailOptions = {
@@ -29,7 +29,18 @@ export const addNotificationsSubscriptionHandler = async ({ ctx, input }: AddSec
   const { user } = ctx;
   const { subscription } = input;
 
-  const parsedSubscription = subscriptionSchema.safeParse(JSON.parse(subscription));
+  let subscriptionJson: unknown;
+  try {
+    subscriptionJson = JSON.parse(subscription);
+  } catch (error) {
+    log.error("Invalid subscription JSON", error);
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid subscription",
+    });
+  }
+
+  const parsedSubscription = subscriptionSchema.safeParse(subscriptionJson);
 
   if (!parsedSubscription.success) {
     log.error("Invalid subscription", parsedSubscription.error, JSON.stringify(subscription));
@@ -65,7 +76,7 @@ export const addNotificationsSubscriptionHandler = async ({ ctx, input }: AddSec
     },
     title: "Test Notification",
     body: "Push Notifications activated successfully",
-    url: "https://app.cal.com/",
+    url: WEBAPP_URL,
     requireInteraction: false,
     type: "TEST_NOTIFICATION",
   });


### PR DESCRIPTION
## What does this PR do?

The "Test Notification" that fires when you enable push notifications hardcodes `url: "https://app.cal.com/"`. The service worker opens that `data.url` on click, so on a self-hosted instance the test notification sends users to cal.com instead of their own deployment. It's the only call site that hardcodes the app URL, so I switched it to `WEBAPP_URL` from `@calcom/lib/constants`, like everywhere else.

I also wrapped the subscription `JSON.parse` in a try/catch so a malformed body returns a clean `BAD_REQUEST` instead of an uncaught 500.

- Fixes #29567

## Visual Demo (For contributors especially)

No visual change here. This only swaps the test push notification's target URL (`https://app.cal.com` → the instance's configured `WEBAPP_URL`). The difference is the URL the notification opens on click, which isn't visible in the UI, so there's nothing to screenshot. It's covered by a unit test instead.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A (no doc-facing change).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

On a self-hosted instance with `WEBAPP_URL` set to a non-cal.com URL, enable push notifications and trigger the test notification; clicking it should open the configured `WEBAPP_URL`, not `https://app.cal.com`. The added unit test asserts the test-notification payload uses `WEBAPP_URL`, and that a malformed subscription body returns `BAD_REQUEST`.

## Checklist

- N/A
