### PR TITLE
fix: autofilled text not using custom color

### DIFF
--- a/apps/web/playwright/autofill-theme.e2e.ts
+++ b/apps/web/playwright/autofill-theme.e2e.ts
@@ -1,0 +1,85 @@
+import { expect } from "@playwright/test";
+
+import { test } from "./lib/fixtures";
+
+test.describe("Autofill text color", () => {
+  test("autofilled input uses theme text color instead of browser default", async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== "chromium", "CDP Autofill.trigger is Chromium-only");
+
+    await page.goto("/auth/login");
+    await page.waitForLoadState("domcontentloaded");
+
+    // CDP autofill only fills credit-card forms, so inject one into the live
+    // page. It is styled by the app's real global stylesheet, which is what
+    // this test exercises: the `:-webkit-autofill` override in globals.css.
+    await page.evaluate(() => {
+      const form = document.createElement("form");
+      form.innerHTML = `
+        <input id="autofill-cc-name" name="cc-name" autocomplete="cc-name" style="color: var(--cal-text)">
+        <input id="autofill-cc-number" name="cc-number" autocomplete="cc-number" style="color: var(--cal-text)">
+        <input id="autofill-cc-exp" name="cc-exp" autocomplete="cc-exp" style="color: var(--cal-text)">
+        <input id="autofill-cc-csc" name="cc-csc" autocomplete="cc-csc" style="color: var(--cal-text)">
+      `;
+      document.body.appendChild(form);
+    });
+
+    const client = await page.context().newCDPSession(page);
+    await client.send("Autofill.enable");
+    const { root } = await client.send("DOM.getDocument");
+    const { nodeId } = await client.send("DOM.querySelector", {
+      nodeId: root.nodeId,
+      selector: "#autofill-cc-number",
+    });
+    const { node } = await client.send("DOM.describeNode", { nodeId });
+    const {
+      frameTree: { frame },
+    } = await client.send("Page.getFrameTree");
+    await client.send("DOM.focus", { nodeId });
+    await client.send("Autofill.trigger", {
+      fieldId: node.backendNodeId,
+      frameId: frame.id,
+      card: {
+        number: "4444444444444444",
+        name: "Test User",
+        expiryMonth: "12",
+        expiryYear: "2030",
+        cvc: "123",
+      },
+    });
+
+    const input = page.locator("#autofill-cc-number");
+    await expect(input).toHaveValue("4444444444444444");
+
+    const assertMatchesTheme = async () => {
+      const result = await input.evaluate((el) => {
+        // Resolve --cal-text to an rgb value via a probe element
+        const probe = document.createElement("span");
+        probe.style.color = "var(--cal-text)";
+        document.body.appendChild(probe);
+        const expected = getComputedStyle(probe).color;
+        probe.remove();
+        return {
+          autofilled: el.matches(":-webkit-autofill"),
+          textFillColor: getComputedStyle(el).webkitTextFillColor,
+          expected,
+        };
+      });
+      // Guard against the test passing vacuously if autofill never triggered
+      expect(result.autofilled).toBe(true);
+      expect(result.textFillColor).toBe(result.expected);
+    };
+
+    // Light theme
+    await assertMatchesTheme();
+
+    // Dark theme: flipping the theme class must recolor the autofilled text
+    await page.evaluate(() => {
+      document.documentElement.classList.remove("light");
+      document.documentElement.classList.add("dark");
+    });
+    await assertMatchesTheme();
+  });
+});

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -150,6 +150,27 @@ html.todesktop.dark {
   }
 }
 
+/*
+ * Browser autofill applies a UA `:-webkit-autofill` rule that sets
+ * `-webkit-text-fill-color` and a pale background (Chrome/Edge/Safari),
+ * ignoring our theme variables — autofilled text renders black even in
+ * dark mode. Only `-webkit-text-fill-color` can win against the UA text
+ * color, and the UA background can only be covered with an inset
+ * box-shadow (without it, theme-colored light text would sit on the UA's
+ * pale-blue background in dark mode and be unreadable).
+ */
+@layer base {
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  textarea:-webkit-autofill,
+  select:-webkit-autofill {
+    -webkit-text-fill-color: var(--cal-text);
+    caret-color: var(--cal-text);
+    box-shadow: inset 0 0 0 1000px var(--cal-bg);
+  }
+}
+
 @layer components {
   .scroll-bar {
     @apply scrollbar-thin scrollbar-thumb-rounded-md dark:scrollbar-thumb-darkgray-300 scrollbar-thumb-gray-300 scrollbar-track-transparent;


### PR DESCRIPTION
## What does this PR do?

Custom text color is not applied when text is autofilled by Chrome. This PR fixes that.

- Fixes #29803

## Visual Demo

Before
<img width="800" height="400" alt="shot-dark-fix0" src="https://github.com/user-attachments/assets/3e4f28fc-d56e-4269-aecc-ecf477c6f7d2" />

After
<img width="800" height="400" alt="shot-dark-fix1" src="https://github.com/user-attachments/assets/9d7db552-cd93-4eaa-bd57-0327bfc8d5ac" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. **N/A**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Spin up a routing form with a custom text color and some common names for fields like "Name" or "Email". Then use Chrome to auto-fill those fields and validate the custom color gets applied.
