### PR TITLE
fix: prevent duplicate Stripe customers from broad catch in createStripeCustomerId

### DIFF
--- a/apps/api/v2/src/modules/stripe/stripe.service.ts
+++ b/apps/api/v2/src/modules/stripe/stripe.service.ts
@@ -236,14 +236,14 @@ export class StripeService {
     let customerId: string;
 
     const stripe = this.getStripe();
-    try {
-      const customersResponse = await stripe.customers.list({
-        email: user.email,
-        limit: 1,
-      });
+    const customersResponse = await stripe.customers.list({
+      email: user.email,
+      limit: 1,
+    });
 
+    if (customersResponse.data.length > 0) {
       customerId = customersResponse.data[0].id;
-    } catch (error) {
+    } else {
       const customer = await stripe.customers.create({ email: user.email });
       customerId = customer.id;
     }


### PR DESCRIPTION
### Overview

The `createStripeCustomerId` function used a broad try/catch that treated all errors the same as 'no customer found'. When Stripe API errors occurred (auth failures, network issues, rate limits), the catch block silently created a new customer instead of propagating the error — resulting in duplicate Stripe customers for the same email.

Fixes #29455

### Changes

- Replaced the broad `try/catch` with an explicit check on `customersResponse.data.length`
- Only creates a new customer when the list is genuinely empty (no existing customer found)
- Real Stripe API errors (auth, network, rate limit) now propagate naturally instead of being swallowed

### Technical Details

**Before:**
```ts
try {
  const customersResponse = await stripe.customers.list({ email, limit: 1 });
  customerId = customersResponse.data[0].id;  // throws if empty list
} catch (error) {
  // catches BOTH 'empty list' AND real Stripe errors
  const customer = await stripe.customers.create({ email });
  customerId = customer.id;
}
```

**After:**
```ts
const customersResponse = await stripe.customers.list({ email, limit: 1 });
if (customersResponse.data.length > 0) {
  customerId = customersResponse.data[0].id;
} else {
  const customer = await stripe.customers.create({ email });
  customerId = customer.id;
}
```

The root cause was that `data[0]` on an empty array returns `undefined`, and accessing `.id` on `undefined` throws a TypeError. The catch block then treated this the same as any real Stripe error and created a new customer — causing duplicates.

### Test plan

- [x] Verified that existing customer is returned when found in Stripe
- [x] Verified that new customer is created only when list is empty
- [x] Verified that Stripe API errors now propagate instead of creating duplicates
- [ ] Recommended: add unit test for `createStripeCustomerId` covering empty list, existing customer, and Stripe error cases