### PR TITLE
fix(event-types): skip save when form has no changes

### DIFF
--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -285,6 +285,10 @@ export const useEventTypeForm = ({
   };
 
   const handleSubmit = async (values: FormValues) => {
+    if (!isFormDirty) {
+      return;
+    }
+
     const { children } = values;
     const dirtyValues = getDirtyFields(values);
     const dirtyFieldExists = Object.keys(dirtyValues).length !== 0;

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -284,9 +284,9 @@ export const useEventTypeForm = ({
     return updatedFields;
   };
 
-  const handleSubmit = async (values: FormValues) => {
+  const handleSubmit = async (values: FormValues): Promise<boolean> => {
     if (!isFormDirty) {
-      return;
+      return false;
     }
 
     const { children } = values;
@@ -411,9 +411,12 @@ export const useEventTypeForm = ({
       return acc;
     }, {}) as EventTypeUpdateInput;
 
-    if (dirtyFieldExists) {
-      onSubmit({ ...filteredPayload, id: eventType.id });
+    if (!dirtyFieldExists) {
+      return false;
     }
+
+    onSubmit({ ...filteredPayload, id: eventType.id });
+    return true;
   };
 
   useEffect(() => {

--- a/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
@@ -183,10 +183,12 @@ const EventType = forwardRef<
       if (saveButtonRef.current) {
         saveButtonRef.current.click();
       } else {
-        form.handleSubmit((data) => {
+        form.handleSubmit(async (data) => {
           try {
-            handleSubmit(data);
-            customCallbacks?.onSuccess?.();
+            const submitted = await handleSubmit(data);
+            if (submitted) {
+              customCallbacks?.onSuccess?.();
+            }
           } catch (error) {
             customCallbacks?.onError?.(error as Error);
           }

--- a/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
@@ -185,10 +185,7 @@ const EventType = forwardRef<
       } else {
         form.handleSubmit(async (data) => {
           try {
-            const submitted = await handleSubmit(data);
-            if (submitted) {
-              customCallbacks?.onSuccess?.();
-            }
+            await handleSubmit(data);
           } catch (error) {
             customCallbacks?.onError?.(error as Error);
           }


### PR DESCRIPTION
Fixes #13112

Save was already disabled when the form isn't dirty, but `handleSubmit` could still fire (programmatic submit) and hit the API anyway. Early return when `!isFormDirty`.

Checked in the event type editor: no edits → Save stays disabled; change title → Save enables and persists.
