### PR TITLE
fix(webhooks): give each no-show subscriber a distinct task referenceUid

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { WebhookTriggerEvents } from "@calcom/prisma/enums";
+
+const { createMock, getWebhooksMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  getWebhooksMock: vi.fn(),
+}));
+
+vi.mock("@calcom/features/tasker", () => ({ default: { create: createMock } }));
+vi.mock("@calcom/features/webhooks/lib/getWebhooks", () => ({ default: getWebhooksMock }));
+
+import { scheduleNoShowTriggers } from "./scheduleNoShowTriggers";
+
+const hostSubscriber = (id: string) => ({
+  id,
+  time: 5,
+  timeUnit: "MINUTE",
+  subscriberUrl: `https://example.com/${id}`,
+  payloadTemplate: null,
+  appId: null,
+  secret: null,
+});
+
+describe("scheduleNoShowTriggers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createMock.mockResolvedValue("task-id");
+  });
+
+  it("uses a distinct referenceUid per subscriber so multiple no-show webhooks don't collide", async () => {
+    // Two webhooks subscribed to the same host no-show trigger.
+    getWebhooksMock.mockImplementation(async ({ triggerEvent }: { triggerEvent: WebhookTriggerEvents }) =>
+      triggerEvent === WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW
+        ? [hostSubscriber("wh-1"), hostSubscriber("wh-2")]
+        : []
+    );
+
+    await scheduleNoShowTriggers({
+      booking: { startTime: new Date("2030-01-01T10:00:00Z"), id: 1, location: "", uid: "BOOKING_UID" },
+      triggerForUser: true,
+      organizerUser: { id: 101 },
+      eventTypeId: 1,
+    });
+
+    expect(createMock).toHaveBeenCalledTimes(2);
+
+    const referenceUids = createMock.mock.calls.map((call) => call[2].referenceUid);
+    // Each subscriber must get its own referenceUid; sharing booking.uid would collide on the
+    // Task @@unique([referenceUid, type]) constraint and silently drop the 2nd subscriber's task.
+    expect(new Set(referenceUids).size).toBe(2);
+    expect(referenceUids).toEqual(["BOOKING_UID-wh-1", "BOOKING_UID-wh-2"]);
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.ts
+++ b/packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.ts
@@ -63,7 +63,10 @@ const _scheduleNoShowTriggers = async (args: ScheduleNoShowTriggersArgs) => {
             // Prevents null values from being serialized
             webhook: { ...webhook, time: webhook.time, timeUnit: webhook.timeUnit },
           },
-          { scheduledAt, referenceUid: booking.uid }
+          // Each subscriber needs a distinct referenceUid: Task has a @@unique([referenceUid, type])
+          // constraint, so sharing booking.uid makes every subscriber after the first collide and
+          // silently lose its no-show task.
+          { scheduledAt, referenceUid: `${booking.uid}-${webhook.id}` }
         );
       }
       return Promise.resolve();
@@ -94,7 +97,10 @@ const _scheduleNoShowTriggers = async (args: ScheduleNoShowTriggersArgs) => {
             // Prevents null values from being serialized
             webhook: { ...webhook, time: webhook.time, timeUnit: webhook.timeUnit },
           },
-          { scheduledAt, referenceUid: booking.uid }
+          // Each subscriber needs a distinct referenceUid: Task has a @@unique([referenceUid, type])
+          // constraint, so sharing booking.uid makes every subscriber after the first collide and
+          // silently lose its no-show task.
+          { scheduledAt, referenceUid: `${booking.uid}-${webhook.id}` }
         );
       }
 

