### PR TITLE
fix(bookings): thread recurring series id through round-robin recurri…

### DIFF
--- a/packages/features/bookings/lib/service/RecurringBookingService.test.ts
+++ b/packages/features/bookings/lib/service/RecurringBookingService.test.ts
@@ -19,13 +19,17 @@ import { getMockRequestDataForBooking } from "@calcom/testing/lib/bookingScenari
 import { setupAndTeardown } from "@calcom/testing/lib/bookingScenario/setupAndTeardown";
 
 import { v4 as uuidv4 } from "uuid";
-import { describe, expect } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+import type { CreateRecurringBookingData } from "@calcom/features/bookings/lib/dto/types";
 import { getRecurringBookingService } from "@calcom/features/bookings/di/RecurringBookingService.container";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
-import { BookingStatus } from "@calcom/prisma/enums";
+import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
 import { test } from "@calcom/testing/lib/fixtures/fixtures";
+
+import type { RegularBookingService } from "./RegularBookingService";
+import { RecurringBookingService } from "./RecurringBookingService";
 
 const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
@@ -266,4 +270,45 @@ describe("handleNewRecurringBooking", () => {
     const freq = type === "yearly" ? 0 : type === "monthly" ? 1 : 2;
     return { freq, count: numberOfOccurrences, interval: 1 };
   }
+});
+
+describe("RecurringBookingService — round-robin third-party recurring series id", () => {
+  it("threads the third-party recurring event id from the first ROUND_ROBIN slot into later slots", async () => {
+    // The first (round-robin) slot creates the third-party recurring series and returns its id on the
+    // booking's references. Every later slot must receive that id so it joins the same series instead
+    // of creating a separate one.
+    const createBooking = vi
+      .fn()
+      .mockResolvedValueOnce({
+        luckyUsers: [101],
+        references: [{ thirdPartyRecurringEventId: "GCAL_SERIES_1" }],
+      })
+      .mockResolvedValue({
+        references: [{ thirdPartyRecurringEventId: "GCAL_SERIES_1" }],
+      });
+
+    const service = new RecurringBookingService({
+      regularBookingService: { createBooking } as unknown as RegularBookingService,
+    });
+
+    const slot = (start: string) => ({
+      start,
+      end: undefined,
+      eventTypeId: 1,
+      schedulingType: SchedulingType.ROUND_ROBIN,
+    });
+
+    await service.createBooking({
+      bookingData: [
+        slot("2026-01-15T10:00:00.000Z"),
+        slot("2026-01-22T10:00:00.000Z"),
+      ] as unknown as CreateRecurringBookingData,
+      creationSource: "WEBAPP",
+    });
+
+    expect(createBooking).toHaveBeenCalledTimes(2);
+    // The second slot must reuse the first slot's third-party recurring series id, not create a new one.
+    const secondSlotData = createBooking.mock.calls[1][0].bookingData;
+    expect(secondSlotData.thirdPartyRecurringEventId).toBe("GCAL_SERIES_1");
+  });
 });

--- a/packages/features/bookings/lib/service/RecurringBookingService.ts
+++ b/packages/features/bookings/lib/service/RecurringBookingService.ts
@@ -8,6 +8,17 @@ export type BookingHandlerInput = {
   bookingData: CreateRecurringBookingData;
 } & CreateBookingMeta;
 
