### PR TITLE
fix: render data table separators as table cells

### DIFF
--- a/apps/web/modules/data-table/components/DataTable.tsx
+++ b/apps/web/modules/data-table/components/DataTable.tsx
@@ -22,6 +22,7 @@ import kebabCase from "lodash/kebabCase";
 import { memo, useEffect, useMemo, useState } from "react";
 import { useColumnResizing } from "~/data-table/hooks/useColumnResizing";
 import { useColumnSizingVars } from "~/data-table/hooks/useColumnSizingVars";
+import { SeparatorRowRenderer } from "./SeparatorRowRenderer";
 
 export type DataTablePropsFromWrapper<TData> = {
   table: ReactTableType<TData>;
@@ -280,19 +281,6 @@ type RowToRender<TData> = {
   row: Row<TData>;
   virtualItem?: VirtualItem;
 };
-
-function SeparatorRowRenderer({ separator, className }: { separator: SeparatorRow; className?: string }) {
-  return (
-    <div
-      className={classNames(
-        "bg-cal-muted text-emphasis w-full px-3 py-2 font-semibold",
-        separator.className,
-        className
-      )}>
-      {separator.label}
-    </div>
-  );
-}
 
 function DataTableBody<TData>({
   table,

--- a/apps/web/modules/data-table/components/SeparatorRowRenderer.test.tsx
+++ b/apps/web/modules/data-table/components/SeparatorRowRenderer.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { SeparatorRowRenderer } from "./SeparatorRowRenderer";
+
+describe("SeparatorRowRenderer", () => {
+  it("renders separator content inside a table cell", () => {
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <SeparatorRowRenderer separator={{ type: "separator", label: "Today" }} />
+          </tr>
+        </tbody>
+      </table>
+    );
+
+    const separatorCell = screen.getByText("Today").closest("td");
+
+    expect(separatorCell).not.toBeNull();
+    expect(separatorCell?.parentElement?.tagName).toBe("TR");
+  });
+});

--- a/apps/web/modules/data-table/components/SeparatorRowRenderer.tsx
+++ b/apps/web/modules/data-table/components/SeparatorRowRenderer.tsx
@@ -1,6 +1,6 @@
 import type { SeparatorRow } from "@calcom/features/data-table/lib/separator";
 import classNames from "@calcom/ui/classNames";
-import { TableCell } from "@calcom/ui/components/table";
+import { TableCell } from "@calcom/ui/components/table/TableNew";
 
 export function SeparatorRowRenderer({
   separator,

--- a/apps/web/modules/data-table/components/SeparatorRowRenderer.tsx
+++ b/apps/web/modules/data-table/components/SeparatorRowRenderer.tsx
@@ -1,0 +1,22 @@
+import type { SeparatorRow } from "@calcom/features/data-table/lib/separator";
+import classNames from "@calcom/ui/classNames";
+import { TableCell } from "@calcom/ui/components/table";
+
+export function SeparatorRowRenderer({
+  separator,
+  className,
+}: {
+  separator: SeparatorRow;
+  className?: string;
+}): JSX.Element {
+  return (
+    <TableCell
+      className={classNames(
+        "w-full bg-cal-muted px-3 py-2 font-semibold text-emphasis",
+        separator.className,
+        className
+      )}>
+      {separator.label}
+    </TableCell>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Data table separator rows currently place a `<div>` directly inside a `<tr>`, producing React DOM-nesting warnings and risking hydration differences. This change renders the separator as a semantic table cell while preserving its styling, and extracts the renderer for focused regression coverage.

- Fixes #28184

## Visual Demo (For contributors especially)

N/A — no visual change. The rendered separator element changes from `<div>` to `<td>`.

## How should this be tested?

- No environment variables or test data are required.
- Run `yarn vitest run apps/web/modules/data-table/components/SeparatorRowRenderer.test.tsx`.
- Expected: the separator label is rendered in a `<td>` whose parent is the table `<tr>`.
- Full validation: `NODE_OPTIONS=--max-old-space-size=8192 yarn type-check:ci --force`

