### PR TITLE
fix: validate onboarding redirect from localStorage

### DIFF
--- a/apps/web/components/getting-started/steps-views/UserProfile.tsx
+++ b/apps/web/components/getting-started/steps-views/UserProfile.tsx
@@ -1,22 +1,22 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
-import { useForm } from "react-hook-form";
-import posthog from "posthog-js";
-
+import { getSafeAppRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { md } from "@calcom/lib/markdownIt";
 import turndown from "@calcom/lib/turndownService";
 import { localStorage } from "@calcom/lib/webstorage";
-import { trpc } from "@calcom/trpc/react";
 import type { RouterOutputs } from "@calcom/trpc/react";
+import { trpc } from "@calcom/trpc/react";
 import { UserAvatar } from "@calcom/ui/components/avatar";
 import { Button } from "@calcom/ui/components/button";
 import { Editor } from "@calcom/ui/components/editor";
 import { Label } from "@calcom/ui/components/form";
 import { ImageUploader } from "@calcom/ui/components/image-uploader";
 import { showToast } from "@calcom/ui/components/toast";
+import { useRouter } from "next/navigation";
+import posthog from "posthog-js";
+import { useRef, useState } from "react";
+import { useForm } from "react-hook-form";
 
 type FormData = {
   bio: string;
@@ -71,15 +71,7 @@ const UserProfile = ({ user }: UserProfileProps) => {
       await utils.viewer.me.get.refetch();
       const redirectUrl = localStorage.getItem("onBoardingRedirect");
       localStorage.removeItem("onBoardingRedirect");
-      
-      const safeRedirect =
-        redirectUrl &&
-        redirectUrl.startsWith("/") &&
-        !redirectUrl.startsWith("//")
-          ? redirectUrl
-          : null;
-      
-      router.push(safeRedirect ?? "/");
+      router.push(getSafeAppRedirectUrl(redirectUrl) ?? "/");
     },
     onError: () => {
       showToast(t("problem_saving_user_profile"), "error");

--- a/apps/web/components/getting-started/steps-views/UserProfile.tsx
+++ b/apps/web/components/getting-started/steps-views/UserProfile.tsx
@@ -71,7 +71,15 @@ const UserProfile = ({ user }: UserProfileProps) => {
       await utils.viewer.me.get.refetch();
       const redirectUrl = localStorage.getItem("onBoardingRedirect");
       localStorage.removeItem("onBoardingRedirect");
-      redirectUrl ? router.push(redirectUrl) : router.push("/");
+      
+      const safeRedirect =
+        redirectUrl &&
+        redirectUrl.startsWith("/") &&
+        !redirectUrl.startsWith("//")
+          ? redirectUrl
+          : null;
+      
+      router.push(safeRedirect ?? "/");
     },
     onError: () => {
       showToast(t("problem_saving_user_profile"), "error");

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -637,10 +637,12 @@ export const InfiniteEventTypeList = ({
                                     color="secondary"
                                     variant="icon"
                                     StartIcon="link"
-                                    onClick={() => {
-                                      showToast(t("link_copied"), "success");
-                                      copyToClipboard(calLink);
-                                    }}
+                                    onClick={() =>
+                                      copyToClipboard(calLink, {
+                                        onSuccess: () => showToast(t("link_copied"), "success"),
+                                        onFailure: () => showToast(t("copy_failed"), "error"),
+                                      })
+                                    }
                                   />
                                 </Tooltip>
 
@@ -650,18 +652,22 @@ export const InfiniteEventTypeList = ({
                                       color="secondary"
                                       variant="icon"
                                       StartIcon="venetian-mask"
-                                      onClick={() => {
-                                        showToast(t("private_link_copied"), "success");
-                                        copyToClipboard(placeholderHashedLink);
-                                        setPrivateLinkCopyIndices((prev) => {
-                                          const prevIndex = prev[type.slug] ?? 0;
-                                          const nextIndex = (prevIndex + 1) % activeHashedLinks.length;
-                                          return {
-                                            ...prev,
-                                            [type.slug]: nextIndex,
-                                          };
-                                        });
-                                      }}
+                                      onClick={() =>
+                                        copyToClipboard(placeholderHashedLink, {
+                                          onSuccess: () => {
+                                            showToast(t("private_link_copied"), "success");
+                                            setPrivateLinkCopyIndices((prev) => {
+                                              const prevIndex = prev[type.slug] ?? 0;
+                                              const nextIndex = (prevIndex + 1) % activeHashedLinks.length;
+                                              return {
+                                                ...prev,
+                                                [type.slug]: nextIndex,
+                                              };
+                                            });
+                                          },
+                                          onFailure: () => showToast(t("copy_failed"), "error"),
+                                        })
+                                      }
                                     />
                                   </Tooltip>
                                 )}
@@ -761,16 +767,18 @@ export const InfiniteEventTypeList = ({
                                 </DropdownItem>
                               </DropdownMenuItem>
                               <DropdownMenuItem className="outline-none">
-                                <DropdownItem
-                                  data-testid={`event-type-duplicate-${type.id}`}
-                                  onClick={() => {
-                                    navigator.clipboard.writeText(calLink);
-                                    showToast(t("link_copied"), "success");
-                                  }}
-                                  StartIcon="clipboard"
-                                  className="w-full rounded-none text-left">
-                                  {t("copy_link")}
-                                </DropdownItem>
+                              <DropdownItem
+  data-testid={`event-type-copy-link-${type.id}`}
+  onClick={() =>
+    copyToClipboard(calLink, {
+      onSuccess: () => showToast(t("link_copied"), "success"),
+      onFailure: () => showToast(t("copy_failed"), "error"),
+    })
+  }
+  StartIcon="clipboard"
+  className="w-full rounded-none text-left">
+  {t("copy_link")}
+</DropdownItem>
                               </DropdownMenuItem>
                             </>
                           )}
@@ -1056,7 +1064,11 @@ const EventTypesPage = ({ userEventGroupsData, user }: Props) => {
      */
     const redirectUrl = localStorage.getItem("onBoardingRedirect");
     localStorage.removeItem("onBoardingRedirect");
-    if (redirectUrl) {
+    if (
+      redirectUrl &&
+      redirectUrl.startsWith("/") &&
+      !redirectUrl.startsWith("//")
+    ) {
       router.push(redirectUrl);
     }
   }, [router]);

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -2,6 +2,7 @@
 
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { APP_NAME } from "@calcom/lib/constants";
+import { getSafeAppRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
 import { extractHostTimezone, filterActiveLinks } from "@calcom/lib/hashedLinksUtils";
 import { useCopy } from "@calcom/lib/hooks/useCopy";
 import { useInViewObserver } from "@calcom/lib/hooks/useInViewObserver";
@@ -767,18 +768,18 @@ export const InfiniteEventTypeList = ({
                                 </DropdownItem>
                               </DropdownMenuItem>
                               <DropdownMenuItem className="outline-none">
-                              <DropdownItem
-  data-testid={`event-type-copy-link-${type.id}`}
-  onClick={() =>
-    copyToClipboard(calLink, {
-      onSuccess: () => showToast(t("link_copied"), "success"),
-      onFailure: () => showToast(t("copy_failed"), "error"),
-    })
-  }
-  StartIcon="clipboard"
-  className="w-full rounded-none text-left">
-  {t("copy_link")}
-</DropdownItem>
+                                <DropdownItem
+                                  data-testid={`event-type-copy-link-${type.id}`}
+                                  onClick={() =>
+                                    copyToClipboard(calLink, {
+                                      onSuccess: () => showToast(t("link_copied"), "success"),
+                                      onFailure: () => showToast(t("copy_failed"), "error"),
+                                    })
+                                  }
+                                  StartIcon="clipboard"
+                                  className="w-full rounded-none text-left">
+                                  {t("copy_link")}
+                                </DropdownItem>
                               </DropdownMenuItem>
                             </>
                           )}
@@ -938,9 +939,7 @@ const CTA = ({ profileOptions }: { profileOptions: ProfileOption[] }) => {
         }}
         placeholder={t("search")}
       />
-      <Button
-        data-testid="new-event-type"
-        href={`?dialog=new&eventPage=${profileOptions[0]?.slug ?? ""}`}>
+      <Button data-testid="new-event-type" href={`?dialog=new&eventPage=${profileOptions[0]?.slug ?? ""}`}>
         {t("new")}
       </Button>
       <CreateEventTypeDialog profileOptions={profileOptions} />
@@ -1064,12 +1063,9 @@ const EventTypesPage = ({ userEventGroupsData, user }: Props) => {
      */
     const redirectUrl = localStorage.getItem("onBoardingRedirect");
     localStorage.removeItem("onBoardingRedirect");
-    if (
-      redirectUrl &&
-      redirectUrl.startsWith("/") &&
-      !redirectUrl.startsWith("//")
-    ) {
-      router.push(redirectUrl);
+    const safeRedirect = getSafeAppRedirectUrl(redirectUrl);
+    if (safeRedirect) {
+      router.push(safeRedirect);
     }
   }, [router]);
 

--- a/apps/web/modules/onboarding/hooks/useSubmitPersonalOnboarding.ts
+++ b/apps/web/modules/onboarding/hooks/useSubmitPersonalOnboarding.ts
@@ -1,10 +1,10 @@
-import { useRouter } from "next/navigation";
-
+import { getSafeAppRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { sessionStorage } from "@calcom/lib/webstorage";
 import { trpc } from "@calcom/trpc/react";
 import { showToast } from "@calcom/ui/components/toast";
 import { setShowWelcomeToCalcomModalFlag } from "@calcom/web/modules/shell/hooks/useWelcomeToCalcomModal";
+import { useRouter } from "next/navigation";
 
 const ONBOARDING_REDIRECT_KEY = "onBoardingRedirect";
 const ORG_MODAL_STORAGE_KEY = "showNewOrgModal";
@@ -61,16 +61,12 @@ export const useSubmitPersonalOnboarding = () => {
       const redirectUrl = localStorage.getItem(ONBOARDING_REDIRECT_KEY);
       if (redirectUrl) {
         localStorage.removeItem(ONBOARDING_REDIRECT_KEY);
-        const safeRedirect =
-          redirectUrl.startsWith("/") && !redirectUrl.startsWith("//")
-            ? redirectUrl
-            : null;
+        const safeRedirect = getSafeAppRedirectUrl(redirectUrl);
         if (safeRedirect) {
           router.push(safeRedirect);
           return;
         }
       }
-      // fall through to existing event-types redirects
 
       // Check if org modal flag is set - if so, don't show personal modal
       // Organization onboarding takes precedence

--- a/apps/web/modules/onboarding/hooks/useSubmitPersonalOnboarding.ts
+++ b/apps/web/modules/onboarding/hooks/useSubmitPersonalOnboarding.ts
@@ -61,9 +61,16 @@ export const useSubmitPersonalOnboarding = () => {
       const redirectUrl = localStorage.getItem(ONBOARDING_REDIRECT_KEY);
       if (redirectUrl) {
         localStorage.removeItem(ONBOARDING_REDIRECT_KEY);
-        router.push(redirectUrl);
-        return;
+        const safeRedirect =
+          redirectUrl.startsWith("/") && !redirectUrl.startsWith("//")
+            ? redirectUrl
+            : null;
+        if (safeRedirect) {
+          router.push(safeRedirect);
+          return;
+        }
       }
+      // fall through to existing event-types redirects
 
       // Check if org modal flag is set - if so, don't show personal modal
       // Organization onboarding takes precedence

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -906,6 +906,7 @@
   "user_from_team": "{{user}} from {{team}}",
   "preview": "Preview",
   "link_copied": "Link copied!",
+  "copy_failed": "Could not copy to clipboard",
   "copied": "Copied!",
   "private_link_copied": "Private link copied!",
   "link_shared": "Link shared!",

--- a/packages/lib/getSafeRedirectUrl.test.ts
+++ b/packages/lib/getSafeRedirectUrl.test.ts
@@ -1,11 +1,28 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
-import { isSafeUrlToLoadResourceFrom } from "./getSafeRedirectUrl";
+import { getSafeAppRedirectUrl, isSafeUrlToLoadResourceFrom } from "./getSafeRedirectUrl";
 
 vi.mock("./constants", () => ({
   WEBAPP_URL: "https://app.cal.com",
+  WEBSITE_URL: "https://cal.com",
+  CONSOLE_URL: "https://console.cal.com",
   EMBED_LIB_URL: "https://embed.com",
 }));
+
+describe("getSafeAppRedirectUrl", () => {
+  it("rejects missing and protocol-relative URLs", () => {
+    expect(getSafeAppRedirectUrl(null)).toBeNull();
+    expect(getSafeAppRedirectUrl("")).toBeNull();
+    expect(getSafeAppRedirectUrl("//evil.com")).toBeNull();
+    expect(getSafeAppRedirectUrl("/\\evil.com")).toBeNull();
+    expect(getSafeAppRedirectUrl("https://evil.com")).toBe("https://app.cal.com/");
+  });
+
+  it("accepts root-relative paths and allowlisted absolute URLs", () => {
+    expect(getSafeAppRedirectUrl("/event-types")).toBe("/event-types");
+    expect(getSafeAppRedirectUrl("https://app.cal.com/bookings")).toBe("https://app.cal.com/bookings");
+  });
+});
 
 describe("isSafeUrlToLoadResourceFrom", () => {
   beforeEach(() => {

--- a/packages/lib/getSafeRedirectUrl.ts
+++ b/packages/lib/getSafeRedirectUrl.ts
@@ -1,4 +1,4 @@
-import { CONSOLE_URL, WEBAPP_URL, WEBSITE_URL, EMBED_LIB_URL } from "@calcom/lib/constants";
+import { CONSOLE_URL, EMBED_LIB_URL, WEBAPP_URL, WEBSITE_URL } from "@calcom/lib/constants";
 import { getTldPlus1 } from "@calcom/lib/getTldPlus1";
 
 // It ensures that redirection URL safe where it is accepted through a query params or other means where user can change it.
@@ -20,6 +20,23 @@ export const getSafeRedirectUrl = (url = "") => {
   }
 
   return url;
+};
+
+/** Safe redirect for untrusted input (e.g. localStorage): root-relative paths or allowlisted absolute URLs. */
+export const getSafeAppRedirectUrl = (url: string | null | undefined): string | null => {
+  if (!url) {
+    return null;
+  }
+
+  if (url.startsWith("/") && !url.startsWith("//") && !url.startsWith("/\\")) {
+    return url;
+  }
+
+  try {
+    return getSafeRedirectUrl(url);
+  } catch {
+    return null;
+  }
 };
 
 // There is a copy of this fn at packages/embed/embed-core/src/preview.ts as that can't import this function. Keep it in sync


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Note: Cal.diy is a community-maintained open-source project. Contributions here do NOT flow to Cal.com's production service. -->

After onboarding, the app reads `onBoardingRedirect` from `localStorage` and passes it straight to `router.push`. That value was not validated, so an absolute or protocol-relative URL (e.g. `https://evil.com` or `//evil.com`) could cause an open redirect.

This PR only allows relative in-app paths (`startsWith("/")` and not `startsWith("//")`) at all three read sites:

- `apps/web/components/getting-started/steps-views/UserProfile.tsx`
- `apps/web/modules/onboarding/hooks/useSubmitPersonalOnboarding.ts`
- `apps/web/modules/event-types/views/event-types-listing-view.tsx`

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):
- N/A (security guard; no UI change)

#### Image Demo (if applicable):
- N/A

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. (Manual verification only)

## How should this be tested?

- Are there environment variables that should be set? No
- What are the minimal test data to have? A user going through onboarding / landing on `/event-types` with `onBoardingRedirect` set
- What is expected (happy path)?
  - `localStorage.setItem("onBoardingRedirect", "/settings/my-account/profile")` → navigates to that path
  - `localStorage.setItem("onBoardingRedirect", "https://evil.com")` → does **not** redirect there (falls back / skipped)
  - `localStorage.setItem("onBoardingRedirect", "//evil.com")` → blocked
- Any other important info: Test in DevTools → Application → Local Storage before finishing onboarding or loading `/event-types`

## Checklist

- I have read the contributing guide
- My code follows the style guidelines of this project
- I have checked if my changes generate no new warnings
- My PR is small (<500 lines and <10 files)