### PR TITLE
docs(claude): add path-scoped frontmatter to four agent rules

### DIFF
--- a/agents/rules/api-thin-controllers.md
+++ b/agents/rules/api-thin-controllers.md
@@ -1,4 +1,6 @@
 ---
+paths:
+  - "apps/api/**/*.controller.ts"
 title: Keep Controllers Thin - HTTP Concerns Only
 impact: HIGH
 impactDescription: Enables technology-agnostic business logic

--- a/agents/rules/architecture-page-level-auth.md
+++ b/agents/rules/architecture-page-level-auth.md
@@ -1,4 +1,7 @@
 ---
+paths:
+  - "apps/**/page.tsx"
+  - "apps/**/layout.tsx"
 title: Page-Level Authorization Checks in Next.js
 impact: CRITICAL
 impactDescription: Prevents unauthorized access to sensitive data

--- a/agents/rules/data-prisma-migrations.md
+++ b/agents/rules/data-prisma-migrations.md
@@ -1,4 +1,6 @@
 ---
+paths:
+  - "packages/prisma/**"
 title: Prisma Schema and Migrations
 impact: HIGH
 impactDescription: Schema changes affect all downstream code and deployments

--- a/agents/rules/testing-playwright.md
+++ b/agents/rules/testing-playwright.md
@@ -1,4 +1,9 @@
 ---
+paths:
+  - "apps/web/playwright/**"
+  - "packages/embeds/**/playwright/**"
+  - "apps/**/*.e2e.ts"
+  - "apps/api/**/e2e/**"
 title: Playwright E2E Testing
 impact: HIGH
 impactDescription: E2E tests catch integration issues before production


### PR DESCRIPTION
## What

Adds `paths:` YAML frontmatter to four existing rules in `agents/rules/` so Claude Code only loads each rule when the agent is working on relevant files.

| Rule | Paths |
|------|-------|
| `architecture-page-level-auth.md` | `apps/**/page.tsx`, `apps/**/layout.tsx` |
| `data-prisma-migrations.md` | `packages/prisma/**` |
| `testing-playwright.md` | `apps/web/playwright/**`, `packages/embeds/**/playwright/**`, `apps/**/*.e2e.ts`, `apps/api/**/e2e/**` |
| `api-thin-controllers.md` | `apps/api/**/*.controller.ts` |

## Why

Cal.com's `agents/rules/` has 40+ rule files. Without path scoping, every rule is loaded into context on every task, regardless of what files the agent is touching. The `paths:` frontmatter (supported by Claude Code's agent rules system) makes each rule load only when the agent is editing matching files — keeping the context window lean for large-monorepo tasks.

No content changes — purely additive frontmatter.

## Test plan

- [ ] Confirm existing rule files are unchanged except for the added frontmatter
- [ ] Verify Claude Code loads `testing-playwright.md` when editing a `.e2e.ts` file but not when editing a Vitest `.spec.ts` file