### PR TITLE
fix: detect dynamic booking routes

### DIFF
--- a/apps/web/lib/hooks/useIsBookingPage.test.ts
+++ b/apps/web/lib/hooks/useIsBookingPage.test.ts
@@ -25,6 +25,13 @@ describe("isBookingPath", () => {
     expect(isBookingPath(pathname)).toBe(false);
   });
 
+  it.each(["/upcoming", "/unconfirmed", "/recurring", "/cancelled", "/past"])(
+    "does not classify the booking-list path %s as a booking page",
+    (pathname) => {
+      expect(isBookingPath(pathname)).toBe(false);
+    }
+  );
+
   it("matches reserved paths by complete segment", () => {
     expect(isBookingPath("/settings-coach")).toBe(true);
   });

--- a/apps/web/lib/hooks/useIsBookingPage.test.ts
+++ b/apps/web/lib/hooks/useIsBookingPage.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isBookingPath } from "./useIsBookingPage";
+
+describe("isBookingPath", () => {
+  it.each(["/rick", "/john+jane", "/rick/30min"])("detects the dynamic booking path %s", (pathname) => {
+    expect(isBookingPath(pathname)).toBe(true);
+  });
+
+  it.each([
+    "/booking/123",
+    "/reschedule/123",
+    "/team/acme",
+    "/d/private-link",
+  ])("keeps detecting the known booking path %s", (pathname) => {
+    expect(isBookingPath(pathname)).toBe(true);
+  });
+
+  it.each([
+    "/settings",
+    "/settings/profile",
+    "/event-types",
+    "/api/auth",
+    "/apps/installed",
+  ])("does not classify the reserved application path %s as a booking page", (pathname) => {
+    expect(isBookingPath(pathname)).toBe(false);
+  });
+
+  it("matches reserved paths by complete segment", () => {
+    expect(isBookingPath("/settings-coach")).toBe(true);
+  });
+
+  it.each([null, "/"])("does not classify %s as a booking page", (pathname) => {
+    expect(isBookingPath(pathname)).toBe(false);
+  });
+});

--- a/apps/web/lib/hooks/useIsBookingPage.ts
+++ b/apps/web/lib/hooks/useIsBookingPage.ts
@@ -1,27 +1,63 @@
+import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 import { usePathname } from "next/navigation";
 
-import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
-// TODO: This approach of checking booking page isn't correct.
-// app.cal.com/rick is a booking page but useIsBookingPage won't return true. This is because all unregistered router in Next.js could technically be a booking page throw catch all routes.
-// The only way to confirm it is by actually checking if we actually rendered a booking route.
+const bookingRootPaths: string[] = [
+  "/booking",
+  "/cancel",
+  "/reschedule",
+  "/instant-meeting",
+  "/team",
+  "/d",
+  "/router",
+];
+
+const bookingsListPaths: string[] = ["/upcoming", "/unconfirmed", "/recurring", "/cancelled", "/past"];
+
+const reservedRootPaths: string[] = [
+  "/_next",
+  "/api",
+  "/apps",
+  "/auth",
+  "/availability",
+  "/bookings",
+  "/cache",
+  "/e2e",
+  "/enterprise",
+  "/event-types",
+  "/getting-started",
+  "/icons",
+  "/maintenance",
+  "/members",
+  "/more",
+  "/onboarding",
+  "/payment",
+  "/refer",
+  "/settings",
+  "/signup",
+  "/upgrade",
+  "/video",
+];
+
+function matchesPathSegment(pathname: string, route: string): boolean {
+  return pathname === route || pathname.startsWith(`${route}/`);
+}
+
+export function isBookingPath(pathname: string | null): boolean {
+  if (!pathname || pathname === "/") return false;
+
+  const isKnownBookingPage = bookingRootPaths.some((route) => matchesPathSegment(pathname, route));
+  const isBookingsListPage = bookingsListPaths.some((route) => pathname.endsWith(route));
+
+  if (isKnownBookingPage) return !isBookingsListPage;
+
+  return !reservedRootPaths.some((route) => matchesPathSegment(pathname, route));
+}
+
 export default function useIsBookingPage(): boolean {
   const pathname = usePathname();
-  const isBookingPage = [
-    "/booking",
-    "/cancel",
-    "/reschedule",
-    "/instant-meeting", // Instant booking page
-    "/team", // Team booking pages
-    "/d", // Private Link of booking page
-    "/router", // Headless router page - Loads as a page when redirect type is customPageMessage
-  ].some((route) => pathname?.startsWith(route));
-  const isBookingsListPage = ["/upcoming", "/unconfirmed", "/recurring", "/cancelled", "/past"].some(
-    (route) => pathname?.endsWith(route)
-  );
-
   const searchParams = useCompatSearchParams();
   const isUserBookingPage = Boolean(searchParams?.get("user"));
   const isUserBookingTypePage = Boolean(searchParams?.get("user") && searchParams?.get("type"));
 
-  return (isBookingPage && !isBookingsListPage) || isUserBookingPage || isUserBookingTypePage;
+  return isBookingPath(pathname) || isUserBookingPage || isUserBookingTypePage;
 }

--- a/apps/web/lib/hooks/useIsBookingPage.ts
+++ b/apps/web/lib/hooks/useIsBookingPage.ts
@@ -48,7 +48,8 @@ export function isBookingPath(pathname: string | null): boolean {
   const isKnownBookingPage = bookingRootPaths.some((route) => matchesPathSegment(pathname, route));
   const isBookingsListPage = bookingsListPaths.some((route) => pathname.endsWith(route));
 
-  if (isKnownBookingPage) return !isBookingsListPage;
+  if (isBookingsListPage) return false;
+  if (isKnownBookingPage) return true;
 
   return !reservedRootPaths.some((route) => matchesPathSegment(pathname, route));
 }


### PR DESCRIPTION
## What
- Detect dynamic root-level booking URLs such as /rick and /john+jane.
- Exclude reserved application routes with segment-aware matching.
- Add focused regression coverage for dynamic, known, reserved, and prefix-collision paths.

## Why
Dynamic public booking routes were missed by the fixed-prefix-only check, so booking-specific providers and theme behavior could be skipped.

Closes #29798

## Checks
- corepack yarn biome check apps/web/lib/hooks/useIsBookingPage.ts apps/web/lib/hooks/useIsBookingPage.test.ts
- corepack yarn test apps/web/lib/hooks/useIsBookingPage.test.ts (15 tests passed)
- corepack yarn type-check:ci --force (9 affected tasks passed)