### PR TITLE
fix(CalEventParser): skip null/undefined values in getUserFieldsResponses

### DIFF
--- a/packages/lib/CalEventParser.test.ts
+++ b/packages/lib/CalEventParser.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
-import { getRichDescription } from "./CalEventParser";
+import { getRichDescription, getUserFieldsResponses } from "./CalEventParser";
 
 describe("getRichDescription", () => {
   const t = ((key: string, _args?: Record<string, unknown>) => key) as TFunction;
@@ -83,5 +83,34 @@ describe("getRichDescription", () => {
     // Should still contain required fields
     expect(description).toContain("what:");
     expect(description).toContain("who:");
+  });
+});
+
+describe("getUserFieldsResponses", () => {
+  const t = ((key: string) => key) as TFunction;
+
+  it("does not render null values for unanswered optional booking questions", () => {
+    // When an optional booking question is left unanswered, customInputs may store null
+    // for that field. Before the fix, null coerced to the string "null" in the template
+    // literal, polluting the calendar event description.
+    const result = getUserFieldsResponses(
+      { customInputs: { "Phone Number": null, Name: "Alice" } },
+      t
+    );
+
+    expect(result).not.toContain("null");
+    expect(result).toContain("Name");
+    expect(result).toContain("Alice");
+  });
+
+  it("does not render empty string values for booking questions", () => {
+    const result = getUserFieldsResponses(
+      { customInputs: { "Phone Number": "", Name: "Bob" } },
+      t
+    );
+
+    expect(result).not.toContain("Phone Number");
+    expect(result).toContain("Name");
+    expect(result).toContain("Bob");
   });
 });

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -117,7 +117,7 @@ export const getUserFieldsResponses = (
   const responsesString = Object.keys(labelValueMap)
     .map((key) => {
       if (!labelValueMap) return "";
-      if (labelValueMap[key] !== "") {
+      if (labelValueMap[key] != null && labelValueMap[key] !== "") {
         return `
 ${t(key)}:
 ${labelValueMap[key]}


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where an optional booking question left unanswered would write the literal string `"null"` or `"undefined"` into the calendar event description (visible to both organiser and attendee).

**Root cause:** `getUserFieldsResponses` iterates over `Object.keys(labelValueMap)` and checks `if (labelValueMap[key] !== "")` before interpolating the value into a template literal. This guard missed `null` and `undefined`, which JavaScript coerces to the strings `"null"` / `"undefined"` inside template literals.

**Fix:** Add a `!= null` guard before the empty-string check.

```diff
- if (labelValueMap[key] !== "") {
+ if (labelValueMap[key] != null && labelValueMap[key] !== "") {
```

## How to reproduce

1. Create an event type with an optional text field (e.g. "Phone Number")
2. Book the event and leave that field blank
3. Check the calendar invite description — it previously contained `undefined`

## Tests

Added two unit tests to `CalEventParser.test.ts`:
- `null` value in `customInputs` is omitted (not rendered as `"null"`)
- Empty string value is omitted (existing behaviour, now explicitly tested)

Fixes #29688