### PR TITLE
docs: add Zenith Hosting badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,10 @@ Currently Vercel Pro Plan is required to be able to Deploy this application with
 
 [![Deploy on Elestio](https://elest.io/images/logos/deploy-to-elestio-btn.png)](https://elest.io/open-source/cal.com)
 
+### Zenith
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/cal-com?ref=gh)
+
 <!-- LICENSE -->
 
 ## License


### PR DESCRIPTION
## What does this PR do?

Adds a deploy to Zenith badge to the README.

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

hey, I'm part of a startup called Zenith Hosting. We help users set up easy to use 1-click OSS deployments on our platform. As part of our catalog, we added cal.diy as something that people can easily deploy (where we manage storage/security/etc.). this PR simply adds a badge under the existing deployments section in the README. (currently it links to https://zenith.hosting/host/cal-com). 

p.s. if you are interested in learning how we partner with OSS devs, shoot us an email :) hello@zenith.hosting 
