### PR TITLE
fix(lib): use maxLength in truncateOnWord instead of hardcoded 148

### DIFF
--- a/packages/lib/text.test.ts
+++ b/packages/lib/text.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
-
-import { truncate } from "./text";
+import { truncate, truncateOnWord } from "./text";
 
 describe("Text util tests", () => {
   describe("fn: truncate", () => {
@@ -65,6 +64,87 @@ describe("Text util tests", () => {
       for (const { input, maxLength, ellipsis, expected } of cases) {
         const result = truncate(input, maxLength, ellipsis);
 
+        expect(result).toEqual(expected);
+      }
+    });
+  });
+
+  describe("fn: truncateOnWord", () => {
+    it("should return the original text when it is shorter than the max length", () => {
+      const cases = [
+        {
+          input: "Hello world",
+          maxLength: 100,
+          expected: "Hello world",
+        },
+        {
+          input: "Hello world",
+          maxLength: 11,
+          expected: "Hello world",
+        },
+      ];
+
+      for (const { input, maxLength, expected } of cases) {
+        const result = truncateOnWord(input, maxLength);
+
+        expect(result).toEqual(expected);
+      }
+    });
+
+    it("should return the truncated text on the last word when it is longer than the max length", () => {
+      const cases = [
+        {
+          input: "The quick brown fox jumps over the lazy dog",
+          maxLength: 12,
+          expected: "The quick...",
+        },
+        {
+          input: "Cal.com is the scheduling infrastructure for everyone",
+          maxLength: 14,
+          expected: "Cal.com is...",
+        },
+      ];
+
+      for (const { input, maxLength, expected } of cases) {
+        const result = truncateOnWord(input, maxLength);
+
+        expect(result).toEqual(expected);
+      }
+    });
+
+    it("should return the truncated text without ellipsis when it is longer than the max length and ellipsis is false", () => {
+      const cases = [
+        {
+          input: "The quick brown fox jumps over the lazy dog",
+          maxLength: 12,
+          ellipsis: false,
+          expected: "The quick",
+        },
+      ];
+
+      for (const { input, maxLength, ellipsis, expected } of cases) {
+        const result = truncateOnWord(input, maxLength, ellipsis);
+
+        expect(result).toEqual(expected);
+      }
+    });
+
+    it("should fallback to character truncation when no spaces are present in the truncated segment", () => {
+      const cases = [
+        {
+          input: "supercalifragilisticexpialidocious",
+          maxLength: 10,
+          expected: "supercalif...",
+        },
+        {
+          input: "https://cal.com/pro/30min/extremely-long-url-without-any-spaces",
+          maxLength: 20,
+          expected: "https://cal.com/pro/...",
+        },
+      ];
+
+      for (const { input, maxLength, expected } of cases) {
+        const result = truncateOnWord(input, maxLength);
         expect(result).toEqual(expected);
       }
     });

--- a/packages/lib/text.ts
+++ b/packages/lib/text.ts
@@ -8,11 +8,14 @@ export const truncateOnWord = (text: string, maxLength: number, ellipsis = true)
   if (text.length <= maxLength) return text;
 
   // First split on maxLength chars
-  let truncatedText = text.substring(0, 148);
+  let truncatedText = text.substring(0, maxLength);
 
   // Then split on the last space, this way we split on the last word,
   // which looks just a bit nicer.
-  truncatedText = truncatedText.substring(0, Math.min(truncatedText.length, truncatedText.lastIndexOf(" ")));
+  const lastSpaceIndex = truncatedText.lastIndexOf(" ");
+  if (lastSpaceIndex !== -1) {
+    truncatedText = truncatedText.substring(0, lastSpaceIndex);
+  }
 
   if (ellipsis) truncatedText += "...";
 


### PR DESCRIPTION
## What does this PR do?

`truncateOnWord(text, maxLength)` ignores its `maxLength` argument and always truncates to a hardcoded `148` characters:

```ts
let truncatedText = text.substring(0, 148); // ← maxLength is never used
```

The only caller — `apps/web/app/_utils.tsx` — passes `158` when building SEO `<meta name="description">` content for event/booking pages, so descriptions are silently cut to 148 characters instead of the requested 158. Additionally, when the truncated segment contains no space, the old `Math.min(length, lastIndexOf(" "))` logic resolves to `-1` and produces an empty string (just `"..."`).

This restores the fix that was **originally merged in #27961** and later reverted by the Cal.diy refactor (#28903 — `git blame` on the hardcoded line points at that refactor commit):

- Truncate to `maxLength` rather than the hardcoded value.
- Fall back to plain character truncation when the segment has no space.
- Restore the `truncateOnWord` unit tests that the refactor also dropped from `text.test.ts`.

## Visual Demo (For contributors especially)

N/A — pure string utility. Behaviour is covered by unit tests:

```text
truncateOnWord("The quick brown fox jumps over the lazy dog", 12)
  before: "The quick brown fox jumps over the lazy..."   (truncated at 148 → whole string, last space)
  after:  "The quick..."                                  (truncated at maxLength = 12, last word)
```

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or data required — `truncateOnWord` is a pure function.

```bash
yarn vitest run packages/lib/text.test.ts
```

Expected: 7 tests pass. The new `fn: truncateOnWord` block covers:
- text shorter than `maxLength` → returned unchanged,
- text longer than `maxLength` → truncated on the last whole word, with/without ellipsis,
- a segment with no spaces → character-level fallback.

I verified the new tests **fail against the current (hardcoded-148) code** and **pass with the fix**, confirming they guard the regression.

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md).
- My code follows the style guidelines of this project.
- I have commented my code, particularly in hard-to-understand areas.
- I have checked that my changes generate no new warnings.
- My PR is small (1 source file + 1 test file).
