### PR TITLE
fix(calendar): handle Office365 webhook validation

### DIFF
--- a/apps/web/app/api/webhooks/calendar-subscription/[provider]/__tests__/route.test.ts
+++ b/apps/web/app/api/webhooks/calendar-subscription/[provider]/__tests__/route.test.ts
@@ -1,7 +1,6 @@
-import { NextRequest } from "next/server";
-import { describe, test, expect, vi, beforeEach } from "vitest";
-
 import { CalendarSubscriptionService } from "@calcom/features/calendar-subscription/lib/CalendarSubscriptionService";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("next/server", () => ({
   NextRequest: class MockNextRequest {
@@ -34,8 +33,12 @@ vi.mock("next/server", () => ({
 }));
 
 vi.mock("@calcom/features/calendar-subscription/lib/CalendarSubscriptionService");
-vi.mock("@calcom/features/calendar-subscription/lib/cache/CalendarCacheEventService");
-vi.mock("@calcom/features/calendar-subscription/lib/sync/CalendarSyncService");
+vi.mock("@calcom/features/calendar-subscription/lib/cache/CalendarCacheEventService", () => ({
+  CalendarCacheEventService: vi.fn(function CalendarCacheEventService() {}),
+}));
+vi.mock("@calcom/features/calendar-subscription/lib/sync/CalendarSyncService", () => ({
+  CalendarSyncService: vi.fn(function CalendarSyncService() {}),
+}));
 vi.mock("@calcom/prisma", () => ({
   prisma: {},
 }));
@@ -94,6 +97,29 @@ describe("/api/webhooks/calendar-subscription/[provider]", () => {
 
       expect(response.status).toBe(200);
       expect(mockProcessWebhook).toHaveBeenCalledWith("office365_calendar", request);
+    });
+
+    test("should respond to office365 validationToken requests as plain text", async () => {
+      const request = new NextRequest(
+        "http://localhost/api/webhooks/calendar-subscription/office365_calendar?validationToken=Validation%3A%20Testing",
+        {
+          method: "POST",
+        }
+      );
+      const mockProcessWebhook = vi.fn();
+
+      mockCalendarSubscriptionService.prototype.processWebhook = mockProcessWebhook;
+
+      const { POST } = await import("../route");
+      const response = await POST(request, {
+        params: Promise.resolve({ provider: "office365_calendar" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("text/plain");
+      await expect(response.text()).resolves.toBe("Validation: Testing");
+      expect(mockCalendarSubscriptionService).not.toHaveBeenCalled();
+      expect(mockProcessWebhook).not.toHaveBeenCalled();
     });
 
     test("should reject unsupported provider", async () => {

--- a/apps/web/app/api/webhooks/calendar-subscription/[provider]/route.ts
+++ b/apps/web/app/api/webhooks/calendar-subscription/[provider]/route.ts
@@ -58,6 +58,7 @@ async function postHandler(request: NextRequest, ctx: { params: Promise<Params> 
 
   const office365ValidationToken = getOffice365ValidationToken(providerFromParams, request);
   if (office365ValidationToken !== null) {
+    log.debug("Responding to Office365 validation token request");
     return new Response(office365ValidationToken, {
       status: 200,
       headers: {

--- a/apps/web/app/api/webhooks/calendar-subscription/[provider]/route.ts
+++ b/apps/web/app/api/webhooks/calendar-subscription/[provider]/route.ts
@@ -29,6 +29,16 @@ function extractAndValidateProviderFromParams(params: Params): CalendarSubscript
   return null;
 }
 
+function getOffice365ValidationToken(
+  provider: CalendarSubscriptionProvider,
+  request: NextRequest
+): string | null {
+  if (provider !== "office365_calendar") {
+    return null;
+  }
+  return request.nextUrl.searchParams.get("validationToken");
+}
+
 /**
  * Handles incoming POST requests for calendar webhooks.
  * It processes the webhook based on the calendar provider specified in the URL.
@@ -44,6 +54,16 @@ async function postHandler(request: NextRequest, ctx: { params: Promise<Params> 
   const providerFromParams = extractAndValidateProviderFromParams(await ctx.params);
   if (!providerFromParams) {
     return NextResponse.json({ message: "Unsupported provider" }, { status: 400 });
+  }
+
+  const office365ValidationToken = getOffice365ValidationToken(providerFromParams, request);
+  if (office365ValidationToken !== null) {
+    return new Response(office365ValidationToken, {
+      status: 200,
+      headers: {
+        "content-type": "text/plain",
+      },
+    });
   }
 
   try {


### PR DESCRIPTION
## What does this PR do?

Fixes #29623.

Handles Microsoft Graph Office365 webhook validation requests before the normal calendar subscription webhook processing flow.

When an Office365 webhook request includes a `validationToken` query parameter, the route now immediately returns:

- HTTP `200`
- `Content-Type: text/plain`
- the decoded validation token as the response body

This matches Microsoft Graph's webhook validation requirements and avoids sending validation handshake requests into the normal webhook path, which expects a channel/subscription ID.

## Why

Microsoft Graph validation requests do not include a channel ID. The existing route passed these requests into `CalendarSubscriptionService.processWebhook`, where the Office365 adapter validated the token but the service then failed while extracting the missing channel ID.

## How should this be tested?

- `yarn vitest run "apps/web/app/api/webhooks/calendar-subscription/[provider]/__tests__/route.test.ts"`
- `yarn biome check --write "apps/web/app/api/webhooks/calendar-subscription/[provider]/route.ts" "apps/web/app/api/webhooks/calendar-subscription/[provider]/__tests__/route.test.ts"`
- `git diff --check`

The focused route test suite passes with 12 tests.