### PR TITLE
docs: remove dead Discussions links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@
     <br />
     <a href="https://github.com/calcom/cal.diy"><strong>GitHub</strong></a>
     <br />
-    <br />
-    <a href="https://github.com/calcom/cal.diy/discussions">Discussions</a>
-    &middot;
     <a href="https://github.com/calcom/cal.diy/issues">Issues</a>
     &middot;
     <a href="./CONTRIBUTING.md">Contributing</a>
@@ -795,7 +792,6 @@ We welcome contributions! Whether it's fixing a typo, improving documentation, o
 > **Important:** Cal.diy is a community fork. Contributions to this repo do **not** flow to Cal.com's production platform. See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 
 - Check out our [Contributing Guide](./CONTRIBUTING.md) for detailed steps.
-- Join the discussion on [GitHub Discussions](https://github.com/calcom/cal.diy/discussions).
 - Please follow our coding standards and commit message conventions to keep the project consistent.
 
 Even small improvements matter — thank you for helping us grow!
@@ -816,7 +812,7 @@ We have a list of [help wanted](https://github.com/calcom/cal.diy/issues?q=is:is
 
 ### Translations
 
-Don't code but still want to contribute? Join our [Discussions](https://github.com/calcom/cal.diy/discussions) and help translate Cal.diy into your language.
+Don't code but still want to contribute? help translate Cal.diy into your language.
 
 <!-- ACKNOWLEDGEMENTS -->
 


### PR DESCRIPTION
## What does this PR do?
Removes 3 dead links to GitHub Discussions from README.md. Discussions 
isn't enabled on calcom/cal.diy, so these links return a 404. Likely 
leftover from when the README was copied from calcom/cal.com.

- Fixes: N/A (found while setting up the project, no existing issue)

## Visual Demo (For contributors especially)
N/A — text/docs-only change, no UI involved.

## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A — this PR is the doc fix itself.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — link removal, verified manually via HTTP request (confirmed 404 before fix).

## How should this be tested?
Visit https://github.com/calcom/cal.diy/discussions — confirms 404 before this fix.
No environment setup needed; this is a documentation-only change.