### PR TITLE
fix(ui): override browser autofill text color in dark mode

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -148,6 +148,18 @@ html.todesktop.dark {
     --tw-ring-color: var(--brand-color);
     border-color: var(--brand-color);
   }
+
+  /* Override browser autofill styles that bypass CSS variables.
+     Browsers inject -webkit-text-fill-color and a colored background on autofill,
+     which ignores our theme tokens and causes black text on dark backgrounds. */
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    -webkit-text-fill-color: var(--cal-text) !important;
+    -webkit-box-shadow: 0 0 0 1000px var(--cal-bg) inset !important;
+    transition: background-color 5000s ease-in-out 0s;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
Fixes #29803

Browser autofill injects `-webkit-text-fill-color` and a solid background color that completely bypass CSS custom properties. In dark mode this renders autofilled inputs with black text on a dark background — unreadable.

**Fix:** add autofill overrides in `@layer base` in `apps/web/styles/globals.css`:

```css
input:-webkit-autofill,
input:-webkit-autofill:hover,
input:-webkit-autofill:focus,
input:-webkit-autofill:active {
  -webkit-text-fill-color: var(--cal-text) !important;
  -webkit-box-shadow: 0 0 0 1000px var(--cal-bg) inset !important;
  transition: background-color 5000s ease-in-out 0s;
}
```

The `--cal-text` and `--cal-bg` tokens are already defined in `packages/config/theme/tokens.css` with correct light/dark values. The `box-shadow` inset trick overrides the browser's autofill background without using `background-color`, which is ignored by autofill UA styles.