### PR TITLE
fix(bookings): keep earlier recurring occurrences' scheduled triggers on cancel-subsequent

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -380,8 +380,11 @@ async function handler(input: CancelBookingInput, dependencies?: Dependencies) {
     const allUpdatedBookings = await bookingRepository.findManyIncludeReferences({
       where: {
         recurringEventId: bookingToDelete.recurringEventId,
+        // Must match the cancelled set above (gte), not "now": for cancelSubsequentBookings, gte is the
+        // target's startTime, so earlier still-active occurrences aren't included and don't get their
+        // scheduled webhook triggers / no-show tasks wiped.
         startTime: {
-          gte: new Date(),
+          gte,
         },
       },
     });

--- a/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
+++ b/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
@@ -1433,7 +1433,6 @@ describe("Cancel Booking", () => {
       },
     });
 
-    // Cancel the MIDDLE occurrence + all subsequent ones.
     await handleCancelBooking({
       bookingData: {
         id: middleId,

--- a/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
+++ b/packages/features/bookings/lib/handleCancelBooking/test/handleCancelBooking.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, vi } from "vitest";
 
 import { processPaymentRefund } from "@calcom/features/bookings/lib/payment/processPaymentRefund";
 import { BookingStatus } from "@calcom/prisma/enums";
+import prismock from "@calcom/testing/lib/__mocks__/prisma";
 import { test } from "@calcom/testing/lib/fixtures/fixtures";
 
 vi.mock("@calcom/features/bookings/lib/payment/processPaymentRefund", () => ({
@@ -1355,6 +1356,102 @@ describe("Cancel Booking", () => {
     expect(result.success).toBe(true);
     expect(result.onlyRemovedAttendee).toBe(false);
     expect(result.bookingId).toBe(idOfBookingToBeCancelled);
+  });
+
+  test("cancelSubsequentBookings must not wipe scheduled triggers of earlier, non-cancelled occurrences", async () => {
+    const handleCancelBooking = (await import("@calcom/features/bookings/lib/handleCancelBooking")).default;
+
+    const booker = getBooker({ email: "booker@example.com", name: "Booker" });
+    const organizer = getOrganizer({
+      name: "Organizer",
+      email: "organizer@example.com",
+      id: 101,
+      schedules: [TestData.schedules.IstWorkHours],
+      credentials: [getGoogleCalendarCredential()],
+      selectedCalendars: [TestData.selectedCalendars.google],
+    });
+
+    const recurringEventId = "rec-sub-series";
+    const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+    const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
+    const { dateString: plus3DateString } = getDate({ dateIncrement: 3 });
+    const firstId = 6080; // earliest upcoming occurrence — NOT being cancelled
+    const middleId = 6081; // the occurrence we cancel (this + subsequent)
+    const lastId = 6082;
+
+    const mkBooking = (id: number, uid: string, dateString: string) => ({
+      id,
+      uid,
+      recurringEventId,
+      eventTypeId: 1,
+      userId: 101,
+      attendees: [{ email: booker.email }],
+      responses: {
+        email: booker.email,
+        name: booker.name,
+        location: { optionValue: "", value: BookingLocations.CalVideo },
+      },
+      status: BookingStatus.ACCEPTED,
+      startTime: `${dateString}T05:00:00.000Z`,
+      endTime: `${dateString}T05:30:00.000Z`,
+    });
+
+    await createBookingScenario(
+      getScenarioData({
+        eventTypes: [
+          {
+            id: 1,
+            slotInterval: 30,
+            length: 30,
+            recurringEvent: { freq: 2, count: 3, interval: 1 },
+            users: [{ id: 101 }],
+          },
+        ],
+        bookings: [
+          mkBooking(firstId, "rec-sub-1", plus1DateString),
+          mkBooking(middleId, "rec-sub-2", plus2DateString),
+          mkBooking(lastId, "rec-sub-3", plus3DateString),
+        ],
+        organizer,
+        apps: [TestData.apps["daily-video"]],
+      })
+    );
+
+    mockSuccessfulVideoMeetingCreation({
+      metadataLookupKey: "dailyvideo",
+      videoMeetingData: { id: "MOCK_ID", password: "MOCK_PASS", url: `http://mock-dailyvideo.example.com/meeting-sub` },
+    });
+    mockCalendarToHaveNoBusySlots("googlecalendar", { create: { id: "MOCKED_GCAL_EVENT_SUB" } });
+
+    // The earliest occurrence has a scheduled webhook trigger (e.g. MEETING_ENDED). It is NOT being cancelled.
+    await prismock.webhookScheduledTriggers.create({
+      data: {
+        bookingId: firstId,
+        subscriberUrl: "http://my-webhook.example.com",
+        payload: "{}",
+        startAfter: new Date(`${plus1DateString}T05:30:00.000Z`),
+      },
+    });
+
+    // Cancel the MIDDLE occurrence + all subsequent ones.
+    await handleCancelBooking({
+      bookingData: {
+        id: middleId,
+        uid: "rec-sub-2",
+        cancelledBy: organizer.email,
+        cancellationReason: "Cancel this and subsequent",
+        cancelSubsequentBookings: true,
+      },
+      userId: organizer.id,
+    });
+
+    // The earliest occurrence must stay ACCEPTED (only middle + last are cancelled)...
+    const first = await prismock.booking.findFirst({ where: { id: firstId }, select: { status: true } });
+    expect(first?.status).toBe(BookingStatus.ACCEPTED);
+
+    // ...and its scheduled webhook trigger must survive, since it was never cancelled.
+    const remainingTriggers = await prismock.webhookScheduledTriggers.findMany({ where: { bookingId: firstId } });
+    expect(remainingTriggers).toHaveLength(1);
   });
 
   test("Should handle booking reference cleanup during cancellation", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes #29816

When cancelling a recurring occurrence with `cancelSubsequentBookings`, `updateMany` cancels bookings with `startTime >= gte` (where `gte` is the **target occurrence's** `startTime` — correct), but the follow-up `findManyIncludeReferences` that drives cleanup hard-codes `startTime >= new Date()` with no status filter. When the target isn't the earliest upcoming occurrence, that fetch is a **superset**: it includes earlier, still-`ACCEPTED` occurrences, whose scheduled `MEETING_STARTED`/`MEETING_ENDED` webhook triggers and no-show tasks then get deleted even though those meetings still happen.

This PR reuses the same `gte` bound for the cleanup fetch so it matches the cancelled set.

<!-- Note: Cal.diy is a community-maintained open-source project. -->

## Visual Demo (For contributors especially)

Backend logic fix with no UI surface — demonstrated with a red→green unit test (see *How should this be tested?*).

#### Video Demo (if applicable):

N/A — no UI change.

#### Image Demo (if applicable):

N/A — no UI change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A (no developer-facing API or docs change)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- **Data:** a recurring event with a `MEETING_STARTED`/`MEETING_ENDED` webhook subscription; a series with ≥3 upcoming occurrences, each with its scheduled triggers.
- **Steps:** cancel the **middle** occurrence with `cancelSubsequentBookings: true` (reachable via API v2 cancel and via `reportBooking`, which auto-sets it for recurring bookings).
- **Expected:** the earlier, non-cancelled occurrences keep their scheduled webhook triggers and no-show tasks.
- **Automated:** new regression test in `handleCancelBooking.test.ts` seeds three ACCEPTED occurrences + a scheduled webhook trigger on the earliest, cancels the middle with `cancelSubsequentBookings`, and asserts the earliest stays `ACCEPTED` **and** keeps its trigger. Verified **red** on current code (`expected [] to have length 1` — the trigger was deleted) and **green** after the fix; the file's existing 23 tests are unaffected (24/24 pass).

## Checklist

- N/A — follows the contributing guide and style guidelines, tests included, PR is small (2 files, ~100 lines incl. the test).
