### PR TITLE
fix(lib): ensure deterministic URL matching by sorting query parameters

### DIFF
--- a/packages/lib/hooks/useUrlMatchesCurrentUrl.test.ts
+++ b/packages/lib/hooks/useUrlMatchesCurrentUrl.test.ts
@@ -79,4 +79,19 @@ describe("useUrlMatchesCurrentUrl", () => {
     const { result } = renderHook(() => useUrlMatchesCurrentUrl("?a=1&b=2#section"));
     expect(result.current).toBe(false); // Because current doesn't have the hash
   });
+
+  it("should handle a null pathname without string coercion", async () => {
+    const { usePathname } = await import("next/navigation");
+    const { useCompatSearchParams } = await import("@calcom/lib/hooks/useCompatSearchParams");
+
+    // @ts-expect-error Mocking
+    usePathname.mockReturnValue(null);
+    
+    // @ts-expect-error Mocking
+    useCompatSearchParams.mockReturnValue(new URLSearchParams("a=1"));
+
+    // Ensure that it doesn't construct "null?a=1" and falsely match
+    const { result } = renderHook(() => useUrlMatchesCurrentUrl("null?a=1"));
+    expect(result.current).toBe(false);
+  });
 });

--- a/packages/lib/hooks/useUrlMatchesCurrentUrl.test.ts
+++ b/packages/lib/hooks/useUrlMatchesCurrentUrl.test.ts
@@ -1,0 +1,82 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { describe, expect, it, vi } from "vitest";
+
+import { useUrlMatchesCurrentUrl } from "./useUrlMatchesCurrentUrl";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+}));
+
+// Mock @calcom/lib/hooks/useCompatSearchParams
+vi.mock("@calcom/lib/hooks/useCompatSearchParams", () => ({
+  useCompatSearchParams: vi.fn(),
+}));
+
+describe("useUrlMatchesCurrentUrl", () => {
+  it("should match urls with same search params in different order", async () => {
+    const { usePathname } = await import("next/navigation");
+    const { useCompatSearchParams } = await import("@calcom/lib/hooks/useCompatSearchParams");
+
+    // @ts-expect-error Mocking
+    usePathname.mockReturnValue("/test");
+    
+    // @ts-expect-error Mocking
+    useCompatSearchParams.mockReturnValue(new URLSearchParams("b=2&a=1"));
+
+    // matchFullPath = true
+    const { result: resultFullPath } = renderHook(() => useUrlMatchesCurrentUrl("/test?a=1&b=2", true));
+    expect(resultFullPath.current).toBe(true);
+
+    // matchFullPath = false (includes)
+    const { result: resultIncludes } = renderHook(() => useUrlMatchesCurrentUrl("?a=1&b=2"));
+    expect(resultIncludes.current).toBe(true);
+  });
+
+  it("should not match urls with different search params", async () => {
+    const { usePathname } = await import("next/navigation");
+    const { useCompatSearchParams } = await import("@calcom/lib/hooks/useCompatSearchParams");
+
+    // @ts-expect-error Mocking
+    usePathname.mockReturnValue("/test");
+    
+    // @ts-expect-error Mocking
+    useCompatSearchParams.mockReturnValue(new URLSearchParams("a=1&b=3"));
+
+    const { result } = renderHook(() => useUrlMatchesCurrentUrl("/test?a=1&b=2", true));
+    expect(result.current).toBe(false);
+  });
+
+  it("should handle duplicate query parameters robustly", async () => {
+    const { usePathname } = await import("next/navigation");
+    const { useCompatSearchParams } = await import("@calcom/lib/hooks/useCompatSearchParams");
+
+    // @ts-expect-error Mocking
+    usePathname.mockReturnValue("/test");
+    
+    // @ts-expect-error Mocking
+    useCompatSearchParams.mockReturnValue(new URLSearchParams("a=2&a=1"));
+
+    // URLSearchParams.sort() is stable, duplicate key order is preserved or sorted properly
+    const { result } = renderHook(() => useUrlMatchesCurrentUrl("/test?a=2&a=1", true));
+    expect(result.current).toBe(true);
+  });
+
+  it("should safely ignore hash fragments in the target URL", async () => {
+    const { usePathname } = await import("next/navigation");
+    const { useCompatSearchParams } = await import("@calcom/lib/hooks/useCompatSearchParams");
+
+    // @ts-expect-error Mocking
+    usePathname.mockReturnValue("/test");
+    
+    // @ts-expect-error Mocking
+    useCompatSearchParams.mockReturnValue(new URLSearchParams("b=2&a=1"));
+
+    // matchFullPath = false (includes) handles hashes by safely leaving them at the end
+    // so "?a=1&b=2#section" is sorted to "?a=1&b=2#section", and "/test?a=1&b=2" does NOT include it.
+    // Wait, if current path is "/test?a=1&b=2", it won't match a target URL containing a hash fragment unless the current path has one, 
+    // which usePathname never does. But the sorting won't corrupt the string.
+    const { result } = renderHook(() => useUrlMatchesCurrentUrl("?a=1&b=2#section"));
+    expect(result.current).toBe(false); // Because current doesn't have the hash
+  });
+});

