### PR TITLE
fix(event-types): make interval limit validation independent of key order

### DIFF
--- a/packages/lib/intervalLimits/validateIntervalLimitOrder.test.ts
+++ b/packages/lib/intervalLimits/validateIntervalLimitOrder.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import type { IntervalLimit } from "./intervalLimitSchema";
+import { validateIntervalLimitOrder } from "./validateIntervalLimitOrder";
+
+describe("fn: validateIntervalLimitOrder", () => {
+  it("should accept limits that ascend with the interval", () => {
+    expect(validateIntervalLimitOrder({ PER_DAY: 1, PER_WEEK: 2, PER_MONTH: 3, PER_YEAR: 4 })).toBe(true);
+    expect(validateIntervalLimitOrder({ PER_DAY: 3, PER_MONTH: 5 })).toBe(true);
+    expect(validateIntervalLimitOrder({ PER_DAY: 9, PER_YEAR: 25 })).toBe(true);
+  });
+
+  it("should reject a smaller interval carrying a larger limit", () => {
+    expect(validateIntervalLimitOrder({ PER_DAY: 60, PER_WEEK: 30 })).toBe(false);
+    expect(validateIntervalLimitOrder({ PER_DAY: 9, PER_MONTH: 5 })).toBe(false);
+    expect(validateIntervalLimitOrder({ PER_WEEK: 10, PER_MONTH: 10, PER_YEAR: 1 })).toBe(false);
+  });
+
+  it("should accept an empty or single limit", () => {
+    expect(validateIntervalLimitOrder({})).toBe(true);
+    expect(validateIntervalLimitOrder({ PER_WEEK: 5 })).toBe(true);
+  });
+
+  it("should not depend on key insertion order", () => {
+    // Every permutation of the same limits must give the same verdict. The
+    // previous implementation sorted by value and let Array.sort's stability
+    // decide the tie, so the object literal's key order changed the answer.
+    const permutations: IntervalLimit[] = [
+      { PER_DAY: 5, PER_WEEK: 5 },
+      { PER_WEEK: 5, PER_DAY: 5 },
+    ];
+
+    for (const limits of permutations) {
+      expect(validateIntervalLimitOrder(limits), JSON.stringify(limits)).toBe(true);
+    }
+
+    const invalid: IntervalLimit[] = [
+      { PER_DAY: 9, PER_WEEK: 2 },
+      { PER_WEEK: 2, PER_DAY: 9 },
+    ];
+
+    for (const limits of invalid) {
+      expect(validateIntervalLimitOrder(limits), JSON.stringify(limits)).toBe(false);
+    }
+  });
+
+  it("should accept equal limits across every interval", () => {
+    expect(validateIntervalLimitOrder({ PER_DAY: 1, PER_YEAR: 1 })).toBe(true);
+    expect(validateIntervalLimitOrder({ PER_DAY: 1, PER_YEAR: 1, PER_WEEK: 1, PER_MONTH: 1 })).toBe(true);
+    expect(validateIntervalLimitOrder({ PER_YEAR: 5, PER_MONTH: 5, PER_WEEK: 5, PER_DAY: 5 })).toBe(true);
+  });
+
+  it("should survive the unit-flip round trip the limits UI performs", () => {
+    // EventLimitsTab re-inserts the key at the end of the object when a row's
+    // unit changes, so flipping a unit and flipping it back reorders the keys
+    // while leaving the limits identical.
+    let limits: IntervalLimit = { PER_DAY: 5, PER_WEEK: 5 };
+    expect(validateIntervalLimitOrder(limits)).toBe(true);
+
+    const flip = (from: keyof IntervalLimit, to: keyof IntervalLimit, current: IntervalLimit) => {
+      const next = { ...current };
+      const value = next[from];
+      delete next[from];
+      return { ...next, [to]: value };
+    };
+
+    limits = flip("PER_DAY", "PER_MONTH", limits);
+    expect(validateIntervalLimitOrder(limits)).toBe(true);
+
+    limits = flip("PER_MONTH", "PER_DAY", limits);
+    expect(Object.keys(limits)).toEqual(["PER_WEEK", "PER_DAY"]);
+    expect(validateIntervalLimitOrder(limits)).toBe(true);
+  });
+
+  it("should ignore keys that are explicitly undefined", () => {
+    expect(validateIntervalLimitOrder({ PER_DAY: 9, PER_WEEK: undefined, PER_MONTH: 20 })).toBe(true);
+  });
+});

