### PR TITLE
fix(ui): resolve mobile overflow in buffer and notice inputs on event limits tab

### DIFF
--- a/packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx
+++ b/packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx
@@ -352,8 +352,8 @@ const MinimumBookingNoticeInput = function MinimumBookingNoticeInput({
   }, [minimumBookingNoticeDisplayValues, setValue, passThroughProps.name]);
 
   return (
-    <div className="flex items-end justify-end">
-      <div className="w-1/2 md:w-full">
+    <div className="flex items-end justify-end w-full">
+      <div className="w-full">
         <InputField
           required
           disabled={passThroughProps.disabled}


### PR DESCRIPTION
## What does this PR do?

Fixes a mobile layout overflow bug in the **Limits** tab of event type settings. On small screens, the `MinimumBookingNoticeInput` and related buffer inputs were constrained to `w-1/2` (half width), causing content to overflow and the input to appear clipped on mobile devices.

Fixes #29426

## Changes

- `packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx`
  - Changed wrapper `div` from `flex items-end justify-end` to `flex items-end justify-end w-full`
  - Changed inner `div` from `w-1/2 md:w-full` to `w-full`

These classes ensured the input was only half-width on mobile but full-width on desktop — the reverse of what's expected for a responsive layout.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this tested?

Manually inspected the Tailwind class hierarchy in the component. The `w-1/2` class applies at all breakpoints below `md:`, meaning mobile viewports get half-width — a clear layout bug.

## Checklist

- [x] I self-reviewed my code
- [x] No new dependencies added
- [x] Visual change only — no logic altered