### PR TITLE
perf: use Set lookups for booking member diffing (O(n*m) -> O(n+m))

### DIFF
--- a/packages/features/bookings/lib/BookingEmailSmsHandler.ts
+++ b/packages/features/bookings/lib/BookingEmailSmsHandler.ts
@@ -200,22 +200,23 @@ export class BookingEmailSmsHandler {
       ...copyEvent.attendees,
     ];
 
-    const matchOriginalMemberWithNewMember = (originalMember: Person, newMember: Person) =>
-      originalMember.email === newMember.email;
+    // Members are matched purely on email, so build lookup sets once instead of
+    // re-scanning the arrays for every member (O(n*m) -> O(n+m)).
+    const originalMemberEmailSet = new Set(originalBookingMemberEmails.map((member) => member.email));
+    const newMemberEmailSet = new Set(newBookingMemberEmails.map((member) => member.email));
 
     const newBookedMembers = newBookingMemberEmails.filter(
-      (member) => !originalBookingMemberEmails.some((om) => matchOriginalMemberWithNewMember(om, member))
+      (member) => !originalMemberEmailSet.has(member.email)
     );
     const cancelledMembers = originalBookingMemberEmails.filter(
-      (member) => !newBookingMemberEmails.some((nm) => matchOriginalMemberWithNewMember(member, nm))
+      (member) => !newMemberEmailSet.has(member.email)
     );
     const rescheduledMembers = newBookingMemberEmails.filter((member) =>
-      originalBookingMemberEmails.some((om) => matchOriginalMemberWithNewMember(om, member))
+      originalMemberEmailSet.has(member.email)
     );
 
-    const reassignedTo = users.find(
-      (user) => !user.isFixed && newBookedMembers.some((member) => member.email === user.email)
-    );
+    const newBookedMemberEmailSet = new Set(newBookedMembers.map((member) => member.email));
+    const reassignedTo = users.find((user) => !user.isFixed && newBookedMemberEmailSet.has(user.email));
 
     const {
       sendRoundRobinRescheduledEmailsAndSMS,


### PR DESCRIPTION
## What does this PR do?

`BookingEmailSmsHandler` diffs the original vs. new booking members four times, and each diff re-scans the opposing array with `.some()`:

```ts
const newBookedMembers = newBookingMemberEmails.filter(
  (member) => !originalBookingMemberEmails.some((om) => matchOriginalMemberWithNewMember(om, member))
);
// ...and the same shape for cancelledMembers / rescheduledMembers / reassignedTo
```

The matcher is `originalMember.email === newMember.email` — a plain email equality. So this is four `O(n*m)` scans where an `O(n+m)` set lookup does the same thing.

This builds the email sets once and looks up in `O(1)`:

```ts
const originalMemberEmailSet = new Set(originalBookingMemberEmails.map((m) => m.email));
const newMemberEmailSet = new Set(newBookingMemberEmails.map((m) => m.email));

const newBookedMembers = newBookingMemberEmails.filter((m) => !originalMemberEmailSet.has(m.email));
const cancelledMembers = originalBookingMemberEmails.filter((m) => !newMemberEmailSet.has(m.email));
const rescheduledMembers = newBookingMemberEmails.filter((m) => originalMemberEmailSet.has(m.email));
```

Behaviour is identical — matching was already email-only. Most visible on round-robin / team bookings with many members and attendees.

- Fixes # N/A (performance refactor, no issue)

## Visual Demo (For contributors especially)

N/A — backend-only change with no user-visible behaviour difference.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — **N/A**
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. — this is a behaviour-preserving refactor covered by the existing `BookingEmailSmsHandler` tests; I was not able to run the suite locally, so I'm leaving this unchecked rather than claiming it.

## How should this be tested?

Existing booking / round-robin reschedule tests should pass unchanged — the member sets produced are identical, only the lookup strategy changed.

<sub>Found with [cleanscore](https://github.com/yoo-minho/cleanscore) (flags linear scans of an outer array inside a loop) and verified by hand. This description was drafted with LLM assistance.</sub>
