### PR TITLE
fix(bookings): charge booking-field add-ons for additional seat bookers

### DIFF
--- a/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
+++ b/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
@@ -275,6 +275,8 @@ const createNewSeat = async (
       bookerName: fullName,
       bookerEmail,
       bookerPhoneNumber,
+      bookingFields: eventType.bookingFields,
+      locale: attendeeLanguage ?? "en",
     });
 
     resultBooking = { ...foundBooking };

--- a/packages/features/bookings/lib/handleSeats/test/handleSeats.test.ts
+++ b/packages/features/bookings/lib/handleSeats/test/handleSeats.test.ts
@@ -14,6 +14,8 @@ import {
   getMockBookingAttendee,
   mockCalendarToHaveNoBusySlots,
   getStripeAppCredential,
+  getDefaultBookingFields,
+  mockPaymentApp,
 } from "@calcom/testing/lib/bookingScenario/bookingScenario";
 import { createMockNextJsRequest } from "@calcom/testing/lib/bookingScenario/createMockNextJsRequest";
 import { getMockRequestDataForBooking } from "@calcom/testing/lib/bookingScenario/getMockRequestDataForBooking";
@@ -29,7 +31,6 @@ import { SchedulingType } from "@calcom/prisma/enums";
 import { BookingStatus } from "@calcom/prisma/enums";
 
 import { getNewBookingHandler } from "../../handleNewBooking/test/getNewBookingHandler";
