### PR TITLE
fix: use custom event name as booking confirmation email subject

### DIFF
--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -1,6 +1,3 @@
-import { default as cloneDeep } from "lodash/cloneDeep";
-import type { z } from "zod";
-
 import dayjs from "@calcom/dayjs";
 import type BaseEmail from "@calcom/emails/templates/_base-email";
 import type { EventNameObjectType } from "@calcom/features/eventtypes/lib/eventNaming";
@@ -12,7 +9,8 @@ import { withReporting } from "@calcom/lib/sentryWrapper";
 import { prisma } from "@calcom/prisma";
 import type { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
-
+import { default as cloneDeep } from "lodash/cloneDeep";
+import type { z } from "zod";
 import AwaitingPaymentSMS from "../sms/attendee/awaiting-payment-sms";
 import CancelledSeatSMS from "../sms/attendee/cancelled-seat-sms";
 import EventCancelledSMS from "../sms/attendee/event-cancelled-sms";
@@ -84,6 +82,9 @@ const _sendScheduledEmailsAndSMS = async (
   eventTypeMetadata?: EventTypeMetadata
 ) => {
   const formattedCalEvent = formatCalEvent(calEvent);
+  // getEventName falls back to the default "X between A and B" template when no custom event name
+  // is configured, so a truthy eventName is what distinguishes a custom title from the default one.
+  formattedCalEvent.hasCustomEventName = Boolean(eventNameObject?.eventName);
   const emailsToSend: Promise<unknown>[] = [];
   const organizationSettings = await fetchOrganizationEmailSettings(calEvent.organizationId);
 
@@ -147,6 +148,7 @@ export const sendReassignedScheduledEmailsAndSMS = async ({
 }) => {
   if (eventTypeDisableHostEmail(eventTypeMetadata)) return;
   const formattedCalEvent = formatCalEvent(calEvent);
+  // hasCustomEventName is intentionally not set here, so the reassignment subject keeps the default template — out of scope for #29658.
   const emailsAndSMSToSend: Promise<unknown>[] = [];
   const eventScheduledSMS = new EventSuccessfullyScheduledSMS(calEvent);
 

--- a/packages/emails/src/templates/BaseScheduledEmail.test.ts
+++ b/packages/emails/src/templates/BaseScheduledEmail.test.ts
@@ -1,0 +1,70 @@
+import type { CalendarEvent, Person } from "@calcom/types/Calendar";
+import type { TFunction } from "i18next";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { BaseScheduledEmail } from "./BaseScheduledEmail";
+
+// The translate mock returns the key it is given, so a default templated subject renders as the
+// raw key ("confirmed_event_type_subject") while a custom event name renders as calEvent.title.
+const t = ((key: string) => key) as unknown as TFunction;
+
+const createPerson = (name: string, email: string): Person => ({
+  name,
+  email,
+  timeZone: "America/New_York",
+  language: { translate: t, locale: "en" },
+});
+
+const createCalEvent = (overrides: Partial<CalendarEvent>): CalendarEvent =>
+  ({
+    type: "30min",
+    title: "30 Minute Meeting between Organizer and Alice",
+    startTime: "2024-01-01T10:00:00.000Z",
+    endTime: "2024-01-01T11:00:00.000Z",
+    organizer: createPerson("Organizer", "organizer@example.com"),
+    attendees: [createPerson("Alice", "alice@example.com")],
+    ...overrides,
+  }) as CalendarEvent;
+
+const renderSubject = (props: Partial<React.ComponentProps<typeof BaseScheduledEmail>>) => {
+  const attendee = props.attendee ?? createPerson("Alice", "alice@example.com");
+  const html = renderToStaticMarkup(
+    createElement(BaseScheduledEmail, {
+      attendee,
+      timeZone: attendee.timeZone,
+      locale: attendee.language.locale,
+      timeFormat: undefined,
+      t,
+      // Skip ManageLink to keep the render focused on the subject under test.
+      callToAction: null,
+      ...props,
+    } as React.ComponentProps<typeof BaseScheduledEmail>)
+  );
+  const match = html.match(/<title>([\s\S]*?)<\/title>/);
+  return match?.[1];
+};
+
+describe("BaseScheduledEmail subject", () => {
+  it("uses the resolved title when a custom event name is set", () => {
+    const calEvent = createCalEvent({ title: "Meeting with Acme Corp", hasCustomEventName: true });
+    expect(renderSubject({ calEvent })).toBe("Meeting with Acme Corp");
+  });
+
+  it("keeps the default templated subject when no custom event name is set", () => {
+    const calEvent = createCalEvent({ hasCustomEventName: false });
+    expect(renderSubject({ calEvent })).toBe("confirmed_event_type_subject");
+  });
+
+  it("falls back to the default templated subject when the flag is absent", () => {
+    const calEvent = createCalEvent({});
+    expect(renderSubject({ calEvent })).toBe("confirmed_event_type_subject");
+  });
+
+  it("lets an explicit subject prop win over the custom event name", () => {
+    const calEvent = createCalEvent({ title: "Meeting with Acme Corp", hasCustomEventName: true });
+    expect(renderSubject({ calEvent, subject: "rescheduled_event_type_subject" })).toBe(
+      "rescheduled_event_type_subject"
+    );
+  });
+});

--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -40,14 +40,20 @@ export const BaseScheduledEmail = (
     return dayjs(props.calEvent.endTime).tz(timeZone).format(format);
   }
 
-  const subject = t(props.subject || "confirmed_event_type_subject", {
-    eventType: props.calEvent.type,
-    name: props.calEvent.team?.name || props.calEvent.organizer.name,
-    date: `${getRecipientStart("h:mma")} - ${getRecipientEnd("h:mma")}, ${t(
-      getRecipientStart("dddd").toLowerCase()
-    )}, ${t(getRecipientStart("MMMM").toLowerCase())} ${getRecipientStart("D, YYYY")}`,
-    interpolation: { escapeValue: false },
-  });
+  // When a custom event name is configured, calEvent.title already resolves booking-field
+  // placeholders (e.g. "{company}"), so prefer it over the default templated subject. An explicit
+  // props.subject still wins to preserve existing per-template overrides.
+  const subject =
+    !props.subject && props.calEvent.hasCustomEventName
+      ? props.calEvent.title
+      : t(props.subject || "confirmed_event_type_subject", {
+          eventType: props.calEvent.type,
+          name: props.calEvent.team?.name || props.calEvent.organizer.name,
+          date: `${getRecipientStart("h:mma")} - ${getRecipientEnd("h:mma")}, ${t(
+            getRecipientStart("dddd").toLowerCase()
+          )}, ${t(getRecipientStart("MMMM").toLowerCase())} ${getRecipientStart("D, YYYY")}`,
+          interpolation: { escapeValue: false },
+        });
 
   let rescheduledBy = props.calEvent.rescheduledBy;
   if (

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -167,6 +167,10 @@ export interface CalendarEvent {
   hashedLink?: string | null;
   type: string;
   title: string;
+  // Transient (not persisted): true when a custom event name was configured for the event type,
+  // so emails use the resolved `title` (booking-field placeholders already interpolated) as the
+  // subject instead of the default templated subject. See BaseScheduledEmail.
+  hasCustomEventName?: boolean;
   startTime: string;
   endTime: string;
   organizer: Person;


### PR DESCRIPTION
## What does this PR do?

Fixes #29658

The booking confirmation email subject was built from a fixed i18n template (`confirmed_event_type_subject`) that used the raw event-type title and ignored the custom calendar event name. As a result, booking-field placeholders like `{company}` resolved correctly in the email body but were never applied to the subject.

This change makes the subject use the already-resolved `calEvent.title` (which contains the interpolated custom event name) when a custom event name is configured, falling back to the existing template otherwise. Default events are unchanged.

## Changes

- `packages/types/Calendar.d.ts` - added an optional transient `hasCustomEventName` flag to `CalendarEvent` (not persisted, no schema change)
- `packages/emails/email-manager.ts` - set the flag at the `getEventName` call site so both organizer and attendee emails inherit it
- `packages/emails/src/templates/BaseScheduledEmail.tsx` - use `calEvent.title` as the subject when a custom event name is set
- `packages/emails/src/templates/BaseScheduledEmail.test.ts` - added tests covering the custom-name, default, and explicit-subject cases

## How was this tested?

Reproduced locally with Mailhog: created an event with a custom `company` booking field and event name `Meeting with {company}`, booked it, and compared the confirmation email subject before and after the change.

> Top rows: after the fix - subject resolves the custom event name (`Meeting with hiii corp`).
> Bottom rows: before the fix - generic template (`Confirmed: 30min with wasim at...`).

<img width="1366" height="768" alt="Screenshot (56)" src="https://github.com/user-attachments/assets/a31052ba-64b0-4072-a0c0-bfd2123ff435" />


Verified that default events with no custom event name keep the original templated subject.

Note: the reassignment email path is intentionally left on the default template, as it's out of scope for this issue.