+function getThirdPartyRecurringEventId(
+  references: { thirdPartyRecurringEventId?: string | null }[] | null | undefined
+): string | null {
+  for (const reference of references ?? []) {
+    if (reference.thirdPartyRecurringEventId) {
+      return reference.thirdPartyRecurringEventId;
+    }
+  }
+  return null;
+}
+
 export const handleNewRecurringBooking = async function (
   this: RecurringBookingService,
   {
@@ -30,7 +41,7 @@ export const handleNewRecurringBooking = async function (
 
   const numSlotsToCheckForAvailability = 1;
 
-  let thirdPartyRecurringEventId = null;
+  let thirdPartyRecurringEventId: string | null = null;
 
   // for round robin, the first slot needs to be handled first to define the lucky user
   const firstBooking = data[0];
@@ -72,13 +83,8 @@ export const handleNewRecurringBooking = async function (
 
     // The first round-robin slot creates the third-party recurring series; carry its id forward so the
     // remaining slots join the same series instead of each creating a new one (mirrors the loop below).
-    if (!thirdPartyRecurringEventId && firstBookingResult.references && firstBookingResult.references.length > 0) {
-      for (const reference of firstBookingResult.references) {
-        if (reference.thirdPartyRecurringEventId) {
-          thirdPartyRecurringEventId = reference.thirdPartyRecurringEventId;
-          break;
-        }
-      }
+    if (!thirdPartyRecurringEventId) {
+      thirdPartyRecurringEventId = getThirdPartyRecurringEventId(firstBookingResult.references);
     }
   }
 
@@ -128,14 +134,7 @@ export const handleNewRecurringBooking = async function (
     createdBookings.push(eachRecurringBooking);
 
     if (!thirdPartyRecurringEventId) {
-      if (eachRecurringBooking.references && eachRecurringBooking.references.length > 0) {
-        for (const reference of eachRecurringBooking.references) {
-          if (reference.thirdPartyRecurringEventId) {
-            thirdPartyRecurringEventId = reference.thirdPartyRecurringEventId;
-            break;
-          }
-        }
-      }
+      thirdPartyRecurringEventId = getThirdPartyRecurringEventId(eachRecurringBooking.references);
     }
   }
 

--- a/packages/features/bookings/lib/service/RecurringBookingService.ts
+++ b/packages/features/bookings/lib/service/RecurringBookingService.ts
@@ -69,6 +69,17 @@ export const handleNewRecurringBooking = async function (
       },
     });
     luckyUsers = firstBookingResult.luckyUsers;
+
+    // The first round-robin slot creates the third-party recurring series; carry its id forward so the
+    // remaining slots join the same series instead of each creating a new one (mirrors the loop below).
+    if (!thirdPartyRecurringEventId && firstBookingResult.references && firstBookingResult.references.length > 0) {
+      for (const reference of firstBookingResult.references) {
+        if (reference.thirdPartyRecurringEventId) {
+          thirdPartyRecurringEventId = reference.thirdPartyRecurringEventId;
+          break;
+        }
+      }
+    }
   }
 
   for (let key = isRoundRobin ? 1 : 0; key < data.length; key++) {


### PR DESCRIPTION
## What does this PR do?

Fixes #29766

For round-robin recurring bookings, `RecurringBookingService` handles the first slot in a pre-loop (to pick the lucky host) but extracted only `luckyUsers` from its result — not `thirdPartyRecurringEventId`. The remaining occurrences then started the loop with a null series id and each created their own third-party recurring series (`withRecurringEventId(null)` → no `existingRecurringEvent` → the calendar service's `events.insert` path), orphaning the first occurrence in a separate series. The non-round-robin path already threads the id (it extracts it after each booking). This PR extracts `thirdPartyRecurringEventId` from the first round-robin slot too, mirroring the main loop, so all occurrences join one series.

<!-- Note: Cal.diy is a community-maintained open-source project. -->

## Visual Demo (For contributors especially)

Backend logic fix with no UI surface — demonstrated with a red→green unit test rather than a recording (see **How should this be tested?**).

#### Video Demo (if applicable):

N/A — no UI change.

#### Image Demo (if applicable):

N/A — no UI change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A (no developer-facing API or docs change)
- [x] I confirm automated tests are in place that prove my fix is effective.

## How should this be tested?

- Data: a round-robin event type with recurrence enabled and hosts connected to Google Calendar. Book several recurring occurrences.
- Expected: all occurrences belong to a single recurring series in the calendar (previously occurrence 0 was orphaned in its own series).
- Automated: new unit test in `RecurringBookingService.test.ts` asserts the second booking is invoked with the first slot's `thirdPartyRecurringEventId` — verified red (`null`) before the fix, green after; the existing recurring integration test in the same file still passes.

## Checklist

- N/A — follows the contributing guide and style guidelines, tests included, PR is small (2 files, ~58 lines).