### PR TITLE
refactor(app-store): move credential query to repository pattern

### DIFF
--- a/packages/app-store/repositories/PrismaCredentialRepository.ts
+++ b/packages/app-store/repositories/PrismaCredentialRepository.ts
@@ -1,0 +1,40 @@
+import { buildNonDelegationCredentials } from "@calcom/lib/delegationCredential";
+import { prisma } from "@calcom/prisma";
+import type { Prisma } from "@calcom/prisma/client";  
+import type { AppCategories } from "@calcom/prisma/client";
+import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
+
+export class PrismaCredentialRepository {
+    constructor(private readonly prismaClient: typeof prisma){}
+
+    async findNonDelegationCredentialsByAppCategories({
+        idToSearchObject,  
+        appCategories,
+    }: {
+        idToSearchObject: Prisma.CredentialWhereInput;  
+        appCategories: AppCategories[];  
+    }){
+
+        const credentials = await this.prismaClient.credential.findMany({
+            where: {
+                ...idToSearchObject,
+                app: {
+                    categories: {
+                        hasSome: appCategories
+                    }
+                }
+            },
+            select: {
+                ...credentialForCalendarServiceSelect,
+                team: {
+                    select: {
+                        name: true
+                    }
+                }
+            }
+        })
+
+
+        return buildNonDelegationCredentials(credentials)
+    }
+}

--- a/packages/app-store/server.ts
+++ b/packages/app-store/server.ts
@@ -7,6 +7,7 @@ import { prisma } from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import { AppCategories } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
+import { PrismaCredentialRepository } from "./repositories/PrismaCredentialRepository";
 
 import getEnabledAppsFromCredentials from "./_utils/getEnabledAppsFromCredentials";
 import { defaultLocations } from "./locations";
@@ -62,23 +63,10 @@ export async function getLocationGroupedOptions(
     });
   }
 
-  const nonDelegationCredentials = await prisma.credential.findMany({
-    where: {
-      ...idToSearchObject,
-      app: {
-        categories: {
-          hasSome: defaultVideoAppCategories,
-        },
-      },
-    },
-    select: {
-      ...credentialForCalendarServiceSelect,
-      team: {
-        select: {
-          name: true,
-        },
-      },
-    },
+  const credentialRepository = new PrismaCredentialRepository(prisma);  
+  const nonDelegationCredentials = await credentialRepository.findNonDelegationCredentialsByAppCategories({  
+    idToSearchObject,
+    appCategories: defaultVideoAppCategories,  
   });
 
   let credentials;
@@ -94,8 +82,7 @@ export async function getLocationGroupedOptions(
     );
     credentials = allCredentials;
   } else {
-    // TODO: We can avoid calling buildNonDelegationCredentials here by moving the above prisma query to the repository and doing it there
-    credentials = buildNonDelegationCredentials(nonDelegationCredentials);
+    credentials = nonDelegationCredentials;  
   }
 
   const integrations = await getEnabledAppsFromCredentials(credentials, { filterOnCredentials: true });

--- a/packages/app-store/server.ts
+++ b/packages/app-store/server.ts
@@ -2,11 +2,9 @@ import type { TFunction } from "i18next";
 
 import { enrichUserWithDelegationConferencingCredentialsWithoutOrgId } from "@calcom/app-store/delegationCredential";
 import { defaultVideoAppCategories } from "@calcom/app-store/utils";
-import { buildNonDelegationCredentials } from "@calcom/lib/delegationCredential";
 import { prisma } from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import { AppCategories } from "@calcom/prisma/enums";
-import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 import { PrismaCredentialRepository } from "./repositories/PrismaCredentialRepository";
 
 import getEnabledAppsFromCredentials from "./_utils/getEnabledAppsFromCredentials";


### PR DESCRIPTION
## What does this PR do?

This PR refactors credential data access in `packages/app-store/server.ts` to follow the Repository Pattern by moving the Prisma query and buildNonDelegationCredentials transformation into a dedicated repository class

Address the TODO as well
<img width="1238" height="93" alt="image" src="https://github.com/user-attachments/assets/4b18adbf-0fa7-4d9b-8b75-578fde9b9ef0" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.