### PR TITLE
fix: admin-users: show proper duplicate user validation errors

### DIFF
--- a/apps/web/modules/users/views/users-add-view.test.tsx
+++ b/apps/web/modules/users/views/users-add-view.test.tsx
@@ -1,0 +1,326 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import UsersAddView from "./users-add-view";
+
+const { mockMutate, mockInvalidate, mockShowToast, capturedCallbacks } = vi.hoisted(() => {
+  const capturedCallbacks: {
+    onSuccess?: () => Promise<void>;
+    onError?: (err: { data?: { code?: string; fields?: string[] } }) => void;
+  } = {};
+  return {
+    mockMutate: vi.fn(),
+    mockInvalidate: vi.fn().mockResolvedValue(undefined),
+    mockShowToast: vi.fn(),
+    capturedCallbacks,
+  };
+});
+
+vi.mock("@calcom/lib/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn().mockReturnValue("/settings/admin/users/add"),
+  useRouter: vi.fn().mockReturnValue({
+    replace: vi.fn(),
+  }),
+}));
+
+vi.mock("@calcom/trpc/react", () => ({
+  trpc: {
+    viewer: {
+      users: {
+        add: {
+          useMutation: vi.fn(
+            (options: { onSuccess: () => Promise<void>; onError: (err: unknown) => void }) => {
+              capturedCallbacks.onSuccess = options.onSuccess;
+              capturedCallbacks.onError = options.onError;
+              return { mutate: mockMutate, isLoading: false };
+            }
+          ),
+        },
+      },
+    },
+    useUtils: vi.fn(() => ({
+      viewer: {
+        users: {
+          list: {
+            invalidate: mockInvalidate,
+          },
+        },
+      },
+    })),
+  },
+}));
+
+vi.mock("@calcom/ui/components/toast", () => ({
+  showToast: (...args: unknown[]) => mockShowToast(...args),
+}));
+
+vi.mock("../components/UserForm", () => ({
+  UserForm: ({
+    onSubmit,
+    submitLabel,
+  }: {
+    onSubmit: (values: Record<string, unknown>) => void;
+    submitLabel: string;
+  }) => (
+    <form
+      data-testid="user-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit({
+          name: "Test User",
+          email: "test@example.com",
+          username: "testuser",
+          bio: "",
+          timeZone: "UTC",
+          weekStart: { value: "Monday" },
+          theme: null,
+          defaultScheduleId: null,
+          locale: { value: "en" },
+          timeFormat: { value: 12 },
+          allowDynamicBooking: true,
+          identityProvider: { value: "CAL" },
+          role: { value: "USER" },
+          avatarUrl: null,
+        });
+      }}>
+      <button type="submit">{submitLabel}</button>
+    </form>
+  ),
+}));
+
+vi.mock("@calcom/ui/components/form", () => ({
+  Form: ({ children, handleSubmit }: { children: ReactNode; handleSubmit: () => void }) => (
+    <form onSubmit={handleSubmit}>{children}</form>
+  ),
+  TextField: (props: Record<string, unknown>) => <input {...props} />,
+  EmailField: (props: Record<string, unknown>) => <input type="email" {...props} />,
+  Label: ({ children }: { children: ReactNode }) => <label>{children}</label>,
+  Select: () => <select />,
+}));
+
+function renderView() {
+  return render(<UsersAddView />);
+}
+
+function buildTrpcError(code: string, fields?: string[]) {
+  return {
+    data: {
+      code,
+      fields,
+    },
+  };
+}
+
+async function submitForm() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /add/i }));
+}
+
+describe("UsersAddView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCallbacks.onSuccess = undefined;
+    capturedCallbacks.onError = undefined;
+  });
+
+  describe("rendering", () => {
+    it("renders the UserForm with submitLabel='add'", () => {
+      renderView();
+      expect(screen.getByTestId("user-form")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /add/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("form submission", () => {
+    it("calls mutation.mutate with the mapped form values on submit", async () => {
+      renderView();
+      await submitForm();
+
+      expect(mockMutate).toHaveBeenCalledOnce();
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Test User",
+          email: "test@example.com",
+          username: "testuser",
+          bio: "",
+          timeZone: "UTC",
+          weekStart: "Monday",
+          locale: "en",
+          timeFormat: 12,
+          identityProvider: "CAL",
+          role: "USER",
+          theme: null,
+          defaultScheduleId: null,
+          allowDynamicBooking: true,
+          avatarUrl: null,
+        })
+      );
+    });
+  });
+
+  describe("onSuccess callback", () => {
+    it("shows a success toast and invalidates the users list", async () => {
+      renderView();
+      await capturedCallbacks.onSuccess!();
+
+      expect(mockShowToast).toHaveBeenCalledOnce();
+      expect(mockShowToast).toHaveBeenCalledWith("user_added_successfully", "success");
+      expect(mockInvalidate).toHaveBeenCalledOnce();
+    });
+
+    it("navigates away by replacing /add with '' in the pathname", async () => {
+      const { useRouter } = await import("next/navigation");
+      const mockReplace = vi.fn();
+      vi.mocked(useRouter).mockReturnValue({
+        replace: mockReplace,
+        push: vi.fn(),
+        back: vi.fn(),
+        forward: vi.fn(),
+        refresh: vi.fn(),
+        prefetch: vi.fn(),
+      });
+
+      renderView();
+      await capturedCallbacks.onSuccess!();
+
+      expect(mockReplace).toHaveBeenCalledWith("/settings/admin/users");
+    });
+  });
+
+  describe("onError callback – CONFLICT: email already exists", () => {
+    it("shows 'user_with_email_already_exists' toast when the conflicting field is 'email'", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("CONFLICT", ["email"]));
+
+      expect(mockShowToast).toHaveBeenCalledOnce();
+      expect(mockShowToast).toHaveBeenCalledWith("user_with_email_already_exists", "error");
+    });
+
+    it("does NOT show any other toast when the email conflict is triggered", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("CONFLICT", ["email"]));
+
+      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      const [message] = mockShowToast.mock.calls[0];
+      expect(message).toBe("user_with_email_already_exists");
+    });
+  });
+
+  describe("onError callback – CONFLICT: username already exists", () => {
+    it("shows 'user_with_username_already_exists' toast when the conflicting field is 'username'", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("CONFLICT", ["username"]));
+
+      expect(mockShowToast).toHaveBeenCalledOnce();
+      expect(mockShowToast).toHaveBeenCalledWith("user_with_username_already_exists", "error");
+    });
+
+    it("does NOT show any other toast when the username conflict is triggered", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("CONFLICT", ["username"]));
+
+      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      const [message] = mockShowToast.mock.calls[0];
+      expect(message).toBe("user_with_username_already_exists");
+    });
+  });
+
+  describe("onError callback – CONFLICT: no specific field match", () => {
+    it("shows generic 'user_already_exists' toast when fields array is empty", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("CONFLICT", []));
+
+      expect(mockShowToast).toHaveBeenCalledOnce();
+      expect(mockShowToast).toHaveBeenCalledWith("user_already_exists", "error");
+    });
+
+    it("shows generic 'user_already_exists' toast when fields is undefined", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("CONFLICT", undefined));
+
+      expect(mockShowToast).toHaveBeenCalledOnce();
+      expect(mockShowToast).toHaveBeenCalledWith("user_already_exists", "error");
+    });
+
+    it("shows generic 'user_already_exists' toast when fields contains an unknown field name", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("CONFLICT", ["phone"]));
+
+      expect(mockShowToast).toHaveBeenCalledOnce();
+      expect(mockShowToast).toHaveBeenCalledWith("user_already_exists", "error");
+    });
+  });
+
+  describe("onError callback – non-CONFLICT error", () => {
+    it("shows 'error_adding_user' toast for a non-CONFLICT tRPC error code", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("INTERNAL_SERVER_ERROR"));
+
+      expect(mockShowToast).toHaveBeenCalledOnce();
+      expect(mockShowToast).toHaveBeenCalledWith("error_adding_user", "error");
+    });
+
+    it("shows 'error_adding_user' toast when error has no data at all", () => {
+      renderView();
+      capturedCallbacks.onError!({});
+
+      expect(mockShowToast).toHaveBeenCalledOnce();
+      expect(mockShowToast).toHaveBeenCalledWith("error_adding_user", "error");
+    });
+
+    it("shows 'error_adding_user' toast for a BAD_REQUEST error", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("BAD_REQUEST"));
+
+      expect(mockShowToast).toHaveBeenCalledOnce();
+      expect(mockShowToast).toHaveBeenCalledWith("error_adding_user", "error");
+    });
+
+    it("shows 'error_adding_user' toast for an UNAUTHORIZED error", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("UNAUTHORIZED"));
+
+      expect(mockShowToast).toHaveBeenCalledOnce();
+      expect(mockShowToast).toHaveBeenCalledWith("error_adding_user", "error");
+    });
+  });
+
+  describe("toast severity", () => {
+    it("uses 'error' severity for all error toasts (email conflict)", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("CONFLICT", ["email"]));
+      expect(mockShowToast.mock.calls[0][1]).toBe("error");
+    });
+
+    it("uses 'error' severity for all error toasts (username conflict)", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("CONFLICT", ["username"]));
+      expect(mockShowToast.mock.calls[0][1]).toBe("error");
+    });
+
+    it("uses 'error' severity for all error toasts (generic conflict)", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("CONFLICT", []));
+      expect(mockShowToast.mock.calls[0][1]).toBe("error");
+    });
+
+    it("uses 'error' severity for all error toasts (non-conflict)", () => {
+      renderView();
+      capturedCallbacks.onError!(buildTrpcError("INTERNAL_SERVER_ERROR"));
+      expect(mockShowToast.mock.calls[0][1]).toBe("error");
+    });
+
+    it("uses 'success' severity for the success toast", async () => {
+      renderView();
+      await capturedCallbacks.onSuccess!();
+      expect(mockShowToast.mock.calls[0][1]).toBe("success");
+    });
+  });
+});

