### PR TITLE
fix: show copy toast only after clipboard succeeds

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -767,18 +767,18 @@ export const InfiniteEventTypeList = ({
                                 </DropdownItem>
                               </DropdownMenuItem>
                               <DropdownMenuItem className="outline-none">
-                                <DropdownItem
-                                  data-testid={`event-type-duplicate-${type.id}`}
-                                  onClick={() =>
-                                    copyToClipboard(calLink, {
-                                      onSuccess: () => showToast(t("link_copied"), "success"),
-                                      onFailure: () => showToast(t("copy_failed"), "error"),
-                                    })
-                                  }
-                                  StartIcon="clipboard"
-                                  className="w-full rounded-none text-left">
-                                  {t("copy_link")}
-                                </DropdownItem>
+                              <DropdownItem
+  data-testid={`event-type-copy-link-${type.id}`}
+  onClick={() =>
+    copyToClipboard(calLink, {
+      onSuccess: () => showToast(t("link_copied"), "success"),
+      onFailure: () => showToast(t("copy_failed"), "error"),
+    })
+  }
+  StartIcon="clipboard"
+  className="w-full rounded-none text-left">
+  {t("copy_link")}
+</DropdownItem>
                               </DropdownMenuItem>
                             </>
                           )}

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -769,10 +769,12 @@ export const InfiniteEventTypeList = ({
                               <DropdownMenuItem className="outline-none">
                                 <DropdownItem
                                   data-testid={`event-type-duplicate-${type.id}`}
-                                  onClick={() => {
-                                    navigator.clipboard.writeText(calLink);
-                                    showToast(t("link_copied"), "success");
-                                  }}
+                                  onClick={() =>
+                                    copyToClipboard(calLink, {
+                                      onSuccess: () => showToast(t("link_copied"), "success"),
+                                      onFailure: () => showToast(t("copy_failed"), "error"),
+                                    })
+                                  }
                                   StartIcon="clipboard"
                                   className="w-full rounded-none text-left">
                                   {t("copy_link")}

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -637,10 +637,12 @@ export const InfiniteEventTypeList = ({
                                     color="secondary"
                                     variant="icon"
                                     StartIcon="link"
-                                    onClick={() => {
-                                      showToast(t("link_copied"), "success");
-                                      copyToClipboard(calLink);
-                                    }}
+                                    onClick={() =>
+                                      copyToClipboard(calLink, {
+                                        onSuccess: () => showToast(t("link_copied"), "success"),
+                                        onFailure: () => showToast(t("copy_failed"), "error"),
+                                      })
+                                    }
                                   />
                                 </Tooltip>
 
@@ -650,18 +652,22 @@ export const InfiniteEventTypeList = ({
                                       color="secondary"
                                       variant="icon"
                                       StartIcon="venetian-mask"
-                                      onClick={() => {
-                                        showToast(t("private_link_copied"), "success");
-                                        copyToClipboard(placeholderHashedLink);
-                                        setPrivateLinkCopyIndices((prev) => {
-                                          const prevIndex = prev[type.slug] ?? 0;
-                                          const nextIndex = (prevIndex + 1) % activeHashedLinks.length;
-                                          return {
-                                            ...prev,
-                                            [type.slug]: nextIndex,
-                                          };
-                                        });
-                                      }}
+                                      onClick={() =>
+                                        copyToClipboard(placeholderHashedLink, {
+                                          onSuccess: () => {
+                                            showToast(t("private_link_copied"), "success");
+                                            setPrivateLinkCopyIndices((prev) => {
+                                              const prevIndex = prev[type.slug] ?? 0;
+                                              const nextIndex = (prevIndex + 1) % activeHashedLinks.length;
+                                              return {
+                                                ...prev,
+                                                [type.slug]: nextIndex,
+                                              };
+                                            });
+                                          },
+                                          onFailure: () => showToast(t("copy_failed"), "error"),
+                                        })
+                                      }
                                     />
                                   </Tooltip>
                                 )}

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -906,6 +906,7 @@
   "user_from_team": "{{user}} from {{team}}",
   "preview": "Preview",
   "link_copied": "Link copied!",
+  "copy_failed": "Could not copy to clipboard",
   "copied": "Copied!",
   "private_link_copied": "Private link copied!",
   "link_shared": "Link shared!",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Note: Cal.diy is a community-maintained open-source project. Contributions here do NOT flow to Cal.com's production service. -->

On the event types list, the “link copied” success toast was shown before the clipboard write completed. If the clipboard API failed (e.g. permission denied or insecure context), users still saw a success message.

This PR:
- Shows success/error toasts from `copyToClipboard` `onSuccess` / `onFailure` for public and private link copy buttons
- Advances the private-link copy index only after a successful copy
- Adds the `copy_failed` translation key

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- N/A (toast-only behavior; no UI layout change)

#### Image Demo (if applicable):

- N/A

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. (Manual verification only)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set? No
- What are the minimal test data to have? A logged-in user with at least one event type (ideally also one with a private hashed link)
- What is expected (happy path) to have (input and output)?
  - Click copy public link → success toast after clipboard write; paste confirms the URL
  - Click copy private link → success toast; private link rotates only on success
  - If clipboard fails → error toast (`copy_failed`), not success
- Any other important info that could help to test that PR: Can simulate failure by denying clipboard permission in the browser

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I have read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas (N/A — small UX fix)
- I have checked if my changes generate no new warnings
- My PR is small (<500 lines and <10 files)