### PR TITLE
docs: add webhook payload and testing documentation

### DIFF
--- a/apps/docs/content/_meta.ts
+++ b/apps/docs/content/_meta.ts
@@ -9,6 +9,7 @@ export default {
   upgrading: "Upgrading",
   docker: "Docker",
   apps: "Apps",
+  webhooks: "Webhooks",
   "-- deployments": {
     type: "separator",
     title: "Deployments",

--- a/apps/docs/content/webhooks.mdx
+++ b/apps/docs/content/webhooks.mdx
@@ -12,9 +12,47 @@ Cal.diy sends webhook payloads when subscribed events occur. Webhook payloads us
 - `organizer`, `attendees`, `responses`, `location`
 - `eventTypeId`, `status`, `metadata`
 
+Example `BOOKING_CREATED` payload:
+
+```json
+{
+  "triggerEvent": "BOOKING_CREATED",
+  "createdAt": "2024-01-15T10:00:00Z",
+  "payload": {
+    "bookingId": 1,
+    "uid": "booking-uid-123",
+    "title": "Test Meeting",
+    "startTime": "2024-01-15T10:00:00Z",
+    "endTime": "2024-01-15T10:30:00Z",
+    "status": "ACCEPTED",
+    "organizer": { "email": "organizer@test.com", "name": "Test Organizer", "utcOffset": 0 },
+    "attendees": [{ "email": "attendee@test.com", "name": "Test Attendee", "utcOffset": 0 }],
+    "location": "https://cal.com/video/123",
+    "eventTitle": "Test Event",
+    "price": 0,
+    "currency": "USD"
+  }
+}
+```
+
 ### Payment events
 
-`BOOKING_PAYMENT_INITIATED` and `BOOKING_PAID` use payment-specific payloads with booking and payment metadata.
+`BOOKING_PAYMENT_INITIATED` and `BOOKING_PAID` use the same booking payload shape with additional `paymentId` and `paymentData` fields.
+
+Example `BOOKING_PAID` payload:
+
+```json
+{
+  "triggerEvent": "BOOKING_PAID",
+  "createdAt": "2024-01-15T10:00:00Z",
+  "payload": {
+    "bookingId": 1,
+    "status": "ACCEPTED",
+    "paymentId": 123,
+    "paymentData": { "stripeId": "stripe_123" }
+  }
+}
+```
 
 ### Meeting events
 
@@ -59,9 +97,40 @@ The `payload` for meeting events contains the full booking object (same fields a
 
 `FORM_SUBMITTED` fires when a routing form is submitted.
 
+Example payload:
+
+```json
+{
+  "triggerEvent": "FORM_SUBMITTED",
+  "createdAt": "2024-01-01T12:00:00.000Z",
+  "payload": {
+    "formId": "form-abc",
+    "formName": "Contact Form",
+    "responses": { "email": "user@example.com" }
+  }
+}
+```
+
 ### Out-of-office events
 
 `OOO_CREATED` fires when an out-of-office entry is created.
+
+Example payload:
+
+```json
+{
+  "triggerEvent": "OOO_CREATED",
+  "createdAt": "2024-01-15T10:00:00Z",
+  "payload": {
+    "oooEntry": {
+      "id": 1,
+      "start": "2024-01-20T00:00:00Z",
+      "end": "2024-01-25T00:00:00Z",
+      "reason": "Vacation"
+    }
+  }
+}
+```
 
 ## Testing webhooks locally
 

--- a/apps/docs/content/webhooks.mdx
+++ b/apps/docs/content/webhooks.mdx
@@ -1,0 +1,92 @@
+# Webhooks
+
+Cal.diy sends webhook payloads when subscribed events occur. Webhook payloads use the `2021-10-20` format unless a subscriber specifies a different version.
+
+## Payload structure by trigger
+
+### Booking events
+
+`BOOKING_CREATED`, `BOOKING_RESCHEDULED`, `BOOKING_CANCELLED`, `BOOKING_REQUESTED`, `BOOKING_REJECTED`, and `BOOKING_NO_SHOW_UPDATED` share the booking payload shape. The `payload` object includes booking details such as:
+
+- `uid`, `title`, `startTime`, `endTime` (ISO 8601 strings)
+- `organizer`, `attendees`, `responses`, `location`
+- `eventTypeId`, `status`, `metadata`
+
+### Payment events
+
+`BOOKING_PAYMENT_INITIATED` and `BOOKING_PAID` use payment-specific payloads with booking and payment metadata.
+
+### Meeting events
+
+`MEETING_STARTED` and `MEETING_ENDED` are **scheduled triggers**, not real-time call events.
+
+| Trigger | When it fires |
+|---------|----------------|
+| `MEETING_STARTED` | At the booking `startTime` |
+| `MEETING_ENDED` | At the booking `endTime` |
+
+These triggers do **not** fire when a host presses an in-call "end meeting" button. They are queued when the webhook is created or updated, based on upcoming bookings.
+
+The `payload` for meeting events contains the full booking object (same fields as stored on the booking record).
+
+### Recording events
+
+`RECORDING_READY` uses a minimal payload:
+
+```json
+{
+  "triggerEvent": "RECORDING_READY",
+  "createdAt": "2024-01-01T12:00:00.000Z",
+  "payload": {
+    "downloadLink": "https://example.com/recording.mp4"
+  }
+}
+```
+
+`RECORDING_TRANSCRIPTION_GENERATED` returns:
+
+```json
+{
+  "payload": {
+    "downloadLinks": {
+      "transcription": "https://example.com/transcript.vtt"
+    }
+  }
+}
+```
+
+### Form events
+
+`FORM_SUBMITTED` fires when a routing form is submitted.
+
+### Out-of-office events
+
+`OOO_CREATED` fires when an out-of-office entry is created.
+
+## Testing webhooks locally
+
+1. Start Cal.diy locally (`yarn dev` or `yarn dx`).
+2. Use a tunneling tool (e.g. [ngrok](https://ngrok.com/)) to expose your machine:
+
+   ```bash
+   ngrok http 3000
+   ```
+
+3. In **Settings → Developer → Webhooks**, create a subscriber URL pointing to your tunnel (e.g. `https://abc123.ngrok.io/api/webhook`).
+4. Subscribe to the events you want to test.
+5. Trigger the event (create a booking, wait for meeting start/end time, etc.).
+6. Inspect the POST body at your endpoint. The top-level shape is:
+
+   ```json
+   {
+     "triggerEvent": "BOOKING_CREATED",
+     "createdAt": "2024-01-01T12:00:00.000Z",
+     "payload": { }
+   }
+   ```
+
+For `MEETING_STARTED` / `MEETING_ENDED`, create a short test booking (1–2 minutes) and wait until the scheduled time, or temporarily adjust the booking times in the database for faster verification.
+
+## Source of truth
+
+Payload builders live in `packages/features/webhooks/lib/factory/`. When in doubt, refer to the versioned builders under `versioned/v2021-10-20/` for the exact fields each trigger returns.


### PR DESCRIPTION
## What does this PR do?

Integrators had no published reference for Cal.diy webhook payload shapes or how to test webhooks locally — they had to read `packages/features/webhooks/lib/factory/` source code.

This PR adds a Webhooks documentation page covering payload structures by trigger, clarifies that `MEETING_STARTED` / `MEETING_ENDED` fire at scheduled booking times (not in-call events), documents local testing with ngrok, and includes JSON examples for all major event types.

- Fixes #15033
- Adds `apps/docs/content/webhooks.mdx` and sidebar nav entry
- Addresses CodeRabbit review: JSON examples for booking, payment, form, and OOO events

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- N/A — documentation-only change.

#### Image Demo (if applicable):

- Screenshot of the docs site showing **Webhooks** in the sidebar and the payload examples rendered on the page.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. (N/A — docs-only change.)

## How should this be tested?

- Are there environment variables that should be set?
  - None required to review docs. For live webhook testing, a tunnel URL (e.g. ngrok) is documented.
- What are the minimal test data to have?
  - Local Cal.diy instance (`yarn dev` or `yarn dx`) to render the docs site.
- What is expected (happy path) to have (input and output)?
  - Input: open the Webhooks page in the docs site.
  - Output: nav entry visible; JSON examples render; payload field descriptions match `packages/features/webhooks/lib/factory/versioned/v2021-10-20/`.
- Any other important info that could help to test that PR
  1. Run the docs site and open the Webhooks page.
  2. Verify nav entry appears under docs sidebar.
  3. Cross-check payload descriptions and JSON examples against payload builders in `packages/features/webhooks/lib/factory/`.