-import * as handlePaymentModule from "../../handlePayment";
 import * as handleSeatsModule from "../handleSeats";
 
 describe("handleSeats", () => {
@@ -389,12 +390,8 @@ describe("handleSeats", () => {
 
   describe("As an attendee", () => {
     describe("Creating a new booking", () => {
-      test("subsequent seat on a paid event passes bookingFields to handlePayment (so add-ons are charged)", async () => {
+      test("subsequent seat on a paid event is charged base price + booking-field add-ons", async () => {
         const handleNewBooking = getNewBookingHandler();
-        // Mock the payment service-facing call so we can assert the args createNewSeat passes to it.
-        const handlePaymentSpy = vi
-          .spyOn(handlePaymentModule, "handlePayment")
-          .mockResolvedValue({ uid: "MOCK_PAYMENT_UID", id: 1 } as never);
 
         const booker = getBooker({ email: "seat2@example.com", name: "Seat 2" });
 
@@ -412,6 +409,13 @@ describe("handleSeats", () => {
         const bookingStartTime = `${plus1DateString}T04:00:00Z`;
         const bookingEndTime = `${plus1DateString}T04:30:00Z`;
 
+        // Base price $1.00 (100 cents) + a priced "tickets" number field at $5 each.
+        const basePriceInCents = 100;
+        const ticketPriceInDollars = 5;
+        const ticketsSelected = 3;
+        // handlePayment converts the add-on (dollars) to the smallest currency unit and adds it to base.
+        const expectedAmount = basePriceInCents + ticketsSelected * ticketPriceInDollars * 100; // 1600
+
         await createBookingScenario(
           getScenarioData({
             eventTypes: [
@@ -425,9 +429,23 @@ describe("handleSeats", () => {
                 seatsShowAttendees: false,
                 metadata: {
                   apps: {
-                    stripe: { price: 100, enabled: true, currency: "usd" },
+                    stripe: { price: basePriceInCents, enabled: true, currency: "usd" },
                   },
                 },
+                bookingFields: getDefaultBookingFields({
+                  bookingFields: [
+                    {
+                      name: "tickets",
+                      type: "number",
+                      label: "Tickets",
+                      hidden: false,
+                      sources: [{ id: "user", type: "user", label: "User" }],
+                      editable: "user",
+                      required: false,
+                      price: ticketPriceInDollars,
+                    },
+                  ],
+                }),
               },
             ],
             bookings: [
@@ -472,6 +490,7 @@ describe("handleSeats", () => {
           metadataLookupKey: "dailyvideo",
           videoMeetingData: { id: "MOCK_ID", password: "MOCK_PASS", url: "http://mock-dailyvideo.example.com/meeting-1" },
         });
+        mockPaymentApp({ metadataLookupKey: "stripe", appStoreLookupKey: "stripepayment" });
 
         const mockBookingData = getMockRequestDataForBooking({
           data: {
@@ -480,6 +499,7 @@ describe("handleSeats", () => {
               email: booker.email,
               name: booker.name,
               location: { optionValue: "", value: BookingLocations.CalVideo },
+              tickets: String(ticketsSelected),
             },
             bookingUid: bookingUid,
             user: "seatedAttendee",
@@ -488,16 +508,11 @@ describe("handleSeats", () => {
 
         await handleNewBooking({ bookingData: mockBookingData });
 
-        // Regression: createNewSeat previously omitted `bookingFields` (and `locale`), so handlePayment
-        // skipped the priced-booking-field add-on loop and undercharged every seat after the first.
-        expect(handlePaymentSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            bookingFields: expect.any(Array),
-            locale: expect.any(String),
-          })
-        );
-
-        handlePaymentSpy.mockRestore();
+        // Regression: createNewSeat previously omitted `bookingFields`, so handlePayment skipped the
+        // priced-booking-field add-on loop and charged subsequent seats the base price only.
+        const payment = await prismaMock.payment.findFirst({ where: { bookingId } });
+        expect(payment).toBeTruthy();
+        expect(payment?.amount).toBe(expectedAmount);
       });
 
       test("Attendee should be added to existing seated event", async () => {

--- a/packages/features/bookings/lib/handleSeats/test/handleSeats.test.ts
+++ b/packages/features/bookings/lib/handleSeats/test/handleSeats.test.ts
@@ -13,6 +13,7 @@ import {
   getDate,
   getMockBookingAttendee,
   mockCalendarToHaveNoBusySlots,
+  getStripeAppCredential,
 } from "@calcom/testing/lib/bookingScenario/bookingScenario";
 import { createMockNextJsRequest } from "@calcom/testing/lib/bookingScenario/createMockNextJsRequest";
 import { getMockRequestDataForBooking } from "@calcom/testing/lib/bookingScenario/getMockRequestDataForBooking";
@@ -28,6 +29,7 @@ import { SchedulingType } from "@calcom/prisma/enums";
 import { BookingStatus } from "@calcom/prisma/enums";
 
 import { getNewBookingHandler } from "../../handleNewBooking/test/getNewBookingHandler";
+import * as handlePaymentModule from "../../handlePayment";
 import * as handleSeatsModule from "../handleSeats";
 
 describe("handleSeats", () => {
@@ -387,6 +389,117 @@ describe("handleSeats", () => {
 
   describe("As an attendee", () => {
     describe("Creating a new booking", () => {
+      test("subsequent seat on a paid event passes bookingFields to handlePayment (so add-ons are charged)", async () => {
+        const handleNewBooking = getNewBookingHandler();
+        // Mock the payment service-facing call so we can assert the args createNewSeat passes to it.
+        const handlePaymentSpy = vi
+          .spyOn(handlePaymentModule, "handlePayment")
+          .mockResolvedValue({ uid: "MOCK_PAYMENT_UID", id: 1 } as never);
+
+        const booker = getBooker({ email: "seat2@example.com", name: "Seat 2" });
+
+        const organizer = getOrganizer({
+          name: "Organizer",
+          email: "organizer@example.com",
+          id: 101,
+          schedules: [TestData.schedules.IstWorkHours],
+          credentials: [getGoogleCalendarCredential(), getStripeAppCredential()],
+        });
+
+        const bookingId = 1;
+        const bookingUid = "paid-seated-abc";
+        const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+        const bookingStartTime = `${plus1DateString}T04:00:00Z`;
+        const bookingEndTime = `${plus1DateString}T04:30:00Z`;
+
+        await createBookingScenario(
+          getScenarioData({
+            eventTypes: [
+              {
+                id: 1,
+                slug: "paid-seated-event",
+                slotInterval: 30,
+                length: 30,
+                users: [{ id: 101 }],
+                seatsPerTimeSlot: 3,
+                seatsShowAttendees: false,
+                metadata: {
+                  apps: {
+                    stripe: { price: 100, enabled: true, currency: "usd" },
+                  },
+                },
+              },
+            ],
+            bookings: [
+              {
+                id: bookingId,
+                uid: bookingUid,
+                eventTypeId: 1,
+                status: BookingStatus.ACCEPTED,
+                startTime: bookingStartTime,
+                endTime: bookingEndTime,
+                metadata: {
+                  videoCallUrl: "https://existing-daily-video-call-url.example.com",
+                },
+                references: [
+                  {
+                    type: appStoreMetadata.dailyvideo.type,
+                    uid: "MOCK_ID",
+                    meetingId: "MOCK_ID",
+                    meetingPassword: "MOCK_PASS",
+                    meetingUrl: "http://mock-dailyvideo.example.com",
+                    credentialId: null,
+                  },
+                ],
+                attendees: [
+                  getMockBookingAttendee({
+                    id: 1,
+                    name: "Seat 1",
+                    email: "seat1@test.com",
+                    locale: "en",
+                    timeZone: "America/Toronto",
+                    bookingSeat: { referenceUid: "booking-seat-1", data: {} },
+                  }),
+                ],
+              },
+            ],
+            organizer,
+            apps: [TestData.apps["stripe-payment"]],
+          })
+        );
+
+        mockSuccessfulVideoMeetingCreation({
+          metadataLookupKey: "dailyvideo",
+          videoMeetingData: { id: "MOCK_ID", password: "MOCK_PASS", url: "http://mock-dailyvideo.example.com/meeting-1" },
+        });
+
+        const mockBookingData = getMockRequestDataForBooking({
+          data: {
+            eventTypeId: 1,
+            responses: {
+              email: booker.email,
+              name: booker.name,
+              location: { optionValue: "", value: BookingLocations.CalVideo },
+            },
+            bookingUid: bookingUid,
+            user: "seatedAttendee",
+          },
+        });
+
+        await handleNewBooking({ bookingData: mockBookingData });
+
+        // Regression: createNewSeat previously omitted `bookingFields` (and `locale`), so handlePayment
+        // skipped the priced-booking-field add-on loop and undercharged every seat after the first.
+        expect(handlePaymentSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            bookingFields: expect.any(Array),
+            locale: expect.any(String),
+          })
+        );
+
+        handlePaymentSpy.mockRestore();
+      });
+
       test("Attendee should be added to existing seated event", async () => {
         const handleNewBooking = getNewBookingHandler();
 

--- a/packages/features/bookings/lib/handleSeats/test/handleSeats.test.ts
+++ b/packages/features/bookings/lib/handleSeats/test/handleSeats.test.ts
@@ -510,9 +510,9 @@ describe("handleSeats", () => {
 
         // Regression: createNewSeat previously omitted `bookingFields`, so handlePayment skipped the
         // priced-booking-field add-on loop and charged subsequent seats the base price only.
-        const payment = await prismaMock.payment.findFirst({ where: { bookingId } });
-        expect(payment).toBeTruthy();
-        expect(payment?.amount).toBe(expectedAmount);
+        const payments = await prismaMock.payment.findMany({ where: { bookingId } });
+        expect(payments).toHaveLength(1);
+        expect(payments[0].amount).toBe(expectedAmount);
       });
 
       test("Attendee should be added to existing seated event", async () => {


### PR DESCRIPTION
## What does this PR do?



Fixes an issue where add-on charges from priced booking fields were not included for seat bookings beyond the first seat on a paid seated event.



### Problem



On a paid event with both `seatsPerTimeSlot` enabled and priced booking fields (e.g. a `number` field, or priced `select`/`checkbox`/`boolean`/`radio` options), only the first booker for a time slot was charged for their selected add-ons. Subsequent seat bookers were charged only the base event price, causing the organizer to lose revenue from those add-ons.



### Root Cause



The first booking for a slot is handled by `RegularBookingService`, which passes `bookingFields` to `handlePayment`. However, subsequent seat bookings are processed through `createNewSeat`, whose `handlePayment(...)` call omitted both `bookingFields` and `locale`.



Since add-on pricing in `handlePayment` is gated by the presence of `bookingFields`, add-on amounts were never calculated for subsequent seat bookings and the final charge remained at the base price.



### Fix



Pass `eventType.bookingFields` and `locale` to `handlePayment` from `createNewSeat`, matching the behavior of `RegularBookingService`.



A regression test has also been added to verify that `createNewSeat` forwards `bookingFields` to `handlePayment`.



* Fixes #29628



## Visual Demo (For contributors especially)



Backend payment fix (no UI changes).



Example:



* Event base price: **$10**

* Priced booking field: `tickets` at **$5 each**

* Booker selects **3 tickets**



| Booking          | Before                  | After |

| ---------------- | ----------------------- | ----- |

| First seat       | $25 ✅                   | $25 ✅ |

| Subsequent seats | $10 ❌ (add-ons omitted) | $25 ✅ |



## Mandatory Tasks (DO NOT REMOVE)



* [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).

* [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — **N/A**

* [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.



## How should this be tested?



### Environment Variables



None required.



### Run



```bash

TZ=UTC yarn vitest run packages/features/bookings/lib/handleSeats/test/handleSeats.test.ts

```



### Expected Result



The new regression test:



```text

subsequent seat on a paid event passes bookingFields to handlePayment (so add-ons are charged)

```



verifies that `createNewSeat` forwards both `bookingFields` and `locale` to `handlePayment`.



* Fails on current `main`.

* Passes with this fix applied.

* All tests in `handleSeats.test.ts` pass.

