### PR TITLE
fix: drop incorrect redirect_uri from Basecamp3 token refresh

### DIFF
--- a/packages/app-store/basecamp3/lib/helpers.test.ts
+++ b/packages/app-store/basecamp3/lib/helpers.test.ts
@@ -1,0 +1,92 @@
+import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
+import type { Credential } from "@calcom/prisma/client";
+import type { CredentialPayload } from "@calcom/types/Credential";
+import { afterEach, expect, test, vi } from "vitest";
+import { refreshAccessToken } from "./helpers";
+import type { BasecampToken } from "./types";
+
+vi.mock("./getBasecampKeys", () => ({
+  getBasecampKeys: vi.fn().mockResolvedValue({
+    client_id: "test-client-id",
+    client_secret: "test-client-secret",
+    user_agent: "Cal.com (test@example.com)",
+  }),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  fetchMock.resetMocks();
+});
+
+const basecampKey: BasecampToken = {
+  projectId: 1,
+  scheduleId: 1,
+  expires_at: 0,
+  expires_in: 1209600,
+  access_token: "old-access-token",
+  refresh_token: "test-refresh-token",
+  account: { id: 1, href: "", name: "", hidden: false, product: "", app_href: "" },
+};
+
+const credential = {
+  id: 1,
+  appId: "basecamp3",
+  type: "basecamp3_other_calendar",
+  userId: 1,
+  user: { email: "test@example.com" },
+  teamId: null,
+  key: basecampKey,
+  invalid: false,
+  encryptedKey: null,
+  delegationCredentialId: null,
+} satisfies CredentialPayload;
+
+const updatedCredentialRow: Credential = {
+  id: credential.id,
+  type: credential.type,
+  key: { ...basecampKey, access_token: "new-access-token" },
+  encryptedKey: null,
+  userId: credential.userId,
+  teamId: credential.teamId,
+  appId: credential.appId,
+  subscriptionId: null,
+  paymentStatus: null,
+  billingCycleStart: null,
+  invalid: false,
+  delegationCredentialId: null,
+};
+
+function mockTokenRefresh() {
+  fetchMock.mockResponseOnce(JSON.stringify({ access_token: "new-access-token", expires_in: 1209600 }));
+  prismaMock.credential.update.mockResolvedValue(updatedCredentialRow);
+}
+
+test("refresh request only sends the documented refresh params and omits redirect_uri", async () => {
+  mockTokenRefresh();
+
+  await refreshAccessToken(credential);
+
+  expect(fetchMock).toHaveBeenCalledOnce();
+  const requestedUrl = fetchMock.mock.calls[0][0] as string;
+
+  expect(requestedUrl).toContain("https://launchpad.37signals.com/authorization/token");
+  expect(requestedUrl).toContain("type=refresh");
+  expect(requestedUrl).toContain(`refresh_token=${basecampKey.refresh_token}`);
+  expect(requestedUrl).toContain("client_id=test-client-id");
+  expect(requestedUrl).toContain("client_secret=test-client-secret");
+  expect(requestedUrl).not.toContain("redirect_uri");
+});
+
+test("persists the refreshed token back to the existing credential", async () => {
+  mockTokenRefresh();
+
+  await refreshAccessToken(credential);
+
+  expect(prismaMock.credential.update).toHaveBeenCalledOnce();
+  const updateArgs = prismaMock.credential.update.mock.calls[0][0];
+  expect(updateArgs.where).toEqual({ id: credential.id });
+  expect(updateArgs.data.key).toMatchObject({
+    access_token: "new-access-token",
+    refresh_token: basecampKey.refresh_token,
+  });
+});

--- a/packages/app-store/basecamp3/lib/helpers.test.ts
+++ b/packages/app-store/basecamp3/lib/helpers.test.ts
@@ -67,14 +67,15 @@ test("refresh request only sends the documented refresh params and omits redirec
   await refreshAccessToken(credential);
 
   expect(fetchMock).toHaveBeenCalledOnce();
-  const requestedUrl = fetchMock.mock.calls[0][0] as string;
+  const url = new URL(fetchMock.mock.calls[0][0] as string);
 
-  expect(requestedUrl).toContain("https://launchpad.37signals.com/authorization/token");
-  expect(requestedUrl).toContain("type=refresh");
-  expect(requestedUrl).toContain(`refresh_token=${basecampKey.refresh_token}`);
-  expect(requestedUrl).toContain("client_id=test-client-id");
-  expect(requestedUrl).toContain("client_secret=test-client-secret");
-  expect(requestedUrl).not.toContain("redirect_uri");
+  expect(url.origin + url.pathname).toBe("https://launchpad.37signals.com/authorization/token");
+  expect(Object.fromEntries(url.searchParams)).toEqual({
+    type: "refresh",
+    refresh_token: basecampKey.refresh_token,
+    client_id: "test-client-id",
+    client_secret: "test-client-secret",
+  });
 });
 
 test("persists the refreshed token back to the existing credential", async () => {

--- a/packages/app-store/basecamp3/lib/helpers.ts
+++ b/packages/app-store/basecamp3/lib/helpers.ts
@@ -1,7 +1,5 @@
-import { WEBAPP_URL } from "@calcom/lib/constants";
 import { prisma } from "@calcom/prisma";
 import type { CredentialPayload } from "@calcom/types/Credential";
-
 import { getBasecampKeys } from "./getBasecampKeys";
 import type { BasecampToken } from "./types";
 
@@ -9,7 +7,7 @@ export const refreshAccessToken = async (credential: CredentialPayload) => {
   const { client_id: clientId, client_secret: clientSecret, user_agent: userAgent } = await getBasecampKeys();
   const credentialKey = credential.key as BasecampToken;
   const tokenInfo = await fetch(
-    `https://launchpad.37signals.com/authorization/token?type=refresh&refresh_token=${credentialKey.refresh_token}&client_id=${clientId}&redirect_uri=${WEBAPP_URL}&client_secret=${clientSecret}`,
+    `https://launchpad.37signals.com/authorization/token?type=refresh&refresh_token=${credentialKey.refresh_token}&client_id=${clientId}&client_secret=${clientSecret}`,
     { method: "POST", headers: { "User-Agent": userAgent } }
   );
   const tokenInfoJson = await tokenInfo.json();

--- a/packages/app-store/basecamp3/lib/helpers.ts
+++ b/packages/app-store/basecamp3/lib/helpers.ts
@@ -6,10 +6,16 @@ import type { BasecampToken } from "./types";
 export const refreshAccessToken = async (credential: CredentialPayload) => {
   const { client_id: clientId, client_secret: clientSecret, user_agent: userAgent } = await getBasecampKeys();
   const credentialKey = credential.key as BasecampToken;
-  const tokenInfo = await fetch(
-    `https://launchpad.37signals.com/authorization/token?type=refresh&refresh_token=${credentialKey.refresh_token}&client_id=${clientId}&client_secret=${clientSecret}`,
-    { method: "POST", headers: { "User-Agent": userAgent } }
-  );
+  const params = new URLSearchParams({
+    type: "refresh",
+    refresh_token: credentialKey.refresh_token,
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+  const tokenInfo = await fetch(`https://launchpad.37signals.com/authorization/token?${params.toString()}`, {
+    method: "POST",
+    headers: { "User-Agent": userAgent },
+  });
   const tokenInfoJson = await tokenInfo.json();
   tokenInfoJson["expires_at"] = Date.now() + 1000 * 3600 * 24 * 14;
   const newCredential = await prisma.credential.update({


### PR DESCRIPTION
## What does this PR do?

The Basecamp3 token-refresh request appended a `redirect_uri` parameter set to the app root URL (`WEBAPP_URL`). That's not the `/api/integrations/basecamp3/callback` URL used during the initial OAuth authorization, and Basecamp's documented refresh request only expects `type=refresh`, `refresh_token`, `client_id` and `client_secret`. Sending an unexpected `redirect_uri` can make the refresh fail once the stored access token expires.

This drops the `redirect_uri` parameter (and the now-unused `WEBAPP_URL` import) so the refresh request matches Basecamp's documented parameters. The initial OAuth exchange, which legitimately uses the callback `redirect_uri`, is left alone. Reference: https://github.com/basecamp/api/blob/master/sections/authentication.md

- Fixes #29585

## Visual Demo (For contributors especially)

N/A. This is a backend-only change to the Basecamp3 token-refresh helper, so there's nothing visual to show.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No env vars or test data needed. The helper is unit-tested in isolation.

```bash
TZ=UTC yarn vitest run packages/app-store/basecamp3/lib/helpers.test.ts
```

The new `helpers.test.ts` mocks `getBasecampKeys`, `fetch`, and Prisma, then asserts the refresh request:

- is sent to `https://launchpad.37signals.com/authorization/token`
- includes `type=refresh`, `refresh_token`, `client_id`, `client_secret`
- does **not** include `redirect_uri`
- persists the refreshed token back onto the existing credential

Restore the `redirect_uri` line and the first test fails on the `redirect_uri` assertion; with the fix it passes.

## Checklist

I've read the contributing guide, the code follows the style guidelines, and there are no new warnings. This is a small PR (2 files).
