### PR TITLE
fix: correct Basecamp3 refresh token request

### DIFF
--- a/packages/app-store/basecamp3/lib/helpers.test.ts
+++ b/packages/app-store/basecamp3/lib/helpers.test.ts
@@ -1,0 +1,116 @@
+import type { CredentialPayload } from "@calcom/types/Credential";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { refreshAccessToken } from "./helpers";
+import type { BasecampToken } from "./types";
+
+const {
+  mockGetBasecampKeys,
+  mockCredentialUpdate,
+}: {
+  mockGetBasecampKeys: ReturnType<typeof vi.fn>;
+  mockCredentialUpdate: ReturnType<typeof vi.fn>;
+} = vi.hoisted(() => ({
+  mockGetBasecampKeys: vi.fn(),
+  mockCredentialUpdate: vi.fn(),
+}));
+
+vi.mock("./getBasecampKeys", () => ({
+  getBasecampKeys: mockGetBasecampKeys,
+}));
+
+vi.mock("@calcom/prisma", () => ({
+  prisma: {
+    credential: {
+      update: mockCredentialUpdate,
+    },
+  },
+}));
+
+const baseCredentialKey: BasecampToken = {
+  projectId: 123,
+  expires_at: 1700000000000,
+  expires_in: 1209600,
+  scheduleId: 456,
+  access_token: "old-access-token",
+  refresh_token: "refresh-token-with symbols",
+  account: {
+    id: 789,
+    href: "https://3.basecampapi.com/789",
+    name: "Example account",
+    hidden: false,
+    product: "bc3",
+    app_href: "https://3.basecamp.com/789",
+  },
+};
+
+const credential = {
+  id: 42,
+  key: baseCredentialKey,
+} as unknown as CredentialPayload;
+
+describe("refreshAccessToken", () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    vi.spyOn(Date, "now").mockReturnValue(1710000000000);
+    mockGetBasecampKeys.mockResolvedValue({
+      client_id: "basecamp-client-id",
+      client_secret: "basecamp-client-secret",
+      user_agent: "cal-diy-test-agent",
+    });
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        access_token: "new-access-token",
+        refresh_token: "new-refresh-token",
+        expires_in: 1209600,
+      }),
+    });
+    mockCredentialUpdate.mockImplementation(async ({ data }) => ({ key: data.key }));
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes tokens using Basecamp's documented refresh-token request", async () => {
+    await refreshAccessToken(credential);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [refreshUrl, requestInit] = mockFetch.mock.calls[0];
+    const parsedRefreshUrl = new URL(refreshUrl);
+
+    expect(parsedRefreshUrl.origin + parsedRefreshUrl.pathname).toBe(
+      "https://launchpad.37signals.com/authorization/token"
+    );
+    expect(parsedRefreshUrl.searchParams.get("type")).toBe("refresh");
+    expect(parsedRefreshUrl.searchParams.get("refresh_token")).toBe(baseCredentialKey.refresh_token);
+    expect(parsedRefreshUrl.searchParams.get("client_id")).toBe("basecamp-client-id");
+    expect(parsedRefreshUrl.searchParams.get("client_secret")).toBe("basecamp-client-secret");
+    expect(parsedRefreshUrl.searchParams.has("redirect_uri")).toBe(false);
+    expect(requestInit).toEqual({
+      method: "POST",
+      headers: { "User-Agent": "cal-diy-test-agent" },
+    });
+  });
+
+  it("stores the refreshed token data on the existing credential", async () => {
+    const refreshedKey = await refreshAccessToken(credential);
+
+    const expectedKey = {
+      ...baseCredentialKey,
+      access_token: "new-access-token",
+      refresh_token: "new-refresh-token",
+      expires_in: 1209600,
+      expires_at: 1710000000000 + 1000 * 3600 * 24 * 14,
+    };
+
+    expect(mockCredentialUpdate).toHaveBeenCalledWith({
+      where: { id: credential.id },
+      data: { key: expectedKey },
+    });
+    expect(refreshedKey).toEqual(expectedKey);
+  });
+});

--- a/packages/app-store/basecamp3/lib/helpers.test.ts
+++ b/packages/app-store/basecamp3/lib/helpers.test.ts
@@ -1,3 +1,4 @@
+import { ErrorCode } from "@calcom/lib/errorCodes";
 import type { CredentialPayload } from "@calcom/types/Credential";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { refreshAccessToken } from "./helpers";
