### PR TITLE
fix(emails): send METHOD:CANCEL in ICS for cancelled bookings

### DIFF
--- a/packages/emails/lib/generateIcsFile.ts
+++ b/packages/emails/lib/generateIcsFile.ts
@@ -36,6 +36,6 @@ export default function generateIcsFile({
       status,
       t,
     }),
-    method: "REQUEST",
+    method: status === "CANCELLED" ? "CANCEL" : "REQUEST",
   };
 }

--- a/packages/emails/lib/generateIcsString.test.ts
+++ b/packages/emails/lib/generateIcsString.test.ts
@@ -46,6 +46,9 @@ const testIcsStringContains = ({
   }
   expect(icsString).toEqual(expect.stringContaining(`DTEND:${DTEND}`));
   expect(icsString).toEqual(expect.stringContaining(`STATUS:${status}`));
+  expect(icsString).toEqual(
+    expect.stringContaining(`METHOD:${status === "CANCELLED" ? "CANCEL" : "REQUEST"}`)
+  );
   //   Getting an error expected icsString to deeply equal stringMatching
   //   for (const attendee of event.attendees) {
   //     expect(icsString).toEqual(

--- a/packages/emails/lib/generateIcsString.ts
+++ b/packages/emails/lib/generateIcsString.ts
@@ -61,7 +61,7 @@ const generateIcsString = ({
   const location = getVideoCallUrlFromCalEvent(event) || event.location;
 
   // Taking care of recurrence rule
-  let recurrenceRule: string | undefined = undefined;
+  let recurrenceRule: string | undefined;
   const icsRole: ParticipationRole = "REQ-PARTICIPANT";
   if (event.recurringEvent?.count) {
     // ics appends "RRULE:" already, so removing it from RRule generated string
@@ -107,7 +107,7 @@ const generateIcsString = ({
         : []),
     ],
     location: location ?? undefined,
-    method: "REQUEST",
+    method: status === "CANCELLED" ? "CANCEL" : "REQUEST",
     status,
     ...(event.hideCalendarEventDetails ? { classification: "PRIVATE" } : {}),
     busyStatus: "BUSY",


### PR DESCRIPTION
## What does this PR do?
#29706 

This PR fixes cancellation `.ics` files being generated with `METHOD:REQUEST` instead of `METHOD:CANCEL`.

According to RFC 5546, calendar clients process event cancellations only when `METHOD:CANCEL` is used. Sending `METHOD:REQUEST` with `STATUS:CANCELLED` causes clients to treat the message as an update rather than a cancellation, leaving cancelled events in attendee calendars with active reminders.

## Root cause

`generateIcsString.ts` always generated ICS files with `METHOD:REQUEST`, regardless of the booking state. Although the event status was set to `STATUS:CANCELLED`, the ICS method was never updated for cancellation events.

`generateIcsFile.ts` also returned the attachment metadata with `method: "REQUEST"` for all cases.

## Changes

* Generate `METHOD:CANCEL` for cancelled booking ICS files.
* Keep `METHOD:REQUEST` for non-cancelled booking invitations.
* Add assertions to verify the generated ICS method in unit tests.

## How to test

1. Start the development environment with MailHog.
2. Create a booking for an attendee without a connected calendar.
3. Cancel the booking.
4. Open the cancellation email in MailHog.
5. Verify the attached `.ics` contains:

   * `METHOD:CANCEL`
   * `STATUS:CANCELLED`
6. Import the cancellation `.ics` into a calendar client (Google Calendar, Outlook, or Apple Calendar) and verify the existing event is cancelled/removed.

## Before

```ics
METHOD:REQUEST
STATUS:CANCELLED
```

## After

```ics
METHOD:CANCEL
STATUS:CANCELLED
```

## Tests

* Added assertions covering the generated ICS method.
* All existing tests pass.
