### PR TITLE
fix: use WEBAPP_URL for test push notification instead of hardcoded app.cal.com

### DIFF
--- a/packages/trpc/server/routers/loggedInViewer/addNotificationsSubscription.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/addNotificationsSubscription.handler.ts
@@ -9,6 +9,7 @@ const subscriptionSchema = z.object({
 });
 import { sendNotification } from "@calcom/features/notifications/sendNotification";
 import logger from "@calcom/lib/logger";
+import { WEBAPP_URL } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
@@ -65,7 +66,7 @@ export const addNotificationsSubscriptionHandler = async ({ ctx, input }: AddSec
     },
     title: "Test Notification",
     body: "Push Notifications activated successfully",
-    url: "https://app.cal.com/",
+    url: WEBAPP_URL,
     requireInteraction: false,
     type: "TEST_NOTIFICATION",
   });


### PR DESCRIPTION
Fix test push notification opening https://app.cal.com even on self-hosted instances.

The url was hardcoded as "https://app.cal.com/". Now uses WEBAPP_URL from constants (which falls back to NEXT_PUBLIC_WEBAPP_URL env).

Closes #29567
