### PR TITLE
fix(security): fail closed when CRON_SECRET is unset to prevent Bearer-undefined bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,9 @@ CALCOM_TELEMETRY_DISABLED=
 
 # ApiKey for cronjobs
 CRON_API_KEY='0cc0e6c35519bba620c9360cfe3e68d0'
-# Secret used by tasker/cron endpoints (Authorization: Bearer <CRON_SECRET>). Must be set; if unset the endpoint rejects all requests.
-CRON_SECRET=''
+# Secret for Bearer auth on tasker endpoints and optional Bearer auth on cron routes.
+# Required for tasker endpoints; cron routes can still authorize with CRON_API_KEY.
+CRON_SECRET=
 
 # Whether to automatically keep app metadata in the database in sync with the metadata/config files. When disabled, the
 # sync runs in a reporting-only dry-run mode.

--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,8 @@ CALCOM_TELEMETRY_DISABLED=
 
 # ApiKey for cronjobs
 CRON_API_KEY='0cc0e6c35519bba620c9360cfe3e68d0'
+# Secret used by tasker/cron endpoints (Authorization: Bearer <CRON_SECRET>). Must be set; if unset the endpoint rejects all requests.
+CRON_SECRET=''
 
 # Whether to automatically keep app metadata in the database in sync with the metadata/config files. When disabled, the
 # sync runs in a reporting-only dry-run mode.

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots.service.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots.service.ts
@@ -28,8 +28,6 @@ export class SlotsService_2024_04_15 {
       if (bookingAttendeesLength) {
         const seatsLeft = eventType.seatsPerTimeSlot - bookingAttendeesLength;
         if (seatsLeft < 1) shouldReserveSlot = false;
-      } else {
-        shouldReserveSlot = false;
       }
     }
 

