### PR TITLE
fix(ui): show markdown heading styles on booking pages

### DIFF
--- a/packages/lib/markdownHtmlFormatting.ts
+++ b/packages/lib/markdownHtmlFormatting.ts
@@ -1,0 +1,31 @@
+/**
+ * Post-process sanitized markdown HTML for Cal UI (lists, links, headings).
+ * Tailwind preflight resets heading sizes; inject utility classes at render time.
+ */
+export function applyMarkdownHtmlFormatting(html: string): string {
+  let formatted = html
+    .replace(
+      /<ul>/g,
+      "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
+    )
+    .replace(
+      /<ol>/g,
+      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
+    )
+    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=")
+    .replace(/<h1>/g, "<h1 class='text-2xl font-semibold mb-2'>")
+    .replace(/<h2>/g, "<h2 class='text-xl font-semibold mb-2'>")
+    .replace(/<h3>/g, "<h3 class='text-lg font-semibold mb-1'>")
+    .replace(/<h4>/g, "<h4 class='text-base font-semibold mb-1'>")
+    .replace(/<h5>/g, "<h5 class='text-sm font-semibold mb-1'>")
+    .replace(/<h6>/g, "<h6 class='text-xs font-semibold mb-1'>");
+
+  // Match: <li>Some text </li><li><ul>...</ul></li>
+  // Convert to: <li>Some text <ul>...</ul></li>
+  formatted = formatted.replace(
+    /<li>([^<]+|<strong>.*?<\/strong>)<\/li>\s*<li>\s*<ul([^>]*)>([\s\S]*?)<\/ul>\s*<\/li>/g,
+    "<li>$1<ul$2>$3</ul></li>"
+  );
+
+  return formatted;
+}

--- a/packages/lib/markdownHtmlFormatting.ts
+++ b/packages/lib/markdownHtmlFormatting.ts
@@ -23,8 +23,8 @@ export function applyMarkdownHtmlFormatting(html: string): string {
     .replace(/<h5>/g, "<h5 class='text-sm font-semibold mb-1'>")
     .replace(/<h6>/g, "<h6 class='text-xs font-semibold mb-1'>");
 
-  // Match: <li>Some text </li><li><ul>...</ul></li>
-  // Convert to: <li>Some text <ul>...</ul></li>
+  // Some markdown renderers emit a sibling <li><ul>…</ul></li> after text-only list items.
+  // Nest that inner list inside the preceding item so bullets render correctly in booking UI.
   formatted = formatted.replace(
     /<li>([^<]+|<strong>.*?<\/strong>)<\/li>\s*<li>\s*<ul([^>]*)>([\s\S]*?)<\/ul>\s*<\/li>/g,
     "<li>$1<ul$2>$3</ul></li>"

--- a/packages/lib/markdownHtmlFormatting.ts
+++ b/packages/lib/markdownHtmlFormatting.ts
@@ -12,7 +12,10 @@ export function applyMarkdownHtmlFormatting(html: string): string {
       /<ol>/g,
       "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
     )
-    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=")
+    .replace(
+      /<a\s+href=/g,
+      "<a target='_blank' rel='noopener noreferrer' class='text-blue-500 hover:text-blue-600' href="
+    )
     .replace(/<h1>/g, "<h1 class='text-2xl font-semibold mb-2'>")
     .replace(/<h2>/g, "<h2 class='text-xl font-semibold mb-2'>")
     .replace(/<h3>/g, "<h3 class='text-lg font-semibold mb-1'>")

--- a/packages/lib/markdownToSafeHTML.test.ts
+++ b/packages/lib/markdownToSafeHTML.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { markdownToSafeHTML } from "./markdownToSafeHTML";
+
+describe("markdownToSafeHTML", () => {
+  it("applies heading styles for large headings", () => {
+    const html = markdownToSafeHTML("# Meeting details");
+
+    expect(html).toContain("<h1 class='text-2xl font-semibold mb-2'>");
+    expect(html).toContain("Meeting details");
+  });
+
+  it("applies heading styles for smaller heading levels", () => {
+    const html = markdownToSafeHTML("## Agenda\n\n### Notes");
+
+    expect(html).toContain("<h2 class='text-xl font-semibold mb-2'>");
+    expect(html).toContain("<h3 class='text-lg font-semibold mb-1'>");
+  });
+});

--- a/packages/lib/markdownToSafeHTML.test.ts
+++ b/packages/lib/markdownToSafeHTML.test.ts
@@ -16,4 +16,11 @@ describe("markdownToSafeHTML", () => {
     expect(html).toContain("<h2 class='text-xl font-semibold mb-2'>");
     expect(html).toContain("<h3 class='text-lg font-semibold mb-1'>");
   });
+
+  it("adds rel noopener on links opened in a new tab", () => {
+    const html = markdownToSafeHTML("[site](https://example.com)");
+
+    expect(html).toContain("rel='noopener noreferrer'");
+    expect(html).toContain("target='_blank'");
+  });
 });

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -1,5 +1,6 @@
 import sanitizeHtml from "sanitize-html";
 
