### PR TITLE
fix(ui): render markdown headings properly in event descriptions

### DIFF
--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -1,6 +1,5 @@
-import sanitizeHtml from "sanitize-html";
-
 import { md } from "@calcom/lib/markdownIt";
+import sanitizeHtml from "sanitize-html";
 
 if (typeof window !== "undefined") {
   // This file imports markdown parser which is a costly dependency, so we want to make sure it's not imported on the client side.
@@ -24,7 +23,13 @@ export function markdownToSafeHTML(markdown: string | null) {
       /<ol>/g,
       "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
     )
-    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
+    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=")
+    .replace(/<h1/g, "<h1 class='mt-6 mb-4 text-2xl font-semibold'")
+    .replace(/<h2/g, "<h2 class='mt-5 mb-3 text-xl font-semibold'")
+    .replace(/<h3/g, "<h3 class='mt-4 mb-2 text-lg font-semibold'")
+    .replace(/<h4/g, "<h4 class='mt-4 mb-2 text-base font-semibold'")
+    .replace(/<h5/g, "<h5 class='mt-4 mb-2 text-sm font-semibold'")
+    .replace(/<h6/g, "<h6 class='mt-4 mb-2 text-xs font-semibold'");
 
   // Match: <li>Some text </li><li><ul>...</ul></li>
   // Convert to: <li>Some text <ul>...</ul></li>

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -24,8 +24,8 @@ export function markdownToSafeHTML(markdown: string | null) {
       "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
     )
     .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=")
-    .replace(/<h1/g, "<h1 class='mt-6 mb-4 text-2xl font-semibold'")
-    .replace(/<h2/g, "<h2 class='mt-5 mb-3 text-xl font-semibold'");
+    .replace(/<h1[^>]*>/g, "<h1 style='font-size: 25px; font-weight: bold; margin-bottom: 8px'>")
+    .replace(/<h2[^>]*>/g, "<h2 style='font-size: 20px; font-weight: bold; margin-bottom: 8px'>");
 
   // Match: <li>Some text </li><li><ul>...</ul></li>
   // Convert to: <li>Some text <ul>...</ul></li>

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -23,7 +23,10 @@ export function markdownToSafeHTML(markdown: string | null) {
       /<ol>/g,
       "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
     )
-    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=")
+    .replace(
+      /<a\s+href=/g,
+      "<a target='_blank' rel='noopener noreferrer' class='text-blue-500 hover:text-blue-600' href="
+    )
     .replace(/<h1/g, "<h1 class='mt-6 mb-4 text-2xl font-semibold'")
     .replace(/<h2/g, "<h2 class='mt-5 mb-3 text-xl font-semibold'")
     .replace(/<h3/g, "<h3 class='mt-4 mb-2 text-lg font-semibold'")

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -23,16 +23,9 @@ export function markdownToSafeHTML(markdown: string | null) {
       /<ol>/g,
       "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
     )
-    .replace(
-      /<a\s+href=/g,
-      "<a target='_blank' rel='noopener noreferrer' class='text-blue-500 hover:text-blue-600' href="
-    )
+    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=")
     .replace(/<h1/g, "<h1 class='mt-6 mb-4 text-2xl font-semibold'")
-    .replace(/<h2/g, "<h2 class='mt-5 mb-3 text-xl font-semibold'")
-    .replace(/<h3/g, "<h3 class='mt-4 mb-2 text-lg font-semibold'")
-    .replace(/<h4/g, "<h4 class='mt-4 mb-2 text-base font-semibold'")
-    .replace(/<h5/g, "<h5 class='mt-4 mb-2 text-sm font-semibold'")
-    .replace(/<h6/g, "<h6 class='mt-4 mb-2 text-xs font-semibold'");
+    .replace(/<h2/g, "<h2 class='mt-5 mb-3 text-xl font-semibold'");
 
   // Match: <li>Some text </li><li><ul>...</ul></li>
   // Convert to: <li>Some text <ul>...</ul></li>

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -1,6 +1,5 @@
-import DOMPurify from "dompurify";
-
 import { md } from "@calcom/lib/markdownIt";
+import DOMPurify from "dompurify";
 
 if (typeof window == "undefined") {
   console.warn(
@@ -24,7 +23,13 @@ export function markdownToSafeHTMLClient(markdown: string | null) {
       /<ol>/g,
       "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
     )
-    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
+    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=")
+    .replace(/<h1/g, "<h1 class='mt-6 mb-4 text-2xl font-semibold'")
+    .replace(/<h2/g, "<h2 class='mt-5 mb-3 text-xl font-semibold'")
+    .replace(/<h3/g, "<h3 class='mt-4 mb-2 text-lg font-semibold'")
+    .replace(/<h4/g, "<h4 class='mt-4 mb-2 text-base font-semibold'")
+    .replace(/<h5/g, "<h5 class='mt-4 mb-2 text-sm font-semibold'")
+    .replace(/<h6/g, "<h6 class='mt-4 mb-2 text-xs font-semibold'");
 
   // Match: <li>Some text </li><li><ul>...</ul></li> or
   // Convert to: <li>Some text <ul>...</ul></li>

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -24,9 +24,8 @@ export function markdownToSafeHTMLClient(markdown: string | null) {
       "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
     )
     .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=")
-    .replace(/<h1/g, "<h1 class='mt-6 mb-4 text-2xl font-semibold'")
-    .replace(/<h2/g, "<h2 class='mt-5 mb-3 text-xl font-semibold'");
-    
+    .replace(/<h1[^>]*>/g, "<h1 style='font-size: 25px; font-weight: bold; margin-bottom: 8px'>")
+    .replace(/<h2[^>]*>/g, "<h2 style='font-size: 20px; font-weight: bold; margin-bottom: 8px'>");
 
   // Match: <li>Some text </li><li><ul>...</ul></li> or
   // Convert to: <li>Some text <ul>...</ul></li>

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -25,11 +25,8 @@ export function markdownToSafeHTMLClient(markdown: string | null) {
     )
     .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=")
     .replace(/<h1/g, "<h1 class='mt-6 mb-4 text-2xl font-semibold'")
-    .replace(/<h2/g, "<h2 class='mt-5 mb-3 text-xl font-semibold'")
-    .replace(/<h3/g, "<h3 class='mt-4 mb-2 text-lg font-semibold'")
-    .replace(/<h4/g, "<h4 class='mt-4 mb-2 text-base font-semibold'")
-    .replace(/<h5/g, "<h5 class='mt-4 mb-2 text-sm font-semibold'")
-    .replace(/<h6/g, "<h6 class='mt-4 mb-2 text-xs font-semibold'");
+    .replace(/<h2/g, "<h2 class='mt-5 mb-3 text-xl font-semibold'");
+    
 
   // Match: <li>Some text </li><li><ul>...</ul></li> or
   // Convert to: <li>Some text <ul>...</ul></li>


### PR DESCRIPTION
## Description
#29645 

**What does this PR do?**
This PR fixes an issue where the "Large Heading" (and other headings) formatted in the event description editor were being rendered as regular body text on the public booking page and booking page previews.

**Root Cause:**
Tailwind CSS's preflight resets the default sizes and margins of `<h1>` to `<h6>` tags. While the rich text editor generated correct HTML headings, the rendering components utilizing `dangerouslySetInnerHTML` lacked the necessary classes (like `prose`) to style them properly.

**Solution:**
Instead of adding wrappers across multiple components, I updated the core markdown conversion utilities (`packages/lib/markdownToSafeHTML.ts` and `packages/lib/markdownToSafeHTMLClient.ts`). The sanitization process now automatically injects appropriate Tailwind typography classes (e.g., `text-2xl font-semibold` for `<h1>`, etc.) directly into the heading tags. 

This ensures that heading stylings are consistently applied everywhere the description is rendered.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots / Screen Recordings
**Before:**

https://github.com/user-attachments/assets/06b75475-adb5-4886-9a0b-65ec6d29f3be



**After:**

https://github.com/user-attachments/assets/56d0177b-75bb-432b-8110-38b15e321701



## Checklist
- [x] Title follows conventional commits (`fix(scope): description`)
- [x] Type check passes (`yarn type-check:ci --force`)
- [x] Lint passes (`yarn lint:fix`)
- [x] Created as draft PR