--- a/apps/web/modules/users/views/users-add-view.tsx
+++ b/apps/web/modules/users/views/users-add-view.tsx
@@ -21,10 +21,25 @@ export default function UsersAddView() {
         router.replace(pathname.replace("/add", ""));
       }
     },
-    onError: (err) => {
-      console.error(err.message);
-      showToast(t("error_adding_user"), "error");
-    },
+onError: (err) => {
+  if (err.data?.code === "CONFLICT") {
+    const fields = err.data?.fields as string[] | undefined;
+
+    if (fields?.includes("email")) {
+      showToast(t("user_with_email_already_exists"), "error");
+      return;
+    }
+
+    if (fields?.includes("username")) {
+      showToast(t("user_with_username_already_exists"), "error");
+      return;
+    }
+    showToast(t("user_already_exists"), "error");
+    return;
+  }
+
+  showToast(t("error_adding_user"), "error");
+},
   });
 
   return (

--- a/apps/web/modules/users/views/users-add-view.tsx
+++ b/apps/web/modules/users/views/users-add-view.tsx
@@ -21,25 +21,25 @@ export default function UsersAddView() {
         router.replace(pathname.replace("/add", ""));
       }
     },
-onError: (err) => {
-  if (err.data?.code === "CONFLICT") {
-    const fields = err.data?.fields as string[] | undefined;
+    onError: (err) => {
+      if (err.data?.code === "CONFLICT") {
+        const fields = err.data?.fields as string[] | undefined;
 
-    if (fields?.includes("email")) {
-      showToast(t("user_with_email_already_exists"), "error");
-      return;
-    }
+        if (fields?.includes("email")) {
+          showToast(t("user_with_email_already_exists"), "error");
+          return;
+        }
 
-    if (fields?.includes("username")) {
-      showToast(t("user_with_username_already_exists"), "error");
-      return;
-    }
-    showToast(t("user_already_exists"), "error");
-    return;
-  }
+        if (fields?.includes("username")) {
+          showToast(t("user_with_username_already_exists"), "error");
+          return;
+        }
+        showToast(t("user_already_exists"), "error");
+        return;
+      }
 
-  showToast(t("error_adding_user"), "error");
-},
+      showToast(t("error_adding_user"), "error");
+    },
   });
 
   return (

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4769,5 +4769,8 @@
   "user_updated_successfully": "User updated successfully.",
   "error_updating_user": "There was an error updating this user.",
   "please_reschedule": "Please reschedule.",
+  "user_already_exists": "A user with the provided details already exists.",
+  "user_with_email_already_exists": "A user with this email already exists.",
+  "user_with_username_already_exists": "A user with this username already exists.",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/trpc/server/errorFormatter.ts
+++ b/packages/trpc/server/errorFormatter.ts
@@ -45,7 +45,7 @@ export function errorFormatter({ shape, error }: ErrorFormatterOptions): ErrorSh
     ...shape,
     data: {
       ...shape.data,
-      fields
+      fields,
     },
   };
 }

