### PR TITLE
fix: parse all-day holiday dates as UTC to avoid off-by-one on UTC+ servers

### DIFF
--- a/packages/lib/holidays/GoogleCalendarClient.test.ts
+++ b/packages/lib/holidays/GoogleCalendarClient.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { GoogleCalendarClient } from "./GoogleCalendarClient";
+
+// Google returns public-holiday events as all-day events, so `start.date` is a
+// bare calendar date ("2025-01-01") with no time or offset. These tests run
+// under a positive-UTC-offset zone (Asia/Tokyo, +09:00) because parsing such a
+// date in server-local time shifts it to the previous UTC day, which is exactly
+// the case the rest of the holiday code does not expect: HolidayService reads
+// every stored date back with `.utc()`, assuming it is UTC midnight.
+const originalTZ = process.env.TZ;
+
+describe("GoogleCalendarClient.fetchHolidays date parsing", () => {
+  beforeAll(() => {
+    process.env.TZ = "Asia/Tokyo";
+  });
+
+  afterAll(() => {
+    process.env.TZ = originalTZ;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const mockFetchOnce = (items: unknown[]) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ json: async () => ({ items }) }) as unknown as Response)
+    );
+  };
+
+  it("parses an all-day holiday date as UTC midnight regardless of server timezone", async () => {
+    mockFetchOnce([
+      {
+        id: "newyear2025",
+        summary: "New Year's Day",
+        start: { date: "2025-01-01" },
+        end: { date: "2025-01-02" },
+      },
+    ]);
+
+    const client = new GoogleCalendarClient("test-key");
+    const holidays = await client.fetchHolidays("JP", 2025);
+
+    expect(holidays).toHaveLength(1);
+    // Must stay on Jan 1 in UTC. Local-time parsing under +09:00 would store
+    // 2024-12-31T15:00:00.000Z, which downstream `.utc()` formatting then reads
+    // back as 2024-12-31 (the holiday silently moves to the day before).
+    expect(holidays[0].date.toISOString()).toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  it("parses a timed event's date part as UTC midnight as well", async () => {
+    mockFetchOnce([
+      {
+        id: "evt",
+        summary: "Some Day",
+        start: { dateTime: "2025-05-05T00:00:00+09:00" },
+        end: { dateTime: "2025-05-05T23:59:59+09:00" },
+      },
+    ]);
+
+    const client = new GoogleCalendarClient("test-key");
+    const holidays = await client.fetchHolidays("JP", 2025);
+
+    expect(holidays[0].date.toISOString()).toBe("2025-05-05T00:00:00.000Z");
+  });
+});

--- a/packages/lib/holidays/GoogleCalendarClient.ts
+++ b/packages/lib/holidays/GoogleCalendarClient.ts
@@ -71,7 +71,7 @@ export class GoogleCalendarClient {
 
     return data.items.map((event) => {
       const dateStr = event.start.date || event.start.dateTime?.split("T")[0];
-      const date = dateStr ? dayjs(dateStr).toDate() : new Date();
+      const date = dateStr ? dayjs.utc(dateStr).toDate() : new Date();
 
       return {
         id: `${countryCode}_${event.id}`,


### PR DESCRIPTION
## What does this PR do?

`GoogleCalendarClient.fetchHolidays` parses each holiday date with `dayjs(dateStr).toDate()`. Google returns public-holiday events as all-day events, so `start.date` is a bare calendar date like `"2025-01-01"` with no time or offset. dayjs parses a bare date in server-local time, so on a server whose timezone is ahead of UTC the resulting `Date` lands on the previous UTC day.

Everything downstream reads that date back as UTC. `HolidayService` says so directly:

```ts
// Use UTC to ensure consistent date formatting regardless of server timezone
// Holiday dates are stored as UTC midnight (e.g., 2025-12-25T00:00:00.000Z)
date: dayjs(cached.date).utc().format("YYYY-MM-DD"),
```

So the producer and the consumers disagree. On a server in `Asia/Tokyo` (+09:00), New Year's Day comes back from Google as `2025-01-01`, gets stored as `2024-12-31T15:00:00.000Z`, and `getHolidayDatesInRange`, `getHolidaysWithStatus`, and `checkConflicts` then all report it as **2024-12-31**. The holiday, the blocked day, and the booking-conflict check all move one day early.

It only affects deployments east of UTC, which is why a UTC CI does not catch it:

| server timezone | offset | New Year's Day stored as |
|---|---|---|
| UTC / Europe/London | 0 | 2025-01-01 (ok) |
| America/New_York | -5 | 2025-01-01 (ok) |
| Asia/Kolkata | +5:30 | 2024-12-31 |
| Asia/Tokyo / Asia/Seoul | +9 | 2024-12-31 |
| Australia/Sydney | +10/+11 | 2024-12-31 |

The fix parses the calendar date as UTC, which is what the rest of the file's consumers already assume (`HolidayService.checkConflicts` reads dates with `dayjs.utc(h.date)`):

```diff
-      const date = dateStr ? dayjs(dateStr).toDate() : new Date();
+      const date = dateStr ? dayjs.utc(dateStr).toDate() : new Date();
```

`dayjs.utc` gives `2025-01-01T00:00:00.000Z` in every timezone, so the stored value matches the documented contract everywhere, and negative-offset servers that were already correct are unchanged.

- Fixes: N/A (no existing issue; found while reading the holiday code)

## How should this be tested?

Added `GoogleCalendarClient.test.ts`. It mocks `fetch`, runs under `TZ=Asia/Tokyo`, and asserts the parsed date is `2025-01-01T00:00:00.000Z`. On `main` that assertion gets `2024-12-31T15:00:00.000Z` and fails; with this change it passes. Negative-offset zones produce the correct date either way.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
