### PR TITLE
feat: add team repository and service

### DIFF
--- a/packages/features/di/containers/Team.ts
+++ b/packages/features/di/containers/Team.ts
@@ -1,0 +1,16 @@
+import type { PrismaTeamRepository } from "@calcom/features/teams/repositories/PrismaTeamRepository";
+import type { TeamService } from "@calcom/features/teams/services/TeamService";
+import { createContainer } from "../di";
+import { teamRepositoryModuleLoader, teamServiceModuleLoader } from "../modules/Team";
+
+const container = createContainer();
+
+export function getTeamService(): TeamService {
+  teamServiceModuleLoader.loadModule(container);
+  return container.get<TeamService>(teamServiceModuleLoader.token);
+}
+
+export function getTeamRepository(): PrismaTeamRepository {
+  teamRepositoryModuleLoader.loadModule(container);
+  return container.get<PrismaTeamRepository>(teamRepositoryModuleLoader.token);
+}

--- a/packages/features/di/modules/Team.ts
+++ b/packages/features/di/modules/Team.ts
@@ -1,0 +1,35 @@
+import { DI_TOKENS } from "@calcom/features/di/tokens";
+import { PrismaTeamRepository } from "@calcom/features/teams/repositories/PrismaTeamRepository";
+import { TeamService } from "@calcom/features/teams/services/TeamService";
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "../di";
+import { moduleLoader as prismaModuleLoader } from "./Prisma";
+
+export const teamRepositoryModule = createModule();
+const repositoryLoadModule = bindModuleToClassOnToken({
+  module: teamRepositoryModule,
+  moduleToken: DI_TOKENS.TEAM_REPOSITORY_MODULE,
+  token: DI_TOKENS.TEAM_REPOSITORY,
+  classs: PrismaTeamRepository,
+  dep: prismaModuleLoader,
+});
+
+export const teamRepositoryModuleLoader: ModuleLoader = {
+  token: DI_TOKENS.TEAM_REPOSITORY,
+  loadModule: repositoryLoadModule,
+};
+
+export const teamServiceModule = createModule();
+const serviceLoadModule = bindModuleToClassOnToken({
+  module: teamServiceModule,
+  moduleToken: DI_TOKENS.TEAM_SERVICE_MODULE,
+  token: DI_TOKENS.TEAM_SERVICE,
+  classs: TeamService,
+  depsMap: {
+    teamRepository: teamRepositoryModuleLoader,
+  },
+});
+
+export const teamServiceModuleLoader: ModuleLoader = {
+  token: DI_TOKENS.TEAM_SERVICE,
+  loadModule: serviceLoadModule,
+};

--- a/packages/features/di/tokens.ts
+++ b/packages/features/di/tokens.ts
@@ -4,6 +4,7 @@ import { FEATURE_OPT_IN_DI_TOKENS } from "@calcom/features/feature-opt-in/di/tok
 import { FLAGS_DI_TOKENS } from "@calcom/features/flags/di/tokens";
 import { HASHED_LINK_DI_TOKENS } from "@calcom/features/hashedLink/di/tokens";
 import { OAUTH_DI_TOKENS } from "@calcom/features/oauth/di/tokens";
+import { TEAM_DI_TOKENS } from "@calcom/features/teams/di/tokens";
 import { TRANSLATION_DI_TOKENS } from "@calcom/features/translation/di/tokens";
 import { WATCHLIST_DI_TOKENS } from "./watchlist/Watchlist.tokens";
 import { WEBHOOK_TOKENS } from "./webhooks/Webhooks.tokens";
@@ -75,4 +76,5 @@ export const DI_TOKENS = {
   ...TRANSLATION_DI_TOKENS,
   ...WEBHOOK_TOKENS,
   ...EVENT_TYPE_DI_TOKENS,
+  ...TEAM_DI_TOKENS,
 };

