### PR TITLE
fix(i18n): add missing translation for oauth_scope_org_attributes_read_write

### DIFF
--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -3011,6 +3011,7 @@
   "access_event_type": "Read, edit, delete your event-types",
   "access_availability": "Read, edit, delete your availability",
   "access_bookings": "Read, edit, delete your bookings",
+  "oauth_scope_org_attributes_read_write": "Read and write organization attributes",
   "allow_client_to_do": "Allow {{clientName}} to do this?",
   "oauth_access_information": "By clicking allow, you allow this app to use your information in accordance with their terms of service and privacy policy.",
   "allow": "Allow",


### PR DESCRIPTION
## What does this PR do?

Adds the missing translation for `oauth_scope_org_attributes_read_write` so that the OAuth consent screen shows a human-readable description ("Read and write organization attributes") instead of the raw translation key.

## Why?

When requesting the `ORG_ATTRIBUTES_READ` and `ORG_ATTRIBUTES_WRITE` scopes during OAuth authentication, the consent screen displays the raw i18n key instead of a proper description. This fix adds the missing translation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #29784