### PR TITLE
perf: batch task deletion in cancelNoShowTasksForBooking

### DIFF
--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -622,15 +622,11 @@ export async function cancelNoShowTasksForBooking({
 
     if (bookings.length === 0) return;
 
-    const promises = bookings.map(async (booking) => {
-      return await prisma.task.deleteMany({
-        where: {
-          referenceUid: booking.uid,
-        },
-      });
+    await prisma.task.deleteMany({
+      where: {
+        referenceUid: { in: bookings.map((booking) => booking.uid) },
+      },
     });
-
-    await Promise.all(promises);
   }
 }
 


### PR DESCRIPTION
When `cancelNoShowTasksForBooking` is called with a webhook, it issues one `prisma.task.deleteMany` per booking inside a `Promise.all` — N queries for N bookings.

A single `deleteMany` with `referenceUid: { in: bookingUids }` deletes the same rows in one query.

No behavior change.