### PR TITLE
fix: correct weekday index range check in weekdayToWeekIndex

### DIFF
--- a/packages/lib/dayjs/index.ts
+++ b/packages/lib/dayjs/index.ts
@@ -165,7 +165,7 @@ type WeekDayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
  */
 export const weekdayToWeekIndex = (weekday: WeekDays | string | number | undefined) => {
   if (typeof weekday === "undefined") return 0;
-  if (typeof weekday === "number") return weekday >= 0 && weekday >= 6 ? (weekday as WeekDayIndex) : 0;
+  if (typeof weekday === "number") return weekday >= 0 && weekday <= 6 ? (weekday as WeekDayIndex) : 0;
   return (weekDays.indexOf(weekday as WeekDays) as WeekDayIndex) || 0;
 };
 

--- a/packages/lib/dayjs/weekdayToWeekIndex.test.ts
+++ b/packages/lib/dayjs/weekdayToWeekIndex.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { weekdayToWeekIndex } from "./index";
+
+describe("weekdayToWeekIndex", () => {
+  it("returns 0 for undefined", () => {
+    expect(weekdayToWeekIndex(undefined)).toBe(0);
+  });
+
+  it("maps weekday strings to their index", () => {
+    expect(weekdayToWeekIndex("Sunday")).toBe(0);
+    expect(weekdayToWeekIndex("Monday")).toBe(1);
+    expect(weekdayToWeekIndex("Saturday")).toBe(6);
+  });
+
+  it("returns a valid numeric weekday index (0-6) unchanged", () => {
+    expect(weekdayToWeekIndex(0)).toBe(0);
+    expect(weekdayToWeekIndex(1)).toBe(1);
+    expect(weekdayToWeekIndex(5)).toBe(5);
+    expect(weekdayToWeekIndex(6)).toBe(6);
+  });
+
+  it("clamps out-of-range numeric input to 0", () => {
+    expect(weekdayToWeekIndex(7)).toBe(0);
+    expect(weekdayToWeekIndex(-1)).toBe(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes an incorrect range check in `weekdayToWeekIndex` (`packages/lib/dayjs/index.ts`).

The function's documented contract is to accept a numeric weekday index (0–6) and return it unchanged, falling back to `0` for anything else. The numeric branch was guarded with:

```ts
return weekday >= 0 && weekday >= 6 ? (weekday as WeekDayIndex) : 0;
```

`weekday >= 0 && weekday >= 6` is equivalent to `weekday >= 6`, which is the inverse of the intended bounds check. As a result, valid indices 1–5 were coerced to `0`, while out-of-range values ≥ 7 were passed through unchanged.

The fix changes the second comparison to `<= 6` so that any valid weekday index (0–6) is returned as-is and out-of-range input correctly falls back to `0`.

## Visual Demo (For contributors especially)

N/A — this is a fix to a pure utility function with no UI surface of its own.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the unit test added in this PR:

```
yarn vitest run packages/lib/dayjs/weekdayToWeekIndex.test.ts
```

- Environment variables: none required.
- Expected: numeric inputs 0–6 return themselves (previously 1–5 returned `0`), inputs ≥ 7 and negatives return `0` (previously ≥ 7 was returned unchanged), weekday strings map to their index, and `undefined` returns `0`. The numeric-range assertions fail against the pre-fix code and pass with the fix.
