### PR TITLE
fix: compare API key expiration with full timestamp precision

### DIFF
--- a/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
+++ b/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
@@ -242,7 +242,7 @@ export class ApiAuthStrategy extends PassportStrategy(BaseStrategy, "api-auth") 
     }
 
     const isKeyExpired =
-      keyData.expiresAt && new Date() > new Date(keyData.expiresAt);
+      keyData.expiresAt && new Date() >= new Date(keyData.expiresAt);
     if (isKeyExpired) {
       throw new UnauthorizedException("ApiAuthStrategy - api key - Your api key is expired");
     }

--- a/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
+++ b/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
@@ -242,7 +242,7 @@ export class ApiAuthStrategy extends PassportStrategy(BaseStrategy, "api-auth") 
     }
 
     const isKeyExpired =
-      keyData.expiresAt && new Date().setHours(0, 0, 0, 0) > keyData.expiresAt.setHours(0, 0, 0, 0);
+      keyData.expiresAt && new Date() > new Date(keyData.expiresAt);
     if (isKeyExpired) {
       throw new UnauthorizedException("ApiAuthStrategy - api key - Your api key is expired");
     }


### PR DESCRIPTION
## Description

API keys with an `expiresAt` timestamp that has already passed were still accepted by the API v2 authentication layer. The expiry comparison used day-level granularity by zeroing the time component of both dates via `setHours(0,0,0,0)`, meaning a key that expired at midnight today remained valid throughout the entire day.

Additionally, `Date.setHours()` mutates the original Date object in-place, so after the comparison the stored `keyData.expiresAt` had its time component zeroed to midnight.

## Fix

Changed the comparison from day-level granularity to full timestamp precision:

```typescript
// Before (buggy)
keyData.expiresAt && new Date().setHours(0,0,0,0) > keyData.expiresAt.setHours(0,0,0,0)

// After (fixed)
keyData.expiresAt && new Date() > new Date(keyData.expiresAt)
```

The fix:
- Compares full Date objects with millisecond precision
- Creates a new Date from `keyData.expiresAt` instead of mutating the original
- Expired keys are immediately rejected, not delayed by up to 24 hours

Fixes #29728