### PR TITLE
fix: prevent race condition allowing multiple admins in /api/auth/setup

### DIFF
--- a/apps/web/app/api/auth/setup/route.ts
+++ b/apps/web/app/api/auth/setup/route.ts
@@ -10,6 +10,7 @@ import { emailRegex } from "@calcom/lib/emailSchema";
 import { HttpError } from "@calcom/lib/http-error";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
+import { Prisma } from "@calcom/prisma/client";
 import { IdentityProvider } from "@calcom/prisma/enums";
 import { CreationSource } from "@calcom/prisma/enums";
 
@@ -30,8 +31,8 @@ async function handler(req: NextRequest) {
   if (userCount !== 0) {
     throw new HttpError({ statusCode: 400, message: "No setup needed." });
   }
-  const body = await parseRequestData(req);
 
+  const body = await parseRequestData(req);
   const parsedQuery = querySchema.safeParse(body);
   if (!parsedQuery.success) {
     throw new HttpError({ statusCode: 422, message: parsedQuery.error.message });
@@ -39,22 +40,33 @@ async function handler(req: NextRequest) {
 
   const username = slugify(parsedQuery.data.username.trim());
   const userEmail = parsedQuery.data.email_address.toLowerCase();
-
   const hashedPassword = await hashPassword(parsedQuery.data.password);
 
-  await prisma.user.create({
-    data: {
-      username,
-      email: userEmail,
-      password: { create: { hash: hashedPassword } },
-      role: "ADMIN",
-      name: parsedQuery.data.full_name,
-      emailVerified: new Date(),
-      locale: "en", // TODO: We should revisit this
-      identityProvider: IdentityProvider.CAL,
-      creationSource: CreationSource.WEBAPP,
-    },
-  });
+  try {
+    await prisma.user.create({
+      data: {
+        username,
+        email: userEmail,
+        password: { create: { hash: hashedPassword } },
+        role: "ADMIN",
+        name: parsedQuery.data.full_name,
+        emailVerified: new Date(),
+        locale: "en", // TODO: We should revisit this
+        identityProvider: IdentityProvider.CAL,
+        creationSource: CreationSource.WEBAPP,
+      },
+    });
+  } catch (err) {
+    // A concurrent request already created the first admin between our
+    // userCount check above and this insert. The partial unique index on
+    // role = 'ADMIN' (see migration only_one_admin_unique_index) is what
+    // actually closes the race; this just returns the same 400 a normal
+    // sequential second request would get, instead of leaking a 500.
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      throw new HttpError({ statusCode: 400, message: "No setup needed." });
+    }
+    throw err;
+  }
 
   return NextResponse.json({ message: "First admin user created successfully." });
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     container_name: database
     image: postgres
     restart: always
+    ports:
+      - "5450:5432"
     volumes:
       - database-data:/var/lib/postgresql
     environment:

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "schema": "packages/prisma/schema.prisma",
     "seed": "ts-node --transpile-only ./packages/prisma/seed.ts"
   },
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.17.0+sha512.c2957de2f9025ab14d63b24d0d8be1f1655810e22c341042c27f7ecd017b180ec12db73d69ac366d71b304ef9f069349ce462de96f04f8f1da317f4f762c95ae",
   "syncpack": {
     "filter": "^(?!@calcom).*",
     "semverRange": ""

--- a/packages/prisma/.env
+++ b/packages/prisma/.env
@@ -1,1 +1,481 @@
-../../.env
+# ********** INDEX **********
+#
+# - LICENSE
+# - DATABASE
+# - SHARED
+#   - NEXTAUTH
+# - E-MAIL SETTINGS
+# - ORGANIZATIONS
+
+# - LICENSE ************************************************************************************
+# This project is licensed under the MIT License.
+# @see https://github.com/calcom/cal.diy/blob/main/LICENSE
+# Cal.diy is fully open source — no license key is required.
+# ***********************************************************************************************************
+
+# - DATABASE ************************************************************************************************
+DATABASE_URL="postgresql://unicorn_user:magical_password@localhost:5450/calendso"
+DATABASE_DIRECT_URL="postgresql://unicorn_user:magical_password@localhost:5450/calendso"
+INSIGHTS_DATABASE_URL=
+
+# ***********************************************************************************************************
+
+# - SHARED **************************************************************************************************
+# Set this to http://app.cal.local:3000 if you want to enable organizations, and
+# check variable ORGANIZATIONS_ENABLED at the bottom of this file
+NEXT_PUBLIC_WEBAPP_URL='http://localhost:3000'
+# Change to 'http://localhost:3001' if running the website simultaneously
+NEXT_PUBLIC_WEBSITE_URL='http://localhost:3000'
+NEXT_PUBLIC_EMBED_LIB_URL='http://localhost:3000/embed/embed.js'
+
+# To enable SAML login, set both these variables
+# @see https://github.com/calcom/cal.diy/tree/main/packages/features/ee#setting-up-saml-login
+# SAML_DATABASE_URL="postgresql://postgres:@localhost:5450/cal-saml"
+SAML_DATABASE_URL=
+# SAML_ADMINS='pro@example.com'
+SAML_ADMINS=
+# NEXT_PUBLIC_HOSTED_CAL_FEATURES=1
+NEXT_PUBLIC_HOSTED_CAL_FEATURES=
+
+# If you use Heroku to deploy Postgres (or use self-signed certs for Postgres) then uncomment the follow line.
+# @see https://devcenter.heroku.com/articles/connecting-heroku-postgres#connecting-in-node-js
+# PGSSLMODE='no-verify'
+PGSSLMODE=
+
+# Define which hostnames are expected for the app to work on
+ALLOWED_HOSTNAMES='"cal.local:3000","localhost:3000"'
+#  Reserved orgs subdomains for our own usage
+RESERVED_SUBDOMAINS='"app","auth","docs","design","console","go","status","api","saml","www","matrix","developer","cal","my","team","support","security","blog","learn","admin"'
+
+#   - NEXTAUTH
+# @see: https://github.com/calendso/calendso/issues/263
+# @see: https://next-auth.js.org/configuration/options#nextauth_url
+# Required for Vercel hosting - set NEXTAUTH_URL to equal your NEXT_PUBLIC_WEBAPP_URL
+NEXTAUTH_URL='http://localhost:3000'
+# @see: https://next-auth.js.org/configuration/options#nextauth_secret
+# You can use: `openssl rand -base64 32` to generate one
+NEXTAUTH_SECRET="q4gFts1HhtiOMfulUybSpPW6dv9byxRJ46go+c/H0RQ="
+# Used for cross-domain cookie authentication
+NEXTAUTH_COOKIE_DOMAIN=
+
+# Set this to '1' if you don't want Cal to collect anonymous usage
+CALCOM_TELEMETRY_DISABLED=
+
+# ApiKey for cronjobs
+CRON_API_KEY='0cc0e6c35519bba620c9360cfe3e68d0'
+
+# Whether to automatically keep app metadata in the database in sync with the metadata/config files. When disabled, the
+# sync runs in a reporting-only dry-run mode.
+CRON_ENABLE_APP_SYNC=false
+
+# Application Key for symmetric encryption and decryption
+# must be 32 bytes for AES256 encryption algorithm
+# You can use: `openssl rand -base64 24` to generate a 32-character key
+CALENDSO_ENCRYPTION_KEY="k0MX1KrQjuRVSNTTjxx529ZN9f4WHmJyCiEY1jZd3Y8="
+
+# Intercom Config
+NEXT_PUBLIC_INTERCOM_APP_ID=
+
+# Secret to enable Intercom Identity Verification
+INTERCOM_SECRET=
+
+# Intercom api token for free users
+INTERCOM_API_TOKEN=
+
+# Posthog Config
+NEXT_PUBLIC_POSTHOG_KEY=
+
+NEXT_PUBLIC_POSTHOG_HOST=
+
+
+
+# Dub Config
+DUB_API_KEY=
+NEXT_PUBLIC_DUB_PROGRAM_ID=
+# Optional: Domain for SMS workflow shortened links
+DUB_SMS_DOMAIN=
+# Optional: Folder ID to organize SMS workflow shortened links in Dub
+DUB_SMS_FOLDER_ID=
+
+# Sink URL Shortener Config
+SINK_API_URL=
+# API key for Sink authentication
+SINK_API_KEY=
+
+# Zendesk Config
+NEXT_PUBLIC_ZENDESK_KEY=
+
+# Help Scout Config
+NEXT_PUBLIC_HELPSCOUT_KEY=
+
+# Fresh Chat Config
+NEXT_PUBLIC_FRESHCHAT_TOKEN=
+NEXT_PUBLIC_FRESHCHAT_HOST=
+
+# Microsoft OAuth credentials
+OUTLOOK_LOGIN_ENABLED=false
+
+
+# For holiday feature:
+# Step-by-step: Get a Google Calendar API Key
+# 1. Go to Google Cloud Console: https://console.cloud.google.com/
+# 2. Select or Create a Project
+# 3. Enable Google Calendar API (APIs & Services → Library , Search for Google Calendar API)
+# 4. Create the API Key (APIs & Services → Credentials)
+GOOGLE_CALENDAR_API_KEY=
+# Google OAuth credentials
+# To enable Login with Google you need to:
+# 1. Set `GOOGLE_API_CREDENTIALS` below
+# 2. Set `GOOGLE_LOGIN_ENABLED` to `true`
+# When self-hosting please ensure you configure the Google integration as an Internal app so no one else can login to your instance
+# @see https://support.google.com/cloud/answer/6158849#public-and-internal&zippy=%2Cpublic-and-internal-applications
+GOOGLE_LOGIN_ENABLED=false
+
+#   - GOOGLE CALENDAR/MEET/LOGIN
+# Needed to enable Google Calendar integration and Login with Google
+# @see https://github.com/calcom/cal.diy#obtaining-the-google-api-credentials
+GOOGLE_API_CREDENTIALS=
+# Token to verify incoming webhooks from Google Calendar
+GOOGLE_WEBHOOK_TOKEN=
+# Optional URL to override for tunelling webhooks. Defaults to NEXT_PUBLIC_WEBAPP_URL.
+GOOGLE_WEBHOOK_URL=
+
+# Token to verify incoming webhooks from Microsoft Calendar
+MICROSOFT_WEBHOOK_TOKEN=
+
+# Optional URL to override for tunelling webhooks. Defaults to NEXT_PUBLIC_WEBAPP_URL.
+MICROSOFT_WEBHOOK_URL=
+
+# Inbox to send user feedback
+SEND_FEEDBACK_EMAIL=
+
+# Sendgrid
+# Used for email reminders in workflows and internal sync services
+SENDGRID_API_KEY=
+SENDGRID_EMAIL=
+NEXT_PUBLIC_SENDGRID_SENDER_NAME=
+
+# Sentry
+SENTRY_ORG=
+SENTRY_PROJECT=
+SENTRY_AUTH_TOKEN=
+# Used for capturing exceptions and logging messages
+NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_DSN_CLIENT=
+SENTRY_DEBUG=
+SENTRY_MAX_SPANS=
+SENTRY_SAMPLE_RATE=
+SENTRY_TRACES_SAMPLE_RATE=
+SENTRY_REPLAYS_SESSION_SAMPLE_RATE=
+SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=
+
+# Formbricks Experience Management Integration
+NEXT_PUBLIC_FORMBRICKS_HOST_URL=https://app.formbricks.com
+NEXT_PUBLIC_FORMBRICKS_ENVIRONMENT_ID=
+FORMBRICKS_FEEDBACK_SURVEY_ID=
+
+# AvatarAPI
+# Used to pre-fill avatar during signup
+AVATARAPI_USERNAME=
+AVATARAPI_PASSWORD=
+
+# For NEXT_PUBLIC_SENDER_ID only letters, numbers and spaces are allowed (max. 11 characters)
+NEXT_PUBLIC_SENDER_ID=
+TWILIO_VERIFY_SID=
+TWILIO_OPT_OUT_ENABLED=
+
+# Set it to "1" if you need to run E2E tests locally.
+NEXT_PUBLIC_IS_E2E=
+
+# Used for internal billing system
+NEXT_PUBLIC_STRIPE_PRO_PLAN_PRICE=
+NEXT_PUBLIC_STRIPE_PREMIUM_PLAN_PRICE=
+NEXT_PUBLIC_IS_PREMIUM_NEW_PLAN=0
+NEXT_PUBLIC_STRIPE_PREMIUM_NEW_PLAN_PRICE=
+STRIPE_TEAM_MONTHLY_PRICE_ID=
+STRIPE_TEAM_ANNUAL_PRICE_ID=
+NEXT_PUBLIC_STRIPE_CREDITS_PRICE_ID=
+ORG_MONTHLY_CREDITS=
+STRIPE_TEAM_PRODUCT_ID=
+# It is a price ID in the product with id STRIPE_ORG_PRODUCT_ID
+STRIPE_ORG_MONTHLY_PRICE_ID=
+STRIPE_ORG_ANNUAL_PRICE_ID=
+STRIPE_ORG_PRODUCT_ID=
+# Used to pass trial days for orgs during the Stripe checkout session
+STRIPE_ORG_TRIAL_DAYS=
+
+STRIPE_WEBHOOK_SECRET=
+STRIPE_WEBHOOK_SECRET_APPS=
+STRIPE_PRIVATE_KEY=
+STRIPE_CLIENT_ID=
+
+# Use for internal Public API Keys and optional
+API_KEY_PREFIX=cal_
+# ***********************************************************************************************************
+
+# - E-MAIL SETTINGS *****************************************************************************************
+# Cal uses nodemailer (@see https://nodemailer.com/about/) to provide email sending. As such we are trying to
+# allow access to the nodemailer transports from the .env file. E-mail templates are accessible within lib/emails/
+# Configures the global From: header whilst sending emails.
+EMAIL_FROM='notifications@yourselfhostedcal.com'
+EMAIL_FROM_NAME='Cal.diy'
+
+# Configure SMTP settings (@see https://nodemailer.com/smtp/).
+# Configuration to receive emails locally (mailhog)
+EMAIL_SERVER_HOST='localhost'
+EMAIL_SERVER_PORT=1025
+
+# Note: The below configuration for Office 365 has been verified to work.
+# EMAIL_SERVER_HOST='smtp.office365.com'
+# EMAIL_SERVER_PORT=587
+# EMAIL_SERVER_USER='<office365_emailAddress>'
+# Keep in mind that if you have 2FA enabled, you will need to provision an App Password.
+# EMAIL_SERVER_PASSWORD='<office365_password>'
+
+# The following configuration for Gmail has been verified to work.
+# EMAIL_SERVER_HOST='smtp.gmail.com'
+# EMAIL_SERVER_PORT=465
+# EMAIL_SERVER_USER='<gmail_emailAddress>'
+## You will need to provision an App Password.
+## @see https://support.google.com/accounts/answer/185833
+# EMAIL_SERVER_PASSWORD='<gmail_app_password>'
+
+# queue or cancel payment reminder email/flow
+AWAITING_PAYMENT_EMAIL_DELAY_MINUTES=
+
+# Used for E2E for email testing
+# Set it to "1" if you need to email checks in E2E tests locally
+# Make sure to run mailhog container manually or with `yarn dx`
+E2E_TEST_MAILHOG_ENABLED=
+
+# Resend
+# Send transactional email using resend
+# RESEND_API_KEY=
+
+# **********************************************************************************************************
+
+# Cloudflare Turnstile
+NEXT_PUBLIC_CLOUDFLARE_SITEKEY=
+NEXT_PUBLIC_CLOUDFLARE_USE_TURNSTILE_IN_BOOKER=
+CLOUDFLARE_TURNSTILE_SECRET=
+
+# 0 = false, 1=true
+NEXT_PUBLIC_VERCEL_USE_BOTID_IN_BOOKER=
+
+# Close.com internal CRM
+CLOSECOM_CLIENT_ID=
+CLOSECOM_CLIENT_SECRET=
+
+# Sendgrid internal sync service
+SENDGRID_SYNC_API_KEY=
+
+# Change your Brand
+NEXT_PUBLIC_APP_NAME="Cal.diy"
+NEXT_PUBLIC_SUPPORT_MAIL_ADDRESS="help@cal.diy"
+NEXT_PUBLIC_COMPANY_NAME="Cal.com, Inc."
+# Set this to true in to disable new signups
+# NEXT_PUBLIC_DISABLE_SIGNUP=true
+NEXT_PUBLIC_DISABLE_SIGNUP=
+
+# Set this to 'non-strict' to enable CSP for support pages. 'strict' isn't supported yet. Also, check the README for details.
+# Content Security Policy
+CSP_POLICY=
+
+# Vercel Edge Config
+EDGE_CONFIG=
+
+NEXT_PUBLIC_MINUTES_TO_BOOK=5               # Minutes
+NEXT_PUBLIC_BOOKER_NUMBER_OF_DAYS_TO_LOAD=0 # Override the booker to only load X number of days worth of data
+
+# Control time intervals on a user's Schedule availability
+NEXT_PUBLIC_AVAILABILITY_SCHEDULE_INTERVAL=
+
+# - ORGANIZATIONS *******************************************************************************************
+# Enable Organizations non-prod domain setup, works in combination with organizations feature flag
+# This is mainly needed locally, because for orgs to work a full domain name needs to point
+# to the app, i.e. app.cal.local instead of using localhost, which is very disruptive
+#
+# This variable should only be set to 1 or true if you are in a non-prod environment and you want to
+# use organizations
+ORGANIZATIONS_ENABLED=
+NEXT_PUBLIC_ORGANIZATIONS_MIN_SELF_SERVE_SEATS=30
+NEXT_PUBLIC_ORGANIZATIONS_SELF_SERVE_PRICE_NEW=37 # $37.00 per seat
+
+# This variable should only be set to 1 or true if you want to autolink external provider sign-ups with
+# existing organizations based on email domain address
+ORGANIZATIONS_AUTOLINK=
+
+# Vercel Config to create subdomains for organizations
+# Get it from https://vercel.com/<TEAM_OR_USER_NAME>/<PROJECT_SLUG>/settings
+PROJECT_ID_VERCEL=
+# Get it from: https://vercel.com/teams/<TEAM_SLUG>/settings
+TEAM_ID_VERCEL=
+# Get it from: https://vercel.com/account/tokens
+AUTH_BEARER_TOKEN_VERCEL=
+# Add the main domain that you want to use for testing vercel domain management for organizations. This is necessary because WEBAPP_URL of local isn't a valid public domain
+# Would create org1.example.com for an org with slug org1
+# LOCAL_TESTING_DOMAIN_VERCEL="example.com"
+
+## Set it to 1 if you use cloudflare to manage your DNS and would like us to manage the DNS for you for organizations
+# CLOUDFLARE_DNS=1
+## Get it from: https://dash.cloudflare.com/profile/api-tokens. Select Edit Zone template and choose a zone(your domain)
+# AUTH_BEARER_TOKEN_CLOUDFLARE=
+## Zone ID can be found in the Overview tab of your domain in Cloudflare
+# CLOUDFLARE_ZONE_ID=
+## It should usually work with the default value. This is the DNS CNAME record content to point to Vercel domain
+# CLOUDFLARE_VERCEL_CNAME=cname.vercel-dns.com
+
+#   - APPLE CALENDAR
+# Used for E2E tests on Apple Calendar
+E2E_TEST_APPLE_CALENDAR_EMAIL=""
+E2E_TEST_APPLE_CALENDAR_PASSWORD=""
+
+# - CALCOM QA ACCOUNT
+# Used for E2E tests on Cal.diy that require 3rd party integrations
+E2E_TEST_CALCOM_QA_EMAIL="qa@example.com"
+# Replace with your own password
+E2E_TEST_CALCOM_QA_PASSWORD="password"
+E2E_TEST_CALCOM_QA_GCAL_CREDENTIALS=
+E2E_TEST_CALCOM_GCAL_KEYS=
+
+# - APP CREDENTIAL SYNC ***********************************************************************************
+# Used for self-hosters that are implementing Cal.diy into their applications that already have certain integrations
+# Under settings/admin/apps ensure that all app secrets are set the same as the parent application
+# You can use: `openssl rand -base64 32` to generate one
+CALCOM_CREDENTIAL_SYNC_SECRET=""
+# This is the header name that will be used to verify the webhook secret. Should be in lowercase
+CALCOM_CREDENTIAL_SYNC_HEADER_NAME="calcom-credential-sync-secret"
+# This the endpoint from which the token is fetched
+CALCOM_CREDENTIAL_SYNC_ENDPOINT=""
+# Key should match on Cal.diy and your application
+# must be 24 bytes for AES256 encryption algorithm
+# You can use: `openssl rand -base64 24` to generate one
+CALCOM_APP_CREDENTIAL_ENCRYPTION_KEY=""
+
+# ***********************************************************************************************************
+
+# api v2
+NEXT_PUBLIC_API_V2_URL="http://localhost:5555/api/v2"
+
+# Tasker features
+TASKER_ENABLE_WEBHOOKS=0
+TASKER_ENABLE_EMAILS=0
+
+# Ratelimiting via Unkey (https://unkey.com)
+# Optional: Only required if you want to enable rate limiting
+# Not needed for testing or self-hosting unless you specifically want rate limiting features
+# Sign up at https://unkey.com to get your Root key
+UNKEY_ROOT_KEY=
+
+# Used for Cal.ai Voice AI Agents
+# https://retellai.com
+RETELL_AI_KEY=
+# Local testing overrides for Retell AI
+RETELL_AI_TEST_MODE=false
+# JSON mapping of local to production event type IDs (e.g. {"50": 747280} without any string)
+RETELL_AI_TEST_EVENT_TYPE_MAP=
+RETELL_AI_TEST_CAL_API_KEY=
+
+# Used for buying phone number for cal ai voice agent
+STRIPE_PHONE_NUMBER_MONTHLY_PRICE_ID=
+
+
+CAL_AI_CALL_RATE_PER_MINUTE=0.29
+
+
+STRIPE_WEBHOOK_SECRET_BILLING=
+
+
+# Price for buying a phone number for cal.ai voice agent (Default is 5)
+NEXT_PUBLIC_CAL_AI_PHONE_NUMBER_MONTHLY_PRICE=
+
+# Used for the huddle01 integration
+HUDDLE01_API_TOKEN=
+
+# Used to disallow emails as being added as guests on bookings
+BLACKLISTED_GUEST_EMAILS=
+
+# Used to allow browser push notifications
+# You can use: 'npx web-push generate-vapid-keys' to generate these keys
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+
+# Custom privacy policy/ terms URLs (for self-hosters: change to your privacy policy / terms URLs)
+NEXT_PUBLIC_WEBSITE_PRIVACY_POLICY_URL=
+NEXT_PUBLIC_WEBSITE_TERMS_URL=
+
+# NEXT_PUBLIC_LOGGER_LEVEL=3 sets to log info, warn, error and fatal logs.
+# [0: silly & upwards, 1: trace & upwards, 2: debug & upwards, 3: info & upwards, 4: warn & upwards, 5: error & fatal, 6: fatal]
+NEXT_PUBLIC_LOGGER_LEVEL=
+
+# For storing Daily Video recordings on S3 Bucket
+CAL_VIDEO_BUCKET_NAME=
+CAL_VIDEO_BUCKET_REGION=
+CAL_VIDEO_ASSUME_ROLE_ARN=
+
+# For local testing of Daily Video
+# Set this to the link of a working Daily Video meeting link
+CAL_VIDEO_MEETING_LINK_FOR_TESTING=
+
+# Used to use lingo.dev SDK, a tool for real-time AI-powered localization
+LINGO_DOT_DEV_API_KEY=
+
+# Comma-separated list of DSyncData.directoryId to log SCIM API requests for. It can be enabled temporarily for debugging the requests being sent to SCIM server.
+DIRECTORY_IDS_TO_LOG=
+
+
+# Set this when Cal.diy is used to serve only one organization's booking pages
+# Read more about it in the README.md
+NEXT_PUBLIC_SINGLE_ORG_SLUG=
+
+IFFY_API_KEY=
+
+## Env variables related to avoiding booking failures
+# Request for checking reservation would be attempted to send every these seconds if the request is stale at that time
+NEXT_PUBLIC_QUERY_RESERVATION_INTERVAL_SECONDS=
+# Request for checking reservation of same slot would be sent only after this time has passed. It must be lower than PUBLIC_QUERY_RESERVATION_INTERVAL_SECONDS
+NEXT_PUBLIC_QUERY_RESERVATION_STALE_TIME_SECONDS=
+# Query available slots interval - Should be kept high in minutes as it could cause significant load on the system
+NEXT_PUBLIC_QUERY_AVAILABLE_SLOTS_INTERVAL_SECONDS=
+# Used to invalidate available slots when navigating to booking form
+NEXT_PUBLIC_INVALIDATE_AVAILABLE_SLOTS_ON_BOOKING_FORM=0
+# Used to enable quick availability checks for x% of all visitors
+NEXT_PUBLIC_QUICK_AVAILABILITY_ROLLOUT=10
+
+# Used to generate token for cal video recordings expiry token
+# You can use: `openssl rand -base64 32` to generate one
+CAL_VIDEO_RECORDING_TOKEN_SECRET=
+
+#  Deprecated. Use NEXT_PUBLIC_BODY_SCRIPTS instead. NEXT_PUBLIC_HEAD_SCRIPTS are now injected into the body only.
+NEXT_PUBLIC_HEAD_SCRIPTS=
+NEXT_PUBLIC_BODY_SCRIPTS=
+
+DATABASE_CHUNK_SIZE=
+
+# Service Account Encryption Key for encrypting/decrypting service account keys
+# You can use: `openssl rand -base64 24` to generate one
+CALCOM_SERVICE_ACCOUNT_ENCRYPTION_KEY=
+
+SALESFORCE_GRAPHQL_DELAY_MS=500
+SALESFORCE_GRAPHQL_MAX_DELAY_MS=2000
+SALESFORCE_GRAPHQL_MAX_RETRIES=3
+
+# Force Node.js to use UTC as process timezone
+TZ=UTC
+
+# test oauth client for `packages/platform/examples/base` (optional)
+SEED_PLATFORM_OAUTH_CLIENT_ID=
+SEED_PLATFORM_OAUTH_CLIENT_SECRET=
+
+# test oauth2 client for `packages/platform/examples/base` (optional)
+SEED_OAUTH2_CLIENT_ID=
+SEED_OAUTH2_CLIENT_SECRET_HASHED=
+
+# Trigger.dev
+ENABLE_ASYNC_TASKER="false" # set to "true" to enable
+TRIGGER_SECRET_KEY=
+TRIGGER_API_URL=https://api.trigger.dev
+TRIGGER_DEV_PROJECT_REF=
+
+GOOGLE_ADS_ENABLED=1      # To enable Google Ads tracking (gclid)
+LINKEDIN_ADS_ENABLED=1    # To enable LinkedIn Ads tracking (li_fat_id)

--- a/packages/prisma/migrations/20260707102758_only_one_admin_unique_index/migration.sql
+++ b/packages/prisma/migrations/20260707102758_only_one_admin_unique_index/migration.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX "only_one_admin_idx"
+ON "users" (role)
+WHERE role = 'ADMIN';


### PR DESCRIPTION
Adds a partial unique index enforcing at most one ADMIN user at the database level, and catches the resulting constraint violation to return 400 instead of a 500, closing the TOCTOU gap between the user-count check and insert.

Fixes #29730

## What does this PR do?
Fixes a TOCTOU (time-of-check-to-time-of-use) race condition in the initial setup flow. POST /api/auth/setup is meant to create exactly one admin user on a fresh instance, but concurrent requests before any user exists could each pass the "is this instance already set up?" check and independently create their own admin account — since different emails/usernames meant no existing unique constraint would block the duplicate inserts.
This PR adds a partial unique index at the database level enforcing at most one user with role = 'ADMIN', and catches the resulting constraint violation on insert to return a clean 400 instead of letting it surface as a 500. This closes the race window (previously ~50ms, corresponding to the password-hashing step between the count check and the insert).
Fixes #29730
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Note: Cal.diy is a community-maintained open-source project. Contributions here do NOT flow to Cal.com's production service. -->

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)
 I have self-reviewed the code
 I have updated the developer docs if this PR makes changes that would require a documentation change — N/A (no user-facing or API-contract docs changed; internal migration only)
 I confirm automated tests are in place that prove my fix is effective


## How should this be tested?

Environment variables: none beyond the standard local dev setup (CALCOM_TELEMETRY_DISABLED=1, NODE_ENV=production for a prod-like run; PostgreSQL 15, Redis 7).
Minimal test data: a fresh database with zero users (this is the precondition that makes /api/auth/setup reachable — the endpoint returns 400 "No setup needed" once any user exists).
Steps:

Spin up a fresh instance with an empty users table.
Fire 5 concurrent POST /api/auth/setup requests, each with a distinct username/full_name/email_address but same password shape, e.g.:

json   { "username": "admin1", "full_name": "Admin User One", "email_address": "admin1@test.com", "password": "TestPassword123!!" }

Expected (before fix): 2–4 of the 5 requests return 200, and SELECT count(*) FROM users WHERE role = 'ADMIN' returns > 1.
Expected (after fix): exactly 1 request returns 200; the remaining requests return 400 (not 500); admin_count is exactly 1.
Optionally reproduce end-to-end via the Dokkimi test definition at dokkimi/dokkimi-in-the-wild/.dokkimi/cal-diy with dokkimi run.

Checklist

 I have read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)
 My code follows the style guidelines of this project
 I have commented my code, particularly in hard-to-understand areas
 I have checked that my changes generate no new warnings
 My PR is appropriately scoped (not >500 lines / >10 files)


