### PR TITLE
fix(web): narrow ShellMainAppDir prop type to props it actually uses

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
@@ -3,9 +3,26 @@ import classNames from "classnames";
 
 import type { LayoutProps } from "~/shell/Shell";
 
+type ShellMainAppDirProps = Pick<
+  LayoutProps,
+  | "heading"
+  | "subtitle"
+  | "headerClassName"
+  | "CTA"
+  | "actions"
+  | "beforeCTAactions"
+  | "afterHeading"
+  | "backPath"
+  | "HeadingLeftIcon"
+  | "smallHeading"
+  | "large"
+  | "flexChildrenContainer"
+  | "children"
+>;
+
 // Copied from `ShellMain` but with a different `ShellMainAppDirBackButton` import
 // for client/server component separation
-export function ShellMainAppDir(props: LayoutProps) {
+export function ShellMainAppDir(props: ShellMainAppDirProps) {
   return (
     <>
       {(props.heading || !!props.backPath) && (


### PR DESCRIPTION
Fixes #24433

Narrowed ShellMainAppDir's prop type from the full `LayoutProps` to a `Pick` of only the fields it actually reads, so the unused props flagged in the issue can no longer be passed silently.

- Checked all existing call sites (event-types, bookings, availability + their skeletons, booking logs) — they only use props that are still in the picked set, so nothing breaks.
- Type-check on apps/web passes clean.
- Biome warnings on the file are pre-existing (confirmed by diffing against main), none added by this change.