### PR TITLE
fix: suppress Zoho Calendar notification emails when creating/updating events

### DIFF
--- a/packages/app-store/zohocalendar/lib/CalendarService.ts
+++ b/packages/app-store/zohocalendar/lib/CalendarService.ts
@@ -126,6 +126,7 @@ class ZohoCalendarService implements Calendar {
     try {
       const query = stringify({
         eventdata: JSON.stringify(this.translateEvent(event)),
+        notify: false,
       });
 
       const eventResponse = await this.fetcher(`/calendars/${calendarId}/events?${query}`, {

--- a/packages/app-store/zohocalendar/lib/CalendarService.ts
+++ b/packages/app-store/zohocalendar/lib/CalendarService.ts
@@ -180,6 +180,7 @@ class ZohoCalendarService implements Calendar {
           ...this.translateEvent(event),
           etag: existingEventData.events[0].etag,
         }),
+        notify: false,
       });
 
       const eventResponse = await this.fetcher(`/calendars/${calendarId}/events/${uid}?${query}`, {


### PR DESCRIPTION
Suppress Zoho Calendar automatic notification emails by passing notify=false in event creation/update API calls.

The Google Calendar integration already suppresses notifications via sendUpdates='none'. Zoho Calendar has a similar parameter (notify=false) to prevent it from sending duplicate event invitation emails when Cal already handles notifications.

Changes:
- Added notify: false to createEvent query params
- Added notify: false to updateEvent query params

Closes #29592
