### PR TITLE
fix(webhooks): schedule a no-show task for every subscriber

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.integration-test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.integration-test.ts
@@ -95,8 +95,14 @@ describe("scheduleNoShowTriggers Integration", () => {
 
   test("scheduling a webhook creates the correct Tasker jobs for no-show webhooks", async () => {
     const currentDate = new Date("2023-01-01T10:00:00.000Z");
-    const bookingData: Partial<Booking> & { startTime: Date; id: number; location: string } = {
+    const bookingData: Partial<Booking> & {
+      startTime: Date;
+      id: number;
+      location: string;
+      uid: string;
+    } = {
       id: testBookingIds[0],
+      uid: "test-uid-no-show-tasks",
       startTime: currentDate,
       endTime: new Date("2023-01-01T10:30:00.000Z"),
       location: DailyLocationType,
@@ -126,8 +132,14 @@ describe("scheduleNoShowTriggers Integration", () => {
 
   test("created task payloads for no-show webhooks are correct", async () => {
     const currentDate = new Date("2023-01-01T11:00:00.000Z");
-    const bookingData: Partial<Booking> & { startTime: Date; id: number; location: string } = {
+    const bookingData: Partial<Booking> & {
+      startTime: Date;
+      id: number;
+      location: string;
+      uid: string;
+    } = {
       id: testBookingIds[1],
+      uid: "test-uid-no-show-payloads",
       startTime: currentDate,
       endTime: new Date("2023-01-01T11:30:00.000Z"),
       location: DailyLocationType,
@@ -194,6 +206,52 @@ describe("scheduleNoShowTriggers Integration", () => {
         timeUnit: TimeUnit.MINUTE,
       }),
     });
+  });
+
+  test("schedules a task for every subscriber sharing the same no-show trigger", async () => {
+    const secondHostWebhook = await prisma.webhook.create({
+      data: {
+        id: "test-host-webhook-id-2",
+        userId: testUser.id,
+        subscriberUrl: "https://example.com/host-webhook-2",
+        eventTriggers: [WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW],
+        active: true,
+        time: 15,
+        timeUnit: TimeUnit.MINUTE,
+      },
+    });
+
+    const bookingUid = "test-uid-multiple-subscribers";
+
+    await scheduleNoShowTriggers({
+      booking: {
+        id: 98770,
+        uid: bookingUid,
+        startTime: new Date("2023-01-01T12:00:00.000Z"),
+        location: DailyLocationType,
+      },
+      organizerUser: { id: testUser.id },
+      eventTypeId: testEventTypeId,
+      triggerForUser: true,
+    });
+
+    const hostTasks = await prisma.task.findMany({
+      where: {
+        type: "triggerHostNoShowWebhook",
+        referenceUid: { startsWith: bookingUid },
+      },
+    });
+
+    expect(hostTasks).toHaveLength(2);
+    expect(new Set(hostTasks.map((task) => task.referenceUid)).size).toBe(2);
+
+    const subscriberUrls = hostTasks.map((task) => JSON.parse(task.payload).webhook.subscriberUrl).sort();
+    expect(subscriberUrls).toEqual([
+      "https://example.com/host-webhook",
+      "https://example.com/host-webhook-2",
+    ]);
+
+    await prisma.webhook.delete({ where: { id: secondHostWebhook.id } });
   });
 
   test("task handler runs properly with the correct payload", async () => {

--- a/packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.test.ts
@@ -1,0 +1,178 @@
+import { DailyLocationType } from "@calcom/app-store/constants";
+import type { WebhookSubscriber } from "@calcom/features/webhooks/lib/dto/types";
+import { TimeUnit, WebhookTriggerEvents } from "@calcom/prisma/enums";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@calcom/features/tasker", () => ({
+  default: { create: vi.fn() },
+}));
+
+vi.mock("@calcom/features/webhooks/lib/getWebhooks", () => ({
+  default: vi.fn(),
+}));
+
+import tasker from "@calcom/features/tasker";
+import getWebhooks from "@calcom/features/webhooks/lib/getWebhooks";
+import { scheduleNoShowTriggers } from "./scheduleNoShowTriggers";
+
+type CreatedTask = { type: string; payload: unknown; referenceUid?: string };
+
+const booking = {
+  id: 101,
+  uid: "booking-uid-1",
+  startTime: new Date("2024-05-01T10:00:00.000Z"),
+  location: DailyLocationType,
+};
+
+const buildSubscriber = (id: string, triggerEvent: WebhookTriggerEvents): WebhookSubscriber => ({
+  id,
+  subscriberUrl: `https://example.com/${id}`,
+  payloadTemplate: null,
+  appId: null,
+  secret: null,
+  time: 5,
+  timeUnit: TimeUnit.MINUTE,
+  eventTriggers: [triggerEvent],
+  version: "2021-10-20",
+});
+
+/**
+ * The Task table enforces `@@unique([referenceUid, type])`, so a fake that ignores that
+ * constraint would hide the very collision this suite guards against.
+ */
+const createTaskerFake = () => {
+  const tasks: CreatedTask[] = [];
+  const uniqueKeys = new Set<string>();
+
+  const create = vi.fn(async (type: string, payload: unknown, options?: { referenceUid?: string }) => {
+    const referenceUid = options?.referenceUid;
+    const uniqueKey = `${referenceUid}:${type}`;
+
+    if (referenceUid !== undefined && uniqueKeys.has(uniqueKey)) {
+      throw new Error(`Unique constraint failed on the fields: (referenceUid, type) for ${uniqueKey}`);
+    }
+
+    uniqueKeys.add(uniqueKey);
+    tasks.push({ type, payload, referenceUid });
+    return `task-${tasks.length}`;
+  });
+
+  return { create, tasks };
+};
+
+describe("scheduleNoShowTriggers", () => {
+  let taskerFake: ReturnType<typeof createTaskerFake>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskerFake = createTaskerFake();
+    vi.mocked(tasker.create).mockImplementation(taskerFake.create as unknown as typeof tasker.create);
+  });
+
+  const mockSubscribers = ({
+    hosts = [],
+    guests = [],
+  }: {
+    hosts?: WebhookSubscriber[];
+    guests?: WebhookSubscriber[];
+  }) => {
+    vi.mocked(getWebhooks).mockImplementation(async ({ triggerEvent }) =>
+      triggerEvent === WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW ? hosts : guests
+    );
+  };
+
+  it("schedules an independent task for every host no-show subscriber", async () => {
+    mockSubscribers({
+      hosts: [
+        buildSubscriber("host-webhook-1", WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW),
+        buildSubscriber("host-webhook-2", WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW),
+      ],
+    });
+
+    await scheduleNoShowTriggers({
+      booking,
+      organizerUser: { id: 1 },
+      eventTypeId: 5,
+      triggerForUser: true,
+    });
+
+    const hostTasks = taskerFake.tasks.filter((task) => task.type === "triggerHostNoShowWebhook");
+    expect(hostTasks).toHaveLength(2);
+    expect(new Set(hostTasks.map((task) => task.referenceUid)).size).toBe(2);
+  });
+
+  it("schedules an independent task for every guest no-show subscriber", async () => {
+    mockSubscribers({
+      guests: [
+        buildSubscriber("guest-webhook-1", WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW),
+        buildSubscriber("guest-webhook-2", WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW),
+      ],
+    });
+
+    await scheduleNoShowTriggers({
+      booking,
+      organizerUser: { id: 1 },
+      eventTypeId: 5,
+      triggerForUser: true,
+    });
+
+    const guestTasks = taskerFake.tasks.filter((task) => task.type === "triggerGuestNoShowWebhook");
+    expect(guestTasks).toHaveLength(2);
+    expect(new Set(guestTasks.map((task) => task.referenceUid)).size).toBe(2);
+  });
+
+  it("does not reject when several subscribers share the same trigger", async () => {
+    mockSubscribers({
+      hosts: [
+        buildSubscriber("host-webhook-1", WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW),
+        buildSubscriber("host-webhook-2", WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW),
+      ],
+      guests: [
+        buildSubscriber("guest-webhook-1", WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW),
+        buildSubscriber("guest-webhook-2", WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW),
+      ],
+    });
+
+    await expect(
+      scheduleNoShowTriggers({
+        booking,
+        organizerUser: { id: 1 },
+        eventTypeId: 5,
+        triggerForUser: true,
+      })
+    ).resolves.not.toThrow();
+
+    expect(taskerFake.tasks).toHaveLength(4);
+  });
+
+  it("keeps the booking uid recoverable from the task reference so cancellation still matches", async () => {
+    mockSubscribers({
+      hosts: [buildSubscriber("host-webhook-1", WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW)],
+    });
+
+    await scheduleNoShowTriggers({
+      booking,
+      organizerUser: { id: 1 },
+      eventTypeId: 5,
+      triggerForUser: true,
+    });
+
+    const [hostTask] = taskerFake.tasks;
+    expect(hostTask.referenceUid).toMatch(new RegExp(`^${booking.uid}(_|$)`));
+  });
+
+  it("skips scheduling for non Cal Video locations", async () => {
+    mockSubscribers({
+      hosts: [buildSubscriber("host-webhook-1", WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW)],
+    });
+
+    await scheduleNoShowTriggers({
+      booking: { ...booking, location: "integrations:zoom" },
+      organizerUser: { id: 1 },
+      eventTypeId: 5,
+      triggerForUser: true,
+    });
+
+    expect(taskerFake.tasks).toHaveLength(0);
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.ts
+++ b/packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.ts
@@ -2,6 +2,7 @@ import { DailyLocationType } from "@calcom/app-store/constants";
 import dayjs from "@calcom/dayjs";
 import tasker from "@calcom/features/tasker";
 import getWebhooks from "@calcom/features/webhooks/lib/getWebhooks";
+import { getNoShowTaskReferenceUid } from "@calcom/features/webhooks/lib/noShowTaskReference";
 import { withReporting } from "@calcom/lib/sentryWrapper";
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 
@@ -63,7 +64,10 @@ const _scheduleNoShowTriggers = async (args: ScheduleNoShowTriggersArgs) => {
             // Prevents null values from being serialized
             webhook: { ...webhook, time: webhook.time, timeUnit: webhook.timeUnit },
           },
-          { scheduledAt, referenceUid: booking.uid }
+          {
+            scheduledAt,
+            referenceUid: getNoShowTaskReferenceUid({ bookingUid: booking.uid, webhookId: webhook.id }),
+          }
         );
       }
       return Promise.resolve();
@@ -94,7 +98,10 @@ const _scheduleNoShowTriggers = async (args: ScheduleNoShowTriggersArgs) => {
             // Prevents null values from being serialized
             webhook: { ...webhook, time: webhook.time, timeUnit: webhook.timeUnit },
           },
-          { scheduledAt, referenceUid: booking.uid }
+          {
+            scheduledAt,
+            referenceUid: getNoShowTaskReferenceUid({ bookingUid: booking.uid, webhookId: webhook.id }),
+          }
         );
       }
 

--- a/packages/features/webhooks/lib/cancelNoShowTasksForBooking.test.ts
+++ b/packages/features/webhooks/lib/cancelNoShowTasksForBooking.test.ts
@@ -1,0 +1,120 @@
+import prismock from "@calcom/testing/lib/__mocks__/prisma";
+import { WebhookTriggerEvents } from "@calcom/prisma/enums";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getNoShowTaskReferenceUid } from "./noShowTaskReference";
+import { cancelNoShowTasksForBooking } from "./scheduleTrigger";
+
+const bookingUid = "booking-uid-1";
+const otherBookingUid = "booking-uid-2";
+
+const createTask = (referenceUid: string, type: string) =>
+  prismock.task.create({
+    data: {
+      type,
+      payload: "{}",
+      referenceUid,
+      scheduledAt: new Date("2024-05-01T10:05:00.000Z"),
+    },
+  });
+
+const getReferenceUids = async (type?: string) => {
+  const tasks = await prismock.task.findMany({ where: type ? { type } : undefined });
+  return tasks.map((task) => task.referenceUid).sort();
+};
+
+describe("cancelNoShowTasksForBooking", () => {
+  beforeEach(async () => {
+    await prismock.task.deleteMany();
+  });
+
+  it("cancels the host no-show task of every subscriber of the booking", async () => {
+    const firstReference = getNoShowTaskReferenceUid({ bookingUid, webhookId: "webhook-1" });
+    const secondReference = getNoShowTaskReferenceUid({ bookingUid, webhookId: "webhook-2" });
+    const otherBookingReference = getNoShowTaskReferenceUid({
+      bookingUid: otherBookingUid,
+      webhookId: "webhook-1",
+    });
+
+    await createTask(firstReference, "triggerHostNoShowWebhook");
+    await createTask(secondReference, "triggerHostNoShowWebhook");
+    await createTask(otherBookingReference, "triggerHostNoShowWebhook");
+
+    await cancelNoShowTasksForBooking({
+      bookingUid,
+      triggerEvent: WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW,
+    });
+
+    expect(await getReferenceUids()).toEqual([otherBookingReference]);
+  });
+
+  it("cancels only the given subscriber's task when a webhookId is provided", async () => {
+    const firstReference = getNoShowTaskReferenceUid({ bookingUid, webhookId: "webhook-1" });
+    const secondReference = getNoShowTaskReferenceUid({ bookingUid, webhookId: "webhook-2" });
+
+    await createTask(firstReference, "triggerHostNoShowWebhook");
+    await createTask(secondReference, "triggerHostNoShowWebhook");
+
+    await cancelNoShowTasksForBooking({
+      bookingUid,
+      triggerEvent: WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW,
+      webhookId: "webhook-1",
+    });
+
+    expect(await getReferenceUids()).toEqual([secondReference]);
+  });
+
+  it("leaves guest no-show tasks untouched when cancelling the host trigger", async () => {
+    const hostReference = getNoShowTaskReferenceUid({ bookingUid, webhookId: "webhook-1" });
+    const guestReference = getNoShowTaskReferenceUid({ bookingUid, webhookId: "webhook-2" });
+
+    await createTask(hostReference, "triggerHostNoShowWebhook");
+    await createTask(guestReference, "triggerGuestNoShowWebhook");
+
+    await cancelNoShowTasksForBooking({
+      bookingUid,
+      triggerEvent: WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW,
+    });
+
+    expect(await getReferenceUids()).toEqual([guestReference]);
+  });
+
+  it("cancels tasks that were scheduled before the reference became webhook scoped", async () => {
+    await createTask(bookingUid, "triggerHostNoShowWebhook");
+
+    await cancelNoShowTasksForBooking({
+      bookingUid,
+      triggerEvent: WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW,
+    });
+
+    expect(await getReferenceUids()).toEqual([]);
+  });
+
+  it("cancels every no-show task of the booking when no trigger is given", async () => {
+    const hostReference = getNoShowTaskReferenceUid({ bookingUid, webhookId: "webhook-1" });
+    const guestReference = getNoShowTaskReferenceUid({ bookingUid, webhookId: "webhook-2" });
+    const otherBookingReference = getNoShowTaskReferenceUid({
+      bookingUid: otherBookingUid,
+      webhookId: "webhook-1",
+    });
+
+    await createTask(hostReference, "triggerHostNoShowWebhook");
+    await createTask(guestReference, "triggerGuestNoShowWebhook");
+    await createTask(otherBookingReference, "triggerHostNoShowWebhook");
+
+    await cancelNoShowTasksForBooking({ bookingUid });
+
+    expect(await getReferenceUids()).toEqual([otherBookingReference]);
+  });
+
+  it("ignores triggers that are not no-show triggers", async () => {
+    const hostReference = getNoShowTaskReferenceUid({ bookingUid, webhookId: "webhook-1" });
+    await createTask(hostReference, "triggerHostNoShowWebhook");
+
+    await cancelNoShowTasksForBooking({
+      bookingUid,
+      triggerEvent: WebhookTriggerEvents.BOOKING_CANCELLED,
+    });
+
+    expect(await getReferenceUids()).toEqual([hostReference]);
+  });
+});

--- a/packages/features/webhooks/lib/noShowTaskReference.ts
+++ b/packages/features/webhooks/lib/noShowTaskReference.ts
@@ -1,0 +1,22 @@
+import type { Prisma } from "@calcom/prisma/client";
+
+/**
+ * Task rows are unique on (referenceUid, type). Keying a no-show task on the booking uid alone
+ * therefore collapses every subscriber of the same trigger into one row, so all subscribers but
+ * the first are rejected. Scoping the reference to the webhook keeps one task per subscriber.
+ */
+export const getNoShowTaskReferenceUid = ({
+  bookingUid,
+  webhookId,
+}: {
+  bookingUid: string;
+  webhookId: string;
+}): string => `${bookingUid}_${webhookId}`;
+
+/**
+ * Booking uids are base58 short-uuids, so the `_` separator cannot appear in the booking part of
+ * the reference. The bare-uid branch keeps tasks scheduled before this key change cancellable.
+ */
+export const getNoShowTaskReferenceUidFilter = (bookingUid: string): Prisma.TaskWhereInput => ({
+  OR: [{ referenceUid: bookingUid }, { referenceUid: { startsWith: `${bookingUid}_` } }],
+});

--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -14,6 +14,7 @@ import type { Prisma, Webhook, Booking, ApiKey } from "@calcom/prisma/client";
 import { BookingStatus, WebhookTriggerEvents } from "@calcom/prisma/enums";
 import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 import { DEFAULT_WEBHOOK_VERSION, type WebhookVersion } from "./interface/IWebhookRepository";
+import { getNoShowTaskReferenceUid, getNoShowTaskReferenceUidFilter } from "./noShowTaskReference";
 
 const SCHEDULING_TRIGGER: WebhookTriggerEvents[] = [
   WebhookTriggerEvents.MEETING_ENDED,
@@ -526,6 +527,7 @@ export async function updateTriggerForExistingBookings(
           cancelNoShowTasksForBooking({
             bookingUid: booking.uid,
             triggerEvent,
+            webhookId: webhook.id,
           })
         ),
       ];
@@ -598,24 +600,32 @@ export async function cancelNoShowTasksForBooking({
   bookingUid,
   triggerEvent,
   webhook,
+  webhookId,
 }: {
   bookingUid?: string;
   triggerEvent?: WebhookTriggerEvents;
   webhook?: Pick<Webhook, "id" | "userId" | "teamId" | "eventTypeId">;
+  webhookId?: string;
 }) {
   if (bookingUid) {
     if (triggerEvent && !NO_SHOW_TRIGGERS.includes(triggerEvent)) return;
 
+    // A booking now holds one no-show task per subscriber, so cancelling for the whole booking has
+    // to match every subscriber's reference while a single subscriber only cancels its own task.
+    const referenceFilter = webhookId
+      ? { referenceUid: getNoShowTaskReferenceUid({ bookingUid, webhookId }) }
+      : getNoShowTaskReferenceUidFilter(bookingUid);
+
     if (triggerEvent === WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW) {
-      await tasker.cancelWithReference(bookingUid, "triggerHostNoShowWebhook");
-    } else if (triggerEvent === WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW) {
-      await tasker.cancelWithReference(bookingUid, "triggerGuestNoShowWebhook");
-    } else {
       await prisma.task.deleteMany({
-        where: {
-          referenceUid: bookingUid,
-        },
+        where: { ...referenceFilter, type: "triggerHostNoShowWebhook" },
       });
+    } else if (triggerEvent === WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW) {
+      await prisma.task.deleteMany({
+        where: { ...referenceFilter, type: "triggerGuestNoShowWebhook" },
+      });
+    } else {
+      await prisma.task.deleteMany({ where: referenceFilter });
     }
   } else if (webhook) {
     const bookings = await fetchBookingsFromWebhook(webhook);
@@ -625,7 +635,10 @@ export async function cancelNoShowTasksForBooking({
     const promises = bookings.map(async (booking) => {
       return await prisma.task.deleteMany({
         where: {
-          referenceUid: booking.uid,
+          OR: [
+            { referenceUid: booking.uid },
+            { referenceUid: getNoShowTaskReferenceUid({ bookingUid: booking.uid, webhookId: webhook.id }) },
+          ],
         },
       });
     });
@@ -673,7 +686,7 @@ export async function scheduleNoShowTaskForBooking(
     },
     {
       scheduledAt,
-      referenceUid: booking.uid,
+      referenceUid: getNoShowTaskReferenceUid({ bookingUid: booking.uid, webhookId: webhook.id }),
     }
   );
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes #29655

When an event type had **more than one active webhook** subscribed to the same Cal Video no-show trigger (`AFTER_HOSTS_CAL_VIDEO_NO_SHOW` / `AFTER_GUESTS_CAL_VIDEO_NO_SHOW`), only the first subscriber's no-show webhook was scheduled. The rest were dropped, and on the booking-confirmation path the failure also aborted the remaining webhook work for that booking.

### Root cause

`Task` is unique on `(referenceUid, type)`:

```prisma
referenceUid String?
@@unique([referenceUid, type])
```

Every no-show task for a booking was created with `referenceUid: booking.uid` and a type that only distinguishes host from guest. So *N* subscribers to the same trigger all resolved to the **same** `(referenceUid, type)` pair. The first insert won; every later one threw `P2002`.

Because `scheduleNoShowTriggers` awaits `Promise.all(...)`, that `P2002` propagated out of `handleConfirmation`, so the `BOOKING_CREATED` payloads dispatched *after* the call were never sent — this is the second symptom described in the issue.

### The fix

Scope the task reference to the subscriber instead of only the booking, via a small shared helper (`packages/features/webhooks/lib/noShowTaskReference.ts`):

```ts
getNoShowTaskReferenceUid({ bookingUid, webhookId }) // `${bookingUid}_${webhookId}`
```

- Both creation sites now use it: `scheduleNoShowTriggers` (booking flow) and `scheduleNoShowTaskForBooking` (webhook create/update flow). Each subscriber gets its own independently scheduled task, and no insert conflicts with another subscriber's.
- `cancelNoShowTasksForBooking` matches every subscriber's reference for a booking, so cancelling a booking still clears all of its no-show tasks. It also accepts an optional `webhookId`, which the "trigger removed from one webhook" path now passes so that deactivating one subscriber no longer cancels its siblings' tasks.
- Cancellation still matches the bare `booking.uid` form, so tasks already queued before this change stay cancellable after deploy. No schema change or migration is needed.

Booking uids are base58 short-uuids, so the `_` separator cannot appear in the booking portion of the reference and the prefix match stays unambiguous.

## Visual Demo (For contributors especially)

N/A — backend-only change with no UI surface. The behaviour is demonstrated by the tests below, including one that reproduces the original `P2002` against a real PostgreSQL database.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A, no documented behaviour or env var changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables are required. Minimal test data is an event type with two active webhooks pointing at different URLs, both subscribed to the same no-show trigger, both with `time` + `timeUnit` set, plus a Cal Video booking.

Expected happy path: each subscriber gets its own `Task` row (`triggerHostNoShowWebhook` / `triggerGuestNoShowWebhook`) with a distinct `referenceUid`, and the `BOOKING_CREATED` webhooks for that booking are still delivered.

Automated tests:

```bash
# Unit — subscriber fan-out and cancellation behaviour
TZ=UTC yarn vitest run \
  packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.test.ts \
  packages/features/webhooks/lib/cancelNoShowTasksForBooking.test.ts

# Integration — needs a database; asserts against the real unique constraint
TZ=UTC VITEST_MODE=integration yarn vitest run \
  packages/features/bookings/lib/handleNewBooking/scheduleNoShowTriggers.integration-test.ts
```

Results on this branch: 11 unit tests pass, 4 integration tests pass. The new integration test `schedules a task for every subscriber sharing the same no-show trigger` fails with `Unique constraint failed on the fields: ("referenceUid", type)` when the source fix is reverted, which is the exact failure from the issue.

`yarn type-check:ci --force` passes (9/9 packages, no TS errors). `yarn lint` (`biome lint`, the CI gate) reports no errors on the changed files, and `biome format` reports nothing to reformat.

For full transparency: `biome check` also raises `assist/source/organizeImports` on `scheduleTrigger.ts` and `scheduleNoShowTriggers.integration-test.ts`, but that is pre-existing on `main` for those same two files (verified against the `main` copies), and applying it would reorder unrelated pre-existing imports. I left it out to keep the diff scoped to the fix.

### Note on the existing integration fixtures

The two pre-existing fixtures in `scheduleNoShowTriggers.integration-test.ts` omitted `uid`, so `referenceUid` was written as `NULL` — and PostgreSQL treats `NULL`s as distinct, which is why the collision never showed up there. I added a `uid` to those fixtures (the flow's type already requires `uid: string`, and real callers always pass one) so the test exercises the same key that production does.

## Checklist

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- I have added tests that prove my fix is effective

