### PR TITLE
fix: restore heading styles stripped by Tailwind preflight in markdown rendering

### DIFF
--- a/packages/lib/markdownHTMLFormatting.ts
+++ b/packages/lib/markdownHTMLFormatting.ts
@@ -1,0 +1,30 @@
+/**
+ * Post-sanitize HTML rewrites applied to markdown output in both server
+ * (markdownToSafeHTML) and client (markdownToSafeHTMLClient) renderers.
+ *
+ * Inline styles are used so the formatting survives Tailwind's preflight
+ * CSS reset, which removes default heading sizes, weights, and margins.
+ */
+export function applyMarkdownHTMLFormatting(html: string): string {
+  let formatted = html
+    .replace(/<h1>/g, "<h1 style='font-size: 1.5em; font-weight: 700; margin-bottom: 8px'>")
+    .replace(/<h2>/g, "<h2 style='font-size: 1.25em; font-weight: 700; margin-bottom: 6px'>")
+    .replace(/<h3>/g, "<h3 style='font-size: 1.1em; font-weight: 600; margin-bottom: 4px'>")
+    .replace(
+      /<ul>/g,
+      "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
+    )
+    .replace(
+      /<ol>/g,
+      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
+    )
+    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
+
+  // Merge <li>text</li><li><ul>…</ul></li> → <li>text<ul>…</ul></li>
+  formatted = formatted.replace(
+    /<li>([^<]+|<strong>.*?<\/strong>)<\/li>\s*<li>\s*<ul([^>]*)>([\s\S]*?)<\/ul>\s*<\/li>/g,
+    "<li>$1<ul$2>$3</ul></li>"
+  );
+
+  return formatted;
+}

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -1,6 +1,7 @@
 import sanitizeHtml from "sanitize-html";
 
 import { md } from "@calcom/lib/markdownIt";
+import { applyMarkdownHTMLFormatting } from "@calcom/lib/markdownHTMLFormatting";
 
 if (typeof window !== "undefined") {
   // This file imports markdown parser which is a costly dependency, so we want to make sure it's not imported on the client side.
@@ -15,26 +16,5 @@ export function markdownToSafeHTML(markdown: string | null) {
 
   const safeHTML = sanitizeHtml(html);
 
-  let safeHTMLWithListFormatting = safeHTML
-    .replace(/<h1>/g, "<h1 style='font-size: 1.5em; font-weight: 700; margin-bottom: 8px'>")
-    .replace(/<h2>/g, "<h2 style='font-size: 1.25em; font-weight: 700; margin-bottom: 6px'>")
-    .replace(/<h3>/g, "<h3 style='font-size: 1.1em; font-weight: 600; margin-bottom: 4px'>")
-    .replace(
-      /<ul>/g,
-      "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(
-      /<ol>/g,
-      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
-
-  // Match: <li>Some text </li><li><ul>...</ul></li>
-  // Convert to: <li>Some text <ul>...</ul></li>
-  safeHTMLWithListFormatting = safeHTMLWithListFormatting.replace(
-    /<li>([^<]+|<strong>.*?<\/strong>)<\/li>\s*<li>\s*<ul([^>]*)>([\s\S]*?)<\/ul>\s*<\/li>/g,
-    "<li>$1<ul$2>$3</ul></li>"
-  );
-
-  return safeHTMLWithListFormatting;
+  return applyMarkdownHTMLFormatting(safeHTML);
 }

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -16,6 +16,9 @@ export function markdownToSafeHTML(markdown: string | null) {
   const safeHTML = sanitizeHtml(html);
 
   let safeHTMLWithListFormatting = safeHTML
+    .replace(/<h1>/g, "<h1 style='font-size: 1.5em; font-weight: 700; margin-bottom: 8px'>")
+    .replace(/<h2>/g, "<h2 style='font-size: 1.25em; font-weight: 700; margin-bottom: 6px'>")
+    .replace(/<h3>/g, "<h3 style='font-size: 1.1em; font-weight: 600; margin-bottom: 4px'>")
     .replace(
       /<ul>/g,
       "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -1,6 +1,7 @@
 import DOMPurify from "dompurify";
 
 import { md } from "@calcom/lib/markdownIt";
+import { applyMarkdownHTMLFormatting } from "@calcom/lib/markdownHTMLFormatting";
 
 if (typeof window == "undefined") {
   console.warn(
@@ -15,26 +16,5 @@ export function markdownToSafeHTMLClient(markdown: string | null) {
 
   const safeHTML = DOMPurify.sanitize(html);
 
-  let safeHTMLWithListFormatting = safeHTML
-    .replace(/<h1>/g, "<h1 style='font-size: 1.5em; font-weight: 700; margin-bottom: 8px'>")
-    .replace(/<h2>/g, "<h2 style='font-size: 1.25em; font-weight: 700; margin-bottom: 6px'>")
-    .replace(/<h3>/g, "<h3 style='font-size: 1.1em; font-weight: 600; margin-bottom: 4px'>")
-    .replace(
-      /<ul>/g,
-      "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(
-      /<ol>/g,
-      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
-
-  // Match: <li>Some text </li><li><ul>...</ul></li> or
-  // Convert to: <li>Some text <ul>...</ul></li>
-  safeHTMLWithListFormatting = safeHTMLWithListFormatting.replace(
-    /<li>([^<]+|<strong>.*?<\/strong>)<\/li>\s*<li>\s*<ul([^>]*)>([\s\S]*?)<\/ul>\s*<\/li>/g,
-    "<li>$1<ul$2>$3</ul></li>"
-  );
-
-  return safeHTMLWithListFormatting;
+  return applyMarkdownHTMLFormatting(safeHTML);
 }

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -16,6 +16,9 @@ export function markdownToSafeHTMLClient(markdown: string | null) {
   const safeHTML = DOMPurify.sanitize(html);
 
   let safeHTMLWithListFormatting = safeHTML
+    .replace(/<h1>/g, "<h1 style='font-size: 1.5em; font-weight: 700; margin-bottom: 8px'>")
+    .replace(/<h2>/g, "<h2 style='font-size: 1.25em; font-weight: 700; margin-bottom: 6px'>")
+    .replace(/<h3>/g, "<h3 style='font-size: 1.1em; font-weight: 600; margin-bottom: 4px'>")
     .replace(
       /<ul>/g,
       "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"


### PR DESCRIPTION
## What does this PR do?

Fixes heading formatting (h1, h2, h3) not being rendered on the booking page when set via the event description editor.

## Root cause

Tailwind's preflight CSS resets all heading elements to unstyled body text. The `markdownToSafeHTML` and `markdownToSafeHTMLClient` functions already applied inline styles to `<ul>`, `<ol>`, and `<a>` elements to work around this — but headings were never included, so any heading formatting was silently stripped.

## Fix

Apply the same inline-style pattern to `<h1>`, `<h2>`, and `<h3>` in both rendering paths (server + client):

```diff
+ .replace(/<h1>/g, "<h1 style='font-size: 1.5em; font-weight: 700; margin-bottom: 8px'>")
+ .replace(/<h2>/g, "<h2 style='font-size: 1.25em; font-weight: 700; margin-bottom: 6px'>")
+ .replace(/<h3>/g, "<h3 style='font-size: 1.1em; font-weight: 600; margin-bottom: 4px'>")
```

## How was this tested?

Verified the markdown-it renderer emits `<h1>`/`<h2>`/`<h3>` tags for heading syntax, and that `sanitize-html` / DOMPurify pass heading tags through by default. The inline styles are applied post-sanitization, consistent with existing list/link handling.

Fixes #29645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->