### PR TITLE
fix: enforce atomic booking limits check with row-level locks (#29605)

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/createBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking/createBooking.ts
@@ -1,4 +1,7 @@
 import dayjs from "@calcom/dayjs";
+import { CheckBookingLimitsService } from "@calcom/features/bookings/lib/checkBookingLimits";
+import { CheckBookingAndDurationLimitsService } from "@calcom/features/bookings/lib/handleNewBooking/checkBookingAndDurationLimits";
+import { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
 import { isPrismaObjOrUndefined } from "@calcom/lib/isPrismaObj";
 import { withReporting } from "@calcom/lib/sentryWrapper";
 import prisma from "@calcom/prisma";
@@ -87,7 +90,11 @@ const _createBooking = async ({
     bookingAndAssociatedData,
     originalRescheduledBooking,
     eventType.paymentAppData,
-    eventType.organizerUser
+    eventType.organizerUser,
+    eventType.eventTypeData,
+    eventType.id,
+    evt.startTime,
+    originalRescheduledBooking?.uid
   );
 };
 
@@ -97,7 +104,11 @@ async function saveBooking(
   bookingAndAssociatedData: ReturnType<typeof buildNewBookingData>,
   originalRescheduledBooking: OriginalRescheduledBooking,
   paymentAppData: PaymentAppData,
-  organizerUser: CreateBookingParams["eventType"]["organizerUser"]
+  organizerUser: CreateBookingParams["eventType"]["organizerUser"],
+  eventTypeData: NewBookingEventType,
+  eventTypeId: EventTypeId,
+  evtStartTime: string,
+  rescheduleUid: string | undefined
 ) {
   const { newBookingData, originalBookingUpdateDataForCancellation } = bookingAndAssociatedData;
   const createBookingObj = {
@@ -137,6 +148,25 @@ async function saveBooking(
   }
 
   return prisma.$transaction(async (tx) => {
+    if (eventTypeId) {
+      // Row-level lock the EventType to serialize concurrent booking requests for this event type
+      await tx.$queryRaw`SELECT id FROM "EventType" WHERE id = ${eventTypeId} FOR UPDATE`;
+    }
+
+    if (eventTypeId && eventTypeData) {
+      const txBookingRepo = new BookingRepository(tx);
+      const txCheckBookingLimitsService = new CheckBookingLimitsService({ bookingRepo: txBookingRepo });
+      const txCheckBookingAndDurationLimitsService = new CheckBookingAndDurationLimitsService({
+        checkBookingLimitsService: txCheckBookingLimitsService,
+      });
+
+      await txCheckBookingAndDurationLimitsService.checkBookingAndDurationLimits({
+        eventType: eventTypeData,
+        reqBodyStart: evtStartTime,
+        reqBodyRescheduleUid: rescheduleUid,
+      });
+    }
+
     if (originalBookingUpdateDataForCancellation) {
       await tx.booking.update(originalBookingUpdateDataForCancellation);
     }

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -75,7 +75,6 @@ export type ManagedEventCancellationResult = {
   status: BookingStatus;
 };
 
-
 type TeamBookingsParamsBase = {
   user: { id: number; email: string };
   teamId: number;
@@ -338,7 +337,7 @@ const selectStatementToGetBookingForCalEventBuilder = {
 };
 
 export class BookingRepository implements IBookingRepository {
-  constructor(private prismaClient: PrismaClient) {}
+  constructor(private prismaClient: PrismaClient | Prisma.TransactionClient) {}
 
   /**
    * Gets the fromReschedule field for a booking by UID
@@ -2019,7 +2018,24 @@ export class BookingRepository implements IBookingRepository {
     newBooking: ManagedEventReassignmentCreatedBooking;
     cancelledBooking: ManagedEventCancellationResult;
   }> {
-    return this.prismaClient.$transaction(async (tx) => {
+    if ("$transaction" in this.prismaClient) {
+      return this.prismaClient.$transaction(async (tx) => {
+        const cancelledBooking = await this.cancelBookingForManagedEventReassignment({
+          bookingId,
+          cancellationReason,
+          metadata,
+          tx,
+        });
+
+        const newBooking = await this.createBookingForManagedEventReassignment({
+          ...newBookingPlan,
+          tx,
+        });
+
+        return { newBooking, cancelledBooking };
+      });
+    } else {
+      const tx = this.prismaClient;
       const cancelledBooking = await this.cancelBookingForManagedEventReassignment({
         bookingId,
         cancellationReason,
@@ -2033,7 +2049,7 @@ export class BookingRepository implements IBookingRepository {
       });
 
       return { newBooking, cancelledBooking };
-    });
+    }
   }
 
   async findByIdForTargetEventTypeSearch(bookingId: number) {


### PR DESCRIPTION
## What does this PR do?
This PR resolves a TOCTOU (Time-of-Check to Time-of-Use) race condition where concurrent booking requests could exceed the configured booking limits for an event type.

### Key Changes:
1. **Row-Level Locking**: In `saveBooking` (which runs in a DB transaction), we lock the corresponding `EventType` row with `SELECT FOR UPDATE` first.
2. **Atomic Recheck**: Inside the same transaction, we re-run the limits checks using transactional instances of `BookingRepository` and the check limits services.
3. **Double-Check Pattern**: The fail-fast limit check is kept outside the transaction to reject requests quickly without DB transaction overhead, while the final strict check runs locked and atomically inside the transaction.
4. **Transaction Client Compatibility**: Updated `BookingRepository`'s constructor and methods to support `Prisma.TransactionClient` safely.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Note: Cal.diy is a community-maintained open-source project. Contributions here do NOT flow to Cal.com's production service. -->

- Fixes #29605 (GitHub issue number)

## Visual Demo (For contributors especially)

N/A (This is a backend concurrency and race condition fix).

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

To run the automated tests covering booking limits:
```bash
npx yarn test packages/features/bookings/lib/handleNewBooking/test/booking-limits.test.ts
```

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

## Checklist

<!-- Remove bullet points below that don't apply to you -->
