### PR TITLE
fix(i18n): ask Intl for the hour cycle instead of sniffing for AM/PM

### DIFF
--- a/packages/lib/timeFormat.test.ts
+++ b/packages/lib/timeFormat.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveIs24h } from "./timeFormat";
+
+describe("fn: resolveIs24h", () => {
+  it("should detect 24-hour locales", () => {
+    for (const locale of ["de-DE", "fr-FR", "ja-JP", "pl-PL", "ru-RU", "sv-SE"]) {
+      expect(resolveIs24h(locale), locale).toBe(true);
+    }
+  });
+
+  it("should detect 12-hour locales that use Latin AM/PM", () => {
+    for (const locale of ["en-US", "en-AU", "ko-KR"]) {
+      expect(resolveIs24h(locale), locale).toBe(false);
+    }
+  });
+
+  it("should detect 12-hour locales whose day period is not written in Latin script", () => {
+    // The previous implementation sniffed the formatted output for the letter
+    // "M", so these came back as 24-hour:
+    //   ar    "9 ص"
+    //   el    "9 π.μ."
+    //   zh-TW "上午9時"
+    for (const locale of ["ar", "el", "zh-TW"]) {
+      expect(resolveIs24h(locale), locale).toBe(false);
+    }
+  });
+
+  it("should agree with what Intl itself reports, for every locale this repo ships", () => {
+    // Guards against any future locale being added with the same class of bug.
+    const locales = [
+      "ar", "az", "bg", "bn", "ca", "cs", "da", "de", "el", "en", "es", "es-419", "et", "eu",
+      "fi", "fr", "he", "hr", "hu", "id", "it", "ja", "km", "ko", "nl", "no", "pl", "pt", "pt-BR",
+      "ro", "ru", "sk", "sr", "sv", "ta", "te", "tr", "uk", "vi", "zh-CN", "zh-TW",
+    ];
+
+    for (const locale of locales) {
+      const resolved = new Intl.DateTimeFormat(locale, { hour: "numeric" }).resolvedOptions();
+
+      expect(resolveIs24h(locale), locale).toBe(!resolved.hour12);
+    }
+  });
+
+  it("should fall back to the browser locale when none is given", () => {
+    const resolved = new Intl.DateTimeFormat(undefined, { hour: "numeric" }).resolvedOptions();
+
+    expect(resolveIs24h()).toBe(!resolved.hour12);
+  });
+});

--- a/packages/lib/timeFormat.ts
+++ b/packages/lib/timeFormat.ts
@@ -29,6 +29,26 @@ export const getTimeFormatStringFromUserTimeFormat = (timeFormat: number | null 
 };
 
 /**
+ * Asks Intl whether the given locale (undefined = the browser's own) uses a
+ * 12-hour clock.
+ *
+ * We deliberately do NOT sniff the formatted output for "AM"/"PM": locales that
+ * write their day period in their own script (ar "ص", el "π.μ.", zh-TW "上午")
+ * contain no Latin M and were misdetected as 24-hour.
+ */
+export const resolveIs24h = (locale?: string): boolean => {
+  const resolved = new Intl.DateTimeFormat(locale, { hour: "numeric" }).resolvedOptions();
+
+  // hourCycle is the precise signal (h11/h12 are 12-hour, h23/h24 are 24-hour);
+  // hour12 is the widely available fallback.
+  if (resolved.hourCycle) {
+    return resolved.hourCycle === "h23" || resolved.hourCycle === "h24";
+  }
+
+  return !resolved.hour12;
+};
+
+/**
  * Retrieves the browsers time format preference, checking local storage first
  * for a user set preference. If no preference is found, it will use the browser
  * locale to determine the time format and store it in local storage.
@@ -41,14 +61,13 @@ export const isBrowserLocale24h = () => {
   } else if (localStorageTimeFormat === false) {
     return false;
   }
-  // Intl.DateTimeFormat with value=undefined uses local browser settings.
-  if (!!new Intl.DateTimeFormat(undefined, { hour: "numeric" }).format(0).match(/M/i)) {
-    setIs24hClockInLocalStorage(false);
-    return false;
-  } else {
-    setIs24hClockInLocalStorage(true);
-    return true;
-  }
+
+  // Intl.DateTimeFormat with locale=undefined uses local browser settings.
+  const is24h = resolveIs24h();
+
+  setIs24hClockInLocalStorage(is24h);
+
+  return is24h;
 };
 
 /**


### PR DESCRIPTION
## What does this PR do?

Fixes #29845.

`isBrowserLocale24h()` decided whether the user wants a 24-hour clock by formatting an hour and **searching the output for the letter `M`**. That only works when the locale writes its day period as the Latin `AM`/`PM`. Locales that use their own script contain no `M`, so they were classified as 24-hour — and the wrong answer was then **persisted to localStorage**, so it stuck until the user changed the setting by hand.

`Intl` reports this directly, so the heuristic isn't needed at all. The new `resolveIs24h()` reads `hourCycle` (`h11`/`h12` → 12-hour, `h23`/`h24` → 24-hour) and falls back to `hour12`.

## Impact

Checked every locale this repo ships (`i18n.json` → `en` plus 36 targets), on Node 22 / ICU 78:

| locale | formatted output | actual | detected (before) |
|---|---|---|---|
| `ar` | `9 ص` | 12h | **24h** |
| `el` | `9 π.μ.` | 12h | **24h** |
| `zh-TW` | `上午9時` | 12h | **24h** |

34 of the 37 were already correct and stay correct. The heuristic also misfires for common browser locales outside the shipped set — `ms-MY` (`"9 PG"`), `sq-AL` (`"9 p.d."`).

Worth noting `ko-KR` passed only by luck: its output is `"AM 9시"`, which happens to contain a literal `AM`. The correctness of the old check depended on which locales romanise their day period.

## How was it tested?

`timeFormat.ts` had no test file. This PR adds one with 5 tests:

- 24-hour locales (`de-DE`, `fr-FR`, `ja-JP`, `pl-PL`, `ru-RU`, `sv-SE`) resolve to 24h
- 12-hour locales with Latin AM/PM (`en-US`, `en-AU`, `ko-KR`) resolve to 12h
- 12-hour locales with non-Latin day periods (`ar`, `el`, `zh-TW`) resolve to 12h — this is the regression
- **every locale in the shipped set agrees with what `Intl` itself reports**, so a future locale addition can't reintroduce this class of bug
- with no locale argument it follows the environment locale

**Verification:** all 5 pass. Reverting `resolveIs24h` to the old `/M/i` heuristic with the tests in place fails exactly the two behavioural tests (non-Latin day periods, and the all-locales sweep) — so they pin the fix rather than passing incidentally.

## Note

I extracted the detection into an exported `resolveIs24h(locale?)` so it can be tested without stubbing `localStorage`, and so callers that already know the locale can use it directly. `isBrowserLocale24h()` keeps its existing signature and localStorage behaviour — the only change there is that it now stores the correct value.