--- a/packages/features/teams/di/tokens.ts
+++ b/packages/features/teams/di/tokens.ts
@@ -1,0 +1,6 @@
+export const TEAM_DI_TOKENS = {
+  TEAM_REPOSITORY: Symbol("TeamRepository"),
+  TEAM_REPOSITORY_MODULE: Symbol("TeamRepositoryModule"),
+  TEAM_SERVICE: Symbol("TeamService"),
+  TEAM_SERVICE_MODULE: Symbol("TeamServiceModule"),
+};

--- a/packages/features/teams/repositories/PrismaTeamRepository.ts
+++ b/packages/features/teams/repositories/PrismaTeamRepository.ts
@@ -1,0 +1,137 @@
+import type { PrismaClient } from "@calcom/prisma";
+import type { Prisma } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
+
+const teamSelect = {
+  id: true,
+  name: true,
+  slug: true,
+  logoUrl: true,
+  bio: true,
+  hideBranding: true,
+  hideTeamProfileLink: true,
+  isPrivate: true,
+  hideBookATeamMember: true,
+  theme: true,
+  brandColor: true,
+  darkBrandColor: true,
+  timeZone: true,
+  weekStart: true,
+  timeFormat: true,
+  parentId: true,
+  isOrganization: true,
+  createdAt: true,
+} satisfies Prisma.TeamSelect;
+
+export type TeamDTO = Prisma.TeamGetPayload<{ select: typeof teamSelect }>;
+
+export type TeamCreateInput = {
+  name: string;
+  slug: string;
+  bio?: string;
+};
+
+export type TeamUpdateInput = Partial<{
+  name: string;
+  slug: string;
+  bio: string | null;
+  logoUrl: string | null;
+  theme: string | null;
+  brandColor: string | null;
+  darkBrandColor: string | null;
+  hideBranding: boolean;
+  hideTeamProfileLink: boolean;
+  isPrivate: boolean;
+  hideBookATeamMember: boolean;
+  timeZone: string;
+  weekStart: string;
+  timeFormat: number | null;
+}>;
+
+export type TeamWithMembershipDTO = TeamDTO & {
+  membership: {
+    role: MembershipRole;
+    accepted: boolean;
+  };
+};
+
+export class PrismaTeamRepository {
+  constructor(private prismaClient: PrismaClient) {}
+
+  async findById({ id }: { id: number }): Promise<TeamDTO | null> {
+    return this.prismaClient.team.findUnique({
+      where: { id },
+      select: teamSelect,
+    });
+  }
+
+  async findBySlug({
+    slug,
+    parentId = null,
+  }: {
+    slug: string;
+    parentId?: number | null;
+  }): Promise<TeamDTO | null> {
+    // Postgres does not enforce @@unique([slug, parentId]) when parentId is NULL
+    // (NULLs are considered distinct), so uniqueness among top-level teams must be
+    // checked explicitly with findFirst.
+    return this.prismaClient.team.findFirst({
+      where: { slug, parentId },
+      select: teamSelect,
+    });
+  }
+
+  async createWithOwner({
+    data,
+    ownerUserId,
+  }: {
+    data: TeamCreateInput;
+    ownerUserId: number;
+  }): Promise<TeamDTO> {
+    return this.prismaClient.team.create({
+      data: {
+        ...data,
+        members: {
+          create: {
+            userId: ownerUserId,
+            role: MembershipRole.OWNER,
+            accepted: true,
+          },
+        },
+      },
+      select: teamSelect,
+    });
+  }
+
+  async update({ id, data }: { id: number; data: TeamUpdateInput }): Promise<TeamDTO> {
+    return this.prismaClient.team.update({
+      where: { id },
+      data,
+      select: teamSelect,
+    });
+  }
+
+  async deleteById({ id }: { id: number }): Promise<void> {
+    await this.prismaClient.team.delete({ where: { id } });
+  }
+
+  async findManyByUserIdIncludeMembership({ userId }: { userId: number }): Promise<TeamWithMembershipDTO[]> {
+    const memberships = await this.prismaClient.membership.findMany({
+      where: {
+        userId,
+        team: { isOrganization: false },
+      },
+      select: {
+        role: true,
+        accepted: true,
+        team: { select: teamSelect },
+      },
+      orderBy: { team: { name: "asc" } },
+    });
+
+    return memberships.map(({ role, accepted, team }) => ({
+      ...team,
+      membership: { role, accepted },
+    }));
+  }
+}

