### PR TITLE
fix: guard useOAuthFlow interceptor against undefined/non-Axios errors

### DIFF
--- a/.changeset/oauthflow-undefined-error-guard.md
+++ b/.changeset/oauthflow-undefined-error-guard.md
@@ -1,0 +1,5 @@
+---
+"@calcom/atoms": patch
+---
+
+fix: prevent crash in useOAuthFlow when the axios response interceptor receives an undefined/non-Axios error

--- a/packages/platform/atoms/hooks/useOAuthFlow.ts
+++ b/packages/platform/atoms/hooks/useOAuthFlow.ts
@@ -36,7 +36,15 @@ export const useOAuthFlow = ({
   useEffect(() => {
     const interceptorId =
       clientAccessToken && http.getAuthorizationHeader()
-        ? http.responseInterceptor.use(undefined, async (err: AxiosError) => {
+        ? http.responseInterceptor.use(undefined, async (err: AxiosError | undefined) => {
+            // Axios can invoke the rejection handler with a non-Axios or
+            // undefined value (e.g. a network failure, or an upstream
+            // interceptor rejecting with something other than an AxiosError).
+            // Dereferencing `err.config` then throws "undefined is not an
+            // object (evaluating 'e.config')", so bail out safely first.
+            if (!err) {
+              return Promise.reject(err);
+            }
             const originalRequest = err.config as AxiosRequestConfig;
             if (refreshUrl && err.response?.status === 498 && !isRefreshing) {
               setIsRefreshing(true);


### PR DESCRIPTION
Fixes #18906

### Problem
The platform atoms throw `undefined is not an object (evaluating 'e.config')` (minified: `let u = e.config`). The crash originates in `useOAuthFlow`'s response-interceptor rejection handler.

### Root cause
In `packages/platform/atoms/hooks/useOAuthFlow.ts` the handler is typed `(err: AxiosError)` and immediately does `const originalRequest = err.config as AxiosRequestConfig`. But axios can invoke the `onRejected` handler with an `undefined` or non-Axios value — e.g. a network failure, or an upstream interceptor rejecting with something other than an `AxiosError`. Dereferencing `err.config` on `undefined` then throws exactly the reported error.

### Fix
Widen the parameter to `AxiosError | undefined` and return early (`Promise.reject(err)`) when there is no error object, before any dereference. After the guard, TypeScript narrows `err` back to `AxiosError`, so the existing 498 token-refresh path is completely unchanged for real errors.

This is a minimal, defensive null-guard — no behavioral change for genuine `AxiosError`s, it only stops the crash when the rejection value is missing/non-Axios.

Added a changeset (`@calcom/atoms` patch).