### PR TITLE
fix(slots): make worker failure handling idempotent

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.spec.ts
@@ -1,0 +1,94 @@
+import type { Worker } from "node:worker_threads";
+import type { ConfigService } from "@nestjs/config";
+import { SlotsWorkerService_2024_04_15 } from "./slots-worker.service";
+
+/**
+ * Builds a ConfigService stub that keeps the worker pool empty on construction
+ * (enableSlotsWorkers = false) so each test can populate the pool deterministically.
+ */
+function createConfigStub(): ConfigService {
+  return {
+    get: (key: string) => {
+      if (key === "enableSlotsWorkers") return false;
+      if (key === "slotsWorkerPoolSize") return 0;
+      if (key === "e2e") return false;
+      return undefined;
+    },
+  } as unknown as ConfigService;
+}
+
+function createFakeWorker(threadId: number): Worker {
+  return {
+    threadId,
+    terminate: jest.fn().mockResolvedValue(undefined),
+    on: jest.fn(),
+    once: jest.fn(),
+    postMessage: jest.fn(),
+  } as unknown as Worker;
+}
+
+type ServiceInternals = {
+  workerPool: Worker[];
+  availableWorkers: Worker[];
+  createNewWorker: () => void;
+  handleWorkerFailure: (worker: Worker) => void;
+};
+
+describe("SlotsWorkerService_2024_04_15", () => {
+  let service: SlotsWorkerService_2024_04_15;
+  let internals: ServiceInternals;
+  let createdReplacements: Worker[];
+
+  beforeEach(() => {
+    service = new SlotsWorkerService_2024_04_15(createConfigStub());
+    internals = service as unknown as ServiceInternals;
+    createdReplacements = [];
+
+    // Stub replacement creation so tests never spawn real worker threads.
+    jest.spyOn(internals, "createNewWorker").mockImplementation(() => {
+      const replacement = createFakeWorker(1000 + createdReplacements.length);
+      createdReplacements.push(replacement);
+      internals.workerPool.push(replacement);
+      internals.availableWorkers.push(replacement);
+    });
+  });
+
+  describe("handleWorkerFailure", () => {
+    it("removes the failed worker and creates exactly one replacement", () => {
+      const failed = createFakeWorker(1);
+      const healthy = createFakeWorker(2);
+      internals.workerPool.push(failed, healthy);
+      internals.availableWorkers.push(failed, healthy);
+
+      internals.handleWorkerFailure(failed);
+
+      expect(internals.workerPool).not.toContain(failed);
+      expect(internals.availableWorkers).not.toContain(failed);
+      expect(internals.workerPool).toContain(healthy);
+      expect(internals.createNewWorker).toHaveBeenCalledTimes(1);
+      expect(internals.workerPool).toHaveLength(2);
+      expect(failed.terminate).toHaveBeenCalledTimes(1);
+    });
+
+    it("is idempotent when the same worker emits both 'error' and 'exit'", () => {
+      const failed = createFakeWorker(1);
+      const healthy = createFakeWorker(2);
+      internals.workerPool.push(failed, healthy);
+      internals.availableWorkers.push(failed, healthy);
+
+      // A crashing worker fires both lifecycle events for the same worker.
+      internals.handleWorkerFailure(failed);
+      internals.handleWorkerFailure(failed);
+
+      // The healthy worker must survive (no stray splice(-1, 1) eviction)...
+      expect(internals.workerPool).toContain(healthy);
+      // ...the failed worker must be gone and terminated only once...
+      expect(internals.workerPool).not.toContain(failed);
+      expect(failed.terminate).toHaveBeenCalledTimes(1);
+      // ...and the pool must not be inflated by a second replacement.
+      expect(internals.createNewWorker).toHaveBeenCalledTimes(1);
+      expect(internals.workerPool).toHaveLength(2);
+      expect(new Set(internals.workerPool).size).toBe(internals.workerPool.length);
+    });
+  });
+});

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.ts
@@ -92,9 +92,18 @@ export class SlotsWorkerService_2024_04_15 implements OnModuleDestroy {
    * @param failedWorker The worker that failed or exited.
    */
   private handleWorkerFailure(failedWorker: Worker): void {
+    const poolIndex = this.workerPool.indexOf(failedWorker);
+    // A crashing worker commonly emits both "error" and "exit", so this can be
+    // invoked twice for the same worker. If it has already been handled it is no
+    // longer in the pool, in which case bail out: otherwise splice(-1, 1) would
+    // drop a healthy worker and createNewWorker() would over-inflate the pool.
+    if (poolIndex === -1) {
+      return;
+    }
+
     // Remove the failed worker from both pools
     this.logger.error(`Handling Worker ${failedWorker.threadId} failure`);
-    this.workerPool.splice(this.workerPool.indexOf(failedWorker), 1);
+    this.workerPool.splice(poolIndex, 1);
     this.availableWorkers = this.availableWorkers.filter((w) => w !== failedWorker);
 
     try {


### PR DESCRIPTION
## What does this PR do?

Makes the slots worker-pool failure handler idempotent.

A crashing worker thread commonly emits **both** an `error` and an `exit` event, so `handleWorkerFailure()` ends up running twice for the same worker. The handler removes the worker with `this.workerPool.splice(this.workerPool.indexOf(failedWorker), 1)`. On the second invocation the worker is already gone, so `indexOf` returns `-1` and `splice(-1, 1)` removes the **last (healthy) worker** in the pool instead. `createNewWorker()` is also called a second time, inflating the pool with an extra worker. The net effect is an inconsistent pool size and a lost healthy worker.

The fix reads the index once and bails out early when the failed worker is no longer in the pool, so the handler is safe to call more than once for the same worker.

- Fixes #29451

File: `apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.ts`

## Visual Demo (For contributors especially)

N/A — this is a backend worker-pool lifecycle fix with no UI surface. The behaviour is covered by the unit tests described below.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or test data are required — the behaviour is covered by a focused unit test that stubs the worker pool (no real worker threads are spawned).

```bash
cd apps/api/v2
yarn jest src/modules/slots/slots-2024-04-15/services/slots-worker.service.spec.ts
```

Expected: both tests pass.

- `removes the failed worker and creates exactly one replacement` — sanity check for the single-failure path.
- `is idempotent when the same worker emits both 'error' and 'exit'` — the regression test. The failed worker is terminated once, the healthy worker is retained, and exactly one replacement worker is created.

I verified that the regression test **fails on `main`** (before the fix it reports `createNewWorker` / `terminate` called twice and the healthy worker evicted) and **passes with the fix applied**. `biome lint` passes on both changed files.

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md).
- My code follows the style guidelines of this project.
- I have commented my code, particularly in hard-to-understand areas.
- I have checked that my changes generate no new warnings.
- My PR is small (1 source file + 1 test file, well under the size limits).