--- a/packages/lib/intervalLimits/validateIntervalLimitOrder.ts
+++ b/packages/lib/intervalLimits/validateIntervalLimitOrder.ts
@@ -1,15 +1,20 @@
 import { ascendingLimitKeys } from "./intervalLimit";
 import type { IntervalLimit } from "./intervalLimitSchema";
 
+/**
+ * A limit for a smaller interval may not exceed the limit for a larger one:
+ * PER_DAY <= PER_WEEK <= PER_MONTH <= PER_YEAR.
+ *
+ * Equal neighbours are valid ("5 per day and 5 per week" is coherent), which is
+ * why this walks the keys in interval order and compares values directly. The
+ * previous implementation sorted by value and compared the resulting key order,
+ * so equal values fell back to `Array.sort`'s stability and the verdict depended
+ * on the object's key insertion order.
+ */
 export const validateIntervalLimitOrder = (input: IntervalLimit) => {
-  // Sort limits by validationOrder
-  const sorted = Object.entries(input)
-    .sort(([, value], [, valuetwo]) => {
-      return value - valuetwo;
-    })
-    .map(([key]) => key);
+  const presentLimits = ascendingLimitKeys
+    .filter((key) => input[key] !== undefined)
+    .map((key) => input[key] as number);
 
-  const validationOrderWithoutMissing = ascendingLimitKeys.filter((key) => sorted.includes(key));
-
-  return sorted.every((key, index) => validationOrderWithoutMissing[index] === key);
+  return presentLimits.every((limit, index) => index === 0 || presentLimits[index - 1] <= limit);
 };


### PR DESCRIPTION
## What does this PR do?

Fixes #29847.

`validateIntervalLimitOrder()` sorted the limits by value and then checked that the resulting *key* order matched `PER_DAY → PER_WEEK → PER_MONTH → PER_YEAR`. When two limits are equal the comparator returns `0`, and since `Array.prototype.sort` is stable the tie was broken by the object's key insertion order. The verdict therefore depended on how the object happened to be built:

```js
validateIntervalLimitOrder({ PER_DAY: 2, PER_WEEK: 2 }); // true
validateIntervalLimitOrder({ PER_WEEK: 2, PER_DAY: 2 }); // false  ← same limits
```

The fix walks the keys in interval order and compares values directly, so only the values decide.

## Why this matters — it's reachable from the UI

`IntervalLimitsManager` re-inserts a key at the **end** of the object when a row's unit changes:

```ts
delete current[limitKey];
const newData = { ...current, [interval?.value as IntervalLimitsKey]: currentValue };
```

So flipping a row's unit and flipping it back leaves the limits identical but the keys reordered:

```
start         {"PER_DAY":5,"PER_WEEK":5}     valid = true
day -> month  {"PER_WEEK":5,"PER_MONTH":5}   valid = true
month -> day  {"PER_WEEK":5,"PER_DAY":5}     valid = false   ← identical limits to start
```

Because the list is rendered sorted by `ascendingLimitKeys`, the form looks **exactly** as it did at the start — same rows, same numbers, same order — but saving now fails with `BAD_REQUEST: "Booking limits must be in ascending order."` from `update.handler.ts`. The message is misleading too: the limits *are* in ascending order, they're equal.

Equal limits are a legitimate configuration ("at most 5 per day and at most 5 per week"), and the existing suite already asserts `{ PER_DAY: 1, PER_YEAR: 1 }` is valid — that assertion only passed because of the order the literal was written in. With all four equal, the old code returned `false`.

## How was it tested?

`validateIntervalLimitOrder` had no dedicated test file (only 9 inline assertions inside `checkBookingLimits.test.ts` / `checkDurationLimits.test.ts`). This PR adds one with 7 tests:

- ascending limits accepted; a smaller interval with a larger limit rejected
- empty and single-limit inputs accepted
- **every permutation of the same limits gives the same verdict** — for a valid set and an invalid one
- equal limits accepted across two intervals and across all four
- the unit-flip round trip the UI performs stays valid, asserting the resulting key order is `["PER_WEEK", "PER_DAY"]` so the test genuinely exercises the reordering
- explicitly `undefined` values are ignored rather than compared

**Verification:**

- All 7 new tests pass.
- Reverting the implementation with the tests in place fails exactly the 3 behavioural tests (key-order independence, equal limits, the UI round trip) — so they pin this fix.
- **All 9 pre-existing assertions** from `checkBookingLimits.test.ts` and `checkDurationLimits.test.ts` still pass against the new implementation. I ran them verbatim against it rather than assuming; no existing test file needed changing.

## Note

The new implementation is also O(n) over the four fixed keys instead of sorting, and it no longer relies on `Object.entries` ordering at all — so this class of bug can't come back through a different call site.
