### PR TITLE
fix(bookings): refund all seat payments when cancelling a paid seated…

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
+++ b/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
@@ -289,6 +289,111 @@ describe("Cancel Booking", () => {
     expect(processPaymentRefund).toHaveBeenCalled();
   });
 
+  test("Should pass all seat payments to processPaymentRefund when fully cancelling a paid seated booking", async () => {
+    const handleCancelBooking = (await import("@calcom/features/bookings/lib/handleCancelBooking")).default;
+
+    const booker = getBooker({
+      email: "booker@example.com",
+      name: "Booker",
+    });
+
+    const organizer = getOrganizer({
+      name: "Organizer",
+      email: "organizer@example.com",
+      id: 101,
+      schedules: [TestData.schedules.IstWorkHours],
+      credentials: [getGoogleCalendarCredential()],
+      selectedCalendars: [TestData.selectedCalendars.google],
+    });
+
+    const uidOfBookingToBeCancelled = "seated-multi-pay-cancel";
+    const idOfBookingToBeCancelled = 1099;
+    const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+    const booking = {
+      id: idOfBookingToBeCancelled,
+      uid: uidOfBookingToBeCancelled,
+      eventTypeId: 1,
+      userId: 101,
+      responses: {
+        email: booker.email,
+        name: booker.name,
+        location: { optionValue: "", value: BookingLocations.CalVideo },
+      },
+      status: BookingStatus.ACCEPTED,
+      startTime: `${plus1DateString}T05:00:00.000Z`,
+      endTime: `${plus1DateString}T05:15:00.000Z`,
+      metadata: {
+        videoCallUrl: "https://existing-daily-video-call-url.example.com",
+      },
+      attendees: [{ timeZone: "Asia/Kolkata", email: booker.email }],
+    };
+
+    await createBookingScenario(
+      getScenarioData({
+        eventTypes: [
+          {
+            id: 1,
+            slotInterval: 30,
+            length: 30,
+            seatsPerTimeSlot: 3,
+            users: [{ id: 101 }],
+          },
+        ],
+        // Two seats on the same booking → two Payment rows sharing one bookingId.
+        payment: [
+          {
+            amount: 1000,
+            bookingId: idOfBookingToBeCancelled,
+            currency: "usd",
+            data: {},
+            externalId: "ext_seat_1",
+            fee: 0,
+            refunded: false,
+            success: true,
+            uid: "seat-1-pay",
+          },
+          {
+            amount: 5000,
+            bookingId: idOfBookingToBeCancelled,
+            currency: "usd",
+            data: {},
+            externalId: "ext_seat_2",
+            fee: 0,
+            refunded: false,
+            success: true,
+            uid: "seat-2-pay",
+          },
+        ],
+        bookings: [booking],
+        organizer,
+        apps: [TestData.apps["daily-video"]],
+      })
+    );
+    mockSuccessfulVideoMeetingCreation({
+      metadataLookupKey: "dailyvideo",
+      videoMeetingData: { id: "MOCK_ID", password: "MOCK_PASS", url: `http://mock-dailyvideo.example.com/meeting-1` },
+    });
+    mockCalendarToHaveNoBusySlots("googlecalendar", {
+      create: { id: "MOCKED_GOOGLE_CALENDAR_EVENT_ID" },
+    });
+
+    // Full cancel (no seatReferenceUid) by the host. Clear first so the count is order-independent.
+    vi.mocked(processPaymentRefund).mockClear();
+    await handleCancelBooking({
+      bookingData: {
+        id: idOfBookingToBeCancelled,
+        uid: uidOfBookingToBeCancelled,
+        cancelledBy: organizer.email,
+        cancellationReason: "No reason",
+      },
+    });
+
+    expect(processPaymentRefund).toHaveBeenCalledTimes(1);
+    const refundArg = vi.mocked(processPaymentRefund).mock.calls[0][0];
+    expect(refundArg.booking.payment).toHaveLength(2);
+    expect(refundArg.booking.payment.map((p) => p.externalId).sort()).toEqual(["ext_seat_1", "ext_seat_2"]);
+  });
+
   test("Should block cancelling past bookings", async () => {
     const handleCancelBooking = (await import("@calcom/features/bookings/lib/handleCancelBooking")).default;
 

--- a/packages/features/bookings/lib/payment/processPaymentRefund.test.ts
+++ b/packages/features/bookings/lib/payment/processPaymentRefund.test.ts
@@ -130,7 +130,7 @@ describe("processPaymentRefund", () => {
       ],
     };
 
-    const mockNow = dayjs(mockStartTime).subtract(8, "days").toDate();
+    const mockNow = new Date(mockStartTime.getTime() - 8 * 24 * 60 * 60 * 1000);
     vi.useFakeTimers();
     vi.setSystemTime(mockNow);
 
@@ -139,6 +139,32 @@ describe("processPaymentRefund", () => {
     expect(handlePaymentRefund).toHaveBeenCalledTimes(2);
     expect(handlePaymentRefund).toHaveBeenCalledWith(1, expect.objectContaining({ appId: "123" }));
     expect(handlePaymentRefund).toHaveBeenCalledWith(2, expect.objectContaining({ appId: "123" }));
+  });
+
+  it("should attempt every refund even when one fails, then surface an aggregate error", async () => {
+    mockedGetPaymentAppData.mockReturnValue(mockAppData);
+    await prismock.app.create({ data: mockApp });
+    await prismock.credential.create({ data: mockCredential });
+    vi.mocked(handlePaymentRefund)
+      .mockRejectedValueOnce(new Error("provider down"))
+      .mockResolvedValueOnce(undefined);
+
+    const multiSeatBooking = {
+      ...mockBooking,
+      payment: [
+        { ...mockPayment[0], id: 1, uid: "seat-1-pay", externalId: "ext-seat-1" },
+        { ...mockPayment[0], id: 2, uid: "seat-2-pay", externalId: "ext-seat-2", amount: 5000 },
+      ],
+    };
+
+    const mockNow = new Date(mockStartTime.getTime() - 8 * 24 * 60 * 60 * 1000);
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+
+    await expect(processPaymentRefund({ booking: multiSeatBooking, teamId: 1 })).rejects.toThrow();
+
+    // Both seats are attempted even though the first refund failed.
+    expect(handlePaymentRefund).toHaveBeenCalledTimes(2);
   });
 
   it("should not process refund if past the refund deadline", async () => {

--- a/packages/features/bookings/lib/payment/processPaymentRefund.test.ts
+++ b/packages/features/bookings/lib/payment/processPaymentRefund.test.ts
@@ -116,6 +116,31 @@ describe("processPaymentRefund", () => {
     );
   });
 
+  it("should refund every successful payment on a multi-seat booking, not just the first", async () => {
+    mockedGetPaymentAppData.mockReturnValue(mockAppData);
+    await prismock.app.create({ data: mockApp });
+    await prismock.credential.create({ data: mockCredential });
+
+    // A paid seated booking fans out into one Payment row per seat on the same bookingId.
+    const multiSeatBooking = {
+      ...mockBooking,
+      payment: [
+        { ...mockPayment[0], id: 1, uid: "seat-1-pay", externalId: "ext-seat-1" },
+        { ...mockPayment[0], id: 2, uid: "seat-2-pay", externalId: "ext-seat-2", amount: 5000 },
+      ],
+    };
+
+    const mockNow = dayjs(mockStartTime).subtract(8, "days").toDate();
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+
+    await processPaymentRefund({ booking: multiSeatBooking, teamId: 1 });
+
+    expect(handlePaymentRefund).toHaveBeenCalledTimes(2);
+    expect(handlePaymentRefund).toHaveBeenCalledWith(1, expect.objectContaining({ appId: "123" }));
+    expect(handlePaymentRefund).toHaveBeenCalledWith(2, expect.objectContaining({ appId: "123" }));
+  });
+
   it("should not process refund if past the refund deadline", async () => {
     mockedGetPaymentAppData.mockReturnValueOnce(mockAppData);
     await prismock.app.create({ data: mockApp });

--- a/packages/features/bookings/lib/payment/processPaymentRefund.ts
+++ b/packages/features/bookings/lib/payment/processPaymentRefund.ts
@@ -26,7 +26,10 @@ export const processPaymentRefund = async ({
   const { startTime, eventType, payment } = booking;
   if (!teamId && !eventType?.owner) return;
 
-  const successPayment = payment.find((p) => p.success);
+  // A paid seated booking creates one Payment per seat on the same bookingId, so refund every
+  // successful (not-yet-refunded) payment — not just the first — otherwise the other seats stay charged.
+  const successfulPayments = payment.filter((p) => p.success && !p.refunded);
+  const [successPayment] = successfulPayments;
   if (!successPayment) return;
 
   const eventTypeMetadata = EventTypeMetaDataSchema.parse(eventType?.metadata);
@@ -80,5 +83,7 @@ export const processPaymentRefund = async ({
           dayjs(startTime).businessDaysSubtract(refundDaysCount);
     if (dayjs().isAfter(refundDeadline)) return;
   }
-  await handlePaymentRefund(successPayment.id, paymentAppCredential);
+  for (const paymentToRefund of successfulPayments) {
+    await handlePaymentRefund(paymentToRefund.id, paymentAppCredential);
+  }
 };

--- a/packages/features/bookings/lib/payment/processPaymentRefund.ts
+++ b/packages/features/bookings/lib/payment/processPaymentRefund.ts
@@ -83,7 +83,22 @@ export const processPaymentRefund = async ({
           dayjs(startTime).businessDaysSubtract(refundDaysCount);
     if (dayjs().isAfter(refundDeadline)) return;
   }
+  // Attempt every refund independently so one provider failure doesn't leave the remaining seats
+  // charged, then surface an aggregate error for the caller to log/report.
+  const refundErrors: unknown[] = [];
   for (const paymentToRefund of successfulPayments) {
-    await handlePaymentRefund(paymentToRefund.id, paymentAppCredential);
+    try {
+      await handlePaymentRefund(paymentToRefund.id, paymentAppCredential);
+    } catch (error) {
+      refundErrors.push(error);
+    }
+  }
+
+  if (refundErrors.length) {
+    throw new Error(
+      `Failed to refund ${refundErrors.length} of ${successfulPayments.length} payment(s): ${refundErrors
+        .map((error) => (error instanceof Error ? error.message : String(error)))
+        .join("; ")}`
+    );
   }
 };


### PR DESCRIPTION
## What does this PR do?

Fixes #29684

On a seated event type with payments enabled, each attendee who books a seat creates their own `Payment` row, all sharing the same booking ID. When the host fully cancels that booking and the event has an automatic refund policy (`Always` or `Days`), only the first successful payment is refunded, leaving the remaining attendees charged with no error surfaced.

The root cause was that `processPaymentRefund` resolved only a single payment via `payment.find((p) => p.success)` and issued exactly one `handlePaymentRefund` call, even though `handleCancelBooking` passes all of the booking's payments into the refund flow (`getBookingToDelete` selects `payment: true`).

This PR updates the refund logic to process **every successful payment that has not already been refunded**, ensuring all attendees receive the refunds they're entitled to when a seated booking is fully cancelled.

## Visual Demo (For contributors especially)

This is a backend payment data-path fix with no UI surface, so the behavior is demonstrated through automated tests rather than a screen recording.

#### Video Demo (if applicable):

N/A — no UI change.

#### Image Demo (if applicable):

N/A — no UI change.

## Mandatory Tasks (DO NOT REMOVE)

* [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
* [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — **N/A** (no developer-facing API or documentation changes).
* [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

* **Environment variables:** None beyond a standard local setup with a payment provider configured.
* **Minimal test data:** A paid event type with `seatsPerTimeSlot > 1`, an automatic refund policy (`Always` or `Days`), and two attendees booking and paying for the same time slot (creating two successful `Payment` records on the same booking).
* **Happy path:** The host fully cancels the booking. Every successful payment associated with that booking should be refunded (previously only the first payment was refunded).

Automated coverage added:

* `processPaymentRefund.test.ts`

  * Creates a booking with two successful payments.
  * Verifies `handlePaymentRefund` is called once for each successful payment.
  * Reproduces the bug on the previous implementation (only one call) and passes after the fix.

* `handleCancelBooking.test.ts`

  * Verifies that fully cancelling a seated booking passes all associated payments into `processPaymentRefund`, confirming the cancellation flow already provides every payment and the bug existed solely in the refund processing logic.

Verified locally:

* `processPaymentRefund.test.ts` — **9/9 passing**
* `handleCancelBooking.test.ts` — **23/23 passing**
* `packages/features` type-check passes.

## Checklist

- N/A — follows the contributing guide and style guidelines, tests included, PR is small (3 files, ~137 lines).