--- a/packages/features/teams/services/TeamService.test.ts
+++ b/packages/features/teams/services/TeamService.test.ts
@@ -1,0 +1,239 @@
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
+import { uploadLogo } from "@calcom/lib/server/avatar";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrismaTeamRepository, TeamDTO } from "../repositories/PrismaTeamRepository";
+import { TeamService } from "./TeamService";
+
+vi.mock("@calcom/lib/server/avatar", () => ({
+  uploadLogo: vi.fn(),
+}));
+
+const buildTeam = (overrides: Partial<TeamDTO> = {}): TeamDTO => ({
+  id: 1,
+  name: "Design Team",
+  slug: "design-team",
+  logoUrl: null,
+  bio: null,
+  hideBranding: false,
+  hideTeamProfileLink: false,
+  isPrivate: false,
+  hideBookATeamMember: false,
+  theme: null,
+  brandColor: null,
+  darkBrandColor: null,
+  timeZone: "Europe/London",
+  weekStart: "Sunday",
+  timeFormat: null,
+  parentId: null,
+  isOrganization: false,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  ...overrides,
+});
+
+describe("TeamService", () => {
+  let service: TeamService;
+  let mockTeamRepository: {
+    findById: ReturnType<typeof vi.fn>;
+    findBySlug: ReturnType<typeof vi.fn>;
+    createWithOwner: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    deleteById: ReturnType<typeof vi.fn>;
+    findManyByUserIdIncludeMembership: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockTeamRepository = {
+      findById: vi.fn(),
+      findBySlug: vi.fn(),
+      createWithOwner: vi.fn(),
+      update: vi.fn(),
+      deleteById: vi.fn(),
+      findManyByUserIdIncludeMembership: vi.fn(),
+    };
+
+    service = new TeamService({
+      teamRepository: mockTeamRepository as unknown as PrismaTeamRepository,
+    });
+  });
+
+  describe("create", () => {
+    it("creates a team with a slugified name and an owner membership", async () => {
+      mockTeamRepository.findBySlug.mockResolvedValue(null);
+      mockTeamRepository.createWithOwner.mockResolvedValue(buildTeam());
+
+      const team = await service.create({ name: "Design Team", ownerUserId: 42 });
+
+      expect(mockTeamRepository.findBySlug).toHaveBeenCalledWith({
+        slug: "design-team",
+        parentId: null,
+      });
+      expect(mockTeamRepository.createWithOwner).toHaveBeenCalledWith({
+        data: { name: "Design Team", slug: "design-team", bio: undefined },
+        ownerUserId: 42,
+      });
+      expect(team.slug).toBe("design-team");
+    });
+
+    it("uses the provided slug over the name", async () => {
+      mockTeamRepository.findBySlug.mockResolvedValue(null);
+      mockTeamRepository.createWithOwner.mockResolvedValue(buildTeam({ slug: "custom" }));
+
+      await service.create({ name: "Design Team", slug: "Custom", ownerUserId: 42 });
+
+      expect(mockTeamRepository.findBySlug).toHaveBeenCalledWith({ slug: "custom", parentId: null });
+      expect(mockTeamRepository.createWithOwner).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ slug: "custom" }) })
+      );
+    });
+
+    it("rejects a slug that is already taken", async () => {
+      mockTeamRepository.findBySlug.mockResolvedValue(buildTeam());
+
+      await expect(service.create({ name: "Design Team", ownerUserId: 42 })).rejects.toMatchObject({
+        code: ErrorCode.BadRequest,
+      });
+      expect(mockTeamRepository.createWithOwner).not.toHaveBeenCalled();
+    });
+
+    it("rejects a name that produces an empty slug", async () => {
+      await expect(service.create({ name: "---", ownerUserId: 42 })).rejects.toBeInstanceOf(ErrorWithCode);
+      expect(mockTeamRepository.findBySlug).not.toHaveBeenCalled();
+    });
+
+    it("uploads a base64 logo and stores the resulting URL", async () => {
+      mockTeamRepository.findBySlug.mockResolvedValue(null);
+      mockTeamRepository.createWithOwner.mockResolvedValue(buildTeam());
+      mockTeamRepository.update.mockResolvedValue(buildTeam({ logoUrl: "/api/avatar/logo.png" }));
+      vi.mocked(uploadLogo).mockResolvedValue("/api/avatar/logo.png");
+
+      const team = await service.create({
+        name: "Design Team",
+        logo: "data:image/png;base64,abc",
+        ownerUserId: 42,
+      });
+
+      expect(uploadLogo).toHaveBeenCalledWith({ teamId: 1, logo: "data:image/png;base64,abc" });
+      expect(mockTeamRepository.update).toHaveBeenCalledWith({
+        id: 1,
+        data: { logoUrl: "/api/avatar/logo.png" },
+      });
+      expect(team.logoUrl).toBe("/api/avatar/logo.png");
+    });
+
+    it("ignores a logo that is not a base64 data URL", async () => {
+      mockTeamRepository.findBySlug.mockResolvedValue(null);
+      mockTeamRepository.createWithOwner.mockResolvedValue(buildTeam());
+
+      await service.create({ name: "Design Team", logo: "https://evil.example/x.png", ownerUserId: 42 });
+
+      expect(uploadLogo).not.toHaveBeenCalled();
+      expect(mockTeamRepository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("update", () => {
+    it("throws NotFound when the team does not exist", async () => {
+      mockTeamRepository.findById.mockResolvedValue(null);
+
+      await expect(service.update({ teamId: 99, data: { name: "New" } })).rejects.toMatchObject({
+        code: ErrorCode.NotFound,
+      });
+    });
+
+    it("updates without a slug uniqueness check when the slug is unchanged", async () => {
+      mockTeamRepository.findById.mockResolvedValue(buildTeam());
+      mockTeamRepository.update.mockResolvedValue(buildTeam({ name: "Renamed" }));
+
+      await service.update({ teamId: 1, data: { name: "Renamed", slug: "design-team" } });
+
+      expect(mockTeamRepository.findBySlug).not.toHaveBeenCalled();
+      expect(mockTeamRepository.update).toHaveBeenCalledWith({
+        id: 1,
+        data: { name: "Renamed", slug: "design-team" },
+      });
+    });
+
+    it("rejects a slug change that collides with another team", async () => {
+      mockTeamRepository.findById.mockResolvedValue(buildTeam());
+      mockTeamRepository.findBySlug.mockResolvedValue(buildTeam({ id: 2, slug: "taken" }));
+
+      await expect(service.update({ teamId: 1, data: { slug: "taken" } })).rejects.toMatchObject({
+        code: ErrorCode.BadRequest,
+      });
+      expect(mockTeamRepository.update).not.toHaveBeenCalled();
+    });
+
+    it("slugifies the new slug before saving", async () => {
+      mockTeamRepository.findById.mockResolvedValue(buildTeam());
+      mockTeamRepository.findBySlug.mockResolvedValue(null);
+      mockTeamRepository.update.mockResolvedValue(buildTeam({ slug: "new-slug" }));
+
+      await service.update({ teamId: 1, data: { slug: "New Slug" } });
+
+      expect(mockTeamRepository.findBySlug).toHaveBeenCalledWith({ slug: "new-slug", parentId: null });
+      expect(mockTeamRepository.update).toHaveBeenCalledWith({ id: 1, data: { slug: "new-slug" } });
+    });
+
+    it("uploads a new base64 logo on update", async () => {
+      mockTeamRepository.findById.mockResolvedValue(buildTeam());
+      mockTeamRepository.update.mockResolvedValue(buildTeam({ logoUrl: "/api/avatar/new.png" }));
+      vi.mocked(uploadLogo).mockResolvedValue("/api/avatar/new.png");
+
+      await service.update({ teamId: 1, data: { logo: "data:image/png;base64,xyz" } });
+
+      expect(uploadLogo).toHaveBeenCalledWith({ teamId: 1, logo: "data:image/png;base64,xyz" });
+      expect(mockTeamRepository.update).toHaveBeenCalledWith({
+        id: 1,
+        data: { logoUrl: "/api/avatar/new.png" },
+      });
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes an existing team", async () => {
+      mockTeamRepository.findById.mockResolvedValue(buildTeam());
+
+      await service.delete({ teamId: 1 });
+
+      expect(mockTeamRepository.deleteById).toHaveBeenCalledWith({ id: 1 });
+    });
+
+    it("throws NotFound for a missing team", async () => {
+      mockTeamRepository.findById.mockResolvedValue(null);
+
+      await expect(service.delete({ teamId: 99 })).rejects.toMatchObject({
+        code: ErrorCode.NotFound,
+      });
+      expect(mockTeamRepository.deleteById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getById", () => {
+    it("returns the team when it exists", async () => {
+      mockTeamRepository.findById.mockResolvedValue(buildTeam());
+
+      await expect(service.getById({ teamId: 1 })).resolves.toMatchObject({ id: 1 });
+    });
+
+    it("throws NotFound when it does not", async () => {
+      mockTeamRepository.findById.mockResolvedValue(null);
+
+      await expect(service.getById({ teamId: 99 })).rejects.toMatchObject({
+        code: ErrorCode.NotFound,
+      });
+    });
+  });
+
+  describe("listUserTeams", () => {
+    it("returns the teams of the user including membership state", async () => {
+      const teams = [{ ...buildTeam(), membership: { role: "OWNER", accepted: true } }];
+      mockTeamRepository.findManyByUserIdIncludeMembership.mockResolvedValue(teams);
+
+      await expect(service.listUserTeams({ userId: 42 })).resolves.toEqual(teams);
+      expect(mockTeamRepository.findManyByUserIdIncludeMembership).toHaveBeenCalledWith({ userId: 42 });
+    });
+  });
+});

--- a/packages/features/teams/services/TeamService.ts
+++ b/packages/features/teams/services/TeamService.ts
@@ -1,0 +1,108 @@
+import { ErrorWithCode } from "@calcom/lib/errors";
+import { uploadLogo } from "@calcom/lib/server/avatar";
+import slugify from "@calcom/lib/slugify";
+import type {
+  PrismaTeamRepository,
+  TeamDTO,
+  TeamUpdateInput,
+  TeamWithMembershipDTO,
+} from "../repositories/PrismaTeamRepository";
+
+export interface ITeamServiceDeps {
+  teamRepository: PrismaTeamRepository;
+}
+
+export type TeamCreateData = {
+  name: string;
+  slug?: string;
+  bio?: string;
+  logo?: string;
+  ownerUserId: number;
+};
+
+export type TeamUpdateData = TeamUpdateInput & {
+  logo?: string;
+};
+
+const isBase64Image = (value: string) => value.startsWith("data:image/");
+
+export class TeamService {
+  constructor(private deps: ITeamServiceDeps) {}
+
+  async create({ name, slug, bio, logo, ownerUserId }: TeamCreateData): Promise<TeamDTO> {
+    const teamSlug = slugify(slug || name);
+    if (!teamSlug) {
+      throw ErrorWithCode.Factory.BadRequest(
+        `Unable to create team: name "${name}" does not produce a valid slug`
+      );
+    }
+    await this.ensureSlugIsAvailable(teamSlug);
+
+    let team = await this.deps.teamRepository.createWithOwner({
+      data: { name, slug: teamSlug, bio },
+      ownerUserId,
+    });
+
+    if (logo && isBase64Image(logo)) {
+      const logoUrl = await uploadLogo({ teamId: team.id, logo });
+      team = await this.deps.teamRepository.update({ id: team.id, data: { logoUrl } });
+    }
+
+    return team;
+  }
+
+  async update({ teamId, data }: { teamId: number; data: TeamUpdateData }): Promise<TeamDTO> {
+    const team = await this.deps.teamRepository.findById({ id: teamId });
+    if (!team) {
+      throw ErrorWithCode.Factory.NotFound(`Team ${teamId} not found`);
+    }
+
+    const { logo, ...updateData } = data;
+
+    if (updateData.slug) {
+      const newSlug = slugify(updateData.slug);
+      if (!newSlug) {
+        throw ErrorWithCode.Factory.BadRequest(
+          `Unable to update team ${teamId}: slug "${updateData.slug}" is not valid`
+        );
+      }
+      if (newSlug !== team.slug) {
+        await this.ensureSlugIsAvailable(newSlug, team.parentId);
+      }
+      updateData.slug = newSlug;
+    }
+
+    if (logo && isBase64Image(logo)) {
+      updateData.logoUrl = await uploadLogo({ teamId, logo });
+    }
+
+    return this.deps.teamRepository.update({ id: teamId, data: updateData });
+  }
+
+  async delete({ teamId }: { teamId: number }): Promise<void> {
+    const team = await this.deps.teamRepository.findById({ id: teamId });
+    if (!team) {
+      throw ErrorWithCode.Factory.NotFound(`Team ${teamId} not found`);
+    }
+    await this.deps.teamRepository.deleteById({ id: teamId });
+  }
+
+  async getById({ teamId }: { teamId: number }): Promise<TeamDTO> {
+    const team = await this.deps.teamRepository.findById({ id: teamId });
+    if (!team) {
+      throw ErrorWithCode.Factory.NotFound(`Team ${teamId} not found`);
+    }
+    return team;
+  }
+
+  async listUserTeams({ userId }: { userId: number }): Promise<TeamWithMembershipDTO[]> {
+    return this.deps.teamRepository.findManyByUserIdIncludeMembership({ userId });
+  }
+
+  private async ensureSlugIsAvailable(slug: string, parentId: number | null = null): Promise<void> {
+    const existing = await this.deps.teamRepository.findBySlug({ slug, parentId });
+    if (existing) {
+      throw ErrorWithCode.Factory.BadRequest(`Team slug "${slug}" is already taken`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

First PR of the MIT-native Teams re-implementation for Cal.diy (plan: Teams core + centralized team availability).

- Adds `packages/features/teams/` with `PrismaTeamRepository` (data access only, explicit `select`s) and `TeamService` (create/update/delete, slug uniqueness among top-level teams, base64 logo upload via existing `uploadLogo`).
- Wires both into the DI system (feature-local tokens + `di/modules/Team.ts` + `di/containers/Team.ts`, following the Holiday/BookingAccessService patterns).
- 16 unit tests for `TeamService`.

The Prisma `Team`/`Membership` models already exist in the schema — no migration needed. Team creation nests the OWNER membership in a single atomic create.

## Next PRs
1. Real role checks in `pbacProcedures.ts` (currently a permissive stub)
2. `viewer.teams` tRPC router (CRUD)
3. Membership management + invitations
4. `/teams` + settings pages

## Test plan
- `TZ=UTC yarn vitest run packages/features/teams/services/TeamService.test.ts` → 16/16 ✅
- `yarn type-check:ci --force --filter=@calcom/features` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)