### PR TITLE
perf: hoist userIdsSet out of the lucky-user while loop

### DIFF
--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -1019,6 +1019,10 @@ async function handler(
       const luckyUsers: typeof users = [];
       // loop through all non-fixed hosts and get the lucky users
       // This logic doesn't run when contactOwner is used because in that case, luckUsers.length === 1
+      // `users` is constant for this whole block, so build the id set once instead of
+      // rebuilding it on every iteration of the inner while-loop.
+      const userIdsSet = new Set(users.map((user) => user.id));
+
       for (const [groupId, luckyUserPool] of Object.entries(luckyUserPools)) {
         let luckUserFound = false;
         while (luckyUserPool.length > 0 && !luckUserFound) {
@@ -1030,7 +1034,6 @@ async function handler(
           assertNonEmptyArray(freeUsers); // make sure TypeScript knows it too with an assertion; the error will never be thrown.
           // freeUsers is ensured
 
-          const userIdsSet = new Set(users.map((user) => user.id));
           const newLuckyUser = await deps.luckyUserService.getLuckyUser({
             availableUsers: freeUsers,
             allRRHosts: eventTypeWithUsers.hosts.filter(


### PR DESCRIPTION
## What does this PR do?

In `RegularBookingService`, the lucky-user selection loop builds a `Set` of user ids on **every iteration of the inner `while` loop**, even though `users` is constant for the whole block:

```ts
for (const [groupId, luckyUserPool] of Object.entries(luckyUserPools)) {
  while (luckyUserPool.length > 0 && !luckUserFound) {
    // ...
    const userIdsSet = new Set(users.map((user) => user.id));  // rebuilt every iteration
    // ...
  }
}
```

This hoists the `Set` construction above the loops so it is built once:

```ts
const userIdsSet = new Set(users.map((user) => user.id));
for (const [groupId, luckyUserPool] of Object.entries(luckyUserPools)) {
  while (...) { /* reuse userIdsSet */ }
}
```

`users` isn't mutated in the loop, so the set is identical each iteration — behaviour is unchanged, only the repeated allocation/rebuild is removed. Most visible for round-robin events with many hosts.

- Fixes # N/A (performance refactor, no issue)

## Visual Demo (For contributors especially)

N/A — backend-only change with no user-visible behaviour difference.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — **N/A**
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. — behaviour-preserving refactor covered by existing round-robin tests; I was not able to run the suite locally, so I'm leaving this unchecked rather than claiming it.

## How should this be tested?

Existing round-robin / lucky-user assignment tests should pass unchanged — the set built is identical, only its construction moved out of the loop.

<sub>Found with [cleanscore](https://github.com/yoo-minho/cleanscore) (flags a Set/Map rebuilt from a loop-invariant source inside a loop) and verified by hand. Description drafted with LLM assistance.</sub>
