### PR TITLE
fix: support @cal.diy iCalUIDs in calendar sync

### DIFF
--- a/packages/features/calendar-subscription/lib/sync/CalendarSyncService.ts
+++ b/packages/features/calendar-subscription/lib/sync/CalendarSyncService.ts
@@ -42,10 +42,10 @@ export class CalendarSyncService {
       },
     });
 
-    // only process cal.com calendar events
-    const calEvents = calendarSubscriptionEvents.filter((e) =>
-      e.iCalUID?.toLowerCase()?.endsWith("@cal.com")
-    );
+    const calEvents = calendarSubscriptionEvents.filter((e) =>{
+      const uid = e.iCalUID?.toLowerCase();
+      return uid?.endsWith("@cal.com") || uid?.endsWith("@cal.diy");
+  });
 
     metrics.distribution("calendar.sync.handleEvents.events_count", calEvents.length, {
       attributes: {

--- a/packages/features/calendar-subscription/lib/sync/__tests__/CalendarSyncService.test.ts
+++ b/packages/features/calendar-subscription/lib/sync/__tests__/CalendarSyncService.test.ts
@@ -96,7 +96,7 @@ const mockBooking = {
 
 const mockCalComEvent: CalendarSubscriptionEventItem = {
   id: "event-1",
-  iCalUID: "test-booking-uid@cal.com",
+  iCalUID: "test-booking-uid@Cal.diy",
   start: new Date("2023-12-01T10:00:00Z"),
   end: new Date("2023-12-01T11:00:00Z"),
   busy: true,
@@ -137,7 +137,7 @@ const mockNonCalComEvent: CalendarSubscriptionEventItem = {
 const mockCancelledEvent: CalendarSubscriptionEventItem = {
   ...mockCalComEvent,
   id: "event-3",
-  iCalUID: "cancelled-booking-uid@cal.com",
+  iCalUID: "cancelled-booking-uid@Cal.diy",
   status: "cancelled",
 };
 
@@ -194,7 +194,7 @@ describe("CalendarSyncService", () => {
     test("should handle mixed case iCalUID", async () => {
       const eventWithMixedCase: CalendarSubscriptionEventItem = {
         ...mockCalComEvent,
-        iCalUID: "test-booking-uid@CAL.COM",
+        iCalUID: "test-booking-uid@CAL.DIY",
       };
 
       mockBookingRepository.findBookingByUidWithEventType = vi.fn().mockResolvedValue(mockBooking);


### PR DESCRIPTION
What does this PR do?

Fixes #29575

Calendar subscription sync currently only processes events whose iCalUID ends with @cal.com.

In default Cal.diy deployments, booking iCalUIDs are generated using the configured app name and commonly use the @Cal.diy suffix. Because of the strict @cal.com filter, valid Cal.diy booking events were ignored during calendar subscription sync and did not trigger booking cancellation or rescheduling workflows.

This PR updates the calendar sync filter to recognize both:

* @cal.com
* @cal.diy

while continuing to ignore external calendar events.

Additionally, regression tests were added to verify support for:

* Cal.diy iCalUIDs
* Legacy @cal.com iCalUIDs
* Mixed-case @CAL.DIY iCalUIDs

Visual Demo (For contributors especially)

N/A – backend-only change with no UI impact.

Mandatory Tasks (DO NOT REMOVE)

* I have self-reviewed the code (A decent size PR without self-review might be rejected).
* I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
* I confirm automated tests are in place that prove my fix is effective or that my feature works.

How should this be tested?

Run:

yarn test packages/features/calendar-subscription/lib/sync/__tests__/CalendarSyncService.test.ts

Verify all tests pass successfully.

Environment Variables

No additional environment variables are required.

Minimal Test Data

Valid iCalUID examples:

* test-booking-uid@cal.com
* test-booking-uid@cal.diy
* test-booking-uid@CAL.DIY

Invalid/external example:

* external-event@external.com

Expected Behavior

Events with:

* @cal.com
* @cal.diy
* mixed-case variants such as @CAL.DIY

should be processed by CalendarSyncService.

Events from external providers should continue to be ignored.

Checklist

* I have read the contributing guide.
* My code follows the style guidelines of this project.
* I have checked that my changes generate no new warnings.
* This PR is small and focused.