### PR TITLE
fix: render heading styles in booking page event description

### DIFF
--- a/apps/web/modules/bookings/components/EventMeta.tsx
+++ b/apps/web/modules/bookings/components/EventMeta.tsx
@@ -183,6 +183,7 @@ export const EventMeta = ({
                 ariaLabel={t("description")}>
                 {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Content is sanitized via markdownToSafeHTMLClient */}
                 <div
+                  className="[&_h1]:mb-4 [&_h1]:text-2xl [&_h1]:font-bold [&_h2]:mb-3 [&_h2]:text-xl [&_h2]:font-bold [&_h3]:mb-2 [&_h3]:text-lg [&_h3]:font-bold"
                   dangerouslySetInnerHTML={{
                     __html: markdownToSafeHTMLClient(translatedDescription ?? event.description),
                   }}


### PR DESCRIPTION
## Summary

- `h1`/`h2`/`h3` tags are correctly generated from markdown in the event description, but had no CSS styling applied on the booking page
- This caused **Large Heading** and **Small Heading** formatting (set in the event editor) to render as plain body text
- Added Tailwind child-selector classes to the description wrapper div in `EventMeta.tsx` to match the editor's own heading styles

## Root Cause

`markdownToSafeHTMLClient` correctly converts `# text` → `<h1>text</h1>`, but the container div had no styles targeting child heading elements. The editor applies its own CSS via `stylesEditor.css`, but that CSS is not present on the booking page.

## Fix

Single line change in `apps/web/modules/bookings/components/EventMeta.tsx` — added `className` with Tailwind arbitrary variant selectors:
- `[&_h1]:text-2xl [&_h1]:font-bold` — matches editor h1 (25px bold)
- `[&_h2]:text-xl [&_h2]:font-bold` — matches editor h2 (20px bold)
- `[&_h3]:text-lg [&_h3]:font-bold` — for h3 consistency

## Test Plan

- [ ] Open an event type, add a description with **Large Heading** formatting
- [ ] Visit the booking page — heading should now render large and bold
- [ ] Verify normal paragraph text is unaffected
- [ ] Verify existing list and link styles still work

Closes #29645