### PR TITLE
fix: add aria-label to duration abbreviations for screen reader accessibility

### DIFF
--- a/apps/web/modules/bookings/components/BookEventForm/BookFormAsModal.tsx
+++ b/apps/web/modules/bookings/components/BookEventForm/BookFormAsModal.tsx
@@ -9,7 +9,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Badge } from "@calcom/ui/components/badge";
 import { DialogContent } from "@calcom/ui/components/dialog";
 
-import { getDurationFormatted } from "../event-meta/Duration";
+import { getDurationFormatted, getDurationAccessibilityLabel } from "../event-meta/Duration";
 import { FromTime } from "@calcom/features/bookings/Booker/utils/dates";
 import { useEvent } from "@calcom/web/modules/schedules/hooks/useEvent";
 import { useBookerTime } from "@calcom/features/bookings/Booker/hooks/useBookerTime";
@@ -65,7 +65,7 @@ export const BookEventFormWrapperComponent = ({
         </Badge>
         {(selectedDuration || eventLength) && (
           <Badge variant="grayWithoutHover" startIcon="clock" size="lg">
-            <span>{getDurationFormatted(selectedDuration || eventLength, t)}</span>
+            <span aria-label={getDurationAccessibilityLabel(selectedDuration || eventLength, t)}>{getDurationFormatted(selectedDuration || eventLength, t)}</span>
           </Badge>
         )}
 

--- a/apps/web/modules/bookings/components/event-meta/Duration.tsx
+++ b/apps/web/modules/bookings/components/event-meta/Duration.tsx
@@ -37,6 +37,27 @@ export const getDurationFormatted = (mins: number | undefined, t: TFunction) => 
   return hourStr || minStr;
 };
 
+/** Returns the full expanded duration text for screen readers (e.g. "30 minutes", "1 hour 30 minutes") */
+export const getDurationAccessibilityLabel = (mins: number | undefined, t: TFunction) => {
+  if (!mins) return null;
+
+  const hours = Math.floor(mins / 60);
+  mins %= 60;
+
+  let minStr = "";
+  if (mins > 0) {
+    minStr = mins === 1 ? t("minute_one", { count: 1 }) : t("minute_other", { count: mins });
+  }
+
+  let hourStr = "";
+  if (hours > 0) {
+    hourStr = hours === 1 ? t("hour_one", { count: 1 }) : t("hour_other", { count: hours });
+  }
+
+  if (hourStr && minStr) return `${hourStr} ${minStr}`;
+  return hourStr || minStr;
+};
+
 export const EventDuration = ({
   event,
 }: {
@@ -90,7 +111,7 @@ export const EventDuration = ({
   }, [selectedDuration, isEmbed]);
 
   if (!event?.metadata?.multipleDuration && !isDynamicEvent)
-    return <>{getDurationFormatted(event.length, t)}</>;
+    return <span aria-label={getDurationAccessibilityLabel(event.length, t)}>{getDurationFormatted(event.length, t)}</span>;
 
   const durations = event?.metadata?.multipleDuration || [15, 30, 60, 90];
   const hideDurationSelector = event?.metadata?.hideDurationSelectorInBookingPage;
@@ -98,7 +119,7 @@ export const EventDuration = ({
   // When duration selector is hidden, show only the selected/default duration as text
   // URL params can still set the duration, but the user cannot change it via UI
   if (hideDurationSelector) {
-    return <>{getDurationFormatted(selectedDuration || event.length, t)}</>;
+    return <span aria-label={getDurationAccessibilityLabel(selectedDuration || event.length, t)}>{getDurationFormatted(selectedDuration || event.length, t)}</span>;
   }
 
   return selectedDuration ? (
@@ -124,6 +145,7 @@ export const EventDuration = ({
               key={index}
               onClick={() => setSelectedDuration(duration)}
               ref={(el) => (itemRefs.current[duration] = el)}
+              aria-label={getDurationAccessibilityLabel(duration, t)}
               className={classNames(
                 selectedDuration === duration ? "bg-emphasis" : "hover:text-emphasis",
                 "text-default cursor-pointer rounded-[4px] px-3 py-1.5 text-sm leading-tight transition"


### PR DESCRIPTION
### Overview

Screen readers announce duration abbreviations incorrectly — '30m' is read as '30 metres' and '1h' as 'one age' instead of '30 minutes' and '1 hour'. This PR adds aria-label attributes with the full expanded text to all duration display elements so screen readers announce them correctly.

Fixes #29750

### Changes

- Added `getDurationAccessibilityLabel` function in `Duration.tsx` that returns the full expanded text (e.g. '30 minutes', '1 hour 30 minutes') using the existing i18n translation keys (`minute_one`, `minute_other`, `hour_one`, `hour_other`)
- Applied `aria-label` to:
  - Single duration display (non-multiple-duration events)
  - Hidden duration selector display
  - Multiple duration selector options (`<li>` elements)
  - BookFormAsModal duration badge

### Technical Details

- Uses existing i18n keys (`minute_one`, `minute_other`, `hour_one`, `hour_other`) which already have the full text forms — no new translations needed
- The visible text remains unchanged (short abbreviations like '30m', '1h') — only the accessible name is expanded
- The `getDurationAccessibilityLabel` function is exported so it can be reused in other components if needed

### Test plan

- [x] Verified that `getDurationAccessibilityLabel` returns correct full text for various durations (30m → '30 minutes', 1h → '1 hour', 1h 30m → '1 hour 30 minutes')
- [x] Verified that `aria-label` is applied to all duration display elements
- [ ] Manual testing with VoiceOver on macOS recommended to confirm screen reader announces correctly