### PR TITLE
fix(prisma): throw clear error when DATABASE_URL is missing

### DIFF
--- a/packages/prisma/index.ts
+++ b/packages/prisma/index.ts
@@ -7,7 +7,14 @@ import { excludeLockedUsersExtension } from "./extensions/exclude-locked-users";
 import { excludePendingPaymentsExtension } from "./extensions/exclude-pending-payment-teams";
 import { PrismaClient, type Prisma } from "./generated/prisma/client";
 
-const connectionString = process.env.DATABASE_URL || "";
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error(
+    "DATABASE_URL environment variable is missing. Please set it in your .env file. Example: DATABASE_URL=\"postgresql://user:password@localhost:5432/calendso\""
+  );
+}
+
 const pool =
   process.env.USE_POOL === "true" || process.env.USE_POOL === "1"
     ? new Pool({


### PR DESCRIPTION
## What does this PR do?

Adds an early validation in the Prisma client initialization that throws a descriptive error when `DATABASE_URL` is not set.

Previously, when `DATABASE_URL` was missing, the Prisma client attempted to connect with an empty string, resulting in a cryptic PostgreSQL connection error that was confusing for new contributors and self-hosters.

## Changes

- `packages/prisma/index.ts`: Replaced `process.env.DATABASE_URL || ""` with an explicit check that throws a clear error message with an example connection string.

## Before

```
Error: Error in PostgreSQL connection: error connecting to server: Connection refused
```

## After

```
Error: DATABASE_URL environment variable is missing. Please set it in your .env file. Example: DATABASE_URL="postgresql://user:password@localhost:5432/calendso"
```

Closes #24485

cc @bandhan-majumder
