### PR TITLE
fix(app-store): explicitly pick safe fields in getConnectedApps

### DIFF
--- a/packages/app-store/_utils/getConnectedApps.test.ts
+++ b/packages/app-store/_utils/getConnectedApps.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PrismaClient } from "@calcom/prisma";
+
+import { getConnectedApps } from "./getConnectedApps";
+
+vi.mock("@calcom/app-store/delegationCredential", () => ({
+  getUsersCredentialsIncludeServiceAccountKey: vi.fn(async () => []),
+}));
+
+vi.mock("./getEnabledAppsFromCredentials", () => ({
+  default: vi.fn(),
+}));
+
+import { getUsersCredentialsIncludeServiceAccountKey } from "@calcom/app-store/delegationCredential";
+
+import getEnabledAppsFromCredentials from "./getEnabledAppsFromCredentials";
+
+const user = {
+  id: 1,
+  name: "Test User",
+  email: "test@example.com",
+  avatarUrl: null,
+} as Parameters<typeof getConnectedApps>[0]["user"];
+
+const baseApp = {
+  slug: "zoom",
+  name: "Zoom",
+  description: "Zoom Video",
+  type: "zoom_video",
+  variant: "conferencing",
+  logo: "/zoom-logo.svg",
+  categories: ["conferencing"],
+  publisher: "Cal.com",
+  url: "https://zoom.us",
+  email: "help@cal.com",
+  isGlobal: false,
+  dirName: "zoomvideo",
+  locationOption: null,
+  enabled: true,
+};
+
+function mockEnabledApps(apps: Record<string, unknown>[]) {
+  vi.mocked(getEnabledAppsFromCredentials).mockResolvedValue(
+    apps as unknown as Awaited<ReturnType<typeof getEnabledAppsFromCredentials>>
+  );
+}
+
+describe("getConnectedApps - field exposure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getUsersCredentialsIncludeServiceAccountKey).mockResolvedValue([]);
+  });
+
+  it("does not leak credentials, credential or key fields to the response", async () => {
+    mockEnabledApps([
+      {
+        ...baseApp,
+        credentials: [{ id: 99, key: { secret: "super-secret" } }],
+        credential: { id: 99, key: { secret: "super-secret" } },
+        key: { apiKey: "global-secret" },
+      },
+    ]);
+
+    const result = await getConnectedApps({ user, input: {}, prisma: {} as PrismaClient });
+    const app = result.items[0];
+
+    expect(app).not.toHaveProperty("credentials");
+    expect(app).not.toHaveProperty("credential");
+    expect(app).not.toHaveProperty("key");
+  });
+
+  it("does not leak an unexpected field added to the app shape (allow-list, not deny-list)", async () => {
+    mockEnabledApps([
+      {
+        ...baseApp,
+        internalSecretField: "should-never-reach-frontend",
+      },
+    ]);
+
+    const result = await getConnectedApps({ user, input: {}, prisma: {} as PrismaClient });
+    const app = result.items[0];
+
+    expect(app).not.toHaveProperty("internalSecretField");
+  });
+
+  it("preserves the safe fields consumers depend on", async () => {
+    mockEnabledApps([baseApp]);
+
+    const result = await getConnectedApps({ user, input: {}, prisma: {} as PrismaClient });
+    const app = result.items[0];
+
+    expect(app.slug).toBe("zoom");
+    expect(app.name).toBe("Zoom");
+    expect(app.description).toBe("Zoom Video");
+    expect(app.type).toBe("zoom_video");
+    expect(app.variant).toBe("conferencing");
+    expect(app.logo).toBe("/zoom-logo.svg");
+    expect(app.categories).toEqual(["conferencing"]);
+    expect(app).toHaveProperty("userCredentialIds");
+    expect(app).toHaveProperty("invalidCredentialIds");
+    expect(app).toHaveProperty("teams");
+    expect(app).toHaveProperty("isInstalled");
+  });
+});

--- a/packages/app-store/_utils/getConnectedApps.ts
+++ b/packages/app-store/_utils/getConnectedApps.ts
@@ -146,9 +146,47 @@ export async function getConnectedApps({
     filterOnCredentials: onlyInstalled,
     ...(appId ? { where: { slug: appId } } : {}),
   });
