### PR TITLE
fix(calendar): omit unanswered optional booking responses

### DIFF
--- a/packages/lib/CalEventParser.test.ts
+++ b/packages/lib/CalEventParser.test.ts
@@ -84,4 +84,22 @@ describe("getRichDescription", () => {
     expect(description).toContain("what:");
     expect(description).toContain("who:");
   });
+
+  it("should not render undefined for unanswered optional booking questions", () => {
+    const eventWithOptionalQuestion = {
+      ...mockCalEvent,
+      userFieldsResponses: {
+        company: {
+          label: "Company",
+          value: undefined,
+          isHidden: false,
+        },
+      },
+    };
+    const description = getRichDescription(
+      eventWithOptionalQuestion as CalendarEvent,
+      t
+    );
+    expect(description).not.toContain("undefined");
+  });
 });

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -115,16 +115,21 @@ export const getUserFieldsResponses = (
     return "";
   }
   const responsesString = Object.keys(labelValueMap)
-    .map((key) => {
-      if (!labelValueMap) return "";
-      if (labelValueMap[key] !== "") {
-        return `
+  .map((key) => {
+    if (!labelValueMap) return "";
+
+    const value = labelValueMap[key];
+
+    if (value !== undefined && value !== null && value !== "") {
+      return `
 ${t(key)}:
-${labelValueMap[key]}
+${value}
   `;
-      }
-    })
-    .join("");
+    }
+
+    return "";
+  })
+  .join("");
 
   return responsesString;
 };


### PR DESCRIPTION
## Summary

Fixes #29688.

When an optional booking question is left unanswered, the calendar event description rendered the literal string `undefined`.

## Root Cause

`getUserFieldsResponses()` only filtered out empty strings:

```ts
if (labelValueMap[key] !== "") {
```

As a result, `undefined` and `null` values were treated as valid responses and were interpolated into the calendar event description.

## Fix

- Skip `undefined`, `null`, and empty string values when generating booking question responses.
- Added a regression test to ensure unanswered optional booking questions are omitted from the calendar description.

## Testing

- Added a regression test for unanswered optional booking questions.
- Verified the new test fails on the previous implementation.
- Verified all `CalEventParser` tests pass after the fix.
