### PR TITLE
fix: scope payment lookup to the seat on multi-seat booking confirmation

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
@@ -7,6 +7,7 @@ import { getBrandingForEventType } from "@calcom/features/profile/lib/getBrandin
 import { shouldHideBrandingForEvent } from "@calcom/features/profile/lib/hideBranding";
 import { parseRecurringEvent } from "@calcom/lib/isRecurringEvent";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
+import { getSeatPaymentUid } from "@calcom/lib/server/getSeatPaymentUid";
 import { maybeGetBookingUidFromSeat } from "@calcom/lib/server/maybeGetBookingUidFromSeat";
 import prisma from "@calcom/prisma";
 import { customInputSchema } from "@calcom/prisma/zod-utils";
@@ -189,9 +190,30 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     await handleSeatsEventTypeOnBooking(eventType, bookingInfo, seatReferenceUid, isLoggedInUserHost);
   }
 
+  // In a multi-seat booking every seat shares the same parent booking, so scoping the payment
+  // lookup only by bookingId would return the first seat's payment for every seat. When a seat is
+  // being viewed, prefer the payment referenced by that seat's metadata so each seat shows its own
+  // price. Seats created before this reference was persisted fall back to the booking-level lookup.
+  let seatPaymentUid: string | undefined;
+  if (seatReferenceUid) {
+    // The seat is already resolved when the page is reached via /booking/<seatReferenceUid>;
+    // otherwise (e.g. /booking/<bookingUid>?seatReferenceUid=...) look it up by its reference.
+    const seatMetadata =
+      maybeBookingUidFromSeat.seatReferenceUid === seatReferenceUid
+        ? maybeBookingUidFromSeat.bookingSeat?.metadata
+        : (
+            await prisma.bookingSeat.findUnique({
+              where: { referenceUid: seatReferenceUid },
+              select: { metadata: true },
+            })
+          )?.metadata;
+    seatPaymentUid = getSeatPaymentUid(seatMetadata);
+  }
+
   const payment = await prisma.payment.findFirst({
     where: {
       bookingId: bookingInfo.id,
+      ...(seatPaymentUid ? { uid: seatPaymentUid } : {}),
     },
     select: {
       appId: true,

--- a/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
+++ b/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
@@ -283,6 +283,27 @@ const createNewSeat = async (
     resultBooking.message = "Payment required";
     resultBooking.paymentUid = payment?.uid;
     resultBooking.id = payment?.id;
+
+    // Persist the payment reference on the seat so the booking confirmation page can resolve
+    // this seat's own payment. All seats of a slot share one parent booking, so without this
+    // link the confirmation page would fall back to the booking's first payment for every seat.
+    if (payment?.uid && newBookingSeat?.referenceUid) {
+      const existingSeatMetadata =
+        newBookingSeat.metadata &&
+        typeof newBookingSeat.metadata === "object" &&
+        !Array.isArray(newBookingSeat.metadata)
+          ? newBookingSeat.metadata
+          : {};
+      await prisma.bookingSeat.update({
+        where: { referenceUid: newBookingSeat.referenceUid },
+        data: {
+          metadata: {
+            ...existingSeatMetadata,
+            paymentUid: payment.uid,
+          },
+        },
+      });
+    }
   } else {
     resultBooking = { ...foundBooking };
   }

--- a/packages/lib/server/getSeatPaymentUid.test.ts
+++ b/packages/lib/server/getSeatPaymentUid.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { getSeatPaymentUid } from "./getSeatPaymentUid";
+
+describe("getSeatPaymentUid", () => {
+  it("returns the paymentUid stored on a seat's metadata", () => {
+    expect(getSeatPaymentUid({ paymentUid: "payment-uid-2" })).toBe("payment-uid-2");
+  });
+
+  it("resolves distinct payments for different seats of the same booking", () => {
+    // Regression for #29664: each seat of a multi-seat paid booking must surface its own payment,
+    // not the booking's first payment.
+    const firstSeatMetadata = { paymentUid: "payment-uid-1" };
+    const secondSeatMetadata = { paymentUid: "payment-uid-2" };
+
+    expect(getSeatPaymentUid(firstSeatMetadata)).toBe("payment-uid-1");
+    expect(getSeatPaymentUid(secondSeatMetadata)).toBe("payment-uid-2");
+  });
+
+  it("preserves unrelated metadata fields while reading paymentUid", () => {
+    expect(getSeatPaymentUid({ paymentUid: "payment-uid-3", someOtherKey: "value" })).toBe("payment-uid-3");
+  });
+
+  it("returns undefined for legacy seats without a stored paymentUid", () => {
+    expect(getSeatPaymentUid({ someOtherKey: "value" })).toBeUndefined();
+    expect(getSeatPaymentUid({})).toBeUndefined();
+  });
+
+  it("returns undefined when there is no seat metadata", () => {
+    expect(getSeatPaymentUid(null)).toBeUndefined();
+    expect(getSeatPaymentUid(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when metadata is not an object", () => {
+    expect(getSeatPaymentUid("not-an-object")).toBeUndefined();
+    expect(getSeatPaymentUid(42)).toBeUndefined();
+  });
+
+  it("returns undefined when paymentUid is present but not a string", () => {
+    expect(getSeatPaymentUid({ paymentUid: 123 })).toBeUndefined();
+  });
+});

--- a/packages/lib/server/getSeatPaymentUid.ts
+++ b/packages/lib/server/getSeatPaymentUid.ts
@@ -1,0 +1,15 @@
+import { bookingSeatMetadataSchema } from "@calcom/prisma/zod-utils";
+
+/**
+ * Resolves the uid of the payment that belongs to a specific seat from its metadata.
+ *
+ * In a multi-seat paid booking every seat shares the same parent booking, so a payment lookup
+ * scoped only by bookingId returns the first seat's payment for every seat. The per-seat payment
+ * uid is persisted on the seat's metadata at creation time; this reads it back so the confirmation
+ * page can show each seat its own price. Returns undefined for seats created before the reference
+ * was persisted, letting callers fall back to the booking-level lookup.
+ */
+export function getSeatPaymentUid(seatMetadata: unknown): string | undefined {
+  if (!seatMetadata) return undefined;
+  return bookingSeatMetadataSchema.safeParse(seatMetadata).data?.paymentUid;
+}

--- a/packages/lib/server/maybeGetBookingUidFromSeat.ts
+++ b/packages/lib/server/maybeGetBookingUidFromSeat.ts
@@ -14,6 +14,7 @@ export async function maybeGetBookingUidFromSeat(prisma: PrismaClient, uid: stri
         },
       },
       data: true,
+      metadata: true,
     },
   });
   if (bookingSeat) return { uid: bookingSeat.booking.uid, seatReferenceUid: uid, bookingSeat };

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -873,6 +873,14 @@ export const bookingSeatDataSchema = z.object({
   responses: bookingResponses,
 });
 
+// BookingSeat.metadata is a free-form record. For paid seated bookings we store the uid of the
+// payment created for that specific seat so the confirmation page can show each seat its own price.
+export const bookingSeatMetadataSchema = z
+  .object({
+    paymentUid: z.string().optional(),
+  })
+  .passthrough();
+
 // Schema for decrypted service account key
 export const serviceAccountKeySchema = z
   .object({


### PR DESCRIPTION
## What does this PR do?

Fixes #29664 — a multi-seat paid booking's confirmation page showed the first seat's price for every seat.

In a multi-seat booking all seats share one parent `Booking`, so the confirmation page's `prisma.payment.findFirst({ where: { bookingId } })` returned the first seat's `Payment` for every seat. `Payment` has no per-seat join key (only `bookingId`), so this links each seat to its own payment via the existing `BookingSeat.metadata` JSONB column — **no schema change**:

- **Write path** (`createNewSeat.ts`): after a seat's payment is created, persist `{ paymentUid }` onto that seat's metadata (merged with any existing metadata).
- **Read path** (`bookings-single-view.getServerSideProps.tsx`): when a `seatReferenceUid` is being viewed, resolve that seat's stored `paymentUid` and scope the payment query to it. Falls back to the original `findFirst({ bookingId })` for non-seat bookings and legacy seats — no regression.
- Adds `bookingSeatMetadataSchema` (zod) and a pure `getSeatPaymentUid` resolver with unit tests.

## Mandatory Tasks
- [x] Added unit tests for the per-seat payment resolver (`packages/lib/server/getSeatPaymentUid.test.ts`).

Fixes #29664