--- a/packages/trpc/server/errorFormatter.ts
+++ b/packages/trpc/server/errorFormatter.ts
@@ -35,11 +35,17 @@ export function errorFormatter({ shape, error }: ErrorFormatterOptions): ErrorSh
       },
     };
   }
+  const causeFields = (error.cause as { fields?: unknown })?.fields;
+  const fields =
+    Array.isArray(causeFields) && causeFields.every((field) => typeof field === "string")
+      ? causeFields
+      : undefined;
+
   return {
     ...shape,
     data: {
       ...shape.data,
-      fields: (error.cause as { fields?: string[] })?.fields,
+      fields
     },
   };
 }

--- a/packages/trpc/server/errorFormatter.ts
+++ b/packages/trpc/server/errorFormatter.ts
@@ -35,5 +35,11 @@ export function errorFormatter({ shape, error }: ErrorFormatterOptions): ErrorSh
       },
     };
   }
-  return shape;
+  return {
+    ...shape,
+    data: {
+      ...shape.data,
+      fields: (error.cause as { fields?: string[] })?.fields,
+    },
+  };
 }

--- a/packages/trpc/server/routers/viewer/users/_router.ts
+++ b/packages/trpc/server/routers/viewer/users/_router.ts
@@ -61,7 +61,7 @@ export const userAdminRouter = router({
     return users;
   }),
   add: authedAdminProcedure.input(userBodySchema).mutation(async (opts) => {
-    const { default: handler } = (await import("./adduser.handler"));
+    const { default: handler } = await import("./adduser.handler");
     return handler(opts);
   }),
   update: authedAdminProcedureWithRequestedUser

