### PR TITLE
fix(basecamp3): remove redirect_uri from token refresh request

### DIFF
--- a/packages/app-store/basecamp3/lib/helpers.ts
+++ b/packages/app-store/basecamp3/lib/helpers.ts
@@ -1,4 +1,3 @@
-import { WEBAPP_URL } from "@calcom/lib/constants";
 import { prisma } from "@calcom/prisma";
 import type { CredentialPayload } from "@calcom/types/Credential";
 
@@ -9,7 +8,7 @@ export const refreshAccessToken = async (credential: CredentialPayload) => {
   const { client_id: clientId, client_secret: clientSecret, user_agent: userAgent } = await getBasecampKeys();
   const credentialKey = credential.key as BasecampToken;
   const tokenInfo = await fetch(
-    `https://launchpad.37signals.com/authorization/token?type=refresh&refresh_token=${credentialKey.refresh_token}&client_id=${clientId}&redirect_uri=${WEBAPP_URL}&client_secret=${clientSecret}`,
+    `https://launchpad.37signals.com/authorization/token?type=refresh&refresh_token=${credentialKey.refresh_token}&client_id=${clientId}&client_secret=${clientSecret}`,
     { method: "POST", headers: { "User-Agent": userAgent } }
   );
   const tokenInfoJson = await tokenInfo.json();


### PR DESCRIPTION
## What does this PR do?

Fixes #29585

The Basecamp3 `refreshAccessToken` helper was including `redirect_uri` (set to `WEBAPP_URL`) in the token refresh request. According to the [Basecamp OAuth docs](https://github.com/basecamp/api/blob/master/sections/authentication.md), the refresh-token request only requires:

- `type=refresh`
- `refresh_token`
- `client_id`
- `client_secret`

Sending an incorrect `redirect_uri` is inconsistent with the documented parameters and inconsistent with the initial OAuth callback URL (`/api/integrations/basecamp3/callback`), which can cause refresh failures when the original access token expires.

**Change:** Remove `&redirect_uri=${WEBAPP_URL}` from the refresh request query string and remove the now-unused `WEBAPP_URL` import.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] I have read the [How to Contribute](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md) guide
- [x] I agree to follow the [Code of Conduct](https://github.com/calcom/cal.com/blob/main/CODE_OF_CONDUCT.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new TypeScript errors
- [x] My change is limited to the affected integration file (no unrelated changes)