--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -633,7 +633,12 @@ export async function cancelNoShowTasksForBooking({
 
     const promises = bookings.map(async (booking) => {
       return await prisma.task.deleteMany({
-        where: matchesBookingTasks(booking.uid),
+        // Disabling a webhook should only cancel its no-show tasks — not other tasks keyed by
+        // booking.uid (e.g. the sendAwaitingPaymentEmail reminder).
+        where: {
+          ...matchesBookingTasks(booking.uid),
+          type: { in: ["triggerHostNoShowWebhook", "triggerGuestNoShowWebhook"] },
+        },
       });
     });
 

--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -603,24 +603,27 @@ export async function cancelNoShowTasksForBooking({
   triggerEvent?: WebhookTriggerEvents;
   webhook?: Pick<Webhook, "id" | "userId" | "teamId" | "eventTypeId">;
 }) {
-  // No-show tasks are keyed by `${bookingUid}-${webhookId}` (one per subscriber), so cancellation
-  // matches every subscriber's task by the bookingUid prefix rather than an exact referenceUid.
+  // A booking's no-show tasks are keyed `${bookingUid}-${webhookId}` (one per subscriber). Match them
+  // by an exact referenceUid (legacy/other tasks) or the delimiter-prefixed scheme — never a bare
+  // prefix, which could also match a different booking whose uid happens to share this one as a prefix.
+  const matchesBookingTasks = (uid: string) => ({
+    OR: [{ referenceUid: uid }, { referenceUid: { startsWith: `${uid}-` } }],
+  });
+
   if (bookingUid) {
     if (triggerEvent && !NO_SHOW_TRIGGERS.includes(triggerEvent)) return;
 
     if (triggerEvent === WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW) {
       await prisma.task.deleteMany({
-        where: { referenceUid: { startsWith: bookingUid }, type: "triggerHostNoShowWebhook" },
+        where: { ...matchesBookingTasks(bookingUid), type: "triggerHostNoShowWebhook" },
       });
     } else if (triggerEvent === WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW) {
       await prisma.task.deleteMany({
-        where: { referenceUid: { startsWith: bookingUid }, type: "triggerGuestNoShowWebhook" },
+        where: { ...matchesBookingTasks(bookingUid), type: "triggerGuestNoShowWebhook" },
       });
     } else {
       await prisma.task.deleteMany({
-        where: {
-          referenceUid: { startsWith: bookingUid },
-        },
+        where: matchesBookingTasks(bookingUid),
       });
     }
   } else if (webhook) {
@@ -630,9 +633,7 @@ export async function cancelNoShowTasksForBooking({
 
     const promises = bookings.map(async (booking) => {
       return await prisma.task.deleteMany({
-        where: {
-          referenceUid: { startsWith: booking.uid },
-        },
+        where: matchesBookingTasks(booking.uid),
       });
     });
 

--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -603,17 +603,23 @@ export async function cancelNoShowTasksForBooking({
   triggerEvent?: WebhookTriggerEvents;
   webhook?: Pick<Webhook, "id" | "userId" | "teamId" | "eventTypeId">;
 }) {
+  // No-show tasks are keyed by `${bookingUid}-${webhookId}` (one per subscriber), so cancellation
+  // matches every subscriber's task by the bookingUid prefix rather than an exact referenceUid.
   if (bookingUid) {
     if (triggerEvent && !NO_SHOW_TRIGGERS.includes(triggerEvent)) return;
 
     if (triggerEvent === WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW) {
-      await tasker.cancelWithReference(bookingUid, "triggerHostNoShowWebhook");
+      await prisma.task.deleteMany({
+        where: { referenceUid: { startsWith: bookingUid }, type: "triggerHostNoShowWebhook" },
+      });
     } else if (triggerEvent === WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW) {
-      await tasker.cancelWithReference(bookingUid, "triggerGuestNoShowWebhook");
+      await prisma.task.deleteMany({
+        where: { referenceUid: { startsWith: bookingUid }, type: "triggerGuestNoShowWebhook" },
+      });
     } else {
       await prisma.task.deleteMany({
         where: {
-          referenceUid: bookingUid,
+          referenceUid: { startsWith: bookingUid },
         },
       });
     }
@@ -625,7 +631,7 @@ export async function cancelNoShowTasksForBooking({
     const promises = bookings.map(async (booking) => {
       return await prisma.task.deleteMany({
         where: {
-          referenceUid: booking.uid,
+          referenceUid: { startsWith: booking.uid },
         },
       });
     });


### PR DESCRIPTION
## What does this PR do?

`scheduleNoShowTriggers` scheduled every no-show task with `referenceUid: booking.uid`. Since `Task` enforces a `@@unique([referenceUid, type])` constraint, event types with **multiple active webhooks subscribed to the same no-show trigger** (`AFTER_HOSTS_CAL_VIDEO_NO_SHOW` or `AFTER_GUESTS_CAL_VIDEO_NO_SHOW`) would hit a unique constraint violation after the first insert.

As a result, only the first subscriber's no-show task was created while the remaining subscribers were silently dropped. During booking confirmation, this rejection could also prevent the `BOOKING_CREATED` webhook from being delivered because the failed scheduling occurred inside the same `try` block.

This PR assigns each subscriber a unique `referenceUid` (`${booking.uid}-${webhook.id}`), preventing collisions while preserving one scheduled task per webhook. `cancelNoShowTasksForBooking` is updated to match tasks by `bookingUid` prefix so cancellation continues to remove all scheduled no-show tasks for a booking.

* Fixes #29655

## Visual Demo (For contributors especially)

### Image Demo

Backend fix. Reproduced the underlying PostgreSQL unique constraint collision before and after the fix:

```text
BUGGY — both subscribers use referenceUid = booking.uid (same type):
  subscriber #1 insert → INSERT 0 1
  subscriber #2 insert → ERROR: duplicate key value violates unique constraint "Task_referenceUid_type_key"
                         DETAIL: Key ("referenceUid", type)=(<bookingUid>, triggerHostNoShowWebhook) already exists.
  tasks created        → 1   (2nd subscriber dropped)

FIXED — per-subscriber referenceUid = `${booking.uid}-${webhook.id}`:
  both inserts         → INSERT 0 1 / INSERT 0 1
  tasks created        → 2 ✅
```

## Mandatory Tasks (DO NOT REMOVE)

* [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
* [x] I have updated the developer docs if this PR makes changes that would require a documentation change. **N/A**
* [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

* **Environment variables:** None.
* **Minimal setup:** A booking with at least two active webhooks subscribed to the same Cal Video no-show trigger.
* **Run:**

  ```bash
  TZ=UTC yarn test packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.test.ts
  ```
* **Expected result:**

  * Multiple subscribers receive distinct `referenceUid`s.
  * One scheduled task is created per subscriber.
  * The new regression test (`uses a distinct referenceUid per subscriber so multiple no-show webhooks don't collide`) fails on `main` because both tasks share `booking.uid`, and passes with this change.
  * Existing `scheduleTrigger` and `WebhookService` tests continue to pass, verifying that cancellation still removes all scheduled no-show tasks.
