### PR TITLE
fix(i18n): add missing space between number and unit in Hebrew duration

### DIFF
--- a/packages/i18n/locales/he/common.json
+++ b/packages/i18n/locales/he/common.json
@@ -919,7 +919,7 @@
   "hide_duration_selector_in_booking_page": "הסתר בורר משך זמן",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
   "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
-  "multiple_duration_timeUnit_short": "{{count}}$t({{unit}}_short)",
+  "multiple_duration_timeUnit_short": "{{count}} $t({{unit}}_short)",
   "minutes": "דקות",
   "use_cal_ai_to_make_call_description": "אפשר להשתמש ב־Cal.ai כדי לקבל מספר טלפון במענה בינה מלאכותית או להתקשר לאורחים.",
   "termination_uri": "כתובת URI לסיום",


### PR DESCRIPTION
## What
#29694
Fixes the missing space between the duration value and the Hebrew minutes abbreviation (`דק'`) in the booker UI.

**Before:** `15דק'`
**After:** `15 דק'`

## Why

The Hebrew (`he`) locale's `multiple_duration_timeUnit_short` translation template concatenated the duration value directly with the translated unit abbreviation:

```diff
- "{{count}}$t({{unit}}_short)"
+ "{{count}} $t({{unit}}_short)"
```

While this formatting works for some locales (e.g. `15m`), it results in reduced readability for Hebrew by rendering `15דק'` without a space.

## How

Updated the Hebrew translation template in:

* `packages/i18n/locales/he/common.json`

Added a space between `{{count}}` and the translated short unit:

```diff
- "multiple_duration_timeUnit_short": "{{count}}$t({{unit}}_short)"
+ "multiple_duration_timeUnit_short": "{{count}} $t({{unit}}_short)"
```

## Before

Duration renders without a space between the number and the Hebrew minutes abbreviation.

> `15דק'`

**Screenshot:**

<img width="1746" height="966" alt="image" src="https://github.com/user-attachments/assets/6d2d8600-884a-47e6-bfc3-90c1b6d119d6" />


## After

Duration renders with the correct spacing, improving readability.

> `15 דק'`

**Screenshot:**

<img width="1896" height="807" alt="image" src="https://github.com/user-attachments/assets/611f48c1-c328-4f43-877e-218f0670674c" />

## Testing

* Switched the booker UI to the Hebrew (`he`) locale.
* Verified that the event duration now renders with the expected spacing.
* Confirmed that the change only affects the Hebrew locale and does not impact other locales.
