### PR TITLE
feat(booking-fields): restrict URL field responses to an allowed domain

### DIFF
--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -782,6 +782,15 @@ function FieldEditDialog({
                       />
                     )}
 
+                    {formFieldType === "url" && (
+                      <InputField
+                        {...fieldForm.register("allowedDomain")}
+                        containerClassName="mt-6"
+                        label={t("url_allowed_domain")}
+                        placeholder="linkedin.com"
+                      />
+                    )}
+
                     {/* Add price field only for fields that support pricing */}
                     {showPriceField && fieldType.supportsPricing && (
                       <InputField

--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -1760,6 +1760,87 @@ describe("getBookingResponsesSchema", () => {
         })
       );
     });
+
+    describe("allowedDomain validation", () => {
+      const buildSchema = (allowedDomain: string) =>
+        getBookingResponsesSchema({
+          bookingFields: [
+            { name: "name", type: "name", required: true },
+            { name: "email", type: "email", required: true },
+            { name: "url", type: "url", required: true, allowedDomain },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+          view: "ALL_VIEWS",
+        });
+
+      test("should pass when url is on the allowed domain", async ({}) => {
+        const parsedResponses = await buildSchema("linkedin.com").safeParseAsync({
+          email: "test@test.com",
+          name: "test",
+          url: "https://linkedin.com/in/someone",
+        });
+        expectResponsesToBe(parsedResponses, {
+          email: "test@test.com",
+          name: "test",
+          url: "https://linkedin.com/in/someone",
+        });
+      });
+
+      test("should pass when url is on a subdomain of the allowed domain", async ({}) => {
+        const parsedResponses = await buildSchema("linkedin.com").safeParseAsync({
+          email: "test@test.com",
+          name: "test",
+          url: "https://www.linkedin.com/in/someone",
+        });
+        expectResponsesToBe(parsedResponses, {
+          email: "test@test.com",
+          name: "test",
+          url: "https://www.linkedin.com/in/someone",
+        });
+      });
+
+      test("should pass when protocol is missing but domain matches", async ({}) => {
+        const parsedResponses = await buildSchema("linkedin.com").safeParseAsync({
+          email: "test@test.com",
+          name: "test",
+          url: "www.linkedin.com/in/someone",
+        });
+        expectResponsesToBe(parsedResponses, {
+          email: "test@test.com",
+          name: "test",
+          url: "www.linkedin.com/in/someone",
+        });
+      });
+
+      test("should fail when url is on a different domain", async ({}) => {
+        const parsedResponses = await buildSchema("linkedin.com").safeParseAsync({
+          email: "test@test.com",
+          name: "test",
+          url: "https://example.com/profile",
+        });
+        expectParsingToFail(
+          parsedResponses,
+          expect.objectContaining({
+            code: "custom",
+            message: `{url}url_domain_not_allowed_error`,
+          })
+        );
+      });
+
+      test("should not falsely match a domain that is only a suffix", async ({}) => {
+        const parsedResponses = await buildSchema("linkedin.com").safeParseAsync({
+          email: "test@test.com",
+          name: "test",
+          url: "https://notlinkedin.com/in/someone",
+        });
+        expectParsingToFail(
+          parsedResponses,
+          expect.objectContaining({
+            code: "custom",
+            message: `{url}url_domain_not_allowed_error`,
+          })
+        );
+      });
+    });
   });
 });
 

