### PR TITLE
fix(bookings): enforce booking limits across all recurring occurrences

### DIFF
--- a/packages/features/bookings/lib/checkBookingLimits.ts
+++ b/packages/features/bookings/lib/checkBookingLimits.ts
@@ -57,6 +57,7 @@ export class CheckBookingLimitsService {
     teamId,
     user,
     includeManagedEvents = false,
+    offset = 0,
   }: {
     eventStartDate: Date;
     eventId?: number;
@@ -67,6 +68,8 @@ export class CheckBookingLimitsService {
     teamId?: number;
     user?: { id: number; email: string };
     includeManagedEvents?: boolean;
+    // Number of other bookings from the same in-flight request that fall in this period.
+    offset?: number;
   }) {
     const eventDateInOrganizerTz = timeZone ? dayjs(eventStartDate).tz(timeZone) : dayjs(eventStartDate);
 
@@ -98,7 +101,7 @@ export class CheckBookingLimitsService {
       });
     }
 
-    if (bookingsInPeriod < limitingNumber) return;
+    if (bookingsInPeriod + offset < limitingNumber) return;
 
     throw new HttpError({
       message: `booking_limit_reached`,
@@ -107,4 +110,53 @@ export class CheckBookingLimitsService {
   }
 
   checkBookingLimit = withReporting(this._checkBookingLimit.bind(this), "checkBookingLimit");
+
+  private async _checkBookingLimitsForRecurringBooking(
+    bookingLimits: IntervalLimit,
+    eventStartDates: Date[],
+    eventId: number,
+    rescheduleUid?: string | undefined,
+    timeZone?: string | null
+  ) {
+    const parsedBookingLimits = parseBookingLimit(bookingLimits);
+    if (!parsedBookingLimits) return false;
+
+    // A single recurring request creates several occurrences at once. Counting only
+    // already-persisted bookings per occurrence lets the request bypass the limit, so we
+    // also account for the other requested occurrences that fall in the same period.
+    const limitChecks = ascendingLimitKeys.flatMap((key) => {
+      const limitingNumber = parsedBookingLimits[key];
+      if (!limitingNumber) return [];
+
+      const unit = intervalLimitKeyToUnit(key);
+      const periodStarts = eventStartDates.map((eventStartDate) => {
+        const eventDateInOrganizerTz = timeZone ? dayjs(eventStartDate).tz(timeZone) : dayjs(eventStartDate);
+        return dayjs(eventDateInOrganizerTz).startOf(unit).valueOf();
+      });
+
+      return [...new Set(periodStarts)].map((periodStart) => {
+        const requestedInPeriod = periodStarts.filter((start) => start === periodStart).length;
+        return this.checkBookingLimit({
+          key,
+          limitingNumber,
+          eventStartDate: new Date(periodStart),
+          eventId,
+          timeZone,
+          rescheduleUid,
+          offset: requestedInPeriod - 1,
+        });
+      });
+    });
+
+    try {
+      return !!(await Promise.all(limitChecks));
+    } catch (error) {
+      throw new HttpError({ message: getErrorFromUnknown(error).message, statusCode: 401 });
+    }
+  }
+
+  checkBookingLimitsForRecurringBooking = withReporting(
+    this._checkBookingLimitsForRecurringBooking.bind(this),
+    "checkBookingLimitsForRecurringBooking"
+  );
 }

--- a/packages/features/bookings/lib/handleNewBooking/checkBookingAndDurationLimits.ts
+++ b/packages/features/bookings/lib/handleNewBooking/checkBookingAndDurationLimits.ts
@@ -3,7 +3,6 @@ import type { CheckBookingLimitsService } from "@calcom/features/bookings/lib/ch
 import { checkDurationLimits } from "@calcom/features/bookings/lib/checkDurationLimits";
 import type { IntervalLimit } from "@calcom/lib/intervalLimits/intervalLimitSchema";
 import { withReporting } from "@calcom/lib/sentryWrapper";
-
 import type { NewBookingEventType } from "./getEventTypesFromDB";
 
 type EventType = Pick<NewBookingEventType, "bookingLimits" | "durationLimits" | "id" | "schedule">;
@@ -11,6 +10,14 @@ type EventType = Pick<NewBookingEventType, "bookingLimits" | "durationLimits" | 
 type InputProps = {
   eventType: EventType;
   reqBodyStart: string;
+  reqBodyRescheduleUid?: string;
+  // Skip the booking-limit check (e.g. already validated up front for a whole recurring series).
+  skipBookingLimits?: boolean;
+};
+
+type RecurringInputProps = {
+  eventType: Pick<EventType, "bookingLimits" | "id" | "schedule">;
+  reqBodyStarts: string[];
   reqBodyRescheduleUid?: string;
 };
 
@@ -26,13 +33,15 @@ export class CheckBookingAndDurationLimitsService {
     "checkBookingAndDurationLimits"
   );
 
-  async _checkBookingAndDurationLimits({ eventType, reqBodyStart, reqBodyRescheduleUid }: InputProps) {
-    if (
-      Object.prototype.hasOwnProperty.call(eventType, "bookingLimits") ||
-      Object.prototype.hasOwnProperty.call(eventType, "durationLimits")
-    ) {
+  async _checkBookingAndDurationLimits({
+    eventType,
+    reqBodyStart,
+    reqBodyRescheduleUid,
+    skipBookingLimits = false,
+  }: InputProps) {
+    if (Object.hasOwn(eventType, "bookingLimits") || Object.hasOwn(eventType, "durationLimits")) {
       const startAsDate = dayjs(reqBodyStart).toDate();
-      if (eventType.bookingLimits && Object.keys(eventType.bookingLimits).length > 0) {
+      if (!skipBookingLimits && eventType.bookingLimits && Object.keys(eventType.bookingLimits).length > 0) {
         await this.dependencies.checkBookingLimitsService.checkBookingLimits(
           eventType.bookingLimits as IntervalLimit,
           startAsDate,
@@ -50,5 +59,26 @@ export class CheckBookingAndDurationLimitsService {
         );
       }
     }
+  }
+
+  checkRecurringBookingLimits = withReporting(
+    this._checkRecurringBookingLimits.bind(this),
+    "checkRecurringBookingLimits"
+  );
+
+  async _checkRecurringBookingLimits({
+    eventType,
+    reqBodyStarts,
+    reqBodyRescheduleUid,
+  }: RecurringInputProps) {
+    if (!eventType.bookingLimits || Object.keys(eventType.bookingLimits).length === 0) return;
+
+    await this.dependencies.checkBookingLimitsService.checkBookingLimitsForRecurringBooking(
+      eventType.bookingLimits as IntervalLimit,
+      reqBodyStarts.map((start) => dayjs(start).toDate()),
+      eventType.id,
+      reqBodyRescheduleUid,
+      eventType.schedule?.timeZone
+    );
   }
 }

--- a/packages/features/bookings/lib/handleNewBooking/checkBookingAndDurationLimits.ts
+++ b/packages/features/bookings/lib/handleNewBooking/checkBookingAndDurationLimits.ts
@@ -39,7 +39,10 @@ export class CheckBookingAndDurationLimitsService {
     reqBodyRescheduleUid,
     skipBookingLimits = false,
   }: InputProps) {
-    if (Object.hasOwn(eventType, "bookingLimits") || Object.hasOwn(eventType, "durationLimits")) {
+    if (
+      Object.prototype.hasOwnProperty.call(eventType, "bookingLimits") ||
+      Object.prototype.hasOwnProperty.call(eventType, "durationLimits")
+    ) {
       const startAsDate = dayjs(reqBodyStart).toDate();
       if (!skipBookingLimits && eventType.bookingLimits && Object.keys(eventType.bookingLimits).length > 0) {
         await this.dependencies.checkBookingLimitsService.checkBookingLimits(

--- a/packages/features/bookings/lib/service/RecurringBookingService.test.ts
+++ b/packages/features/bookings/lib/service/RecurringBookingService.test.ts
@@ -19,7 +19,7 @@ import { getMockRequestDataForBooking } from "@calcom/testing/lib/bookingScenari
 import { setupAndTeardown } from "@calcom/testing/lib/bookingScenario/setupAndTeardown";
 
 import { v4 as uuidv4 } from "uuid";
-import { describe, expect } from "vitest";
+import { beforeEach, describe, expect, vi } from "vitest";
 
 import { getRecurringBookingService } from "@calcom/features/bookings/di/RecurringBookingService.container";
 import { WEBAPP_URL } from "@calcom/lib/constants";
@@ -254,6 +254,93 @@ describe("handleNewRecurringBooking", () => {
         timeout
       );
     });
+  });
+
+  describe("Booking limits:", () => {
+    beforeEach(() => {
+      // Anchor to the 1st so the recurring occurrences below stay within the same month.
+      vi.setSystemTime(new Date("2024-08-01T00:00:00.000Z"));
+    });
+
+    test(
+      `rejects a recurring request when its occurrences exceed the event type booking limit,
+        and does not persist any of them (all-or-nothing)`,
+      async ({}) => {
+        const booker = getBooker({ email: "booker@example.com", name: "Booker" });
+        const organizer = getOrganizer({
+          name: "Organizer",
+          email: "organizer@example.com",
+          id: 101,
+          schedules: [TestData.schedules.IstWorkHours],
+        });
+
+        const numOfSlotsToBeBooked = 3;
+        await createBookingScenario(
+          getScenarioData({
+            eventTypes: [
+              {
+                id: 1,
+                slotInterval: 30,
+                length: 30,
+                recurringEvent: getRecurrence({ type: "weekly", numberOfOccurrences: numOfSlotsToBeBooked }),
+                bookingLimits: { PER_MONTH: 2 },
+                // Unconfirmed bookings are created as PENDING; the per-period count ignores them,
+                // which is exactly how a recurring request could previously bypass the limit.
+                requiresConfirmation: true,
+                users: [{ id: 101 }],
+              },
+            ],
+            organizer,
+            apps: [TestData.apps["daily-video"]],
+          })
+        );
+
+        mockSuccessfulVideoMeetingCreation({
+          metadataLookupKey: "dailyvideo",
+          videoMeetingData: { id: "MOCK_ID", password: "MOCK_PASS", url: "http://mock.example.com/m" },
+        });
+        await mockCalendarToHaveNoBusySlots("googlecalendar", {});
+
+        const mockBookingData = getMockRequestDataForBooking({
+          data: {
+            eventTypeId: 1,
+            start: `2024-08-05T04:00:00.000Z`,
+            end: `2024-08-05T04:30:00.000Z`,
+            recurringEventId: uuidv4(),
+            recurringCount: numOfSlotsToBeBooked,
+            responses: {
+              email: booker.email,
+              name: booker.name,
+              location: { optionValue: "", value: "integrations:daily" },
+            },
+          },
+        });
+
+        // All three occurrences fall in August, exceeding the PER_MONTH limit of 2.
+        const bookingDataArray = Array(numOfSlotsToBeBooked)
+          .fill(mockBookingData)
+          .map((data, index) => ({
+            ...data,
+            start: getPlusDayDate(data.start, index).toISOString(),
+            end: getPlusDayDate(data.end, index).toISOString(),
+          }));
+
+        const recurringBookingService = getRecurringBookingService();
+
+        await expect(
+          recurringBookingService.createBooking({
+            bookingData: bookingDataArray,
+            bookingMeta: { userId: -1 },
+            creationSource: "WEBAPP",
+          })
+        ).rejects.toThrowError("booking_limit_reached");
+
+        const { default: prisma } = await import("@calcom/prisma");
+        const bookingCount = await prisma.booking.count({ where: { eventTypeId: 1 } });
+        expect(bookingCount).toBe(0);
+      },
+      timeout
+    );
   });
 
   function getRecurrence({

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -674,6 +674,21 @@ async function handler(
     bookerEmail,
   });
 
+  // A recurring request creates several occurrences in one call. Validate booking limits against
+  // all of them here, before any occurrence is persisted, so the request can't bypass the limit
+  // (e.g. unconfirmed occurrences that aren't yet counted) or leave partial bookings behind.
+  if (
+    !skipEventLimitsCheck &&
+    input.bookingData.isFirstRecurringSlot &&
+    input.bookingData.allRecurringDates
+  ) {
+    await deps.checkBookingAndDurationLimitsService.checkRecurringBookingLimits({
+      eventType,
+      reqBodyStarts: input.bookingData.allRecurringDates.map((date) => date.start),
+      reqBodyRescheduleUid: reqBody.rescheduleUid,
+    });
+  }
+
   // For unconfirmed bookings or round robin bookings with the same attendee and timeslot, return the original booking
   if (
     (!isConfirmedByDefault && !userReschedulingIsOwner) ||
@@ -814,10 +829,13 @@ async function handler(
   });
 
   if (!skipEventLimitsCheck) {
+    // For recurring requests, booking limits are validated up front against all occurrences (see
+    // above), so skip the per-occurrence booking-limit check here. Duration limits still run.
     await deps.checkBookingAndDurationLimitsService.checkBookingAndDurationLimits({
       eventType,
       reqBodyStart: reqBody.start,
       reqBodyRescheduleUid: reqBody.rescheduleUid,
+      skipBookingLimits: !!input.bookingData.allRecurringDates,
     });
   }
 


### PR DESCRIPTION
## What does this PR do?

Booking limits (per day/week/month/year) were only evaluated per individual occurrence when creating a recurring booking. Because the per-period count only includes `ACCEPTED` bookings, a single recurring request could exceed a configured limit - most clearly when occurrences are created as `PENDING` (event types that require confirmation), where none of the in-flight occurrences are counted. This affects the API v2 recurring path (`POST /v2/bookings` with `recurrenceCount`) as well as the web booking flow, since both go through the same handler.

This validates the whole recurring series up front, on the first slot, before any occurrence is persisted - so the request is rejected atomically with `booking_limit_reached` instead of partially creating bookings up to the cap and then failing. The per-occurrence booking-limit check is skipped for the remaining recurring slots (duration limits still run per occurrence).

- Fixes #28542

## Visual Demo (For contributors especially)

No visual change - this is a server-side booking-limit enforcement fix. Covered by a unit/integration test (see below).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A - no behavior change to documented APIs.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

A regression test was added to `packages/features/bookings/lib/service/RecurringBookingService.test.ts`:

```
TZ=UTC yarn vitest run packages/features/bookings/lib/service/RecurringBookingService.test.ts
```

It sets up an event type with `bookingLimits: { PER_MONTH: 2 }` and `requiresConfirmation: true`, then sends a recurring request with 3 occurrences in the same month. It asserts the request rejects with `booking_limit_reached` and that no bookings are persisted (all-or-nothing). The test fails on `main` (all 3 occurrences are created) and passes with this change. The existing recurring success test and the single-booking limit tests (`global-booking-limits.test.ts`) still pass.

No special environment variables or test data are required beyond the existing booking-scenario test harness.

## Checklist

- I have read the contributing guide.
- My code follows the style guidelines of this project (Biome).
- I have commented my code where the reason isn't obvious.
- My changes generate no new warnings.
- My PR is small and focused (4 files).
