### PR TITLE
fix(google-calendar): retry PATCH requests and 403 rate-limit errors

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarAuth.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarAuth.ts
@@ -27,6 +27,23 @@ import { getGoogleAppKeys } from "./getGoogleAppKeys";
 type DelegatedTo = NonNullable<CredentialForCalendarServiceWithEmail["delegatedTo"]>;
 const log = logger.getSubLogger({ prefix: ["app-store/googlecalendar/lib/CalendarAuth"] });
 
+// gaxios (the HTTP client behind googleapis) does not retry PATCH or HTTP 403 by default. Creating a
+// Google Calendar event does an insert (POST) followed by a PATCH to add description/location/
+// conferenceData, and Google returns 403 for rateLimitExceeded
+// (https://developers.google.com/workspace/calendar/api/guides/errors). A transient 403 on that PATCH
+// was therefore never retried, silently desyncing the calendar event from the booking. PATCH is
+// idempotent so retrying it is safe; POST/insert is intentionally left out to avoid duplicate events.
+const GOOGLE_CALENDAR_RETRY_CONFIG = {
+  retry: 3,
+  httpMethodsToRetry: ["GET", "HEAD", "PUT", "OPTIONS", "DELETE", "PATCH"],
+  statusCodesToRetry: [
+    [100, 199],
+    [403, 403],
+    [429, 429],
+    [500, 599],
+  ],
+};
+
 class MyGoogleOAuth2Client extends OAuth2Client {
   constructor(client_id: string, client_secret: string, redirect_uri: string) {
     super({
@@ -303,6 +320,7 @@ export class CalendarAuth {
 
     return new calendar_v3.Calendar({
       auth: googleAuthClient,
+      retryConfig: GOOGLE_CALENDAR_RETRY_CONFIG,
     });
   }
 }

--- a/packages/app-store/googlecalendar/lib/CalendarAuth.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarAuth.ts
@@ -33,12 +33,14 @@ const log = logger.getSubLogger({ prefix: ["app-store/googlecalendar/lib/Calenda
 // (https://developers.google.com/workspace/calendar/api/guides/errors). A transient 403 on that PATCH
 // was therefore never retried, silently desyncing the calendar event from the booking. PATCH is
 // idempotent so retrying it is safe; POST/insert is intentionally left out to avoid duplicate events.
+// 408 (request timeout) is also included as a transient, retryable status alongside gaxios's defaults.
 const GOOGLE_CALENDAR_RETRY_CONFIG = {
   retry: 3,
   httpMethodsToRetry: ["GET", "HEAD", "PUT", "OPTIONS", "DELETE", "PATCH"],
   statusCodesToRetry: [
     [100, 199],
     [403, 403],
+    [408, 408],
     [429, 429],
     [500, 599],
   ],

--- a/packages/app-store/googlecalendar/lib/__tests__/CalendarService.auth.test.ts
+++ b/packages/app-store/googlecalendar/lib/__tests__/CalendarService.auth.test.ts
@@ -328,5 +328,6 @@ describe("GoogleCalendarService retry configuration", () => {
     expect(retryConfig?.httpMethodsToRetry).toContain("PATCH");
     expect(retryConfig?.httpMethodsToRetry).not.toContain("POST");
     expect(retryConfig?.statusCodesToRetry).toContainEqual([403, 403]);
+    expect(retryConfig?.statusCodesToRetry).toContainEqual([408, 408]);
   });
 });

--- a/packages/app-store/googlecalendar/lib/__tests__/CalendarService.auth.test.ts
+++ b/packages/app-store/googlecalendar/lib/__tests__/CalendarService.auth.test.ts
@@ -193,9 +193,11 @@ describe("GoogleCalendarService credential handling", () => {
 
       expectOAuth2InstanceToBeCreated();
 
-      expect(calendarMock.calendar_v3.Calendar).toHaveBeenCalledWith({
-        auth: getLastCreatedOAuth2Client(),
-      });
+      expect(calendarMock.calendar_v3.Calendar).toHaveBeenCalledWith(
+        expect.objectContaining({
+          auth: getLastCreatedOAuth2Client(),
+        })
+      );
       await expectCredentialsInDb([
         expect.objectContaining({
           id: regularCredential.id,
@@ -308,5 +310,23 @@ describe("GoogleCalendarService credential handling", () => {
       await calendarService.listCalendars();
       expectOAuth2InstanceToBeCreated();
     });
+  });
+});
+
+describe("GoogleCalendarService retry configuration", () => {
+  test("retries PATCH requests and 403 rate-limit errors, but not POST", async () => {
+    const regularCredential = await createCredentialForCalendarService();
+    mockSuccessfulCalendarListFetch();
+    const calendarService = BuildCalendarService(regularCredential);
+    await calendarService.listCalendars();
+
+    const lastCall = calendarMock.calendar_v3.Calendar.mock.calls.at(-1);
+    const retryConfig = lastCall?.[0]?.retryConfig;
+    expect(retryConfig).toBeDefined();
+
+    // PATCH (idempotent) and 403 rate-limit errors are retried; POST/insert is not (avoids duplicate events)
+    expect(retryConfig?.httpMethodsToRetry).toContain("PATCH");
+    expect(retryConfig?.httpMethodsToRetry).not.toContain("POST");
+    expect(retryConfig?.statusCodesToRetry).toContainEqual([403, 403]);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Google Calendar event creation performs an `insert` (POST) followed by a `PATCH` to add metadata such as description, location, and conference data.

The Google Calendar client previously relied on gaxios's default retry configuration, which does not retry `PATCH` requests or HTTP `403` responses. Since Google's `rateLimitExceeded` errors can be returned as either `403` or `429`, a transient `403` during the follow-up `PATCH` was never retried, causing the calendar event to become out of sync with the booking while the booking itself still appeared successful.

This PR adds an explicit `retryConfig` to the Google Calendar client that:

* Adds `PATCH` to `httpMethodsToRetry`
* Adds `403` to `statusCodesToRetry`

`POST` requests remain intentionally excluded to avoid duplicate event creation.

* Fixes #28834

## Visual Demo (For contributors especially)

No UI changes. This is a backend integration fix.

**Before**

```ts
httpMethodsToRetry: [GET, HEAD, PUT, OPTIONS, DELETE]
statusCodesToRetry: [[100,199], [429,429], [500,599]]
```

**After**

```ts
httpMethodsToRetry: [GET, HEAD, PUT, OPTIONS, DELETE, PATCH]
statusCodesToRetry: [[100,199], [403,403], [429,429], [500,599]]
```

## Mandatory Tasks (DO NOT REMOVE)

* [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
* [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — **N/A**
* [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

* **Environment variables:** None required.
* **Minimal test data:** None required.
* Run:

```bash
TZ=UTC yarn vitest run packages/app-store/googlecalendar/lib/__tests__/CalendarService.auth.test.ts
```

**Expected result:**

* The calendar client is configured to retry `PATCH` requests.
* HTTP `403` responses are included in retryable status codes.
* `POST` requests are not retried.
* All tests pass.

## Checklist

N/A — contributing guide followed, project style adhered to, no new warnings introduced, and PR size is small.
