### PR TITLE
fix(i18n): localize the required-field message when enabling two-factor auth

### DIFF
--- a/apps/web/components/settings/EnableTwoFactorModal.test.tsx
+++ b/apps/web/components/settings/EnableTwoFactorModal.test.tsx
@@ -1,0 +1,58 @@
+import { TooltipProvider } from "@radix-ui/react-tooltip";
+import { render, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+
+import EnableTwoFactorModal from "./EnableTwoFactorModal";
+
+vi.mock("./TwoFactorAuthAPI", () => ({
+  default: { setup: vi.fn(), enable: vi.fn() },
+}));
+
+// t returns the key, so the assertions below prove the message comes from the catalog
+// rather than from the browser.
+vi.mock("@calcom/lib/hooks/useLocale", () => ({
+  useLocale: () => ({ t: (key: string) => key, isLocaleReady: true, i18n: { exists: () => false } }),
+}));
+
+// The dialog reads the app router, which isn't mounted under jsdom.
+vi.mock("next/navigation", async () => ({
+  ...((await vi.importActual("next/navigation")) as object),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  usePathname: () => "/settings/security/two-factor-auth",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const renderModal = () => {
+  render(
+    <TooltipProvider>
+      <EnableTwoFactorModal open onOpenChange={vi.fn()} onEnable={vi.fn()} onCancel={vi.fn()} />
+    </TooltipProvider>
+  );
+  return document.querySelector('input[name="password"]') as HTMLInputElement;
+};
+
+describe("EnableTwoFactorModal", () => {
+  it("reports the empty password with a translated message instead of the browser's", () => {
+    const password = renderModal();
+
+    expect(password.required).toBe(true);
+    expect(password.validity.valueMissing).toBe(true);
+
+    password.checkValidity();
+
+    expect(password.validity.customError).toBe(true);
+    expect(password.validationMessage).toBe("field_required");
+  });
+
+  it("clears the message once the field is edited so it can go valid again", () => {
+    const password = renderModal();
+
+    password.checkValidity();
+    expect(password.validity.customError).toBe(true);
+
+    fireEvent.input(password, { target: { value: "hunter2" } });
+
+    expect(password.validity.customError).toBe(false);
+    expect(password.checkValidity()).toBe(true);
+  });
+});

--- a/apps/web/components/settings/EnableTwoFactorModal.tsx
+++ b/apps/web/components/settings/EnableTwoFactorModal.tsx
@@ -181,7 +181,15 @@ const EnableTwoFactorModal = ({ onEnable, onCancel, open, onOpenChange }: Enable
                 id="password"
                 required
                 value={password}
-                onInput={(e) => setPassword(e.currentTarget.value)}
+                onInput={(e) => {
+                  // A non-empty customValidity keeps the field invalid until it is
+                  // cleared, so drop the message set by onInvalid on every edit.
+                  e.currentTarget.setCustomValidity("");
+                  setPassword(e.currentTarget.value);
+                }}
+                // The browser renders constraint-validation messages in its own
+                // locale, which ignores the user's language setting.
+                onInvalid={(e) => e.currentTarget.setCustomValidity(t("field_required"))}
               />
               {errorMessage && <p className="mt-1 text-sm text-red-700">{errorMessage}</p>}
             </div>

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -74,6 +74,7 @@ export default defineConfig({
       { find: "~", replacement: path.resolve(__dirname, "apps/api/v1") },
       // apps/web path aliases
       { find: "@lib", replacement: path.resolve(__dirname, "apps/web/lib") },
+      { find: "@components", replacement: path.resolve(__dirname, "apps/web/components") },
       { find: "app", replacement: path.resolve(__dirname, "apps/web/app") },
       { find: "@calcom/web", replacement: path.resolve(__dirname, "apps/web") },
       // Platform packages that need to be resolved from source in CI


### PR DESCRIPTION
## What does this PR do?

Found this with Cal set to 繁體中文 on an English browser.

The enable-2FA dialog is translated the whole way through, `t("incorrect_password")`,
`t("something_went_wrong")` and the rest. Then you press Enter on an empty password field and the
browser answers in its own language: "Please fill out this field.", where the dialog around it says
此欄位為必填.

Enter is the path that matters here. That `<form onSubmit={handleSetup}>` holds the password input
and nothing else — Continue lives down in the footer, inside the other `<Form>`, and is `disabled`
until you type. A form with one field and no submit button of its own submits implicitly on Enter,
and `InputField` passes `required` down to the native input, so the message is the browser's to
render and it comes out in the browser's locale.

Fix sets the message in `onInvalid` and clears it in the existing `onInput` so a corrected field can
go valid again. `field_required` already exists and is already translated (zh-TW `此欄位為必填`, ja
`このフィールドは必須です`, fr `Ce champ est obligatoire`), so there are no new strings and nothing
for lingo.dev.

Nothing else changes — still native validation, still blocks submit on the same field, `handleSetup`
untouched. Only the text differs.

## Visual Demo

Nothing to screenshot. The bubble is browser chrome, drawn outside the page. So I read it off the
running app instead, on `/settings/security/two-factor-auth`, Cal on 繁體中文, browser on `en-US`,
driving the same submission path Enter takes:

```js
const pw = document.querySelector('input[name="password"]');
pw.form.requestSubmit();
pw.validationMessage; // 此欄位為必填, was "Please fill out this field."
pw.validity.valid;    // false, still blocks submit
```

| | `validationMessage` |
| --- | --- |
| today | `Please fill out this field.` |
| after | `此欄位為必填` |

Submit stays blocked either way.

## How should this be tested?

Nothing special to set up. Settings → Security → Two-factor auth, Cal on any non-English language,
click Enable, then press Enter with the password field empty. Clicking Continue won't show it — the
button is disabled until the field has a value.

Or `yarn vitest run apps/web/components/settings/EnableTwoFactorModal.test.tsx`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

The test needed one thing to run at all. `vitest.config.mts` resolves `@lib` and `@calcom/web` but
not `@components`, so nothing in `apps/web` that imports `@components/...` can be mounted in a test,
and this modal pulls in `@components/auth/TwoFactor`. Added the alias next to the others, same as
`apps/web/tsconfig.json` already has it. Happy to split that into its own PR if you'd rather keep
this one to the fix.

Typecheck passes. Typing into the field clears the message and it goes valid again, so nothing gets
stuck.
