### PR TITLE
chore: remove obsolete ts comment

### DIFF
--- a/packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx
+++ b/packages/features/eventtypes/components/tabs/limits/EventLimitsTab.tsx
@@ -1030,7 +1030,6 @@ export const IntervalLimitsManager = <K extends "durationLimits" | "bookingLimit
 
           setValue(
             propertyName,
-            // TODO: Remove @ts-expect-error, type error no longer exists in later TS versions.
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             {
               ...watchIntervalLimits,


### PR DESCRIPTION
## What does this PR do?

Removes an obsolete TODO comment
The comment referred to a previously required @ts-expect-error around the setValue call used when adding an interval limit.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
