### PR TITLE
fix(office365video): use PATCH for updateMeeting and implement deleteMeeting

### DIFF
--- a/packages/app-store/office365video/lib/VideoApiAdapter.test.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.test.ts
@@ -7,14 +7,20 @@ import { internalServerErrorResponse, successResponse } from "../../_utils/testU
 import config from "../config.json";
 import VideoApiAdapter from "./VideoApiAdapter";
 
+const MEETING_ID = "FAKE_MEETING_ID";
+
 const URLS = {
   CREATE_MEETING: {
     url: "https://graph.microsoft.com/v1.0/me/onlineMeetings",
     method: "POST",
   },
   UPDATE_MEETING: {
-    url: "https://graph.microsoft.com/v1.0/me/onlineMeetings",
-    method: "POST",
+    url: `https://graph.microsoft.com/v1.0/me/onlineMeetings/${MEETING_ID}`,
+    method: "PATCH",
+  },
+  DELETE_MEETING: {
+    url: `https://graph.microsoft.com/v1.0/me/onlineMeetings/${MEETING_ID}`,
+    method: "DELETE",
   },
 };
 
@@ -59,9 +65,24 @@ const testCredential = {
   encryptedKey: null,
 };
 
+const testEvent = {
+  title: "Test Meeting",
+  description: "Test Description",
+  startTime: new Date(),
+  endTime: new Date(),
+};
+
+const testBookingRef = {
+  type: "office365_video",
+  uid: "FAKE_UID",
+  meetingId: MEETING_ID,
+  meetingUrl: "https://existing_join_url.example.com",
+};
+
+// ─── createMeeting ────────────────────────────────────────────────────────────
+
 describe("createMeeting", () => {
   test("Successful `createMeeting` call", async () => {
-
     const videoApi = VideoApiAdapter(testCredential);
 
     mockRequestRaw.mockImplementation(({ url }) => {
@@ -71,7 +92,6 @@ describe("createMeeting", () => {
             json: {
               id: 1,
               joinWebUrl: "https://join_web_url.example.com",
-              joinUrl: "https://join_url.example.com",
             },
           })
         );
@@ -79,27 +99,20 @@ describe("createMeeting", () => {
       throw new Error("Unexpected URL");
     });
 
-    const event = {
-      title: "Test Meeting",
-      description: "Test Description",
-      startTime: new Date(),
-      endTime: new Date(),
-    };
+    const createdMeeting = await videoApi?.createMeeting(testEvent);
 
-    const createdMeeting = await videoApi?.createMeeting(event);
     expect(OAuthManager).toHaveBeenCalled();
     expect(mockRequestRaw).toHaveBeenCalledWith({
       url: URLS.CREATE_MEETING.url,
       options: {
         method: "POST",
         body: JSON.stringify({
-          startDateTime: event.startTime,
-          endDateTime: event.endTime,
-          subject: event.title,
+          startDateTime: testEvent.startTime,
+          endDateTime: testEvent.endTime,
+          subject: testEvent.title,
         }),
       },
     });
-
     expect(createdMeeting).toEqual({
       id: 1,
       password: "",
@@ -108,8 +121,7 @@ describe("createMeeting", () => {
     });
   });
 
-  test(" `createMeeting` when there is no joinWebUrl and only joinUrl", async () => {
-
+  test("`createMeeting` fails when joinWebUrl is missing from Graph response", async () => {
     const videoApi = VideoApiAdapter(testCredential);
 
     mockRequestRaw.mockImplementation(({ url }) => {
@@ -118,10 +130,7 @@ describe("createMeeting", () => {
           successResponse({
             json: {
               id: 1,
-              joinUrl: "https://join_url.example.com",
-              error: {
-                message: "ERROR",
-              },
+              // joinWebUrl intentionally missing → triggers the validation error
             },
           })
         );
@@ -129,155 +138,149 @@ describe("createMeeting", () => {
       throw new Error("Unexpected URL");
     });
 
-    const event = {
-      title: "Test Meeting",
-      description: "Test Description",
-      startTime: new Date(),
-      endTime: new Date(),
-    };
-
-    await expect(() => videoApi?.createMeeting(event)).rejects.toThrowError(
+    await expect(() => videoApi?.createMeeting(testEvent)).rejects.toThrowError(
       "Error creating MS Teams meeting"
     );
-    expect(OAuthManager).toHaveBeenCalled();
-    expect(mockRequestRaw).toHaveBeenCalledWith({
-      url: URLS.CREATE_MEETING.url,
-      options: {
-        method: "POST",
-        body: JSON.stringify({
-          startDateTime: event.startTime,
-          endDateTime: event.endTime,
-          subject: event.title,
-        }),
-      },
-    });
   });
 
-  test("Failing `createMeeting` call", async () => {
+  test("Failing `createMeeting` call — server error", async () => {
     const videoApi = VideoApiAdapter(testCredential);
 
     mockRequestRaw.mockImplementation(({ url }) => {
       if (url === URLS.CREATE_MEETING.url) {
-        return Promise.resolve(
-          internalServerErrorResponse({
-            json: {
-              id: 1,
-              joinWebUrl: "https://example.com",
-              joinUrl: "https://example.com",
-            },
-          })
-        );
+        return Promise.resolve(internalServerErrorResponse({ json: {} }));
       }
       throw new Error("Unexpected URL");
     });
 
-    const event = {
-      title: "Test Meeting",
-      description: "Test Description",
-      startTime: new Date(),
-      endTime: new Date(),
-    };
-
-    await expect(() => videoApi?.createMeeting(event)).rejects.toThrowError("Internal Server Error");
-    expect(OAuthManager).toHaveBeenCalled();
-    expect(mockRequestRaw).toHaveBeenCalledWith({
-      url: URLS.CREATE_MEETING.url,
-      options: {
-        method: "POST",
-        body: JSON.stringify({
-          startDateTime: event.startTime,
-          endDateTime: event.endTime,
-          subject: event.title,
-        }),
-      },
-    });
+    await expect(() => videoApi?.createMeeting(testEvent)).rejects.toThrowError("Internal Server Error");
   });
 });
 
+// ─── updateMeeting ────────────────────────────────────────────────────────────
+
 describe("updateMeeting", () => {
-  test("Successful `updateMeeting` call", async () => {
+  test("Successful `updateMeeting` uses PATCH /onlineMeetings/{meetingId}", async () => {
     const videoApi = VideoApiAdapter(testCredential);
 
-    mockRequestRaw.mockImplementation(({ url }) => {
-      if (url === URLS.CREATE_MEETING.url) {
+    mockRequestRaw.mockImplementation(({ url, options }) => {
+      if (url === URLS.UPDATE_MEETING.url && options.method === "PATCH") {
         return Promise.resolve(
           successResponse({
             json: {
-              id: 1,
-              joinWebUrl: "https://join_web_url.example.com",
-              joinUrl: "https://join_url.example.com",
+              id: MEETING_ID,
+              joinWebUrl: "https://updated_join_web_url.example.com",
             },
           })
         );
       }
-      throw new Error("Unexpected URL");
+      throw new Error(`Unexpected request: ${options.method} ${url}`);
     });
 
-    const event = {
-      title: "Test Meeting",
-      description: "Test Description",
-      startTime: new Date(),
-      endTime: new Date(),
-    };
+    const updatedMeeting = await videoApi?.updateMeeting(testBookingRef, testEvent);
 
-    const updatedMeeting = await videoApi?.updateMeeting(null, event);
-    expect(OAuthManager).toHaveBeenCalled();
     expect(mockRequestRaw).toHaveBeenCalledWith({
-      url: URLS.CREATE_MEETING.url,
+      url: URLS.UPDATE_MEETING.url,
       options: {
-        method: "POST",
+        method: "PATCH",
         body: JSON.stringify({
-          startDateTime: event.startTime,
-          endDateTime: event.endTime,
-          subject: event.title,
+          startDateTime: testEvent.startTime,
+          endDateTime: testEvent.endTime,
+          subject: testEvent.title,
         }),
       },
     });
     expect(updatedMeeting).toEqual({
-      id: 1,
+      id: MEETING_ID,
       password: "",
-      type: config.type,
-      url: "https://join_web_url.example.com",
+      type: "office365_video",
+      url: "https://updated_join_web_url.example.com",
     });
   });
 
-  test("Failing `updateMeeting` call", async () => {
+  test("`updateMeeting` falls back to createMeeting when meetingId is missing", async () => {
     const videoApi = VideoApiAdapter(testCredential);
 
     mockRequestRaw.mockImplementation(({ url }) => {
       if (url === URLS.CREATE_MEETING.url) {
         return Promise.resolve(
-          internalServerErrorResponse({
+          successResponse({
             json: {
-              id: 1,
-              joinWebUrl: "https://join_web_url.example.com",
-              joinUrl: "https://join_url.example.com",
+              id: "NEW_MEETING_ID",
+              joinWebUrl: "https://new_join_web_url.example.com",
             },
           })
         );
       }
-      throw new Error("Unexpected URL");
+      throw new Error(`Unexpected URL: ${url}`);
     });
 
-    const event = {
-      title: "Test Meeting",
-      description: "Test Description",
-      startTime: new Date(),
-      endTime: new Date(),
-    };
+    const bookingRefWithoutMeetingId = { ...testBookingRef, meetingId: null };
+    const result = await videoApi?.updateMeeting(bookingRefWithoutMeetingId, testEvent);
 
-    await expect(() => videoApi?.updateMeeting(null, event)).rejects.toThrowError("Internal Server Error");
-    expect(OAuthManager).toHaveBeenCalled();
+    // Should have fallen back to POST /onlineMeetings via adapter.createMeeting()
     expect(mockRequestRaw).toHaveBeenCalledWith({
       url: URLS.CREATE_MEETING.url,
-      options: {
-        method: "POST",
-        body: JSON.stringify({
-          startDateTime: event.startTime,
-          endDateTime: event.endTime,
-          subject: event.title,
-        }),
-      },
+      options: expect.objectContaining({ method: "POST" }),
     });
+    expect(result?.url).toBe("https://new_join_web_url.example.com");
+  });
+
+  test("Failing `updateMeeting` — server error propagates correctly", async () => {
+    const videoApi = VideoApiAdapter(testCredential);
+
+    mockRequestRaw.mockImplementation(({ url, options }) => {
+      if (url === URLS.UPDATE_MEETING.url && options.method === "PATCH") {
+        return Promise.resolve(internalServerErrorResponse({ json: {} }));
+      }
+      throw new Error(`Unexpected request: ${options.method} ${url}`);
+    });
+
+    await expect(() => videoApi?.updateMeeting(testBookingRef, testEvent)).rejects.toThrowError(
+      "Internal Server Error"
+    );
+  });
+});
+
+// ─── deleteMeeting ────────────────────────────────────────────────────────────
+
+describe("deleteMeeting", () => {
+  test("Successful `deleteMeeting` calls DELETE /onlineMeetings/{uid}", async () => {
+    const videoApi = VideoApiAdapter(testCredential);
+
+    mockRequestRaw.mockImplementation(({ url, options }) => {
+      if (url === URLS.DELETE_MEETING.url && options.method === "DELETE") {
+        return Promise.resolve(successResponse({ json: {} }));
+      }
+      throw new Error(`Unexpected request: ${options.method} ${url}`);
+    });
+
+    await expect(videoApi?.deleteMeeting(MEETING_ID)).resolves.toBeUndefined();
+
+    expect(mockRequestRaw).toHaveBeenCalledWith({
+      url: URLS.DELETE_MEETING.url,
+      options: { method: "DELETE" },
+    });
+  });
+
+  test("`deleteMeeting` ignores 404 — meeting already gone", async () => {
+    const videoApi = VideoApiAdapter(testCredential);
+
+    mockRequestRaw.mockImplementation(() => {
+      return Promise.resolve({ ok: false, status: 404, statusText: "Not Found" });
+    });
+
+    // Should NOT throw when 404 — idempotent delete
+    await expect(videoApi?.deleteMeeting(MEETING_ID)).resolves.toBeUndefined();
+  });
+
+  test("Failing `deleteMeeting` — server error propagates correctly", async () => {
+    const videoApi = VideoApiAdapter(testCredential);
+
+    mockRequestRaw.mockImplementation(() => {
+      return Promise.resolve(internalServerErrorResponse({ json: {} }));
+    });
+
+    await expect(() => videoApi?.deleteMeeting(MEETING_ID)).rejects.toThrowError("Internal Server Error");
   });
 });

--- a/packages/app-store/office365video/lib/VideoApiAdapter.test.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.test.ts
@@ -68,8 +68,23 @@ const testCredential = {
 const testEvent = {
   title: "Test Meeting",
   description: "Test Description",
-  startTime: new Date(),
-  endTime: new Date(),
+  startTime: "2024-01-01T10:00:00.000Z",
+  endTime: "2024-01-01T11:00:00.000Z",
+  organizer: {
+    email: "example@cal.com",
+    name: "Test Organizer",
+    timeZone: "UTC",
+    language: { translate: (key: string) => key, locale: "en" },
+  },
+  attendees: [
+    {
+      email: "attendee@cal.com",
+      name: "Test Attendee",
+      timeZone: "UTC",
+      language: { translate: (key: string) => key, locale: "en" },
+    },
+  ],
+  uid: "FAKE_UID",
 };
 
 const testBookingRef = {

--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -329,17 +329,19 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
 
         log.debug("Teams meeting updated", { meetingId });
 
+        const joinUrl = resultObject.joinWebUrl || bookingRef.meetingUrl;
+        if (!joinUrl) {
+          throw new HttpError({
+            statusCode: 500,
+            message: `Error updating MS Teams meeting ${meetingId}: response is missing joinWebUrl and no existing meeting URL is available`,
+          });
+        }
+
         return Promise.resolve({
           type: "office365_video",
           id: resultObject.id ?? meetingId,
           password: "",
-          url: (() => {
-            const joinUrl = resultObject.joinWebUrl;
-            if (!joinUrl) {
-              log.warn("Teams PATCH response missing joinWebUrl, falling back to existing meeting URL", { meetingId });
-            }
-            return joinUrl || bookingRef.meetingUrl || "";
-          })(),
+          url: joinUrl,
         });
       } catch (error) {
         log.error(`Error updating MS Teams meeting for booking ${event.uid}`, error);

--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -222,36 +222,81 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
       : "https://graph.microsoft.com/v1.0/me";
   }
 
-  // Since the meeting link is not tied to an event we only need the create and update functions
-  return {
+  const adapter: VideoApiAdapter = {
     getAvailability: () => {
       return Promise.resolve([]);
     },
-    updateMeeting: async (bookingRef: PartialReference, event: CalendarEvent) => {
+    deleteMeeting: async (uid: string): Promise<void> => {
       try {
         const response = await auth.requestRaw({
-          url: `${await getUserEndpoint()}/onlineMeetings`,
+          url: `${await getUserEndpoint()}/onlineMeetings/${uid}`,
           options: {
-            method: "POST",
-            body: JSON.stringify(translateEvent(event)),
+            method: "DELETE",
           },
         });
 
-        if (!response.ok) {
+        if (!response.ok && response.status !== 404) {
           throw new HttpError({
             statusCode: response.status,
             message: response.statusText,
           });
         }
 
-        const resultString = await response.text();
+        log.debug("Teams meeting deleted", { meetingId: uid });
+        return Promise.resolve();
+      } catch (error) {
+        log.error(`Error deleting MS Teams meeting ${uid}`, error);
+        if (error instanceof HttpError) {
+          throw error;
+        }
+        throw new HttpError({
+          statusCode: 500,
+          message: `Error deleting MS Teams meeting ${uid}`,
+        });
+      }
+    },
+    updateMeeting: async (bookingRef: PartialReference, event: CalendarEvent): Promise<VideoCallData> => {
+      const meetingId = bookingRef.meetingId;
+
+      // If no meetingId is available, fall back to creating a new meeting
+      if (!meetingId) {
+        log.warn(`No meetingId found in bookingRef for booking ${event.uid}, falling back to createMeeting`);
+        return adapter.createMeeting(event);
+      }
+
+      try {
+        const patchResponse = await auth.requestRaw({
+          url: `${await getUserEndpoint()}/onlineMeetings/${meetingId}`,
+          options: {
+            method: "PATCH",
+            body: JSON.stringify(translateEvent(event)),
+          },
+        });
+
+        if (!patchResponse.ok) {
+          throw new HttpError({
+            statusCode: patchResponse.status,
+            message: patchResponse.statusText,
+          });
+        }
+
+        // PATCH returns 200 with the updated meeting object
+        const resultString = await patchResponse.text();
         const resultObject = JSON.parse(resultString);
+
+        log.debug("Teams meeting updated", { meetingId });
 
         return Promise.resolve({
           type: "office365_video",
-          id: resultObject.id,
+          id: resultObject.id ?? meetingId,
           password: "",
-          url: resultObject.joinWebUrl || resultObject.joinUrl,
+          url: (() => {
+            const joinUrl = resultObject.joinWebUrl;
+            if (!joinUrl) {
+              log.warn("Teams PATCH response missing joinWebUrl, falling back to existing meeting URL", { meetingId });
+            }
+            return joinUrl || bookingRef.meetingUrl || "";
+          })(),
         });
       } catch (error) {
         log.error(`Error updating MS Teams meeting for booking ${event.uid}`, error);
@@ -263,9 +308,6 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
           message: `Error updating MS Teams meeting for booking ${event.uid}`,
         });
       }
-    },
-    deleteMeeting:() => {
-      return Promise.resolve([]);
     },
     createMeeting: async (event: CalendarEvent): Promise<VideoCallData> => {
       const url = `${await getUserEndpoint()}/onlineMeetings`;
@@ -289,7 +331,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
 
         const resultObject = JSON.parse(resultString);
 
-        if (!resultObject.id || !resultObject.joinUrl || !resultObject.joinWebUrl) {
+        if (!resultObject.id || !resultObject.joinWebUrl) {
           throw new HttpError({
             statusCode: 500,
             message: `Error creating MS Teams meeting: ${resultObject.error?.message || "missing required fields in response"}`,
@@ -302,7 +344,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
           type: "office365_video",
           id: resultObject.id,
           password: "",
-          url: resultObject.joinWebUrl || resultObject.joinUrl,
+          url: resultObject.joinWebUrl,
         });
       } catch (error) {
         log.error(`Error creating MS Teams meeting for booking ${event.uid}`, error);
@@ -316,6 +358,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
       }
     },
   };
+  return adapter;
 };
 
 export default TeamsVideoApiAdapter;

--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -304,7 +304,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
       // If no meetingId is available, fall back to creating a new meeting
       if (!meetingId) {
         log.warn(`No meetingId found in bookingRef for booking ${event.uid}, falling back to createMeeting`);
-        return adapter.createMeeting(event);
+        return adapter!.createMeeting(event);
       }
 
       try {

--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -33,6 +33,10 @@ const o365VideoAppKeysSchema = z.object({
   client_secret: z.string(),
 });
 
+/**
+ * Retrieves and validates the Office 365 Video app's OAuth client credentials
+ * (`client_id` / `client_secret`) from the app config slug.
+ */
 const getO365VideoAppKeys = async () => {
   return getParsedAppKeysFromSlug(config.slug, o365VideoAppKeysSchema);
 };
@@ -42,6 +46,11 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
   let azureUserId: string | null;
   const tokenResponse = oAuthManagerHelper.getTokenObjectFromCredential(credential);
 
+  /**
+   * Fires the delegation-credential error webhook when a DelegationCredential
+   * is misconfigured or its grant is invalid, so admins are notified out-of-band.
+   * No-ops if the credential is not associated with a delegated user/app.
+   */
   async function triggerDelegationCredentialError(error: Error): Promise<void> {
     if (credential.userId && credential.user && credential.appId && credential.delegatedToId) {
       await triggerDelegationCredentialErrorWebhook({
@@ -127,6 +136,12 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
     },
   });
 
+  /**
+   * Builds the Microsoft Identity Platform token endpoint URL.
+   * For DelegationCredential flows this requires a tenantId and throws a
+   * CalendarAppDelegationCredentialInvalidGrantError (and fires the error
+   * webhook) if one isn't present; otherwise falls back to the common/multi-tenant endpoint.
+   */
   async function getAuthUrl(delegatedTo: boolean, tenantId?: string): Promise<string> {
     if (delegatedTo) {
       if (!tenantId) {
@@ -144,6 +159,10 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
     return "https://login.microsoftonline.com/common/oauth2/v2.0/token";
   }
 
+  /**
+   * Maps a Cal.com CalendarEvent into the subset of fields the Microsoft
+   * Graph onlineMeetings API expects (startDateTime/endDateTime/subject).
+   */
   const translateEvent = (event: CalendarEvent) => {
     return {
       startDateTime: event.startTime,
@@ -152,6 +171,13 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
     };
   };
 
+  /**
+   * Resolves the Azure AD user id for a DelegationCredential by exchanging
+   * client credentials for an app-only token and looking the user up by email
+   * via the Graph `/users` endpoint. Returns null for non-delegated credentials,
+   * caches the result in `azureUserId`, and throws/fires the delegation error
+   * webhook if the credential is misconfigured or the user can't be found.
+   */
   async function getAzureUserId(credential: CredentialForCalendarServiceWithTenantId) {
     if (azureUserId) return azureUserId;
 
@@ -215,6 +241,11 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
     return azureUserId;
   }
 
+  /**
+   * Returns the Microsoft Graph base URL to use for onlineMeetings requests:
+   * the specific delegated user's `/users/{id}` endpoint when a DelegationCredential
+   * is in play, otherwise the authenticated `/me` endpoint.
+   */
   async function getUserEndpoint(): Promise<string> {
     const azureUserId = await getAzureUserId(credential);
     return azureUserId
@@ -226,6 +257,11 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
     getAvailability: () => {
       return Promise.resolve([]);
     },
+    /**
+     * Deletes a Teams online meeting via `DELETE /onlineMeetings/{uid}`.
+     * A 404 from Microsoft (meeting already gone) is treated as a successful
+     * no-op rather than an error, since the end state we want is already true.
+     */
     deleteMeeting: async (uid: string): Promise<void> => {
       try {
         const response = await auth.requestRaw({
@@ -255,6 +291,13 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         });
       }
     },
+    /**
+     * Updates an existing Teams meeting via `PATCH /onlineMeetings/{meetingId}`
+     * instead of re-POSTing (which previously created duplicate meetings).
+     * Falls back to `createMeeting` when no `meetingId` is present on the
+     * booking reference, and falls back to the previously stored meeting URL
+     * if the PATCH response is missing `joinWebUrl`.
+     */
     updateMeeting: async (bookingRef: PartialReference, event: CalendarEvent): Promise<VideoCallData> => {
       const meetingId = bookingRef.meetingId;
 
@@ -309,6 +352,11 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         });
       }
     },
+    /**
+     * Creates a new Teams online meeting via `POST /onlineMeetings`.
+     * Treats a response missing `id` or `joinWebUrl` as a failure even when
+     * the HTTP status itself is OK, since both fields are required downstream.
+     */
     createMeeting: async (event: CalendarEvent): Promise<VideoCallData> => {
       const url = `${await getUserEndpoint()}/onlineMeetings`;
       try {


### PR DESCRIPTION
Reopens #29499, which was auto-closed due to inactivity by the stale bot.

Fixes #29498

## What does this PR do?
Fixes two broken behaviors in the Office 365 Video (MS Teams) integration:
- `updateMeeting()` was sending POST instead of PATCH `/onlineMeetings/{meetingId}`, creating duplicate meetings on every update
- `deleteMeeting()` was a no-op — no HTTP request was sent, leaving the remote meeting active on Microsoft's side

The CodeRabbit docstring-coverage warning from the original PR has also been addressed.

## How should this be tested?
Minimal test data: any existing booking with MS Teams as the video provider.

Happy path:
- Update the booking → PATCH /onlineMeetings/{meetingId} is called, existing meeting is updated (no duplicate created)
- Delete the booking → DELETE /onlineMeetings/{meetingId} is called, meeting is removed on Microsoft's side

Unit tests covering both flows are included in VideoApiAdapter.test.ts