### PR TITLE
fix: use exact timestamp comparison for API key expiry check

### DIFF
--- a/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
+++ b/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
@@ -241,8 +241,7 @@ export class ApiAuthStrategy extends PassportStrategy(BaseStrategy, "api-auth") 
       throw new UnauthorizedException("ApiAuthStrategy - api key - Your api key is not valid");
     }
 
-    const isKeyExpired =
-      keyData.expiresAt && new Date().setHours(0, 0, 0, 0) > keyData.expiresAt.setHours(0, 0, 0, 0);
+    const isKeyExpired = keyData.expiresAt && new Date() > keyData.expiresAt;
     if (isKeyExpired) {
       throw new UnauthorizedException("ApiAuthStrategy - api key - Your api key is expired");
     }


### PR DESCRIPTION
## Problem
API keys with an `expiresAt` timestamp that has already passed are still accepted by the API v2 authentication layer. The expiry comparison uses day-level granularity via `setHours(0, 0, 0, 0)`, causing:
1. Keys expired at any time during the day to be accepted until midnight
2. The `expiresAt` Date object to be mutated (time zeroed to midnight)

Fixes #29728

## Solution
Changed the comparison to use exact timestamps instead of day-level granularity:
```typescript
// Before
const isKeyExpired = keyData.expiresAt && new Date().setHours(0, 0, 0, 0) > keyData.expiresAt.setHours(0, 0, 0, 0);

// After  
const isKeyExpired = keyData.expiresAt && new Date() > keyData.expiresAt;
```

This ensures:
- Expired keys are rejected immediately when their exact `expiresAt` time has passed
- The original `expiresAt` Date object is not mutated