### PR TITLE
fix(bookings): resolve mobile OTP screen overlap and UI spacing

### DIFF
--- a/apps/web/modules/bookings/components/Booker.tsx
+++ b/apps/web/modules/bookings/components/Booker.tsx
@@ -584,10 +584,10 @@ const BookerComponent = ({
       </>
       <BookFormAsModal
         onCancel={() => setSelectedTimeslot(null)}
-        visible={bookerState === "booking" && shouldShowFormInDialog}>
+        visible={bookerState === "booking" && shouldShowFormInDialog && !isEmailVerificationModalVisible}>
         {EventBooker}
       </BookFormAsModal>
-      <Dialog open={isMobile && isSlotSelectionModalVisible}>
+      <Dialog open={isMobile && isSlotSelectionModalVisible && !isEmailVerificationModalVisible}>
         <DialogContent
           type={undefined}
           enableOverflow

--- a/apps/web/modules/bookings/components/VerifyCodeDialog.tsx
+++ b/apps/web/modules/bookings/components/VerifyCodeDialog.tsx
@@ -83,7 +83,7 @@ export const VerifyCodeDialog = ({
   useEffect(() => setValue(""), [isOpenDialog]);
 
   const digitClassName =
-    "h-12 w-12 text-center text-xl! text-emphasis caret-emphasis [-webkit-text-fill-color:currentColor]";
+    "h-10 w-8 sm:h-12 sm:w-12 text-center text-base sm:text-xl! text-emphasis caret-emphasis [-webkit-text-fill-color:currentColor] px-0! sm:px-3!";
 
   return (
     <Dialog
@@ -92,11 +92,10 @@ export const VerifyCodeDialog = ({
         resetErrors();
       }}>
       <DialogContent className="sm:max-w-md">
-        <div className="flex flex-row">
-          <div className="w-full">
-            <DialogHeader title={t("verify_your_email")} subtitle={t("enter_digit_code", { email })} />
-            <Label htmlFor="code">{t("code")}</Label>
-            <div className="flex flex-row justify-between">
+        <DialogHeader title={t("verify_your_email")} subtitle={t("enter_digit_code", { email })} />
+        <div className="mb-8 mt-2">
+          <Label htmlFor="code">{t("code")}</Label>
+            <div className="flex flex-row justify-between gap-1 sm:gap-2">
               <Input
                 className={digitClassName}
                 name="2fa1"
@@ -119,14 +118,13 @@ export const VerifyCodeDialog = ({
                 <p>{error}</p>
               </div>
             )}
-            <DialogFooter noSticky>
-              <DialogClose onClick={() => setIsOpenDialog(false)} />
-              <Button type="submit" onClick={verifyCode} loading={isPending}>
-                {t("submit")}
-              </Button>
-            </DialogFooter>
-          </div>
         </div>
+        <DialogFooter showDivider>
+          <DialogClose onClick={() => setIsOpenDialog(false)} />
+          <Button type="submit" onClick={verifyCode} loading={isPending}>
+            {t("submit")}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/modules/bookings/components/VerifyCodeDialog.tsx
+++ b/apps/web/modules/bookings/components/VerifyCodeDialog.tsx
@@ -83,7 +83,7 @@ export const VerifyCodeDialog = ({
   useEffect(() => setValue(""), [isOpenDialog]);
 
   const digitClassName =
-    "h-10 w-8 sm:h-12 sm:w-12 text-center text-base sm:text-xl! text-emphasis caret-emphasis [-webkit-text-fill-color:currentColor] px-0! sm:px-3!";
+    "h-12 w-12 max-[350px]:h-10 max-[350px]:w-8 text-center text-xl! max-[350px]:text-base text-emphasis caret-emphasis [-webkit-text-fill-color:currentColor] max-[350px]:px-0!";
 
   return (
     <Dialog


### PR DESCRIPTION
## Description

This PR fixes a bug where the Email Verification (OTP) screen was failing to display or render correctly on mobile and tablet viewports, along with fixing a UI layout issue on the dialog itself.

### 🐛 The Issue

**1. Mobile/Tablet Rendering Failure (Overlapping Modals)**
During investigation, I found that on mobile viewports (`shouldShowFormInDialog = true`), the `BookEventForm` and `SlotSelectionModal` are rendered inside a Radix UI `<Dialog>`. When a user attempts to verify their email, the `VerifyCodeDialog` (which is also a `<Dialog>`) is triggered. Radix UI struggles with sibling dialogs being active simultaneously, causing focus traps and `pointer-events: none` to block the verification modal from appearing or functioning. 

**2. OTP Dialog UI & Spacing Issues**
The action buttons in the `DialogFooter` had improper spacing because they were nested inside extra wrapper divs (`<div className="flex flex-row"><div className="w-full">`), which broke the default negative margin layout provided by `@calcom/ui`. Additionally, on extremely small screens (e.g., `320px` width), the 6 OTP input boxes were overflowing.

### 🛠️ The Fix

1. **Dialog Hierarchy Fix**: Updated `Booker.tsx` to conditionally hide `BookFormAsModal` and `SlotSelectionModal` whenever `isEmailVerificationModalVisible` is active. This ensures only one modal is battling for focus and screen presence on mobile viewports at a time.
2. **UI Spacing Fix**: Removed the unnecessary wrapper divs in `VerifyCodeDialog.tsx` so `DialogFooter` correctly inherits its expected spacing.
3. **Small Screen Input Fix**: Adjusted the OTP input field sizing from `w-12` down to `w-8`, removed padding on mobile, and added a safe `gap-1` flex structure so the inputs gracefully fit on `320px` width screens without squishing or overflowing.

### 🎯 Expected Behavior

- Users on Mobile/Tablet can seamlessly enter the email verification flow without the screen disappearing or freezing.
- The 6-digit OTP boxes fit perfectly on devices as small as `320px`.
- The 'Submit' and 'Cancel' buttons are cleanly aligned within the dialog footer.

## 📹 Proof (Before vs After)

### Before
*(The OTP modal fails to appear/interact on mobile, and inputs are squished on small screens)*


https://github.com/user-attachments/assets/e36bb86e-7c56-40f6-adb8-23c2b8784833


### After
*(The OTP modal opens smoothly on mobile, replacing the booking form temporarily. Layout is crisp and fits all screen sizes)*



https://github.com/user-attachments/assets/16661d97-13bf-4766-9cb3-42647cac600d





## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX improvement

## Checklist
- [x] I have tested these changes on Desktop, Tablet, and Mobile viewports (including `320px` width).
- [x] I have run `yarn type-check:ci --force` to ensure type safety.
- [x] I have formatted my code using `yarn biome check --write .`.