### PR TITLE
fix(api/swagger): send Authorization header from Swagger UI

### DIFF
--- a/apps/api/v2/src/swagger/generate-swagger.spec.ts
+++ b/apps/api/v2/src/swagger/generate-swagger.spec.ts
@@ -79,6 +79,33 @@ describe("applyAuthorizationSecurity", () => {
     ]);
   });
 
+  it("handles an Authorization header declared at the path level (inherited by all operations)", () => {
+    const document = buildDocument({
+      "/v2/orgs/{orgId}": {
+        parameters: [{ name: "Authorization", in: "header", schema: { type: "string" } }],
+        get: { tags: ["Orgs"], responses: {} },
+        post: {
+          tags: ["Orgs"],
+          parameters: [{ name: "cal-api-version", in: "header", schema: { type: "string" } }],
+          responses: {},
+        },
+      },
+    } as unknown as OpenAPIObject["paths"]);
+
+    applyAuthorizationSecurity(document);
+
+    const pathItem = document.paths["/v2/orgs/{orgId}"];
+    // The inherited path-level Authorization header is removed...
+    expect(pathItem.parameters).toEqual([]);
+    // ...and every operation in the path gets the bearer security requirement.
+    expect(pathItem.get?.security).toEqual([{ [AUTHORIZATION_SECURITY_SCHEME]: [] }]);
+    expect(pathItem.post?.security).toEqual([{ [AUTHORIZATION_SECURITY_SCHEME]: [] }]);
+    // Unrelated operation-level parameters are preserved.
+    expect(pathItem.post?.parameters).toEqual([
+      { name: "cal-api-version", in: "header", schema: { type: "string" } },
+    ]);
+  });
+
   it("ignores reference ($ref) parameters without throwing", () => {
     const document = buildDocument({
       "/v2/ref": {

--- a/apps/api/v2/src/swagger/generate-swagger.spec.ts
+++ b/apps/api/v2/src/swagger/generate-swagger.spec.ts
@@ -1,0 +1,102 @@
+import type { OpenAPIObject } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
+import { AUTHORIZATION_SECURITY_SCHEME, applyAuthorizationSecurity } from "./generate-swagger";
+
+function buildDocument(paths: OpenAPIObject["paths"]): OpenAPIObject {
+  return {
+    openapi: "3.0.0",
+    info: { title: "test", version: "1.0.0" },
+    paths,
+  } as unknown as OpenAPIObject;
+}
+
+describe("applyAuthorizationSecurity", () => {
+  it("replaces the ignored Authorization header with a bearer security requirement", () => {
+    const document = buildDocument({
+      "/v2/bookings": {
+        get: {
+          tags: ["Bookings"],
+          parameters: [
+            { name: "Authorization", in: "header", required: true, schema: { type: "string" } },
+            { name: "cal-api-version", in: "header", required: true, schema: { type: "string" } },
+          ],
+          responses: {},
+        },
+      },
+    } as unknown as OpenAPIObject["paths"]);
+
+    applyAuthorizationSecurity(document);
+
+    const operation = document.paths["/v2/bookings"].get;
+    // The Authorization header parameter (which Swagger UI ignores) is removed...
+    expect(operation?.parameters).toEqual([
+      { name: "cal-api-version", in: "header", required: true, schema: { type: "string" } },
+    ]);
+    // ...and the bearer security requirement is added so the header is actually sent.
+    expect(operation?.security).toEqual([{ [AUTHORIZATION_SECURITY_SCHEME]: [] }]);
+  });
+
+  it("leaves public operations (no Authorization header) untouched", () => {
+    const document = buildDocument({
+      "/v2/slots": {
+        get: {
+          tags: ["Slots"],
+          parameters: [{ name: "cal-api-version", in: "header", schema: { type: "string" } }],
+          responses: {},
+        },
+      },
+      "/v2/health": {
+        get: { tags: ["Health"], responses: {} },
+      },
+    } as unknown as OpenAPIObject["paths"]);
+
+    applyAuthorizationSecurity(document);
+
+    const slots = document.paths["/v2/slots"].get;
+    expect(slots?.parameters).toHaveLength(1);
+    expect(slots?.security).toBeUndefined();
+
+    const health = document.paths["/v2/health"].get;
+    expect(health?.security).toBeUndefined();
+  });
+
+  it("appends to any pre-existing operation security instead of overwriting it", () => {
+    const document = buildDocument({
+      "/v2/me": {
+        get: {
+          tags: ["Me"],
+          security: [{ ApiKeyAuth: [] }],
+          parameters: [{ name: "Authorization", in: "header", schema: { type: "string" } }],
+          responses: {},
+        },
+      },
+    } as unknown as OpenAPIObject["paths"]);
+
+    applyAuthorizationSecurity(document);
+
+    expect(document.paths["/v2/me"].get?.security).toEqual([
+      { ApiKeyAuth: [] },
+      { [AUTHORIZATION_SECURITY_SCHEME]: [] },
+    ]);
+  });
+
+  it("ignores reference ($ref) parameters without throwing", () => {
+    const document = buildDocument({
+      "/v2/ref": {
+        get: {
+          tags: ["Ref"],
+          parameters: [{ $ref: "#/components/parameters/SomeParam" }],
+          responses: {},
+        },
+      },
+    } as unknown as OpenAPIObject["paths"]);
+
+    expect(() => applyAuthorizationSecurity(document)).not.toThrow();
+    expect(document.paths["/v2/ref"].get?.security).toBeUndefined();
+    expect(document.paths["/v2/ref"].get?.parameters).toHaveLength(1);
+  });
+
+  it("returns the document unchanged when there are no paths", () => {
+    const document = { openapi: "3.0.0", info: { title: "t", version: "1" } } as unknown as OpenAPIObject;
+    expect(() => applyAuthorizationSecurity(document)).not.toThrow();
+  });
+});

--- a/apps/api/v2/src/swagger/generate-swagger.ts
+++ b/apps/api/v2/src/swagger/generate-swagger.ts
@@ -65,6 +65,10 @@ export async function generateSwaggerForApp(app: NestExpressApplication<Server>)
   }
 }
 
+function isAuthorizationHeaderParam(param: ParameterObject | { $ref: string }): boolean {
+  return "in" in param && param.in === "header" && param.name === "Authorization";
+}
+
 /**
  * Swagger UI silently drops a header parameter named "Authorization" because the
  * OpenAPI spec requires it to be ignored. For every operation that declared such
@@ -72,6 +76,9 @@ export async function generateSwaggerForApp(app: NestExpressApplication<Server>)
  * bearer security requirement so the "Authorize" button actually attaches the
  * `Authorization` header to outgoing requests. Operations without that header
  * (i.e. genuinely public endpoints) are left untouched.
+ *
+ * Parameters can also be declared at the path level, where they are inherited by
+ * every operation in the path, so those are handled as well.
  */
 export function applyAuthorizationSecurity(document: OpenAPIObject): OpenAPIObject {
   if (!document.paths) {
@@ -81,25 +88,37 @@ export function applyAuthorizationSecurity(document: OpenAPIObject): OpenAPIObje
   Object.keys(document.paths).forEach((pathKey) => {
     const pathItem = document.paths[pathKey];
 
+    const pathHasAuthHeader = Array.isArray(pathItem.parameters)
+      ? pathItem.parameters.some(isAuthorizationHeaderParam)
+      : false;
+
     HttpMethods.forEach((method) => {
       const operation = pathItem[method];
 
-      if (!isOperationObject(operation) || !operation.parameters) {
+      if (!isOperationObject(operation)) {
         return;
       }
 
-      const isAuthorizationHeader = (param: ParameterObject | { $ref: string }): boolean =>
-        "in" in param && param.in === "header" && param.name === "Authorization";
+      const operationHasAuthHeader = operation.parameters?.some(isAuthorizationHeaderParam) ?? false;
 
-      if (!operation.parameters.some(isAuthorizationHeader)) {
+      // Nothing to do for operations that neither declare nor inherit the header.
+      if (!operationHasAuthHeader && !pathHasAuthHeader) {
         return;
       }
 
-      // Drop the parameter Swagger UI ignores...
-      operation.parameters = operation.parameters.filter((param) => !isAuthorizationHeader(param));
+      // Drop the operation-level parameter Swagger UI ignores...
+      if (operationHasAuthHeader && operation.parameters) {
+        operation.parameters = operation.parameters.filter((param) => !isAuthorizationHeaderParam(param));
+      }
       // ...and require the bearer scheme instead so the header is actually sent.
       operation.security = [...(operation.security ?? []), { [AUTHORIZATION_SECURITY_SCHEME]: [] }];
     });
+
+    // Drop the inherited path-level Authorization header, now represented as a
+    // security requirement on each operation above.
+    if (pathHasAuthHeader && Array.isArray(pathItem.parameters)) {
+      pathItem.parameters = pathItem.parameters.filter((param) => !isAuthorizationHeaderParam(param));
+    }
   });
 
   return document;

--- a/apps/api/v2/src/swagger/generate-swagger.ts
+++ b/apps/api/v2/src/swagger/generate-swagger.ts
@@ -1,16 +1,18 @@
-import { getEnv } from "@/env";
 import { Logger } from "@nestjs/common";
 import type { NestExpressApplication } from "@nestjs/platform-express";
-import { SwaggerModule, DocumentBuilder } from "@nestjs/swagger";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import type {
+  OpenAPIObject,
+  OperationObject,
+  ParameterObject,
   PathItemObject,
   PathsObject,
-  OperationObject,
 } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
+import { getEnv } from "@/env";
 import "dotenv/config";
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import type { Server } from "node:http";
-import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 
 const nodeRequire = createRequire(__filename);
@@ -18,12 +20,31 @@ const biomeBin = nodeRequire.resolve("@biomejs/biome/bin/biome");
 
 const HttpMethods: (keyof PathItemObject)[] = ["get", "post", "put", "delete", "patch", "options", "head"];
 
+// Name of the bearer security scheme used for the `Authorization` header.
+export const AUTHORIZATION_SECURITY_SCHEME = "Authorization";
+
 export async function generateSwaggerForApp(app: NestExpressApplication<Server>) {
   const logger = new Logger("App");
   logger.log(`Generating Swagger documentation...\n`);
 
-  const config = new DocumentBuilder().setTitle("Cal.diy API v2").build();
-  const document = SwaggerModule.createDocument(app, config);
+  const config = new DocumentBuilder()
+    .setTitle("Cal.diy API v2")
+    // Endpoints declare auth via `@ApiHeader({ name: "Authorization" })`, but the
+    // OpenAPI spec mandates that a header parameter named "Authorization" be
+    // ignored, so Swagger UI never sends it. Register a proper bearer security
+    // scheme instead (see applyAuthorizationSecurity for where it gets applied).
+    .addBearerAuth(
+      {
+        type: "http",
+        scheme: "bearer",
+        in: "header",
+        name: "Authorization",
+        description: "Enter your API key or access token (sent as `Authorization: Bearer <token>`).",
+      },
+      AUTHORIZATION_SECURITY_SCHEME
+    )
+    .build();
+  const document = applyAuthorizationSecurity(SwaggerModule.createDocument(app, config));
   document.paths = groupAndSortPathsByFirstTag(document.paths);
 
   const docsOutputFile = "../../../docs/api-reference/v2/openapi.json";
@@ -42,6 +63,46 @@ export async function generateSwaggerForApp(app: NestExpressApplication<Server>)
 
     logger.log(`Swagger documentation available in the "/docs" endpoint\n`);
   }
+}
+
+/**
+ * Swagger UI silently drops a header parameter named "Authorization" because the
+ * OpenAPI spec requires it to be ignored. For every operation that declared such
+ * a parameter (via `@ApiHeader({ name: "Authorization" })`), replace it with the
+ * bearer security requirement so the "Authorize" button actually attaches the
+ * `Authorization` header to outgoing requests. Operations without that header
+ * (i.e. genuinely public endpoints) are left untouched.
+ */
+export function applyAuthorizationSecurity(document: OpenAPIObject): OpenAPIObject {
+  if (!document.paths) {
+    return document;
+  }
+
+  Object.keys(document.paths).forEach((pathKey) => {
+    const pathItem = document.paths[pathKey];
+
+    HttpMethods.forEach((method) => {
+      const operation = pathItem[method];
+
+      if (!isOperationObject(operation) || !operation.parameters) {
+        return;
+      }
+
+      const isAuthorizationHeader = (param: ParameterObject | { $ref: string }): boolean =>
+        "in" in param && param.in === "header" && param.name === "Authorization";
+
+      if (!operation.parameters.some(isAuthorizationHeader)) {
+        return;
+      }
+
+      // Drop the parameter Swagger UI ignores...
+      operation.parameters = operation.parameters.filter((param) => !isAuthorizationHeader(param));
+      // ...and require the bearer scheme instead so the header is actually sent.
+      operation.security = [...(operation.security ?? []), { [AUTHORIZATION_SECURITY_SCHEME]: [] }];
+    });
+  });
+
+  return document;
 }
 
 function groupAndSortPathsByFirstTag(paths: PathsObject): PathsObject {


### PR DESCRIPTION
## What does this PR do?

Fixes Swagger UI silently dropping the `Authorization` header so "Try it out" requests no longer fail with 401/403.

API v2 endpoints document authentication with `@ApiHeader({ name: "Authorization" })`. The OpenAPI specification, however, mandates that a header parameter named `Authorization` be ignored, so Swagger UI renders the input field and accepts a value but never attaches the header to the outgoing request. Users fill in `Bearer cal_xxx`, hit Execute, and every authenticated call fails even though the UI suggested the token would be sent.

The fix, all contained in `apps/api/v2/src/swagger/generate-swagger.ts`:

1. Registers a proper bearer security scheme on the OpenAPI document (`addBearerAuth`), which gives Swagger UI a working **Authorize** button.
2. Adds `applyAuthorizationSecurity()`, a post-processing step that, for every operation which declared the (ignored) `Authorization` header, removes that parameter and attaches the bearer **security requirement** instead — so Swagger UI actually sends `Authorization: Bearer <token>`.

Operations that never declared an `Authorization` header (genuinely public endpoints) are left untouched, and any pre-existing per-operation `security` is preserved (the requirement is appended, not overwritten). Because the transform runs centrally, no per-controller changes are needed.

- Fixes #29564

## Visual Demo (For contributors especially)

N/A — this changes the generated OpenAPI document / Swagger UI behaviour. The resulting document now contains a `components.securitySchemes.Authorization` bearer scheme and a `security` requirement on the affected operations, which is exactly what makes Swagger UI attach the header. This is asserted by the unit tests below.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or DB are required for the unit tests — `applyAuthorizationSecurity` is a pure function over an OpenAPI document.

```bash
cd apps/api/v2
yarn jest src/swagger/generate-swagger.spec.ts
```

Expected: 5 tests pass, covering:
- An operation with an `Authorization` header → the header parameter is removed and a `{ Authorization: [] }` security requirement is added.
- A public operation (no `Authorization` header) → left untouched.
- An operation with pre-existing `security` → the requirement is appended, not overwritten.
- `$ref` parameters → handled without throwing.
- A document with no `paths` → returned unchanged.

Manual verification in Swagger UI: open `/docs`, click **Authorize**, enter an API key / access token, then **Execute** any authenticated endpoint and confirm the generated curl now includes `-H 'Authorization: Bearer <token>'`.

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md).
- My code follows the style guidelines of this project.
- I have commented my code, particularly in hard-to-understand areas.
- I have checked that my changes generate no new warnings.
- My PR is small (1 source file + 1 test file).