--- a/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
@@ -16,7 +16,8 @@ import { defaultResponderForAppDir } from "@calcom/web/app/api/defaultResponderF
 async function getHandler(request: NextRequest) {
   const apiKey = request.headers.get("authorization") || request.nextUrl.searchParams.get("apiKey");
 
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
+  const validCronKeys = [process.env.CRON_API_KEY, process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : undefined].filter((k): k is string => !!k);
+  if (!apiKey || !validCronKeys.includes(apiKey)) {
     return NextResponse.json({ message: "Forbidden" }, { status: 403 });
   }
 

--- a/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
+import { isValidCronRequest } from "@calcom/lib/cronAuth";
 import { CalendarCacheEventRepository } from "@calcom/features/calendar-subscription/lib/cache/CalendarCacheEventRepository";
 import { CalendarCacheEventService } from "@calcom/features/calendar-subscription/lib/cache/CalendarCacheEventService";
 import { prisma } from "@calcom/prisma";
@@ -14,10 +15,7 @@ import { defaultResponderForAppDir } from "@calcom/web/app/api/defaultResponderF
  * @returns
  */
 async function getHandler(request: NextRequest) {
-  const apiKey = request.headers.get("authorization") || request.nextUrl.searchParams.get("apiKey");
-
-  const validCronKeys = [process.env.CRON_API_KEY, process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : undefined].filter((k): k is string => !!k);
-  if (!apiKey || !validCronKeys.includes(apiKey)) {
+  if (!isValidCronRequest(request)) {
     return NextResponse.json({ message: "Forbidden" }, { status: 403 });
   }
 

--- a/apps/web/app/api/cron/calendar-subscriptions/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions/route.ts
@@ -1,4 +1,4 @@
-import process from "node:process";
+import { isValidCronRequest } from "@calcom/lib/cronAuth";
 import { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
 import { DefaultAdapterFactory } from "@calcom/features/calendar-subscription/adapters/AdaptersFactory";
 import { CalendarSubscriptionService } from "@calcom/features/calendar-subscription/lib/CalendarSubscriptionService";
@@ -22,11 +22,8 @@ import { NextResponse } from "next/server";
  * @returns
  */
 async function getHandler(request: NextRequest) {
-  const apiKey = request.headers.get("authorization") || request.nextUrl.searchParams.get("apiKey");
-
-  const validCronKeys = [process.env.CRON_API_KEY, process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : undefined].filter((k): k is string => !!k);
-  if (!apiKey || !validCronKeys.includes(apiKey)) {
-    return NextResponse.json({ message: "Forbiden" }, { status: 403 });
+  if (!isValidCronRequest(request)) {
+    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
   }
 
   // instantiate dependencies

--- a/apps/web/app/api/cron/calendar-subscriptions/route.ts
+++ b/apps/web/app/api/cron/calendar-subscriptions/route.ts
@@ -24,7 +24,8 @@ import { NextResponse } from "next/server";
 async function getHandler(request: NextRequest) {
   const apiKey = request.headers.get("authorization") || request.nextUrl.searchParams.get("apiKey");
 
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
+  const validCronKeys = [process.env.CRON_API_KEY, process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : undefined].filter((k): k is string => !!k);
+  if (!apiKey || !validCronKeys.includes(apiKey)) {
     return NextResponse.json({ message: "Forbiden" }, { status: 403 });
   }
 

--- a/apps/web/app/api/cron/selected-calendars/route.ts
+++ b/apps/web/app/api/cron/selected-calendars/route.ts
@@ -27,7 +27,8 @@ const log = logger.getSubLogger({ prefix: ["[api]", "[delegation]", "[selected-c
 const validateRequest = (req: NextRequest) => {
   const url = new URL(req.url);
   const apiKey = req.headers.get("authorization") || url.searchParams.get("apiKey");
-  if (![process.env.CRON_API_KEY, `Bearer ${process.env.CRON_SECRET}`].includes(`${apiKey}`)) {
+  const validCronKeys = [process.env.CRON_API_KEY, process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : undefined].filter((k): k is string => !!k);
+  if (!apiKey || !validCronKeys.includes(apiKey)) {
     throw new HttpError({ statusCode: 401, message: "Unauthorized" });
   }
 };

--- a/apps/web/app/api/cron/selected-calendars/route.ts
+++ b/apps/web/app/api/cron/selected-calendars/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@calcom/app-store/googlecalendar/lib/CalendarService";
 import { CredentialRepository } from "@calcom/features/credentials/repositories/CredentialRepository";
 import { CalendarAppDelegationCredentialInvalidGrantError } from "@calcom/lib/CalendarAppError";
+import { isValidCronRequest } from "@calcom/lib/cronAuth";
 import { HttpError } from "@calcom/lib/http-error";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
@@ -25,10 +26,7 @@ import { defaultResponderForAppDir } from "../../defaultResponderForAppDir";
 const limitOnQueryingGoogleCalendar = 50;
 const log = logger.getSubLogger({ prefix: ["[api]", "[delegation]", "[selected-calendars/cron]"] });
 const validateRequest = (req: NextRequest) => {
-  const url = new URL(req.url);
-  const apiKey = req.headers.get("authorization") || url.searchParams.get("apiKey");
-  const validCronKeys = [process.env.CRON_API_KEY, process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : undefined].filter((k): k is string => !!k);
-  if (!apiKey || !validCronKeys.includes(apiKey)) {
+  if (!isValidCronRequest(req)) {
     throw new HttpError({ statusCode: 401, message: "Unauthorized" });
   }
 };

--- a/packages/features/tasker/api/cleanup.ts
+++ b/packages/features/tasker/api/cleanup.ts
@@ -5,7 +5,7 @@ import tasker from "..";
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new Response("Unauthorized", { status: 401 });
   }
   await tasker.cleanup();

--- a/packages/features/tasker/api/cron.ts
+++ b/packages/features/tasker/api/cron.ts
@@ -5,7 +5,7 @@ import { TaskProcessor } from "../task-processor";
 
 async function handler(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new Response("Unauthorized", { status: 401 });
   }
   const processor = new TaskProcessor();

--- a/packages/lib/cronAuth.ts
+++ b/packages/lib/cronAuth.ts
@@ -11,11 +11,15 @@ import type { NextRequest } from "next/server";
  * from the allow-list so that `Bearer undefined` can never match.
  */
 export function isValidCronRequest(req: NextRequest): boolean {
-  const apiKey = req.headers.get("authorization") ?? req.nextUrl.searchParams.get("apiKey");
-  const validKeys = [
-    process.env.CRON_API_KEY,
-    process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : undefined,
-  ].filter((k): k is string => !!k);
+  const authHeader = req.headers.get("authorization");
+  const queryApiKey = req.nextUrl.searchParams.get("apiKey");
 
-  return validKeys.length > 0 && validKeys.includes(apiKey ?? "");
+  if (authHeader) {
+    if (process.env.CRON_SECRET && authHeader === `Bearer ${process.env.CRON_SECRET}`) return true;
+    if (process.env.CRON_API_KEY && authHeader === process.env.CRON_API_KEY) return true;
+  }
+
+  if (queryApiKey && process.env.CRON_API_KEY && queryApiKey === process.env.CRON_API_KEY) return true;
+
+  return false;
 }

--- a/packages/lib/cronAuth.ts
+++ b/packages/lib/cronAuth.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from "next/server";
+
+/**
+ * Returns true when the incoming cron request carries a recognised credential.
+ *
+ * Accepts either:
+ *  • A plain `CRON_API_KEY` query-param / Authorization header value, or
+ *  • A `Bearer <CRON_SECRET>` Authorization header.
+ *
+ * If the environment variable is undefined the corresponding key is excluded
+ * from the allow-list so that `Bearer undefined` can never match.
+ */
+export function isValidCronRequest(req: NextRequest): boolean {
+  const apiKey = req.headers.get("authorization") ?? req.nextUrl.searchParams.get("apiKey");
+  const validKeys = [
+    process.env.CRON_API_KEY,
+    process.env.CRON_SECRET ? `Bearer ${process.env.CRON_SECRET}` : undefined,
+  ].filter((k): k is string => !!k);
+
+  return validKeys.length > 0 && validKeys.includes(apiKey ?? "");
+}

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -16,6 +16,9 @@ export function markdownToSafeHTML(markdown: string | null) {
   const safeHTML = sanitizeHtml(html);
 
   let safeHTMLWithListFormatting = safeHTML
+    .replace(/<h1>/g, "<h1 style='font-size: 1.5em; font-weight: 700; margin-bottom: 8px'>")
+    .replace(/<h2>/g, "<h2 style='font-size: 1.25em; font-weight: 700; margin-bottom: 6px'>")
+    .replace(/<h3>/g, "<h3 style='font-size: 1.1em; font-weight: 600; margin-bottom: 4px'>")
     .replace(
       /<ul>/g,
       "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -16,6 +16,9 @@ export function markdownToSafeHTMLClient(markdown: string | null) {
   const safeHTML = DOMPurify.sanitize(html);
 
   let safeHTMLWithListFormatting = safeHTML
+    .replace(/<h1>/g, "<h1 style='font-size: 1.5em; font-weight: 700; margin-bottom: 8px'>")
+    .replace(/<h2>/g, "<h2 style='font-size: 1.25em; font-weight: 700; margin-bottom: 6px'>")
+    .replace(/<h3>/g, "<h3 style='font-size: 1.1em; font-weight: 600; margin-bottom: 4px'>")
     .replace(
       /<ul>/g,
       "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"

--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.test.ts
@@ -51,9 +51,12 @@ const buildContext = () => {
 };
 
 describe("reserveSlotHandler seated event reservation", () => {
+  const originalWebappUrl = process.env.NEXT_PUBLIC_WEBAPP_URL;
+
   afterEach(() => {
     vi.resetModules();
-    delete process.env.NEXT_PUBLIC_WEBAPP_URL;
+    if (originalWebappUrl === undefined) delete process.env.NEXT_PUBLIC_WEBAPP_URL;
+    else process.env.NEXT_PUBLIC_WEBAPP_URL = originalWebappUrl;
   });
 
   it("reserves the slot for the first attendee of a seated event (no existing booking)", async () => {

--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.test.ts
@@ -1,3 +1,4 @@
+import type { PrismaClient } from "@calcom/prisma";
 import { vi, describe, it, expect, afterEach } from "vitest";
 
 // We want to test that the UID cookie set by reserveSlotHandler is configured with the correct
@@ -33,7 +34,7 @@ const buildContext = () => {
     selectedSlots: {
       upsert: vi.fn().mockResolvedValue(null),
     },
-  } as unknown as any;
+  } as unknown as PrismaClient;
 
   // Capture header values to assert on.
   let cookieHeaderValue: string | null = null;
@@ -79,7 +80,7 @@ describe("reserveSlotHandler seated event reservation", () => {
       selectedSlots: {
         upsert: upsertMock,
       },
-    } as unknown as any;
+    } as unknown as PrismaClient;
 
     await reserveSlotHandler({
       ctx: { prisma: prismaStub, req: { cookies: {} }, res: { setHeader: vi.fn() } },
@@ -116,7 +117,7 @@ describe("reserveSlotHandler seated event reservation", () => {
       selectedSlots: {
         upsert: upsertMock,
       },
-    } as unknown as any;
+    } as unknown as PrismaClient;
 
     await reserveSlotHandler({
       ctx: { prisma: prismaStub, req: { cookies: {} }, res: { setHeader: vi.fn() } },

--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.test.ts
@@ -50,6 +50,86 @@ const buildContext = () => {
   return { prismaStub, resStub, reqStub, getCookieHeader: () => cookieHeaderValue };
 };
 
+describe("reserveSlotHandler seated event reservation", () => {
+  afterEach(() => {
+    vi.resetModules();
+    delete process.env.NEXT_PUBLIC_WEBAPP_URL;
+  });
+
+  it("reserves the slot for the first attendee of a seated event (no existing booking)", async () => {
+    process.env.NEXT_PUBLIC_WEBAPP_URL = "https://example.com";
+    vi.resetModules();
+    const { reserveSlotHandler } = await dynamicImportHandler();
+
+    const upsertMock = vi.fn().mockResolvedValue(null);
+    const prismaStub = {
+      eventType: {
+        findUnique: vi.fn().mockResolvedValue({
+          users: [{ id: 1 }],
+          seatsPerTimeSlot: 5,
+        }),
+      },
+      booking: {
+        // No existing booking — first person to reserve this seated slot
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+      selectedSlots: {
+        upsert: upsertMock,
+      },
+    } as unknown as any;
+
+    await reserveSlotHandler({
+      ctx: { prisma: prismaStub, req: { cookies: {} }, res: { setHeader: vi.fn() } },
+      input: {
+        slotUtcStartDate: new Date().toISOString(),
+        slotUtcEndDate: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        eventTypeId: 1,
+        bookingUid: undefined,
+        _isDryRun: false,
+      },
+    });
+
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks reservation when all seats on a seated event are taken", async () => {
+    process.env.NEXT_PUBLIC_WEBAPP_URL = "https://example.com";
+    vi.resetModules();
+    const { reserveSlotHandler } = await dynamicImportHandler();
+
+    const upsertMock = vi.fn().mockResolvedValue(null);
+    const prismaStub = {
+      eventType: {
+        findUnique: vi.fn().mockResolvedValue({
+          users: [{ id: 1 }],
+          seatsPerTimeSlot: 2,
+        }),
+      },
+      booking: {
+        findFirst: vi.fn().mockResolvedValue({
+          attendees: [{ id: 10 }, { id: 11 }], // 2 attendees = seats full
+        }),
+      },
+      selectedSlots: {
+        upsert: upsertMock,
+      },
+    } as unknown as any;
+
+    await reserveSlotHandler({
+      ctx: { prisma: prismaStub, req: { cookies: {} }, res: { setHeader: vi.fn() } },
+      input: {
+        slotUtcStartDate: new Date().toISOString(),
+        slotUtcEndDate: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        eventTypeId: 1,
+        bookingUid: undefined,
+        _isDryRun: false,
+      },
+    });
+
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("reserveSlotHandler cookie settings", () => {
   const originalWebappUrl = process.env.NEXT_PUBLIC_WEBAPP_URL;
 

--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
@@ -57,9 +57,6 @@ export const reserveSlotHandler = async ({ ctx, input }: ReserveSlotOptions) => 
     if (bookingAttendeesLength) {
       const seatsLeft = eventType.seatsPerTimeSlot - bookingAttendeesLength;
       if (seatsLeft < 1) shouldReserveSlot = false;
-    } else {
-      // If there is no booking yet then don't reserve the slot
-      shouldReserveSlot = false;
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes an authentication bypass on cron/tasker endpoints that occurs when `CRON_SECRET` is not set in the environment.

## Root cause

When `CRON_SECRET` is absent from the environment, JavaScript template literals evaluate `process.env.CRON_SECRET` to `undefined`, producing the literal string `"Bearer undefined"`. Endpoints checking `authHeader !== \`Bearer ${process.env.CRON_SECRET}\`` would accept any request that sent `Authorization: Bearer undefined`.

The array-based calendar cron routes had the same flaw — `\`Bearer ${process.env.CRON_SECRET}\`` was included in the allowed-key array unconditionally, so `"Bearer undefined"` was always an accepted key.

**Affected endpoints:**
- `POST/GET /api/tasks/cron` — triggers `processor.processQueue()`
- `GET /api/tasks/cleanup` — triggers `tasker.cleanup()` (deletes data)
- `GET /api/cron/calendar-subscriptions`
- `GET /api/cron/calendar-subscriptions-cleanup`
- `GET /api/cron/selected-calendars`

## Fix

- **tasker cleanup/cron:** add `!process.env.CRON_SECRET` guard so the check fails closed when the variable is absent
- **calendar cron routes:** build the allowed-key list by filtering out `undefined` values before calling `.includes()`
- **`.env.example`:** document `CRON_SECRET` so deployers know to set it

Fixes #29565