### PR TITLE
fix(bookings): preserve delegationCredentialId and thirdPartyRecurringEventId on rescheduled booking references

### DIFF
--- a/packages/features/bookings/lib/EventManager.ts
+++ b/packages/features/bookings/lib/EventManager.ts
@@ -652,6 +652,8 @@ export default class EventManager {
             meetingUrl: true,
             externalCalendarId: true,
             credentialId: true,
+            delegationCredentialId: true,
+            thirdPartyRecurringEventId: true,
           },
         },
         destinationCalendar: true,

--- a/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
@@ -289,6 +289,149 @@ describe("handleNewBooking", () => {
       );
 
       test(
+        `should preserve delegationCredentialId and thirdPartyRecurringEventId on the booking references of the rescheduled booking
+          1. Should carry both fields from the original booking's references onto the new booking
+          2. Guards against losing the delegation-credential/recurring-event linkage needed for future cancel/reschedule
+    `,
+        async () => {
+          const handleNewBooking = getNewBookingHandler();
+          const booker = getBooker({
+            email: "booker@example.com",
+            name: "Booker",
+          });
+
+          const organizer = getOrganizer({
+            name: "Organizer",
+            email: "organizer@example.com",
+            id: 101,
+            schedules: [TestData.schedules.IstWorkHours],
+            credentials: [getGoogleCalendarCredential()],
+            selectedCalendars: [TestData.selectedCalendars.google],
+          });
+
+          const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+          const uidOfBookingToBeRescheduled = "n5Wv3eHgconAED2j4gcVhP";
+          const iCalUID = `${uidOfBookingToBeRescheduled}@Cal.diy`;
+          const delegationCredentialId = "delegation-credential-abc";
+          const thirdPartyRecurringEventId = "third-party-recurring-xyz";
+
+          await createBookingScenario(
+            getScenarioData({
+              eventTypes: [
+                {
+                  id: 1,
+                  slotInterval: 15,
+                  length: 15,
+                  users: [
+                    {
+                      id: 101,
+                    },
+                  ],
+                },
+              ],
+              bookings: [
+                {
+                  uid: uidOfBookingToBeRescheduled,
+                  eventTypeId: 1,
+                  status: BookingStatus.ACCEPTED,
+                  startTime: `${plus1DateString}T05:00:00.000Z`,
+                  endTime: `${plus1DateString}T05:15:00.000Z`,
+                  metadata: {
+                    videoCallUrl: "https://existing-daily-video-call-url.example.com",
+                  },
+                  references: [
+                    {
+                      type: appStoreMetadata.dailyvideo.type,
+                      uid: "MOCK_ID",
+                      meetingId: "MOCK_ID",
+                      meetingPassword: "MOCK_PASS",
+                      meetingUrl: "http://mock-dailyvideo.example.com",
+                      credentialId: null,
+                    },
+                    {
+                      type: appStoreMetadata.googlecalendar.type,
+                      uid: "MOCK_ID",
+                      meetingId: "MOCK_ID",
+                      meetingPassword: "MOCK_PASSWORD",
+                      meetingUrl: "https://UNUSED_URL",
+                      externalCalendarId: "MOCK_EXTERNAL_CALENDAR_ID",
+                      credentialId: null,
+                      delegationCredentialId,
+                      thirdPartyRecurringEventId,
+                    },
+                  ],
+                  iCalUID,
+                },
+              ],
+              organizer,
+              apps: [TestData.apps["google-calendar"], TestData.apps["daily-video"]],
+            })
+          );
+
+          mockSuccessfulVideoMeetingCreation({
+            metadataLookupKey: "dailyvideo",
+          });
+
+          await mockCalendarToHaveNoBusySlots("googlecalendar", {
+            create: {
+              uid: "MOCK_ID",
+            },
+            update: {
+              uid: "UPDATED_MOCK_ID",
+              iCalUID,
+            },
+          });
+
+          const mockBookingData = getMockRequestDataForBooking({
+            data: {
+              eventTypeId: 1,
+              rescheduleUid: uidOfBookingToBeRescheduled,
+              start: `${plus1DateString}T04:00:00.000Z`,
+              end: `${plus1DateString}T04:15:00.000Z`,
+              responses: {
+                email: booker.email,
+                name: booker.name,
+                location: { optionValue: "", value: BookingLocations.CalVideo },
+              },
+              rescheduledBy: organizer.email,
+            },
+          });
+
+          const createdBooking = await handleNewBooking({
+            bookingData: mockBookingData,
+          });
+
+          await expectBookingInDBToBeRescheduledFromTo({
+            from: {
+              uid: uidOfBookingToBeRescheduled,
+            },
+            to: {
+              description: "",
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              uid: createdBooking.uid!,
+              eventTypeId: mockBookingData.eventTypeId,
+              status: BookingStatus.ACCEPTED,
+              location: BookingLocations.CalVideo,
+              responses: expect.objectContaining({
+                email: booker.email,
+                name: booker.name,
+              }),
+              references: [
+                {
+                  type: appStoreMetadata.googlecalendar.type,
+                  uid: "MOCK_ID",
+                  externalCalendarId: "MOCK_EXTERNAL_CALENDAR_ID",
+                  delegationCredentialId,
+                  thirdPartyRecurringEventId,
+                },
+              ],
+            },
+          });
+        },
+        timeout
+      );
+
+      test(
         `should reschedule a booking successfully and update the event in the same externalCalendarId as was used in the booking earlier.
           1. Should cancel the existing booking
           2. Should create a new booking in the database


### PR DESCRIPTION

## What does this PR do?

When a booking is rescheduled, `EventManager.reschedule()` reloads the original
booking's references with a Prisma `select` that omits `delegationCredentialId`
and `thirdPartyRecurringEventId`. On a plain reschedule (same host, same
location) those references are copied verbatim onto the new booking, so both
columns are lost (persisted as `NULL`) on the new booking row.

Those two fields are exactly what later calendar operations depend on:

- `delegationCredentialId` — how `getCalendarCredential()` resolves a
  domain-wide **delegation** credential (delegation bookings have
  `credentialId = NULL`). Without it, credential lookup falls back to a
  match-by-type heuristic and the calendar event is deleted from the wrong
  account or not at all — leaving a **ghost event** on the organizer's calendar.
- `thirdPartyRecurringEventId` — the id used to delete an occurrence of a
  recurring third-party calendar series.

The fix adds those two fields to the `select`, so rescheduled bookings keep the
same reference data the original booking had. This mirrors the cancel path, which
already selects both fields (`getBookingToDelete.ts`).

- Fixes #29811

## Visual Demo (For contributors especially)

N/A — this is a backend data-integrity fix (a Prisma `select` in the reschedule
path). There is no UI change. The behavioural change is proven by an automated
test (see below), which fails before the fix and passes after.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A — no developer-docs change required (behaviour is restored to what the cancel path already assumes).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables required. Unit/integration test only (Vitest + prismock).

Run the added test:

```bash
TZ=UTC yarn vitest run \
  packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts \
  -t "should preserve delegationCredentialId and thirdPartyRecurringEventId"
```

Expected:

- **Without the fix** (revert the two added `select` lines): the test fails —
  the rescheduled booking's references come back with `delegationCredentialId:
  null` and `thirdPartyRecurringEventId: null`.
- **With the fix**: the test passes.

Minimal test data: a booking whose google-calendar `BookingReference` has
`credentialId: null`, `delegationCredentialId` set, and
`thirdPartyRecurringEventId` set; then reschedule it to a new time.

Regression check (surrounding suites stay green):

```bash
TZ=UTC yarn vitest run \
  packages/features/bookings/lib/handleNewBooking/test \
  packages/features/bookings/lib/service \
  packages/features/bookings/lib/handleSeats
# => 152 passed | 1 skipped | 2 todo
```

Lint / type-check:

```bash
yarn biome lint --config-path=biome-staged.json \
  packages/features/bookings/lib/EventManager.ts \
  packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts   # exit 0
yarn turbo run type-check --filter=@calcom/features                          # 2 successful
```

## Checklist

- Fix is 2 lines of production code (a Prisma `select`) plus one new test.
- Diff is small and focused (2 files: `EventManager.ts` +2, `reschedule.test.ts` +143).
- No schema/migration change (both columns already exist on `BookingReference`).
