### PR TITLE
feat(teams): add option to pause team members

### DIFF
--- a/apps/web/modules/users/components/UserTable/UserListTable.tsx
+++ b/apps/web/modules/users/components/UserTable/UserListTable.tsx
@@ -338,7 +338,7 @@ function UserListTableContent({
                   data-testid={`member-${username}-username`}
                   className="font-medium text-emphasis text-sm leading-none flex items-center gap-2">
                   {displayName}
-                  {status === "PAUSED" && <Badge variant="gray">Paused</Badge>}
+                  {status === "PAUSED" && <Badge variant="gray">{t("paused")}</Badge>}
                 </div>
                 <div
                   data-testid={`member-${username}-email`}

--- a/apps/web/modules/users/components/UserTable/UserListTable.tsx
+++ b/apps/web/modules/users/components/UserTable/UserListTable.tsx
@@ -322,7 +322,7 @@ function UserListTableContent({
         size: 200,
         header: t("members"),
         cell: ({ row }: CellContext<UserTableUser, unknown>) => {
-          const { username, name, email, avatarUrl } = row.original;
+          const { username, name, email, avatarUrl, status } = row.original;
           const displayName = name || username || "No username";
           return (
             <div className="flex items-center gap-2">
@@ -336,8 +336,9 @@ function UserListTableContent({
               <div className="">
                 <div
                   data-testid={`member-${username}-username`}
-                  className="font-medium text-emphasis text-sm leading-none">
+                  className="font-medium text-emphasis text-sm leading-none flex items-center gap-2">
                   {displayName}
+                  {status === "PAUSED" && <Badge variant="gray">Paused</Badge>}
                 </div>
                 <div
                   data-testid={`member-${username}-email`}

--- a/apps/web/modules/users/components/UserTable/UserTableActions.tsx
+++ b/apps/web/modules/users/components/UserTable/UserTableActions.tsx
@@ -42,6 +42,22 @@ export function TableActions({
     isPending: false,
   };
 
+  const utils = trpc.useUtils();
+  const updateMembershipStatusMutation = trpc.viewer.users.updateMembershipStatus.useMutation({
+    onSuccess: () => {
+      showToast(
+        user.status === "PAUSED"
+          ? t("membership_unpaused_successfully")
+          : t("membership_paused_successfully"),
+        "success"
+      );
+      // Let the component reload naturally or rely on the parent
+    },
+    onError: (err) => {
+      showToast(err.message || t("error_updating_membership"), "error");
+    },
+  });
+
   const sendPasswordResetMutation = {
     mutate: (..._args: unknown[]) => {},
     mutateAsync: async () => ({}),
@@ -94,6 +110,22 @@ export function TableActions({
                       }
                       StartIcon="pencil">
                       {t("edit")}
+                    </DropdownItem>
+                  </DropdownMenuItem>
+                )}
+                {permissionsForUser.canEdit && (
+                  <DropdownMenuItem>
+                    <DropdownItem
+                      type="button"
+                      onClick={() => {
+                        updateMembershipStatusMutation.mutate({
+                          userId: user.id,
+                          teamId: orgId,
+                          status: user.status === "PAUSED" ? "ACTIVE" : "PAUSED",
+                        });
+                      }}
+                      StartIcon={user.status === "PAUSED" ? "play" : "pause"}>
+                      {user.status === "PAUSED" ? t("unpause_membership") : t("pause_membership")}
                     </DropdownItem>
                   </DropdownMenuItem>
                 )}
@@ -197,6 +229,22 @@ export function TableActions({
                     }
                     StartIcon="pencil">
                     {t("edit")}
+                  </DropdownItem>
+                </DropdownMenuItem>
+              )}
+              {permissionsForUser.canEdit && (
+                <DropdownMenuItem>
+                  <DropdownItem
+                    type="button"
+                    onClick={() => {
+                      updateMembershipStatusMutation.mutate({
+                        userId: user.id,
+                        teamId: orgId,
+                        status: user.status === "PAUSED" ? "ACTIVE" : "PAUSED",
+                      });
+                    }}
+                    StartIcon={user.status === "PAUSED" ? "play" : "pause"}>
+                    {user.status === "PAUSED" ? t("unpause_membership") : t("pause_membership")}
                   </DropdownItem>
                 </DropdownMenuItem>
               )}

--- a/apps/web/modules/users/components/UserTable/UserTableActions.tsx
+++ b/apps/web/modules/users/components/UserTable/UserTableActions.tsx
@@ -51,7 +51,7 @@ export function TableActions({
           : t("membership_paused_successfully"),
         "success"
       );
-      // Let the component reload naturally or rely on the parent
+      utils.viewer.users.get.invalidate();
     },
     onError: (err) => {
       showToast(err.message || t("error_updating_membership"), "error");

--- a/apps/web/modules/users/components/UserTable/types.ts
+++ b/apps/web/modules/users/components/UserTable/types.ts
@@ -9,6 +9,8 @@ export type UserTableUser = {
   avatarUrl: string | null;
   accepted: boolean;
   completedOnboarding: boolean;
+  status?: "ACTIVE" | "PAUSED";
+  membershipId?: number;
   lastActiveAt: Date | null;
   createdAt?: Date | null;
   updatedAt?: Date | null;

--- a/packages/features/bookings/lib/getLuckyUser.ts
+++ b/packages/features/bookings/lib/getLuckyUser.ts
@@ -698,6 +698,10 @@ export class LuckyUserService implements ILuckyUserService {
       weight?: number | null;
     },
   >(getLuckyUserParams: GetLuckyUserParams<T>) {
+    // Note: PAUSED team members are already filtered out from both `availableUsers` and `allRRHosts` 
+    // upstream in `loadAndValidateUsers` and `getEventTypesFromDB.ts`. This ensures they are completely 
+    // excluded from the Round Robin assignment algorithm before calculating booking shortfalls.
+
     // Early return if only one available user to avoid unnecessary data fetching
     if (getLuckyUserParams.availableUsers.length === 1) {
       return getLuckyUserParams.availableUsers[0];

--- a/packages/features/bookings/lib/handleNewBooking/getEventTypesFromDB.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getEventTypesFromDB.ts
@@ -131,6 +131,9 @@ const getEventTypesFromDBSelect = {
   },
   enablePerHostLocations: true,
   hosts: {
+    where: {
+      OR: [{ memberId: null }, { member: { status: "ACTIVE" } }],
+    },
     select: {
       isFixed: true,
       priority: true,

--- a/packages/features/bookings/lib/handleNewBooking/loadAndValidateUsers.ts
+++ b/packages/features/bookings/lib/handleNewBooking/loadAndValidateUsers.ts
@@ -152,6 +152,23 @@ const _loadAndValidateUsers = async ({
 
   users = eligibleUsers;
 
+  // Exclude users whose membership is PAUSED in this team
+  if (eventType.teamId) {
+    const activeMemberships = await prisma.membership.findMany({
+      where: {
+        teamId: eventType.teamId,
+        userId: { in: users.map((u) => u.id) },
+        status: "ACTIVE",
+      },
+      select: { userId: true },
+    });
+    const activeUserIds = new Set(activeMemberships.map((m) => m.userId));
+    users = users.filter((u) => activeUserIds.has(u.id));
+    if (users.length === 0) {
+      throw new HttpError({ statusCode: 404, message: "eventTypeUser.notFound" });
+    }
+  }
+
   // map fixed users
   users = users.map((user) => ({
     ...user,

--- a/packages/features/host/repositories/HostRepository.ts
+++ b/packages/features/host/repositories/HostRepository.ts
@@ -33,6 +33,7 @@ export class HostRepository {
         },
         eventTypeId,
         isFixed: false,
+        OR: [{ memberId: null }, { member: { status: "ACTIVE" } }],
         createdAt: {
           gte: startDate,
         },
@@ -44,6 +45,7 @@ export class HostRepository {
     return await this.prismaClient.host.findMany({
       where: {
         eventTypeId,
+        OR: [{ memberId: null }, { member: { status: "ACTIVE" } }],
       },
       select: {
         userId: true,
@@ -95,6 +97,7 @@ export class HostRepository {
     const hosts = await this.prismaClient.host.findMany({
       where: {
         eventTypeId,
+        OR: [{ memberId: null }, { member: { status: "ACTIVE" } }],
         ...(cursor && { userId: { gt: cursor } }),
       },
       take: limit + 1,
@@ -156,6 +159,7 @@ export class HostRepository {
     const hosts = await this.prismaClient.host.findMany({
       where: {
         eventTypeId,
+        OR: [{ memberId: null }, { member: { status: "ACTIVE" } }],
         ...(cursor && { userId: { gt: cursor } }),
         ...(search && {
           OR: [
@@ -214,6 +218,7 @@ export class HostRepository {
     const hosts = await this.prismaClient.host.findMany({
       where: {
         eventTypeId,
+        OR: [{ memberId: null }, { member: { status: "ACTIVE" } }],
         ...(userIdFilter && { userId: userIdFilter }),
         ...(search && {
           OR: [
@@ -261,6 +266,7 @@ export class HostRepository {
       where: {
         eventTypeId,
         isFixed: false,
+        OR: [{ memberId: null }, { member: { status: "ACTIVE" } }],
       },
       select: {
         userId: true,
@@ -326,7 +332,10 @@ export class HostRepository {
 
   async findHostsWithConferencingCredentials(eventTypeId: number) {
     return await this.prismaClient.host.findMany({
-      where: { eventTypeId },
+      where: { 
+        eventTypeId,
+        OR: [{ memberId: null }, { member: { status: "ACTIVE" } }],
+      },
       select: {
         userId: true,
         user: {

--- a/packages/features/host/services/EventTypeHostService.ts
+++ b/packages/features/host/services/EventTypeHostService.ts
@@ -192,13 +192,19 @@ export class EventTypeHostService implements IEventTypeHostService {
         teamId,
       });
 
-      const members: ExportedWeightMember[] = memberships.map((m) => ({
-        userId: m.user.id,
-        name: m.user.name,
-        email: m.user.email,
-        avatarUrl: m.user.avatarUrl,
-        weight: null,
-      }));
+      // Filter out PAUSED members
+      const activeMemberships = await this.membershipRepository.findActiveMembershipsByTeamId(teamId);
+      const activeUserIds = new Set(activeMemberships.map((m) => m.userId));
+
+      const members: ExportedWeightMember[] = memberships
+        .filter((m) => activeUserIds.has(m.user.id))
+        .map((m) => ({
+          userId: m.user.id,
+          name: m.user.name,
+          email: m.user.email,
+          avatarUrl: m.user.avatarUrl,
+          weight: null,
+        }));
 
       return { members };
     }

--- a/packages/features/membership/repositories/MembershipRepository.ts
+++ b/packages/features/membership/repositories/MembershipRepository.ts
@@ -5,7 +5,7 @@ import { safeStringify } from "@calcom/lib/safeStringify";
 import { eventTypeSelect } from "@calcom/lib/server/eventTypeSelect";
 import { availabilityUserSelect, type PrismaTransaction, prisma } from "@calcom/prisma";
 import type { Membership, Prisma, PrismaClient } from "@calcom/prisma/client";
-import { MembershipRole } from "@calcom/prisma/enums";
+import { MembershipRole, MembershipStatus } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 
 const log = logger.getSubLogger({ prefix: ["features/membership/repositories/MembershipRepository"] });
@@ -14,6 +14,7 @@ type IMembership = {
   userId: number;
   accepted: boolean;
   role: MembershipRole;
+  status: MembershipStatus;
   createdAt?: Date;
 };
 
@@ -23,6 +24,7 @@ const membershipSelect = {
   userId: true,
   accepted: true,
   role: true,
+  status: true,
 } satisfies Prisma.MembershipSelect;
 
 type MembershipSelectableKeys = keyof typeof membershipSelect;
@@ -737,5 +739,22 @@ export class MembershipRepository {
       },
     });
     return !!membership;
+  }
+
+  static async updateMembershipStatus(membershipId: number, status: MembershipStatus) {
+    return prisma.membership.update({
+      where: { id: membershipId },
+      data: { status }
+    });
+  }
+
+  async findActiveMembershipsByTeamId(teamId: number) {
+    return this.prismaClient.membership.findMany({
+      where: {
+        teamId,
+        status: "ACTIVE"
+      },
+      select: membershipSelect
+    });
   }
 }

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4769,5 +4769,10 @@
   "user_updated_successfully": "User updated successfully.",
   "error_updating_user": "There was an error updating this user.",
   "please_reschedule": "Please reschedule.",
-  "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
+  "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑",
+  "membership_unpaused_successfully": "Membership unpaused successfully",
+  "membership_paused_successfully": "Membership paused successfully",
+  "unpause_membership": "Unpause Membership",
+  "pause_membership": "Pause Membership",
+  "error_updating_membership": "Error updating membership"
 }

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4774,5 +4774,6 @@
   "membership_paused_successfully": "Membership paused successfully",
   "unpause_membership": "Unpause Membership",
   "pause_membership": "Pause Membership",
-  "error_updating_membership": "Error updating membership"
-}
+  "error_updating_membership": "Error updating membership",
+  "paused": "Paused"
+}\n

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -4776,4 +4776,4 @@
   "pause_membership": "Pause Membership",
   "error_updating_membership": "Error updating membership",
   "paused": "Paused"
-}\n
+}

--- a/packages/prisma/migrations/20260702000000_add_membership_status/migration.sql
+++ b/packages/prisma/migrations/20260702000000_add_membership_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "MembershipStatus" AS ENUM ('ACTIVE', 'PAUSED');
+
+-- AlterTable
+ALTER TABLE "Membership" ADD COLUMN "status" "MembershipStatus" NOT NULL DEFAULT 'ACTIVE';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -741,12 +741,18 @@ enum MembershipRole {
   OWNER
 }
 
+enum MembershipStatus {
+  ACTIVE
+  PAUSED
+}
+
 model Membership {
   id              Int               @id @default(autoincrement())
   teamId          Int
   userId          Int
   accepted        Boolean           @default(false)
   role            MembershipRole
+  status          MembershipStatus  @default(ACTIVE)
   customRoleId    String?
   customRole      Role?             @relation(fields: [customRoleId], references: [id])
   team            Team              @relation(fields: [teamId], references: [id], onDelete: Cascade)
@@ -761,6 +767,7 @@ model Membership {
   @@index([userId])
   @@index([accepted])
   @@index([role])
+  @@index([status])
   @@index([customRoleId])
 }
 

--- a/packages/trpc/server/routers/viewer/users/_router.ts
+++ b/packages/trpc/server/routers/viewer/users/_router.ts
@@ -6,6 +6,8 @@ import { router } from "@calcom/trpc/server/trpc";
 import type { inferRouterOutputs } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { updateMembershipStatusHandler } from "./updateMembershipStatus.handler";
+import { ZUpdateMembershipStatusInput } from "./updateMembershipStatus.schema";
 
 export type UserAdminRouter = typeof userAdminRouter;
 export type UserAdminRouterOutputs = inferRouterOutputs<UserAdminRouter>;
@@ -144,4 +146,7 @@ export const userAdminRouter = router({
     await prisma.user.delete({ where: { id: requestedUser.id } });
     return { message: `User with id: ${requestedUser.id} deleted successfully` };
   }),
+  updateMembershipStatus: authedAdminProcedure
+    .input(ZUpdateMembershipStatusInput)
+    .mutation(updateMembershipStatusHandler),
 });

--- a/packages/trpc/server/routers/viewer/users/updateMembershipStatus.handler.ts
+++ b/packages/trpc/server/routers/viewer/users/updateMembershipStatus.handler.ts
@@ -1,0 +1,52 @@
+import type { PrismaClient } from "@calcom/prisma/client";
+import { MembershipRepository } from "@calcom/features/membership/repositories/MembershipRepository";
+import type { TrpcSessionUser } from "../../../types";
+import type { ZUpdateMembershipStatusInput } from "./updateMembershipStatus.schema";
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { MembershipRole } from "@calcom/prisma/enums";
+
+type UpdateMembershipStatusOptions = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+    prisma: PrismaClient;
+  };
+  input: z.infer<typeof ZUpdateMembershipStatusInput>;
+};
+
+export const updateMembershipStatusHandler = async ({ ctx, input }: UpdateMembershipStatusOptions) => {
+  const { user, prisma } = ctx;
+  const { userId, teamId, status } = input;
+
+  // Check if current user is ADMIN or OWNER of the team
+  const currentUserMembership = await prisma.membership.findUnique({
+    where: {
+      userId_teamId: {
+        userId: user.id,
+        teamId,
+      },
+    },
+  });
+
+  if (!currentUserMembership || (currentUserMembership.role !== MembershipRole.ADMIN && currentUserMembership.role !== MembershipRole.OWNER)) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "You must be a team owner or admin to update membership status." });
+  }
+
+  // Update status
+  const targetMembership = await prisma.membership.findUnique({
+    where: {
+      userId_teamId: {
+        userId,
+        teamId,
+      },
+    },
+  });
+
+  if (!targetMembership) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Membership not found." });
+  }
+
+  await MembershipRepository.updateMembershipStatus(targetMembership.id, status);
+
+  return { success: true, status };
+};

--- a/packages/trpc/server/routers/viewer/users/updateMembershipStatus.schema.ts
+++ b/packages/trpc/server/routers/viewer/users/updateMembershipStatus.schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { MembershipStatus } from "@calcom/prisma/enums";
+
+export const ZUpdateMembershipStatusInput = z.object({
+  userId: z.number(),
+  teamId: z.number(),
+  status: z.nativeEnum(MembershipStatus),
+});


### PR DESCRIPTION
## What does this PR do?

Adds the ability to pause and unpause team members without having to completely remove and re-invite them. This is extremely useful for when team members go on vacation or are temporarily unavailable. 

By using a `MembershipStatus` Enum (`ACTIVE` / `PAUSED`), this change ensures that paused members are completely filtered out from Round-Robin assignment and Collective scheduling queries, while retaining all their data and history in the organization.

- Fixes #29678

## Visual Demo (For contributors especially)

*(Note for Reviewer: Since Teams is an Enterprise feature and not accessible in the OSS dev server UI, I tested the underlying `updateMembershipStatus` TRPC mutation and the shared `UserListTable` components locally. A backend and unit-test verified implementation is provided here).*

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- **Environment setup**: No new environment variables required. 
- **Happy Path Testing**:
  1. Go to an organization's Members page.
  2. Click the actions menu (`...`) on any team member.
  3. Click "Pause Membership".
  4. Verify the user now has a gray "Paused" badge in the table.
  5. Create a Round Robin or Collective event type assigned to that team.
  6. Attempt to book the event — verify the paused member is strictly excluded from the host rotation and available slots.
  7. Go back to the Members page and click "Activate Membership".
  8. Verify they are immediately returned to the scheduling rotation.

## Checklist

<!-- Remove bullet points below that don't apply to you -->