+import { applyMarkdownHtmlFormatting } from "@calcom/lib/markdownHtmlFormatting";
 import { md } from "@calcom/lib/markdownIt";
 
 if (typeof window !== "undefined") {
@@ -15,23 +16,5 @@ export function markdownToSafeHTML(markdown: string | null) {
 
   const safeHTML = sanitizeHtml(html);
 
-  let safeHTMLWithListFormatting = safeHTML
-    .replace(
-      /<ul>/g,
-      "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(
-      /<ol>/g,
-      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
-
-  // Match: <li>Some text </li><li><ul>...</ul></li>
-  // Convert to: <li>Some text <ul>...</ul></li>
-  safeHTMLWithListFormatting = safeHTMLWithListFormatting.replace(
-    /<li>([^<]+|<strong>.*?<\/strong>)<\/li>\s*<li>\s*<ul([^>]*)>([\s\S]*?)<\/ul>\s*<\/li>/g,
-    "<li>$1<ul$2>$3</ul></li>"
-  );
-
-  return safeHTMLWithListFormatting;
+  return applyMarkdownHtmlFormatting(safeHTML);
 }

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -1,5 +1,6 @@
 import DOMPurify from "dompurify";
 
+import { applyMarkdownHtmlFormatting } from "@calcom/lib/markdownHtmlFormatting";
 import { md } from "@calcom/lib/markdownIt";
 
 if (typeof window == "undefined") {
@@ -15,23 +16,5 @@ export function markdownToSafeHTMLClient(markdown: string | null) {
 
   const safeHTML = DOMPurify.sanitize(html);
 
-  let safeHTMLWithListFormatting = safeHTML
-    .replace(
-      /<ul>/g,
-      "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(
-      /<ol>/g,
-      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
-
-  // Match: <li>Some text </li><li><ul>...</ul></li> or
-  // Convert to: <li>Some text <ul>...</ul></li>
-  safeHTMLWithListFormatting = safeHTMLWithListFormatting.replace(
-    /<li>([^<]+|<strong>.*?<\/strong>)<\/li>\s*<li>\s*<ul([^>]*)>([\s\S]*?)<\/ul>\s*<\/li>/g,
-    "<li>$1<ul$2>$3</ul></li>"
-  );
-
-  return safeHTMLWithListFormatting;
+  return applyMarkdownHtmlFormatting(safeHTML);
 }


### PR DESCRIPTION
Fixes #29645

Headings in the event description (`# Before you book` etc.) rendered the same size as body text on the booking page preview. Tailwind's preflight resets `h1`–`h6`, so the sanitized HTML needed typography classes on those tags.

Pulled list/link formatting into `markdownHtmlFormatting.ts` and added heading classes there. Both server and client markdown paths use it now.

`yarn vitest run packages/lib/markdownToSafeHTML.test.ts` — 2/2.
