### PR TITLE
fix(availability): don't offer round-robin slots when a mandatory fixed host is unavailable

### DIFF
--- a/packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.test.ts
+++ b/packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.test.ts
@@ -50,6 +50,30 @@ describe("getAggregatedAvailability", () => {
     expect(isAvailable(result, timeRangeToCheckAvailable)).toBe(true);
   });
 
+  it("does not offer slots for a ROUND_ROBIN event when a mandatory fixed host is unavailable", () => {
+    const userAvailability = [
+      {
+        // mandatory fixed host is fully busy → no availability
+        dateRanges: [],
+        oooExcludedDateRanges: [],
+        user: { isFixed: true },
+      },
+      {
+        // round-robin host is available 11:00–12:00
+        dateRanges: [],
+        oooExcludedDateRanges: [
+          { start: dayjs("2025-01-23T11:00:00.000Z"), end: dayjs("2025-01-23T12:00:00.000Z") },
+        ],
+        user: { isFixed: false },
+      },
+    ];
+
+    const result = getAggregatedAvailability(userAvailability, "ROUND_ROBIN");
+
+    // A slot must not be offered when the mandatory fixed host cannot attend.
+    expect(result).toEqual([]);
+  });
+
   it("it returns the right amount of date ranges even if the end time is before the start time", () => {
     const userAvailability = [
       {

--- a/packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.ts
+++ b/packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.ts
@@ -42,7 +42,10 @@ export const getAggregatedAvailability = (
   const fixedDateRanges = mergeOverlappingDateRanges(
     intersect(fixedHosts.map((s) => (!isTeamEvent ? s.dateRanges : s.oooExcludedDateRanges)))
   );
-  const dateRangesToIntersect = fixedDateRanges.length ? [fixedDateRanges] : [];
+  // When fixed (mandatory) hosts exist but have no common availability, force the aggregate empty
+  // instead of dropping the constraint — otherwise round-robin hosts alone would leak bookable slots
+  // that the booking layer then rejects (FixedHostsUnavailableForBooking).
+  const dateRangesToIntersect = fixedHosts.length ? [fixedDateRanges] : [];
   const roundRobinHosts = userAvailability.filter(({ user }) => user?.isFixed !== true);
   if (roundRobinHosts.length) {
     // Group round robin hosts by their groupId


### PR DESCRIPTION
## What does this PR do?

Fixes #29800

`getAggregatedAvailability` dropped the fixed-host constraint whenever the fixed hosts' intersection was empty — but that's empty both when there are **no** fixed hosts *and* when fixed hosts exist but can't overlap (a mandatory host is busy). `fixedDateRanges.length ? [fixedDateRanges] : []` conflated them, so a ROUND_ROBIN event with a busy fixed host leaked slots driven by the round-robin hosts alone — slots the booking layer then rejects with `FixedHostsUnavailableForBooking`. Gating on `fixedHosts.length` instead forces an empty fixed-host intersection to make the aggregate empty.

<!-- Note: Cal.diy is a community-maintained open-source project. -->

## Visual Demo (For contributors especially)

Backend logic fix with no UI surface — demonstrated with a red→green unit test rather than a recording (see *How should this be tested?*).

#### Video Demo (if applicable):

N/A — no UI change.

#### Image Demo (if applicable):

N/A — no UI change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A (no developer-facing API or docs change)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- **Data:** a ROUND_ROBIN event with a fixed host + round-robin host(s); make the fixed host busy while a round-robin host is free.
- **Expected:** no slots are offered for the busy fixed host's times (previously they were offered and then failed at booking with `FixedHostsUnavailableForBooking`).
- **Automated:** new unit test in `getAggregatedAvailability.test.ts` asserts a `ROUND_ROBIN` input with a busy fixed host + an available round-robin host returns `[]` — verified **red** before the fix, **green** after; the other 10 tests in the file and the broader availability/schedules suites (213 tests) are unaffected.

## Checklist

- N/A — follows the contributing guide and style guidelines, tests included, PR is small (2 files, ~28 lines).
