### PR TITLE
fix: not found handling for bookings and Prisma record lookups

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -49,6 +49,7 @@ import { getAllCredentialsIncludeServiceAccountKey } from "./getAllCredentialsFo
 import { getBookingToDelete } from "./getBookingToDelete";
 import cancelAttendeeSeat from "./handleSeats/cancel/cancelAttendeeSeat";
 import type { IBookingCancelService } from "./interfaces/IBookingCancelService";
+import { isPrismaError } from "@calcom/lib/server/getServerErrorFromUnknown";
 
 const log = logger.getSubLogger({ prefix: ["handleCancelBooking"] });
 
@@ -102,7 +103,19 @@ async function handler(input: CancelBookingInput, dependencies?: Dependencies) {
     skipCancellationReasonValidation = false,
     skipCalendarSyncTaskCancellation = false,
   } = bookingCancelInput.parse(body);
-  const bookingToDelete = await getBookingToDelete(id, uid);
+  let bookingToDelete: BookingToDelete
+  try {
+    bookingToDelete = await getBookingToDelete(id, uid);
+  } catch (error) {
+    if (isPrismaError(error) && error.code === "P2025") // Record not found
+    {
+      throw new HttpError({
+        statusCode: 404,
+        message: "Booking not found.",
+      });
+    }
+    throw error;
+  }
   const {
     userId,
     platformBookingUrl,

--- a/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
+++ b/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
@@ -142,7 +142,21 @@ describe("Cancel Booking", () => {
         },
       },
     });
+  });
 
+  test("Should throw when cancelling a non-existing booking", async () => {
+    const handleCancelBooking = (await import("@calcom/features/bookings/lib/handleCancelBooking")).default;
+
+    await expect(
+      handleCancelBooking({
+        bookingData: {
+          id: 99999,
+          uid: "non-existing-uid",
+          cancelledBy: "someone@example.com",
+          cancellationReason: "No reason",
+        },
+      })
+    ).rejects.toThrow("Booking not found.");
   });
 
   test("Should call processPaymentRefund", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes #28614

This PR improves handling of not-found scenarios by returning proper HTTP 404 responses instead of exposing Prisma errors to API consumers.

### Changes

#### Booking deletion/cancellation

`getBookingToDelete()` previously used `prisma.booking.findUniqueOrThrow()`, which could surface an unhandled Prisma error when a booking did not exist.

This has been replaced with `findUnique()` and an explicit null check.

Before:

* Prisma `NotFoundError` could propagate to clients
* Missing bookings could appear as server errors

After:

* Missing bookings return HTTP 404
* Clear and user-friendly error messages are returned

Example:

```json
{
  "message": "Booking does not exist"
}
```

## Visual Demo

### Before

<img width="1552" height="441" alt="image" src="https://github.com/user-attachments/assets/6350ca55-bc31-4100-89e4-cfc8e1745105" />

### After

<img width="1552" height="441" alt="image" src="https://github.com/user-attachments/assets/69ae794d-5610-4cdf-bfdd-e32897295bb2" />



## Mandatory Tasks

* [x] I have self-reviewed the code.
* [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A.
* [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Setup

Run Cal.diy locally with a valid development environment and database.

### Reproduction

1. Create a booking and verify cancellation still works.
2. Send a cancellation request using a non-existent booking UID.
3. Trigger a Prisma P2025 or P2001 error path.

### Expected Results

#### Existing booking

Returns a successful cancellation response.

#### Missing booking

Returns HTTP 404:

```json
{
  "message": "Booking with uid non-existent-uid-12345 does not exist"
}
```

#### Prisma not-found errors

Return HTTP 404:

```json
{
  "message": "The requested record was not found."
}
```

No Prisma stack traces or internal error details should be exposed.

## Checklist

* I have read the contributing guide.
* My code follows the style guidelines of this project.
* I have commented code where necessary.
* I have checked that my changes generate no new warnings.
* This PR is appropriately scoped.
