### PR TITLE
fix: make mobile nav backgrounds fully opaque

### DIFF
--- a/apps/web/modules/shell/TopNav.tsx
+++ b/apps/web/modules/shell/TopNav.tsx
@@ -24,7 +24,7 @@ function TopNav() {
     <>
       <nav
         style={isEmbed ? { display: "none" } : {}}
-        className="bg-cal-muted/50 border-subtle sticky top-0 z-40 flex w-full items-center justify-between border-b px-4 py-1.5 backdrop-blur-lg sm:p-4 md:hidden">
+        className="border-subtle sticky top-0 z-40 flex w-full items-center justify-between border-b bg-cal-muted px-4 py-1.5 backdrop-blur-lg sm:p-4 md:hidden">
         <Link href="/event-types">
           <Logo />
         </Link>

--- a/apps/web/modules/shell/navigation/Navigation.tsx
+++ b/apps/web/modules/shell/navigation/Navigation.tsx
@@ -113,7 +113,7 @@ const MobileNavigation = () => {
     <>
       <nav
         className={classNames(
-          "fixed bottom-0 left-0 z-30 pwa:-mx-2 flex w-full border-subtle border-t bg-cal-muted/40 px-1 pwa:pb-[max(0.25rem,env(safe-area-inset-bottom))] shadow backdrop-blur-md md:hidden",
+          "fixed bottom-0 left-0 z-30 pwa:-mx-2 flex w-full border-subtle border-t bg-cal-muted px-1 pwa:pb-[max(0.25rem,env(safe-area-inset-bottom))] shadow backdrop-blur-md md:hidden",
           isEmbed && "hidden"
         )}>
         {mobileNavigationBottomItems.map((item) => (


### PR DESCRIPTION
fixes #29757

the mobile top nav and bottom nav were using semi-transparent backgrounds (`bg-cal-muted/50` and `bg-cal-muted/40` respectively). when you scroll down on any page, the content underneath bleeds through and overlaps with the nav text, making it unreadable.

changed both to use `bg-cal-muted` (fully opaque) so the nav stays solid regardless of scroll position. kept the `backdrop-blur` for the visual effect.

**what changed:**
- `TopNav.tsx`: `bg-cal-muted/50` → `bg-cal-muted`
- `Navigation.tsx`: `bg-cal-muted/40` → `bg-cal-muted`

tested on chrome/android, scrolling up and down on event-types and bookings pages. nav stays opaque now, no text bleeding through.

cc @dhairyashiil @bandhan-majumder would appreciate a review when you get a chance