### PR TITLE
fix(booking): preserve original email for verification check

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/checkIfBookerEmailIsBlocked.ts
+++ b/packages/features/bookings/lib/handleNewBooking/checkIfBookerEmailIsBlocked.ts
@@ -70,7 +70,7 @@ export const checkIfBookerEmailIsBlocked = async ({
       let isValid = false;
 
       try {
-        isValid = await verifyCodeUnAuthenticated(baseEmail, verificationCode);
+        isValid = await verifyCodeUnAuthenticated(bookerEmail, verificationCode);
       } catch {
         throw new ErrorWithCode(
           ErrorCode.UnableToValidateVerificationCode,

--- a/packages/features/bookings/lib/handleNewBooking/test/booking-validations.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/booking-validations.test.ts
@@ -750,6 +750,87 @@ describe("Booking Validation Specifications", () => {
       expect(verifyCodeUnAuthenticated).toHaveBeenCalledWith("user@example.com", "valid-code-123");
     });
 
+    test("should validate a plus-addressed booker code against the address used to generate it", async () => {
+      const handleNewBooking = getNewBookingHandler();
+      const { verifyCodeUnAuthenticated } = await import(
+        "@calcom/features/auth/lib/verifyCodeUnAuthenticated"
+      );
+
+      vi.mocked(verifyCodeUnAuthenticated).mockResolvedValue(true);
+
+      const booker = getBooker({
+        email: "user+verification@example.com",
+        name: "User",
+      });
+
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+        emailVerified: new Date(),
+      });
+
+      const userWithVerificationRequired = getOrganizer({
+        name: "User",
+        email: "user@example.com",
+        id: 201,
+        schedules: [TestData.schedules.IstWorkHours],
+        emailVerified: new Date(),
+        requiresBookerEmailVerification: true,
+      });
+
+      await createBookingScenario(
+        getScenarioData({
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 30,
+              length: 30,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+            },
+          ],
+          organizer,
+          usersApartFromOrganizer: [userWithVerificationRequired],
+          apps: [TestData.apps["google-calendar"]],
+        })
+      );
+
+      await mockCalendarToHaveNoBusySlots("googlecalendar", {});
+
+      const mockBookingData = getMockRequestDataForBooking({
+        data: {
+          eventTypeId: 1,
+          responses: {
+            email: booker.email,
+            name: booker.name,
+            location: { optionValue: "", value: "New York" },
+          },
+          verificationCode: "valid-code-123",
+        },
+      });
+
+      const createdBooking = await handleNewBooking({
+        bookingData: mockBookingData,
+      });
+
+      expect(createdBooking).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+          uid: expect.any(String),
+          status: BookingStatus.ACCEPTED,
+        })
+      );
+
+      expect(verifyCodeUnAuthenticated).toHaveBeenCalledWith(booker.email, "valid-code-123");
+    });
+
     test("should require verification when secondary email of user with verification setting is used as main booker", async () => {
       const handleNewBooking = getNewBookingHandler();
 


### PR DESCRIPTION
## What does this PR do?

Preserves the exact booker email identity used to generate an email verification code while retaining existing normalized-email lookups.

## Problem

The email verification code is generated for the exact booker address entered. During the final booking flow, verification was performed with a normalized base address instead. When the original and normalized values differ, this can reject a valid verification code.

## Fix

The code verification step now receives the original booker address. Existing normalization for user, blocklist, and other identity lookups remains unchanged.

## Tests

- A new regression test first reproduced the address-identity mismatch.
- Corrected focused regression test: 1/1 passed.
- Full relevant booking validation suite: 15/15 passed.
- Biome formatting and lint passed with existing notices only.
- Monorepo type check: 9/9 tasks passed.
- An independent existing suite completed 5/6 tests.
- Its remaining pre-existing test reproducibly exceeds its fixed 20-second timeout and is not changed by this two-file diff.

## Scope

- Exactly two files.
- No configuration, deployment, provider, website, service, mail, or production changes.

## Visual Demo (For contributors especially)

Not applicable. This is a server-side verification identity fix covered by an automated regression test.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] Developer documentation changes are not required for this fix (N/A).
- [x] Automated tests are in place to prove the fix is effective.

## How should this be tested?

No additional environment variables are required. Run the focused booking validation test with synthetic data and confirm that verification uses the exact submitted booker address while normalized lookup behavior remains unchanged.

## Checklist

All template warnings were reviewed; none apply to this focused two-file bug fix.