### PR TITLE
fix(booking-page): hide duplicate phone fields for attendee phone location

### DIFF
--- a/apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx
+++ b/apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx
@@ -9,7 +9,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { FormBuilderField } from "@calcom/web/modules/form-builder/components/FormBuilderField";
-import { useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
 
@@ -54,30 +54,33 @@ export const BookingFields = ({
   // Track last synced value to avoid redundant updates
   const lastSyncedPhoneRef = useRef<string | null>(null);
 
-  // Event-driven sync function
-  const syncPhoneFields = (locationValue: unknown) => {
-    const parsed = PhoneLocationSchema.safeParse(locationValue);
-    if (!parsed.success) return;
-    const { optionValue } = parsed.data;
-    const phone = (optionValue ?? "").trim();
+  const syncPhoneFromLocation = useCallback(
+    (locationValue: unknown) => {
+      const parsed = PhoneLocationSchema.safeParse(locationValue);
+      if (!parsed.success) return;
+      const phone = (parsed.data.optionValue ?? "").trim();
 
-    // Skip if empty or same as last sync (avoid redundant updates during typing)
-    if (!phone || phone === lastSyncedPhoneRef.current) return;
+      if (!phone || phone === lastSyncedPhoneRef.current) return;
 
-    // Copy phone to other phone fields (only if user hasn't manually touched them)
-    otherPhoneFieldNames.forEach((name) => {
-      const targetTouched = !!(formState.touchedFields as TouchedFields)?.responses?.[name];
+      otherPhoneFieldNames.forEach((name) => {
+        const targetTouched = !!(formState.touchedFields as TouchedFields)?.responses?.[name];
 
-      if (!targetTouched) {
-        setValue(`responses.${name}`, phone, {
-          shouldDirty: false,
-          shouldValidate: false,
-        });
-      }
-    });
+        if (!targetTouched) {
+          setValue(`responses.${name}`, phone, {
+            shouldDirty: false,
+            shouldValidate: false,
+          });
+        }
+      });
 
-    lastSyncedPhoneRef.current = phone;
-  };
+      lastSyncedPhoneRef.current = phone;
+    },
+    [otherPhoneFieldNames, formState.touchedFields, setValue]
+  );
+
+  useEffect(() => {
+    syncPhoneFromLocation(locationResponse);
+  }, [locationResponse, syncPhoneFromLocation]);
 
   const getPriceFormattedLabel = (label: string, price: number) =>
     `${label} (${Intl.NumberFormat(i18n.language, {
@@ -154,14 +157,6 @@ export const BookingFields = ({
         }
 
         if (shouldHideDuplicatePhoneField(field, locationResponse?.value)) {
-          // Phone booking questions duplicate the attendee-phone location field — sync from location and hide.
-          const phone = (locationResponse?.optionValue ?? "").trim();
-          if (phone) {
-            setValue(`responses.${field.name}`, phone, {
-              shouldDirty: false,
-              shouldValidate: false,
-            });
-          }
           return null;
         }
 
@@ -251,7 +246,7 @@ export const BookingFields = ({
             key={index}
             {...(field.name === SystemField.Enum.location && {
               onValueChange: ({ value }) => {
-                syncPhoneFields(value);
+                syncPhoneFromLocation(value);
               },
             })}
           />

--- a/apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx
+++ b/apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx
@@ -13,6 +13,8 @@ import { useMemo, useRef } from "react";
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
 
+import { shouldHideDuplicatePhoneField } from "./phoneFieldUtils";
+
 type TouchedFields = {
   responses?: Record<string, boolean>;
 };
@@ -151,11 +153,7 @@ export const BookingFields = ({
           readOnly = false;
         }
 
-        if (
-          field.type === "phone" &&
-          field.name !== SystemField.Enum.location &&
-          locationResponse?.value === "phone"
-        ) {
+        if (shouldHideDuplicatePhoneField(field, locationResponse?.value)) {
           // Phone booking questions duplicate the attendee-phone location field — sync from location and hide.
           const phone = (locationResponse?.optionValue ?? "").trim();
           if (phone) {

--- a/apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx
+++ b/apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx
@@ -151,14 +151,23 @@ export const BookingFields = ({
           readOnly = false;
         }
 
-        if (field.name === SystemField.Enum.smsReminderNumber) {
-          // `smsReminderNumber` and location.optionValue when location.value===phone are the same data point. We should solve it in a better way in the Form Builder itself.
-          // I think we should have a way to connect 2 fields together and have them share the same value in Form Builder
-          if (locationResponse?.value === "phone") {
-            setValue(`responses.${SystemField.Enum.smsReminderNumber}`, locationResponse?.optionValue);
-            // Just don't render the field now, as the value is already connected to attendee phone location
-            return null;
+        if (
+          field.type === "phone" &&
+          field.name !== SystemField.Enum.location &&
+          locationResponse?.value === "phone"
+        ) {
+          // Phone booking questions duplicate the attendee-phone location field — sync from location and hide.
+          const phone = (locationResponse?.optionValue ?? "").trim();
+          if (phone) {
+            setValue(`responses.${field.name}`, phone, {
+              shouldDirty: false,
+              shouldValidate: false,
+            });
           }
+          return null;
+        }
+
+        if (field.name === SystemField.Enum.smsReminderNumber) {
           // `smsReminderNumber` can be edited during reschedule even though it's a system field
           readOnly = false;
         }

--- a/apps/web/modules/bookings/components/BookEventForm/phoneFieldUtils.test.ts
+++ b/apps/web/modules/bookings/components/BookEventForm/phoneFieldUtils.test.ts
@@ -1,0 +1,42 @@
+import { SystemField } from "@calcom/lib/bookings/SystemField";
+import { describe, expect, it } from "vitest";
+
+import { ATTENDEE_PHONE_LOCATION_VALUE, shouldHideDuplicatePhoneField } from "./phoneFieldUtils";
+
+describe("shouldHideDuplicatePhoneField", () => {
+  it("hides phone fields when location is attendee phone", () => {
+    expect(
+      shouldHideDuplicatePhoneField({ type: "phone", name: "custom-phone" }, ATTENDEE_PHONE_LOCATION_VALUE)
+    ).toBe(true);
+  });
+
+  it("hides smsReminderNumber when location is attendee phone", () => {
+    expect(
+      shouldHideDuplicatePhoneField(
+        { type: "phone", name: SystemField.Enum.smsReminderNumber },
+        ATTENDEE_PHONE_LOCATION_VALUE
+      )
+    ).toBe(true);
+  });
+
+  it("does not hide the location field itself", () => {
+    expect(
+      shouldHideDuplicatePhoneField(
+        { type: "phone", name: SystemField.Enum.location },
+        ATTENDEE_PHONE_LOCATION_VALUE
+      )
+    ).toBe(false);
+  });
+
+  it("shows phone fields when location is not attendee phone", () => {
+    expect(
+      shouldHideDuplicatePhoneField({ type: "phone", name: "custom-phone" }, "zoom")
+    ).toBe(false);
+  });
+
+  it("shows non-phone fields regardless of location", () => {
+    expect(
+      shouldHideDuplicatePhoneField({ type: "text", name: "company" }, ATTENDEE_PHONE_LOCATION_VALUE)
+    ).toBe(false);
+  });
+});

--- a/apps/web/modules/bookings/components/BookEventForm/phoneFieldUtils.ts
+++ b/apps/web/modules/bookings/components/BookEventForm/phoneFieldUtils.ts
@@ -1,0 +1,15 @@
+import { SystemField } from "@calcom/lib/bookings/SystemField";
+
+/** Location option value when the booker provides their phone number. */
+export const ATTENDEE_PHONE_LOCATION_VALUE = "phone";
+
+export function shouldHideDuplicatePhoneField(
+  field: { type: string; name: string },
+  locationValue: string | undefined
+): boolean {
+  return (
+    field.type === "phone" &&
+    field.name !== SystemField.Enum.location &&
+    locationValue === ATTENDEE_PHONE_LOCATION_VALUE
+  );
+}


### PR DESCRIPTION
## What does this PR do?

When an event type uses **Attendee phone** as the location and also has additional phone booking questions, the booking page showed duplicate phone inputs — the same data point collected twice.

This PR hides duplicate phone fields when location is set to attendee phone and syncs the phone value from the location field into other phone responses before submit. Logic is extracted to `shouldHideDuplicatePhoneField` with unit tests.

- Fixes #23117
- Updates `apps/web/modules/bookings/components/BookEventForm/BookingFields.tsx`
- Adds `phoneFieldUtils.ts` and `phoneFieldUtils.test.ts`

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Record the booking form: select **Attendee phone** as location with an extra phone question configured. Before: two phone inputs. After: one phone input; submitted booking contains the correct phone value.

#### Image Demo (if applicable):

- Side-by-side screenshot: **before** (duplicate phone fields) vs **after** (single phone input when location is attendee phone).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Are there environment variables that should be set?
  - None.
- What are the minimal test data to have?
  - Event type with location = **Attendee phone** and an additional phone booking question.
- What is expected (happy path) to have (input and output)?
  - Input: open booking page, select Attendee phone, enter a number in the location phone field, submit.
  - Output: only one phone input visible; booking stores the phone value correctly.
- Any other important info that could help to test that PR
  - Run: `yarn vitest run apps/web/modules/bookings/components/BookEventForm/phoneFieldUtils.test.ts` (5 tests pass).