--- a/packages/lib/hooks/useUrlMatchesCurrentUrl.ts
+++ b/packages/lib/hooks/useUrlMatchesCurrentUrl.ts
@@ -9,16 +9,31 @@ export const useUrlMatchesCurrentUrl = (url: string, matchFullPath?: boolean) =>
   // It can certainly have null value https://nextjs.org/docs/app/api-reference/functions/use-pathname#:~:text=usePathname%20can%20return%20null%20when%20a%20fallback%20route%20is%20being%20rendered%20or%20when%20a%20pages%20directory%20page%20has%20been%20automatically%20statically%20optimized%20by%20Next.js%20and%20the%20router%20is%20not%20ready.
   const pathname = usePathname() as null | string;
   const searchParams = useCompatSearchParams();
-  const query = searchParams?.toString();
-  let pathnameWithQuery: string | null;
-  if (query) {
-    pathnameWithQuery = `${pathname}?${query}`;
-  } else {
-    pathnameWithQuery = pathname;
+  let sortedCurrentQuery = "";
+  if (searchParams) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.sort();
+    sortedCurrentQuery = params.toString();
   }
+
+  const pathnameWithQuery = sortedCurrentQuery ? `${pathname}?${sortedCurrentQuery}` : pathname;
+
+  let sortedTargetUrl = url;
+  const hashSplit = url.split("#");
+  const hash = hashSplit.length > 1 ? `#${hashSplit[1]}` : "";
+  const pathAndQuery = hashSplit[0];
+  
+  const [targetPath, targetQueryString] = pathAndQuery.split("?");
+  if (targetQueryString !== undefined) {
+    const targetParams = new URLSearchParams(targetQueryString);
+    targetParams.sort();
+    const sortedTargetQuery = targetParams.toString();
+    sortedTargetUrl = sortedTargetQuery ? `${targetPath}?${sortedTargetQuery}${hash}` : `${targetPath}${hash}`;
+  }
+
   if (matchFullPath) {
-    return pathnameWithQuery ? pathnameWithQuery === url : false;
+    return pathnameWithQuery ? pathnameWithQuery === sortedTargetUrl : false;
   }
-  // TODO: It should actually re-order the params before comparing ?a=1&b=2 should match with ?b=2&a=1
-  return pathnameWithQuery ? pathnameWithQuery.includes(url) : false;
+  
+  return pathnameWithQuery ? pathnameWithQuery.includes(sortedTargetUrl) : false;
 };

--- a/packages/lib/hooks/useUrlMatchesCurrentUrl.ts
+++ b/packages/lib/hooks/useUrlMatchesCurrentUrl.ts
@@ -16,7 +16,7 @@ export const useUrlMatchesCurrentUrl = (url: string, matchFullPath?: boolean) =>
     sortedCurrentQuery = params.toString();
   }
 
-  const pathnameWithQuery = sortedCurrentQuery ? `${pathname}?${sortedCurrentQuery}` : pathname;
+  const pathnameWithQuery = pathname !== null && sortedCurrentQuery ? `${pathname}?${sortedCurrentQuery}` : pathname;
 
   let sortedTargetUrl = url;
   const hashSplit = url.split("#");


### PR DESCRIPTION
**What changed:**
- Updated `useUrlMatchesCurrentUrl` to parse and sort query parameters using `URLSearchParams.sort()`.
- Added logic to safely split and preserve hash fragments (`#`) during comparison.
- Added a test suite to cover re-ordered parameters, duplicates, and hash fragments.

**Why:**
Previously, the hook relied on naive string comparison (`===` and `.includes()`). This caused active navigation states and tabs to fail if URL parameters were appended in a different order (e.g., `?a=1&b=2` failing to match `?b=2&a=1`). Sorting the `URLSearchParams` makes the matching deterministic.