### PR TITLE
fix(hitpay): derive drop-in iframe domain from checkout URL hostname

### DIFF
--- a/apps/web/components/apps/hitpay/HitpayPaymentComponent.tsx
+++ b/apps/web/components/apps/hitpay/HitpayPaymentComponent.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { useHitPayDropIn } from "@calcom/app-store/hitpay/components/HitPayDropIn";
+import { getCheckoutIframeDomain } from "@calcom/app-store/hitpay/lib/getCheckoutIframeDomain";
 import { useRouter } from "next/navigation";
 import qs from "qs";
 import { useEffect, useRef } from "react";
 import { z } from "zod";
-
-import { useHitPayDropIn } from "@calcom/app-store/hitpay/components/HitPayDropIn";
 
 const PaymentHitpayDataSchema = z.object({
   id: z.string(),
@@ -41,9 +41,7 @@ export const HitpayPaymentComponent = (props: IPaymentComponentProps) => {
     if (parsedData.success) {
       if (window.self !== window.top && window.top) {
         if (!isInitialized) {
-          const subUrl = parsedData.data.url.substring("https://securecheckout.".length);
-          const arr = subUrl.split("/");
-          const domain = arr[0];
+          const domain = getCheckoutIframeDomain(parsedData.data.url);
 
           init(
             parsedData.data.defaultLink || "",

--- a/packages/app-store/hitpay/lib/getCheckoutIframeDomain.test.ts
+++ b/packages/app-store/hitpay/lib/getCheckoutIframeDomain.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { getCheckoutIframeDomain } from "./getCheckoutIframeDomain";
+
+describe("getCheckoutIframeDomain", () => {
+  it("strips the Checkout V1 subdomain", () => {
+    expect(getCheckoutIframeDomain("https://securecheckout.hit-pay.com/payment-request/@merchant/abc")).toBe(
+      "hit-pay.com"
+    );
+  });
+
+  it("strips the Checkout V2 subdomain", () => {
+    expect(getCheckoutIframeDomain("https://checkout.hit-pay.com/payment-request/@merchant/abc")).toBe(
+      "hit-pay.com"
+    );
+  });
+
+  it("strips the Checkout V1 sandbox subdomain", () => {
+    expect(getCheckoutIframeDomain("https://securecheckout.sandbox.hit-pay.com/payment-request/abc")).toBe(
+      "sandbox.hit-pay.com"
+    );
+  });
+
+  it("strips the Checkout V2 sandbox subdomain", () => {
+    expect(getCheckoutIframeDomain("https://checkout.sandbox.hit-pay.com/payment-request/abc")).toBe(
+      "sandbox.hit-pay.com"
+    );
+  });
+
+  it("returns the hostname unchanged when there is no checkout subdomain", () => {
+    expect(getCheckoutIframeDomain("https://hit-pay.com/payment-request/abc")).toBe("hit-pay.com");
+  });
+
+  it("only strips a leading checkout subdomain label", () => {
+    expect(getCheckoutIframeDomain("https://pay.checkout.hit-pay.com/abc")).toBe("pay.checkout.hit-pay.com");
+  });
+
+  it("returns undefined for a malformed URL", () => {
+    expect(getCheckoutIframeDomain("not-a-url")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty string", () => {
+    expect(getCheckoutIframeDomain("")).toBeUndefined();
+  });
+});

--- a/packages/app-store/hitpay/lib/getCheckoutIframeDomain.ts
+++ b/packages/app-store/hitpay/lib/getCheckoutIframeDomain.ts
@@ -1,0 +1,13 @@
+// HitPay serves the Drop-In iframe (/hitpay-iframe.html) from the base domain,
+// while payment request URLs live on a checkout subdomain: `securecheckout.`
+// for Checkout V1 and `checkout.` for Checkout V2 (including their
+// `*.sandbox.hit-pay.com` equivalents). The subdomain must be stripped to
+// build a valid iframe URL for either checkout version.
+export function getCheckoutIframeDomain(paymentUrl: string): string | undefined {
+  try {
+    const { hostname } = new URL(paymentUrl);
+    return hostname.replace(/^(securecheckout|checkout)\./, "");
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

- Fixes #29503

Merchants on HitPay **Checkout V2** were redirected to `https://y.com/hitpay-iframe.html?...` instead of the HitPay Drop-In checkout, breaking payment entirely.

**Root cause:** `HitpayPaymentComponent` derived the Drop-In iframe domain by stripping a hard-coded 23-character prefix from the payment request URL:

```ts
const subUrl = parsedData.data.url.substring("https://securecheckout.".length);
const domain = subUrl.split("/")[0];
```

This assumes every payment URL is hosted on `securecheckout.hit-pay.com` (Checkout V1). Checkout V2 payment URLs are hosted on `checkout.hit-pay.com`, so `substring(23)` cuts mid-hostname:

```
https://checkout.hit-pay.com/payment-request/...
       └──── 23 chars ────┘└→ "y.com/payment-request/..." → domain = "y.com"
```

**Fix:** a new `getCheckoutIframeDomain()` helper parses the URL with `new URL().hostname` and strips only a leading `securecheckout.` or `checkout.` subdomain label. This handles Checkout V1, Checkout V2, and both sandbox hosts (`*.sandbox.hit-pay.com`). Malformed URLs return `undefined`, letting the Drop-In fall back to its `hit-pay.com` default instead of building a garbage URL.

| Payment URL host | Before (domain) | After (domain) |
| --- | --- | --- |
| `securecheckout.hit-pay.com` (V1) | `hit-pay.com` ✅ | `hit-pay.com` ✅ |
| `checkout.hit-pay.com` (V2) | `y.com` ❌ | `hit-pay.com` ✅ |
| `securecheckout.sandbox.hit-pay.com` | `sandbox.hit-pay.com` ✅ | `sandbox.hit-pay.com` ✅ |
| `checkout.sandbox.hit-pay.com` | `x.sandbox.hit-pay.com` ❌ | `sandbox.hit-pay.com` ✅ |

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

N/A — behaviour is fully covered by the reproduction table above and unit tests; the issue screenshot in #29503 shows the broken `y.com` redirect this PR removes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- No environment variables needed for the unit tests: `TZ=UTC yarn vitest run packages/app-store/hitpay/lib/getCheckoutIframeDomain.test.ts` (8 tests covering V1, V2, both sandbox hosts, bare domain, non-leading subdomain, malformed URL, empty string).
- End-to-end: configure the HitPay payment app, set a price on an event type, and book it from an embedded/iframe context with a merchant account on Checkout V2 — the Drop-In iframe should now load from `https://hit-pay.com/hitpay-iframe.html` instead of `https://y.com/...`.
- Regression check: merchants still on Checkout V1 (`securecheckout.` URLs) keep working unchanged.
- Also verified locally: `yarn type-check:ci --force` passes (including `@calcom/web` and `@calcom/app-store`) and Biome reports no issues on the new files.