-  //TODO: Refactor this to pick up only needed fields and prevent more leaking
   let apps = await Promise.all(
-    enabledApps.map(async ({ credentials: _, credential, key: _2 /* don't leak to frontend */, ...app }) => {
+    enabledApps.map(async ({ credential, ...enabledApp }) => {
+      // Allow-list of safe metadata so newly added fields (e.g. credential keys) don't leak to the frontend by default.
+      const app = {
+        installed: enabledApp.installed,
+        type: enabledApp.type,
+        title: enabledApp.title,
+        name: enabledApp.name,
+        description: enabledApp.description,
+        variant: enabledApp.variant,
+        slug: enabledApp.slug,
+        category: enabledApp.category,
+        categories: enabledApp.categories,
+        extendsFeature: enabledApp.extendsFeature,
+        logo: enabledApp.logo,
+        publisher: enabledApp.publisher,
+        url: enabledApp.url,
+        docsUrl: enabledApp.docsUrl,
+        verified: enabledApp.verified,
+        trending: enabledApp.trending,
+        rating: enabledApp.rating,
+        reviews: enabledApp.reviews,
+        isGlobal: enabledApp.isGlobal,
+        simplePath: enabledApp.simplePath,
+        email: enabledApp.email,
+        feeType: enabledApp.feeType,
+        price: enabledApp.price,
+        commission: enabledApp.commission,
+        licenseRequired: enabledApp.licenseRequired,
+        appData: enabledApp.appData,
+        paid: enabledApp.paid,
+        dirName: enabledApp.dirName,
+        isTemplate: enabledApp.isTemplate,
+        __template: enabledApp.__template,
+        dependencies: enabledApp.dependencies,
+        concurrentMeetings: enabledApp.concurrentMeetings,
+        createdAt: enabledApp.createdAt,
+        isOAuth: enabledApp.isOAuth,
+        delegationCredential: enabledApp.delegationCredential,
+        locationOption: enabledApp.locationOption,
+      };
       const userCredentialIds = credentials.filter((c) => c.appId === app.slug && !c.teamId).map((c) => c.id);
       const invalidCredentialIds = credentials
         .filter((c) => c.appId === app.slug && c.invalid)


### PR DESCRIPTION
## What does this PR do?

`getConnectedApps` built each app in the response by destructuring out a few sensitive fields and then spreading the rest: `({ credentials: _, credential, key: _2, ...app })`. That is a deny-list - every field on the app/credential shape that isn't explicitly excluded is forwarded to the frontend, so any field added later (internal config, metadata, a new credential field) leaks by default. There was already a `// TODO: Refactor this to pick up only needed fields and prevent more leaking` note on this line.

This switches the deny-list to an explicit allow-list: the response now picks only the known-safe app-store metadata fields (the full `App` metadata minus `key`, plus `locationOption`). No field currently read by consumers (`integrations.handler`, `AppList`, event-types app cards, API v2 conferencing) is dropped - I cross-checked the picked set against the `App` interface and the fields the consumers actually read.

- Fixes #28923

## Visual Demo (For contributors especially)

No visual change - this is a backend utility that shapes the connected-apps API response. It's covered by a new unit test (`getConnectedApps.test.ts`) asserting `credentials`/`credential`/`key` and any unexpected field are not present in the response while the safe fields are preserved.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A - no docs change needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

```
TZ=UTC yarn vitest run packages/app-store/_utils/getConnectedApps.test.ts
```

No env vars or seed data required. The test mocks `getEnabledAppsFromCredentials` to return an app object that includes `credentials`/`credential`/`key` plus an injected unexpected field, and asserts none of them reach the response while `slug`/`name`/`logo`/`categories`/`variant`/`type`/`description` and the computed fields (`userCredentialIds`, `teams`, `isInstalled`, ...) are still present. The unexpected-field assertion fails on `main` and passes with this change.

## Checklist

- My code follows the style guidelines of this project
- I have commented my code where needed (one line explaining the allow-list)
- My changes generate no new warnings
- This is a small, focused PR (1 source file + 1 test file)