--- a/packages/features/form-builder/schema.ts
+++ b/packages/features/form-builder/schema.ts
@@ -257,7 +257,7 @@ export const fieldTypesSchemaMap = {
     preprocess: ({ response }) => {
       return stringifyResponse(response).trim();
     },
-    superRefine: ({ response, ctx, m }) => {
+    superRefine: ({ field, response, ctx, m }) => {
       const value = response ?? "";
       const urlSchema = z.string().url();
 
@@ -270,25 +270,43 @@ export const fieldTypesSchemaMap = {
         return;
       }
 
-      // 1. Try validating the original value
+      // Determine the valid URL string, accepting the raw value or a https://-prepended form.
+      let validUrl: string | null = null;
       if (urlSchema.safeParse(value).success) {
-        return;
-      }
-
-      // 2. If it failed, try prepending https://
-      const domainLike = /^[a-z0-9.-]+\.[a-z]{2,}(\/.*)?$/i;
-      if (domainLike.test(value)) {
-        const valueWithHttps = `https://${value}`;
-        if (urlSchema.safeParse(valueWithHttps).success) {
-          return;
+        validUrl = value;
+      } else {
+        const domainLike = /^[a-z0-9.-]+\.[a-z]{2,}(\/.*)?$/i;
+        if (domainLike.test(value)) {
+          const valueWithHttps = `https://${value}`;
+          if (urlSchema.safeParse(valueWithHttps).success) {
+            validUrl = valueWithHttps;
+          }
         }
       }
 
-      // 3. If all attempts fail, throw err
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: m("url_validation_error"),
-      });
+      if (!validUrl) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: m("url_validation_error"),
+        });
+        return;
+      }
+
+      // Optionally restrict the URL to a configured domain (and its subdomains).
+      const allowedDomain = field?.allowedDomain
+        ?.trim()
+        .toLowerCase()
+        .replace(/^https?:\/\//, "");
+      if (allowedDomain) {
+        const host = new URL(validUrl).hostname.toLowerCase();
+        const matchesDomain = host === allowedDomain || host.endsWith(`.${allowedDomain}`);
+        if (!matchesDomain) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: m("url_domain_not_allowed_error", { domain: allowedDomain }),
+          });
+        }
+      }
     },
   }),
 };

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -1585,6 +1585,8 @@
   "email_validation_error": "That doesn't look like an email address",
   "emails_must_be_unique_valid": "Emails must be unique and valid",
   "url_validation_error": "That doesn't look like a URL",
+  "url_allowed_domain": "Allowed domain",
+  "url_domain_not_allowed_error": "The URL must be on {{domain}}",
   "place_where_cal_widget_appear": "Place this code in your HTML where you want your {{appName}} widget to appear.",
   "create_update_react_component": "Create or update an existing React component as shown below.",
   "copy_code": "Copy code",

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -1027,6 +1027,8 @@ export const baseFieldSchema = z.object({
   excludeEmails: excludeOrRequireEmailSchema.optional(),
   // Emails that need to be required
   requireEmails: excludeOrRequireEmailSchema.optional(),
+  // For `url` fields: restrict accepted URLs to this domain (and its subdomains)
+  allowedDomain: z.string().optional(),
   // Price associated with the field which works like addons which users can add to the booking
   price: z.coerce.number().min(0).optional(),
 });


### PR DESCRIPTION
## What
Adds an optional **Allowed domain** setting to URL-type booking questions. When set, a submitted URL must be on that domain or one of its subdomains (e.g. `linkedin.com` also accepts `www.linkedin.com`). Leaving it blank keeps the current behavior.

## Why
Organizers often ask for a specific kind of link (LinkedIn profile, GitHub, etc.). This lets them enforce that the booker actually pastes a URL on the expected domain.

## How
- `allowedDomain` added to `baseFieldSchema` (`packages/prisma/zod-utils.ts`). Booking fields are stored as JSON on the EventType, so **no DB migration**.
- Admin UI: a URL-only "Allowed domain" input in `FormBuilder.tsx`, gated like the existing email require/exclude options.
- Validation in `fieldTypesSchemaMap.url.superRefine` (`packages/features/form-builder/schema.ts`), which runs on **both** the public booking form and server-side booking creation via `superRefineField`.
- i18n keys `url_allowed_domain`, `url_domain_not_allowed_error`.

## Testing
- `getBookingResponsesSchema` suite: **74/74 pass**, including 5 new cases (on-domain, subdomain, protocol-less, wrong domain, and a `notlinkedin.com` suffix-spoof guard).

## Verified locally
- Ran the full app against a local database and confirmed the **Allowed domain** field appears when adding a URL question (Event Type → Advanced → Add a question → Input type: URL).
- No new type errors introduced (confirmed by diffing the web type-check against a clean baseline).

## Notes / why this is low-risk
- Opt-in: behavior is unchanged unless an organizer sets a domain.
- No schema/DB migration (booking fields are JSON).
- Single-domain + subdomain matching (not regex) — deliberately simple/safe for non-technical admins; the field is a plain string so a regex mode could be layered on later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)