### PR TITLE
fix: derive drop-in iframe domain from checkout URL hostname

### DIFF
--- a/apps/web/components/apps/hitpay/HitpayPaymentComponent.tsx
+++ b/apps/web/components/apps/hitpay/HitpayPaymentComponent.tsx
@@ -1,15 +1,15 @@
 "use client";
 
+import { useHitPayDropIn } from "@calcom/app-store/hitpay/components/HitPayDropIn";
+import { getCheckoutIframeDomain } from "@calcom/app-store/hitpay/lib/getCheckoutIframeDomain";
 import { useRouter } from "next/navigation";
 import qs from "qs";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
-
-import { useHitPayDropIn } from "@calcom/app-store/hitpay/components/HitPayDropIn";
 
 const PaymentHitpayDataSchema = z.object({
   id: z.string(),
-  url: z.string(),
+  url: z.string().url(),
   defaultLink: z.string(),
   eventTypeSlug: z.string(),
   bookingUid: z.string(),
@@ -26,6 +26,7 @@ interface IPaymentComponentProps {
 export const HitpayPaymentComponent = (props: IPaymentComponentProps) => {
   const { isInitialized, init } = useHitPayDropIn();
   const isSucceeded = useRef<boolean>(false);
+  const [hasUntrustedDomain, setHasUntrustedDomain] = useState(false);
   const router = useRouter();
   const { payment } = props;
   const { data } = payment;
@@ -41,9 +42,12 @@ export const HitpayPaymentComponent = (props: IPaymentComponentProps) => {
     if (parsedData.success) {
       if (window.self !== window.top && window.top) {
         if (!isInitialized) {
-          const subUrl = parsedData.data.url.substring("https://securecheckout.".length);
-          const arr = subUrl.split("/");
-          const domain = arr[0];
+          const domain = getCheckoutIframeDomain(parsedData.data.url);
+
+          if (!domain) {
+            setHasUntrustedDomain(true);
+            return;
+          }
 
           init(
             parsedData.data.defaultLink || "",
@@ -95,7 +99,7 @@ export const HitpayPaymentComponent = (props: IPaymentComponentProps) => {
     }
   };
 
-  if (!parsedData.success || !parsedData.data?.url) {
+  if (!parsedData.success || !parsedData.data?.url || hasUntrustedDomain) {
     return wrongUrl;
   }
 

--- a/packages/app-store/hitpay/lib/getCheckoutIframeDomain.test.ts
+++ b/packages/app-store/hitpay/lib/getCheckoutIframeDomain.test.ts
@@ -1,0 +1,67 @@
+import process from "node:process";
+import { describe, expect, it, vi } from "vitest";
+import { getCheckoutIframeDomain } from "./getCheckoutIframeDomain";
+
+describe("getCheckoutIframeDomain", () => {
+  it("strips the Checkout V1 subdomain", () => {
+    expect(getCheckoutIframeDomain("https://securecheckout.hit-pay.com/payment-request/@merchant/abc")).toBe(
+      "hit-pay.com"
+    );
+  });
+
+  it("strips the Checkout V2 subdomain", () => {
+    expect(getCheckoutIframeDomain("https://checkout.hit-pay.com/payment-request/@merchant/abc")).toBe(
+      "hit-pay.com"
+    );
+  });
+
+  it("strips the Checkout V1 sandbox subdomain", () => {
+    expect(getCheckoutIframeDomain("https://securecheckout.sandbox.hit-pay.com/payment-request/abc")).toBe(
+      "sandbox.hit-pay.com"
+    );
+  });
+
+  it("strips the Checkout V2 sandbox subdomain", () => {
+    expect(getCheckoutIframeDomain("https://checkout.sandbox.hit-pay.com/payment-request/abc")).toBe(
+      "sandbox.hit-pay.com"
+    );
+  });
+
+  it("returns the hostname unchanged when there is no checkout subdomain", () => {
+    expect(getCheckoutIframeDomain("https://hit-pay.com/payment-request/abc")).toBe("hit-pay.com");
+  });
+
+  it("only strips a leading checkout subdomain label", () => {
+    expect(getCheckoutIframeDomain("https://pay.checkout.hit-pay.com/abc")).toBe("pay.checkout.hit-pay.com");
+  });
+
+  it("returns undefined for a malformed URL", () => {
+    expect(getCheckoutIframeDomain("not-a-url")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty string", () => {
+    expect(getCheckoutIframeDomain("")).toBeUndefined();
+  });
+
+  it("returns undefined for a host outside HitPay's known domains", () => {
+    // A resolved host must never escape hit-pay.com / sandbox.hit-pay.com.
+    expect(getCheckoutIframeDomain("https://checkout.evil.com/payment-request/abc")).toBeUndefined();
+  });
+
+  it("never regresses to the original 23-character substring bug", () => {
+    // Original bug: a fixed 23-char slice truncated Checkout V2 hostnames into "y.com".
+    expect(getCheckoutIframeDomain("https://checkout.hit-pay.com/payment-request/abc")).not.toBe("y.com");
+  });
+
+  it("does not crash at import time when an env-configured HitPay URL is malformed", async () => {
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_API_HITPAY_PRODUCTION = "not-a-valid-url";
+    const fresh = await import("./getCheckoutIframeDomain");
+    delete process.env.NEXT_PUBLIC_API_HITPAY_PRODUCTION;
+
+    // the import itself must not throw, and the other (still-valid) host must still work
+    expect(fresh.getCheckoutIframeDomain("https://checkout.sandbox.hit-pay.com/payment-request/abc")).toBe(
+      "sandbox.hit-pay.com"
+    );
+  });
+});

--- a/packages/app-store/hitpay/lib/getCheckoutIframeDomain.ts
+++ b/packages/app-store/hitpay/lib/getCheckoutIframeDomain.ts
@@ -1,0 +1,32 @@
+import { API_HITPAY, SANDBOX_API_HITPAY } from "@calcom/app-store/hitpay/lib/constants";
+
+// HitPay's checkout URL uses a securecheckout./checkout. subdomain (V1/V2) that must be stripped to get the iframe's real domain.
+const CHECKOUT_V1_SUBDOMAIN = "securecheckout";
+const CHECKOUT_V2_SUBDOMAIN = "checkout";
+const CHECKOUT_SUBDOMAIN_PATTERN = new RegExp(`^(${CHECKOUT_V1_SUBDOMAIN}|${CHECKOUT_V2_SUBDOMAIN})\\.`);
+
+// Reuses the same env-configurable constants as the rest of the HitPay integration. Skips any that
+// aren't valid URLs so a misconfigured env var can't crash the module at import time.
+const ALLOWED_IFRAME_HOSTS = [API_HITPAY, SANDBOX_API_HITPAY].flatMap((url) => {
+  try {
+    return [new URL(url).hostname.replace(/^api\./, "")];
+  } catch {
+    return [];
+  }
+});
+
+// Guards against an untrusted host picking the iframe's origin.
+function isTrustedHitPayHost(hostname: string): boolean {
+  return ALLOWED_IFRAME_HOSTS.some((allowed) => hostname === allowed || hostname.endsWith(`.${allowed}`));
+}
+
+export function getCheckoutIframeDomain(paymentUrl: string): string | undefined {
+  try {
+    const { hostname } = new URL(paymentUrl);
+    const domain = hostname.replace(CHECKOUT_SUBDOMAIN_PATTERN, "");
+
+    return isTrustedHitPayHost(domain) ? domain : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the HitPay drop-in checkout iframe loading the wrong domain for Checkout V2 merchants.

The old code cut a fixed 23 characters off the payment URL to get the iframe's domain. That worked for Checkout V1 URLs (`https://securecheckout.hit-pay.com/...`), but Checkout V2 URLs are 6 characters shorter (`https://checkout.hit-pay.com/...`), so the same cut lands mid-hostname and turns `hit-pay.com` into `y.com`. The iframe then tries to load a domain that doesn't exist, and checkout breaks.

Fixed by actually parsing the URL instead of guessing an offset, and stripping whichever checkout subdomain is really there. Also added a check that the resulting domain is actually one of HitPay's own domains before it's used as an iframe's origin — if it isn't, we show the existing "couldn't obtain payment URL" message instead of quietly falling back to a guessed default.

- Fixes #29503

## Visual Demo

N/A — this only affects a runtime iframe `src` during payment, there's nothing to screenshot. Covered by the test file instead.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- No environment variables needed, it's plain URL parsing.
- Test data: a Checkout V2 payment URL, e.g. `https://checkout.hit-pay.com/payment-request/@merchant/abc`
- Happy path: that URL should resolve to `hit-pay.com`, not `y.com`.
- Run `TZ=UTC yarn vitest run packages/app-store/hitpay/lib/getCheckoutIframeDomain.test.ts` to see all cases (V1, V2, sandbox, malformed input, untrusted domain).

## Checklist

N/A — none of these apply.