@@ -53,6 +54,9 @@ describe("refreshAccessToken", () => {
   const originalFetch = global.fetch;
 
   beforeEach(() => {
+    mockFetch.mockReset();
+    mockGetBasecampKeys.mockReset();
+    mockCredentialUpdate.mockReset();
     global.fetch = mockFetch;
     vi.spyOn(Date, "now").mockReturnValue(1710000000000);
     mockGetBasecampKeys.mockResolvedValue({
@@ -61,6 +65,9 @@ describe("refreshAccessToken", () => {
       user_agent: "cal-diy-test-agent",
     });
     mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
       json: async () => ({
         access_token: "new-access-token",
         refresh_token: "new-refresh-token",
@@ -94,6 +101,30 @@ describe("refreshAccessToken", () => {
       method: "POST",
       headers: { "User-Agent": "cal-diy-test-agent" },
     });
+  });
+
+  it("does not update the credential when the refresh request fails", async () => {
+    const json = vi.fn(async () => ({
+      error: "invalid_grant",
+    }));
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json,
+    });
+
+    await expect(refreshAccessToken(credential)).rejects.toMatchObject({
+      code: ErrorCode.InternalServerError,
+      message: "Failed to refresh Basecamp token: 401 Unauthorized",
+      data: {
+        status: 401,
+        statusText: "Unauthorized",
+      },
+    });
+
+    expect(json).not.toHaveBeenCalled();
+    expect(mockCredentialUpdate).not.toHaveBeenCalled();
   });
 
   it("stores the refreshed token data on the existing credential", async () => {

--- a/packages/app-store/basecamp3/lib/helpers.ts
+++ b/packages/app-store/basecamp3/lib/helpers.ts
@@ -1,3 +1,5 @@
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import { prisma } from "@calcom/prisma";
 import type { CredentialPayload } from "@calcom/types/Credential";
 import { getBasecampKeys } from "./getBasecampKeys";
@@ -18,6 +20,17 @@ export const refreshAccessToken = async (credential: CredentialPayload): Promise
     method: "POST",
     headers: { "User-Agent": userAgent },
   });
+  if (!tokenInfo.ok) {
+    const status = [tokenInfo.status, tokenInfo.statusText].filter(Boolean).join(" ");
+    let message = "Failed to refresh Basecamp token";
+    if (status) {
+      message = `${message}: ${status}`;
+    }
+    throw new ErrorWithCode(ErrorCode.InternalServerError, message, {
+      status: tokenInfo.status,
+      statusText: tokenInfo.statusText,
+    });
+  }
   const tokenInfoJson = (await tokenInfo.json()) as BasecampRefreshTokenResponse;
   const refreshedToken: BasecampToken = {
     ...credentialKey,

--- a/packages/app-store/basecamp3/lib/helpers.ts
+++ b/packages/app-store/basecamp3/lib/helpers.ts
@@ -1,24 +1,34 @@
-import { WEBAPP_URL } from "@calcom/lib/constants";
 import { prisma } from "@calcom/prisma";
 import type { CredentialPayload } from "@calcom/types/Credential";
-
 import { getBasecampKeys } from "./getBasecampKeys";
 import type { BasecampToken } from "./types";
 
-export const refreshAccessToken = async (credential: CredentialPayload) => {
+type BasecampRefreshTokenResponse = Pick<BasecampToken, "access_token" | "refresh_token" | "expires_in">;
+
+export const refreshAccessToken = async (credential: CredentialPayload): Promise<BasecampToken> => {
   const { client_id: clientId, client_secret: clientSecret, user_agent: userAgent } = await getBasecampKeys();
   const credentialKey = credential.key as BasecampToken;
-  const tokenInfo = await fetch(
-    `https://launchpad.37signals.com/authorization/token?type=refresh&refresh_token=${credentialKey.refresh_token}&client_id=${clientId}&redirect_uri=${WEBAPP_URL}&client_secret=${clientSecret}`,
-    { method: "POST", headers: { "User-Agent": userAgent } }
-  );
-  const tokenInfoJson = await tokenInfo.json();
-  tokenInfoJson["expires_at"] = Date.now() + 1000 * 3600 * 24 * 14;
-  const newCredential = await prisma.credential.update({
+  const params = new URLSearchParams({
+    type: "refresh",
+    refresh_token: credentialKey.refresh_token,
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+  const tokenInfo = await fetch(`https://launchpad.37signals.com/authorization/token?${params.toString()}`, {
+    method: "POST",
+    headers: { "User-Agent": userAgent },
+  });
+  const tokenInfoJson = (await tokenInfo.json()) as BasecampRefreshTokenResponse;
+  const refreshedToken: BasecampToken = {
+    ...credentialKey,
+    ...tokenInfoJson,
+    expires_at: Date.now() + 1000 * 3600 * 24 * 14,
+  };
+  await prisma.credential.update({
     where: { id: credential.id },
     data: {
-      key: { ...credentialKey, ...tokenInfoJson },
+      key: refreshedToken,
     },
   });
-  return newCredential.key;
+  return refreshedToken;
 };


### PR DESCRIPTION
## Summary

Fixes #29585

- Remove the incorrect `redirect_uri` parameter from Basecamp3 refresh-token requests
- Build the refresh-token request with `URLSearchParams` so credential values are encoded safely
- Add focused unit coverage for the refresh request shape and credential update behavior

## Root Cause

The Basecamp3 OAuth callback used the correct callback URL during the initial token exchange, but the refresh-token helper sent `redirect_uri` as the app root URL. Basecamp's documented refresh-token request only requires `type=refresh`, `refresh_token`, `client_id`, and `client_secret`.

## Testing

- `yarn biome check --write packages/app-store/basecamp3/lib/helpers.ts packages/app-store/basecamp3/lib/helpers.test.ts`
- `yarn vitest run packages/app-store/basecamp3/lib/helpers.test.ts`