--- a/packages/trpc/server/routers/viewer/users/_router.ts
+++ b/packages/trpc/server/routers/viewer/users/_router.ts
@@ -12,7 +12,7 @@ export type UserAdminRouterOutputs = inferRouterOutputs<UserAdminRouter>;
 
 const userIdSchema = z.object({ userId: z.coerce.number() });
 
-const userBodySchema = UserSchema.pick({
+export const userBodySchema = UserSchema.pick({
   name: true,
   email: true,
   username: true,
@@ -60,10 +60,9 @@ export const userAdminRouter = router({
     const users = await prisma.user.findMany();
     return users;
   }),
-  add: authedAdminProcedure.input(userBodySchema).mutation(async ({ ctx, input }) => {
-    const { prisma } = ctx;
-    const user = await prisma.user.create({ data: { ...input, creationSource: CreationSource.WEBAPP } });
-    return { user, message: `User with id: ${user.id} added successfully` };
+  add: authedAdminProcedure.input(userBodySchema).mutation(async (opts) => {
+    const { default: handler } = (await import("./adduser.handler"));
+    return handler(opts);
   }),
   update: authedAdminProcedureWithRequestedUser
     .input(userBodySchema.partial())

--- a/packages/trpc/server/routers/viewer/users/adduser.handler.ts
+++ b/packages/trpc/server/routers/viewer/users/adduser.handler.ts
@@ -8,60 +8,55 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 
 type GetOptions = {
-    ctx: {
-        user: NonNullable<TrpcSessionUser>;
-    };
-    input: z.infer<typeof userBodySchema>;
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+  };
+  input: z.infer<typeof userBodySchema>;
 };
 
 function getConstraintFields(error: unknown): string[] {
-    const prismaError = error as {
-        meta?: {
-            target?: string[];
-            driverAdapterError?: {
-                cause?: {
-                    constraint?: {
-                        fields?: string[];
-                    };
-                };
-            };
+  const prismaError = error as {
+    meta?: {
+      target?: string[];
+      driverAdapterError?: {
+        cause?: {
+          constraint?: {
+            fields?: string[];
+          };
         };
+      };
     };
+  };
 
-    return (
-        prismaError.meta?.target ??
-        prismaError.meta?.driverAdapterError?.cause?.constraint?.fields ??
-        []
-    );
+  return prismaError.meta?.target ?? prismaError.meta?.driverAdapterError?.cause?.constraint?.fields ?? [];
 }
 
 const addUserHandler = async ({ input }: GetOptions) => {
-    const userRepository = getUserRepository();
-    try {
-        const user = await userRepository.create({
-            ...input,
-            creationSource: CreationSource.WEBAPP,
-            organizationId: null,
-            locked: false,
-        });
+  const userRepository = getUserRepository();
+  try {
+    const user = await userRepository.create({
+      ...input,
+      creationSource: CreationSource.WEBAPP,
+      organizationId: null,
+      locked: false,
+    });
 
-        return {
-            user,
-            message: `User with id: ${user.id} added successfully`,
-        };
-    } catch (error) {
-        if (isPrismaError(error) && error.code === "P2002") {
-            const constraintFields = getConstraintFields(error);
-            throw new TRPCError({
-                code: "CONFLICT",
-                message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS,
-                cause: {
-                    fields: constraintFields,
-                }
-            });
-        }
-        throw error;
+    return {
+      user,
+      message: `User with id: ${user.id} added successfully`,
+    };
+  } catch (error) {
+    if (isPrismaError(error) && error.code === "P2002") {
+      const constraintFields = getConstraintFields(error);
+      throw new TRPCError({
+        code: "CONFLICT",
+        message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS,
+        cause: {
+          fields: constraintFields,
+        },
+      });
     }
-
-}
+    throw error;
+  }
+};
 export default addUserHandler;

--- a/packages/trpc/server/routers/viewer/users/adduser.handler.ts
+++ b/packages/trpc/server/routers/viewer/users/adduser.handler.ts
@@ -1,0 +1,69 @@
+
+
+import { getUserRepository } from "@calcom/features/di/containers/UserRepository";
+import { CreationSource } from "@calcom/prisma/enums";
+import { isPrismaError } from "@calcom/lib/server/getServerErrorFromUnknown";
+import type { TrpcSessionUser } from "../../../types";
+import { userBodySchema } from "./_router";
+import { SIGNUP_ERROR_CODES } from "@calcom/features/auth/signup/constants";
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+
+type GetOptions = {
+    ctx: {
+        user: NonNullable<TrpcSessionUser>;
+    };
+    input: z.infer<typeof userBodySchema>;
+};
+
+function getConstraintFields(error: unknown): string[] {
+    const prismaError = error as {
+        meta?: {
+            target?: string[];
+            driverAdapterError?: {
+                cause?: {
+                    constraint?: {
+                        fields?: string[];
+                    };
+                };
+            };
+        };
+    };
+
+    return (
+        prismaError.meta?.target ??
+        prismaError.meta?.driverAdapterError?.cause?.constraint?.fields ??
+        []
+    );
+}
+
+const addUserHandler = async ({ input }: GetOptions) => {
+    const userRepository = getUserRepository();
+    try {
+        const user = await userRepository.create({
+            ...input,
+            creationSource: CreationSource.WEBAPP,
+            organizationId: null,
+            locked: false,
+        });
+
+        return {
+            user,
+            message: `User with id: ${user.id} added successfully`,
+        };
+    } catch (error) {
+        if (isPrismaError(error) && error.code === "P2002") {
+            const constraintFields = getConstraintFields(error);
+            throw new TRPCError({
+                code: "CONFLICT",
+                message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS,
+                cause: {
+                    fields: constraintFields,
+                }
+            });
+        }
+        throw error;
+    }
+
+}
+export default addUserHandler;

--- a/packages/trpc/server/routers/viewer/users/adduser.handler.ts
+++ b/packages/trpc/server/routers/viewer/users/adduser.handler.ts
@@ -1,5 +1,3 @@
-
-
 import { getUserRepository } from "@calcom/features/di/containers/UserRepository";
 import { CreationSource } from "@calcom/prisma/enums";
 import { isPrismaError } from "@calcom/lib/server/getServerErrorFromUnknown";


### PR DESCRIPTION
## What does this PR do?

Fixes the user creation flow in the Admin Users page when attempting to create a user with an existing email or username.

### Changes

* Replaced direct Prisma user creation in the router with a dedicated `addUserHandler` that uses `UserRepository.create()`.
* Added handling for Prisma `P2002` unique constraint violations and mapped them to structured TRPC conflict responses.
* Returned the affected constraint fields (`email` or `username`) to the frontend.
* Updated frontend error handling to display specific validation messages for duplicate email and username conflicts instead of showing a generic "Internal Server Error".

- Fixes #29610

## Visual Demo

### Before
<img width="815" height="350" alt="image" src="https://github.com/user-attachments/assets/b8267572-1602-4e8c-834e-d88c49dc49b5" />

```json

[
    {
        "error": {
            "json": {
                "message": "\nInvalid `prisma.user.create()` invocation in\n/home/chayan/Projects/cal.com/apps/web/.next/dev/server/chunks/[root-of-the-server]__13eljfh._.js:9434:40\n\n  9431 }),\n  9432 add: __TURBOPACK__imported__module__$5b$project$5d2f$packages$2f$trpc$2f$server$2f$procedures$2f$authedProcedure$2e$ts__$5b$api$5d$__$28$ecmascript$29$__[\"authedAdminProcedure\"].input(userBodySchema).mutation(async ({ ctx, input })=>{\n  9433     const { prisma } = ctx;\n→ 9434     const user = await prisma.user.create(\nUnique constraint failed on the fields: (`email`)",
                "code": -32603,
                "data": {
                    "code": "INTERNAL_SERVER_ERROR",
                    "httpStatus": 500,
                    "stack": "PrismaClientKnownRequestError: \nInvalid `prisma.user.create()` invocation in\n/home/chayan/Projects/cal.com/apps/web/.next/dev/server/chunks/[root-of-the-server]__13eljfh._.js                                   
                   "path": "add"
                }
            }
        }
    }
]

```

- The API response also exposed internal implementation details, including Prisma query information, server file paths, and stack traces.
- Creating a user with an existing email or username resulted in a generic **"Internal Server Error"** message.

### After

Creating a user with an existing email or username now displays a clear validation message:

* "A user with this email already exists"
* "A user with this username already exists"

<img width="815" height="350" alt="image" src="https://github.com/user-attachments/assets/15151aed-9d33-45e5-8f6e-16a833b80d0f" />
<img width="815" height="350" alt="image" src="https://github.com/user-attachments/assets/76803cc9-0491-4534-b0b8-4a3455ed8623" />


## Mandatory Tasks (DO NOT REMOVE)

* [x] I have self-reviewed the code.
* [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A.
* [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Start the application and log in as an admin.
2. Navigate to **Admin → Users → Add User**.
3. Create a user with a unique email and username.

   * Expected: User is created successfully.
4. Attempt to create another user using an existing email.

   * Expected: "User with this email already exists" error is shown.
5. Attempt to create another user using an existing username.

   * Expected: "User with this username already exists" error is shown.
6. Verify that no generic "Internal Server Error" message is displayed for these validation conflicts.

### Environment Variables

* No additional environment variables required.

### Test Data

* At least one existing user in the database.

### Expected Result

* Duplicate email and username conflicts are surfaced as user-friendly validation errors.

## Checklist

* [x] My code follows the style guidelines of this project.
* [x] I have commented my code where necessary.
* [x] I have checked that my changes generate no new warnings.
* [x] This PR is small and focused.
