### PR TITLE
chore(ui): fix typescript error in ToggleGroup css variables

### DIFF
--- a/packages/ui/components/form/toggleGroup/ToggleGroup.tsx
+++ b/packages/ui/components/form/toggleGroup/ToggleGroup.tsx
@@ -63,11 +63,12 @@ export const ToggleGroup = ({
           }
           onValueChange?.(value);
         }}
-        style={{
-          // @ts-expect-error --toggle-group-shadow is not a valid CSS property but can be a variable
-          "--toggle-group-shadow":
-            "0px 2px 3px 0px rgba(0, 0, 0, 0.03), 0px 2px 2px -1px rgba(0, 0, 0, 0.03)",
-        }}
+        style={
+          {
+            "--toggle-group-shadow":
+              "0px 2px 3px 0px rgba(0, 0, 0, 0.03), 0px 2px 2px -1px rgba(0, 0, 0, 0.03)",
+          } as React.CSSProperties
+        }
         className={classNames(
           `bg-muted rounded-[10px] p-0.5`,
           orientation === "horizontal" && "inline-flex gap-0.5 rtl:flex-row-reverse",

--- a/packages/ui/components/form/toggleGroup/ToggleGroup.tsx
+++ b/packages/ui/components/form/toggleGroup/ToggleGroup.tsx
@@ -1,5 +1,5 @@
 import * as RadixToggleGroup from "@radix-ui/react-toggle-group";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { useState } from "react";
 
 import classNames from "@calcom/ui/classNames";
@@ -67,7 +67,7 @@ export const ToggleGroup = ({
           {
             "--toggle-group-shadow":
               "0px 2px 3px 0px rgba(0, 0, 0, 0.03), 0px 2px 2px -1px rgba(0, 0, 0, 0.03)",
-          } as React.CSSProperties
+          } as CSSProperties
         }
         className={classNames(
           `bg-muted rounded-[10px] p-0.5`,


### PR DESCRIPTION
## Description

This PR fixes a TypeScript warning in the ToggleGroup component where --toggle-group-shadow was throwing a type error because it's a CSS Variable. The // @ts-expect-error comment was removed and the style object was safely cast to React.CSSProperties.

This cleans up the compiler warnings and maintains strict typings.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Run pnpm run type-check or view packages/ui/components/form/toggleGroup/ToggleGroup.tsx to verify there are no TypeScript errors.