### PR TITLE
docs: add windows/powershell setup troubleshooting for prisma

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ for Logger level to be set at info, for example.
    </details>
 
    If you don't want to create a local DB. Then you can also consider using services like railway.app, Northflank or render.
+   
 
    - [Setup postgres DB with railway.app](https://docs.railway.app/guides/postgresql)
    - [Setup postgres DB with Northflank](https://northflank.com/guides/deploy-postgres-database-on-northflank)
@@ -235,6 +236,15 @@ for Logger level to be set at info, for example.
    yarn workspace @calcom/prisma db-deploy
    ```
 
+  **Note for Windows/PowerShell users:** If running the database deployment scripts fails with an error stating `Environment variable not found: DATABASE_DIRECT_URL`, Turbo might be failing to inject the root `.env` variables. You can bypass this by executing the commands directly from the prisma package directory in PowerShell:
+
+```powershell
+cd packages/prisma
+$env:DATABASE_URL="postgresql://postgres:YOUR_PASSWORD@localhost:5432/postgres"; $env:DATABASE_DIRECT_URL="postgresql://postgres:YOUR_PASSWORD@localhost:5432/postgres"
+npx prisma db push
+cd ../..
+```
+   
 4. Run [mailhog](https://github.com/mailhog/MailHog) to view emails sent during development
 
    > **_NOTE:_** Required when `E2E_TEST_MAILHOG_ENABLED` is "1"


### PR DESCRIPTION
Adds a note explaining how to manually push schema using PowerShell when Turbo fails to pass environment variables down to the prisma workspace.

## What does this PR do?

This PR adds a troubleshooting note to the `README.md` file specifically for Windows and PowerShell users. It provides a workaround for when `Turbo` fails to inject the root `.env` variables (specifically `DATABASE_DIRECT_URL`) during database schema deployments.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (N/A - Documentation only)

## How should this be tested?

This is a documentation-only change to the main `README.md`. No code functionality is affected. It can be verified by reviewing the Markdown formatting in the file.

## Checklist

- My PR is small (under 500 lines) and focused on a single documentation improvement.