### PR TITLE
feat(stripe): add bookingDate to Stripe transaction metadata

### DIFF
--- a/packages/app-store/stripepayment/lib/PaymentService.ts
+++ b/packages/app-store/stripepayment/lib/PaymentService.ts
@@ -86,6 +86,12 @@ class StripePaymentService implements IAbstractPaymentService {
         bookerPhoneNumber
       );
 
+      const booking = await prisma.booking.findUnique({
+        where: { id: bookingId },
+        select: { startTime: true },
+      });
+      const bookingDate = booking?.startTime ? booking.startTime.toISOString() : "";
+
       const params: Stripe.PaymentIntentCreateParams = {
         amount: payment.amount,
         currency: payment.currency,
@@ -102,6 +108,7 @@ class StripePaymentService implements IAbstractPaymentService {
           bookerPhoneNumber: bookerPhoneNumber ?? null,
           eventTitle: eventTitle || "",
           bookingTitle: bookingTitle || "",
+          bookingDate,
         }),
       };
 
@@ -277,6 +284,7 @@ class StripePaymentService implements IAbstractPaymentService {
           bookerPhoneNumber: booking.attendees[0].phoneNumber ?? null,
           eventTitle: booking.eventType?.title || null,
           bookingTitle: booking.title,
+          bookingDate: booking.startTime.toISOString(),
         }),
       };
 
@@ -458,6 +466,7 @@ class StripePaymentService implements IAbstractPaymentService {
     bookerPhoneNumber,
     eventTitle,
     bookingTitle,
+    bookingDate,
   }: {
     bookingId: number;
     userId: number | null | undefined;
@@ -467,6 +476,7 @@ class StripePaymentService implements IAbstractPaymentService {
     bookerPhoneNumber: string | null;
     eventTitle: string | null;
     bookingTitle: string;
+    bookingDate: string;
   }) {
     return {
       identifier: "cal.com",
@@ -478,6 +488,7 @@ class StripePaymentService implements IAbstractPaymentService {
       bookerPhoneNumber: bookerPhoneNumber ?? null,
       eventTitle: eventTitle || "",
       bookingTitle: bookingTitle || "",
+      bookingDate,
     };
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds the `bookingDate` (the customer-chosen date/time of the booking) as part of the Stripe PaymentIntent metadata. 

For accounting and reconciliation processes, it is important to know the date of the event directly on the payment transaction without querying the booking database. This PR retrieves the booking's `startTime` and appends it to the metadata object under the key `bookingDate`.

- Fixes #29682

## Visual Demo (For contributors especially)

#### Metadata fields passed to Stripe PaymentIntent:
- **Before:**
  - `identifier`, `bookingId`, `calAccountId`, `calUsername`, `bookerName`, `bookerEmail`, `bookerPhoneNumber`, `eventTitle`, `bookingTitle`
- **After:**
  - `identifier`, `bookingId`, `calAccountId`, `calUsername`, `bookerName`, `bookerEmail`, `bookerPhoneNumber`, `eventTitle`, `bookingTitle`, **`bookingDate`** (e.g. `2026-07-02T18:21:40.000Z`)
