### PR TITLE
fix: skip undefined/null custom field responses in calendar event description

### DIFF
--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -117,7 +117,7 @@ export const getUserFieldsResponses = (
   const responsesString = Object.keys(labelValueMap)
     .map((key) => {
       if (!labelValueMap) return "";
-      if (labelValueMap[key] !== "") {
+      if (labelValueMap[key] !== "" && labelValueMap[key] != null) {
         return `
 ${t(key)}:
 ${labelValueMap[key]}


### PR DESCRIPTION
Fix 'undefined' appearing in calendar event description when optional booking questions are left unanswered.

The condition only checked for empty string, but labelValueMap[key] is 'undefined' when a field has no response, causing the literal string 'undefined' to appear in the ICS/calendar invite description.

Added != null check to skip both undefined and null values.

Closes #29688
