### PR TITLE
fix(slots): respect afterEventBuffer of bookings just before the requested range

### DIFF
--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -1422,6 +1422,69 @@ describe("getSchedule", () => {
       );
     });
 
+    // Regression test for #29532: when the slots query starts mid-day, an earlier
+    // booking whose afterEventBuffer reaches into the requested range must still
+    // block the buffered slots, even though the booking itself ends before the range.
+    test("afterBuffer of a booking that ends before the requested range still blocks slots", async () => {
+      const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
+
+      CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
+
+      const scenarioData = {
+        eventTypes: [
+          {
+            id: 1,
+            length: 30,
+            slotInterval: 30,
+            beforeEventBuffer: 0,
+            afterEventBuffer: 60,
+            users: [{ id: 101 }],
+          },
+        ],
+        users: [
+          {
+            ...TestData.users.example,
+            id: 101,
+            schedules: [TestData.schedules.IstWorkHours],
+            credentials: [getGoogleCalendarCredential()],
+            selectedCalendars: [TestData.selectedCalendars.google],
+          },
+        ],
+        bookings: [
+          {
+            userId: 101,
+            eventTypeId: 1,
+            // Ends at 04:00; a 60 min afterEventBuffer keeps the host busy until 05:00.
+            startTime: `${plus2DateString}T03:30:00.000Z`,
+            endTime: `${plus2DateString}T04:00:00.000Z`,
+            status: "ACCEPTED" as BookingStatus,
+          },
+        ],
+        apps: [TestData.apps["google-calendar"]],
+      };
+
+      await createBookingScenario(scenarioData);
+
+      const schedule = await availableSlotsService.getAvailableSlots({
+        input: {
+          eventTypeId: 1,
+          eventTypeSlug: "",
+          // Range starts after the booking ends but inside its afterEventBuffer.
+          startTime: `${plus2DateString}T04:05:00.000Z`,
+          endTime: `${plus2DateString}T07:00:00.000Z`,
+          timeZone: Timezones["+5:30"],
+          isTeamEvent: false,
+          orgSlug: null,
+        },
+      });
+
+      // `04:30:00.000Z` is inside the buffer (04:00-05:00) and must not be offered.
+      expect(schedule).toHaveTimeSlots([`05:00:00.000Z`, `05:30:00.000Z`, `06:00:00.000Z`, `06:30:00.000Z`], {
+        dateString: plus2DateString,
+        doExactMatch: true,
+      });
+    });
+
     test("Start times are offset (offsetStart)", async () => {
       const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
       const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -37,6 +37,7 @@ import type { BookingRepository } from "@calcom/features/bookings/repositories/B
 import type { BusyTimesService } from "@calcom/features/busyTimes/services/getBusyTimes";
 import type { getBusyTimesService } from "@calcom/features/di/containers/BusyTimes";
 import { getDefaultEvent } from "@calcom/features/eventtypes/lib/defaultEvents";
+import { getDefinedBufferTimes } from "@calcom/features/eventtypes/lib/getDefinedBufferTimes";
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import type { PrismaOOORepository } from "@calcom/features/ooo/repositories/PrismaOOORepository";
 import type { IRedisService } from "@calcom/features/redis/IRedisService";
@@ -725,11 +726,20 @@ export class AvailableSlotsService {
     const userIdAndEmailMap = new Map(usersWithCredentials.map((user) => [user.id, user.email]));
     const allUserIds = Array.from(userIdAndEmailMap.keys());
 
+    // Widen the prefetch window by the largest possible buffer so that bookings ending
+    // before the requested range, whose afterEventBuffer reaches into it, are still
+    // fetched. getBusyTimes already widens this way; without it those buffers are
+    // dropped and the slots endpoint offers times that booking validation rejects (#29532).
+    const definedBufferTimes = getDefinedBufferTimes();
+    const maxBuffer = definedBufferTimes[definedBufferTimes.length - 1];
+    const bookingsStartDate = dayjs(startTimeDate).subtract(maxBuffer, "minute").toDate();
+    const bookingsEndDate = dayjs(endTimeDate).add(maxBuffer, "minute").toDate();
+
     const bookingRepo = this.dependencies.bookingRepo;
     const [currentBookingsAllUsers, outOfOfficeDaysAllUsers] = await Promise.all([
       bookingRepo.findAllExistingBookingsForEventTypeBetween({
-        startDate: startTimeDate,
-        endDate: endTimeDate,
+        startDate: bookingsStartDate,
+        endDate: bookingsEndDate,
         eventTypeId: eventType.id,
         seatedEvent: Boolean(eventType.seatsPerTimeSlot),
         userIdAndEmailMap,


### PR DESCRIPTION
The slots endpoint prefetches existing bookings using the raw requested window and passes them to `getBusyTimes` as `currentBookings`, which then skips its own buffer-widened query. So a booking that ends just before the range but whose `afterEventBuffer` reaches into it never gets fetched, its buffer isn't applied, and we offer a slot that booking validation then rejects with `no_available_users_found_error` (after the booker may have already paid).

Fix: widen the prefetch window by the max defined buffer on both sides, same as `getBusyTimes` already does. Added a `getSchedule` regression test.

Closes #29532
