### PR TITLE
fix(bookings): keep the guest whose email survived deduplication

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
@@ -208,10 +208,18 @@ export async function sanitizeAndFilterGuests(
   const guestEmailsLowerCase = deduplicatedGuests.map((email) => extractBaseEmail(email).toLowerCase());
   const emailToRequiresVerification = await getEmailVerificationRequirements(guestEmailsLowerCase);
 
-  // Create a map of email to guest object for easy lookup
-  const emailToGuestMap = new Map(
-    guests.map((guest) => [extractBaseEmail(guest.email).toLowerCase(), guest])
-  );
+  // Create a map of email to guest object for easy lookup.
+  // deduplicateGuestEmails keeps the FIRST occurrence of a base email, so this
+  // map has to keep the first one too - `new Map(entries)` would let a later
+  // duplicate overwrite it and we'd return a guest whose email didn't survive
+  // deduplication.
+  const emailToGuestMap = new Map<string, (typeof guests)[number]>();
+  for (const guest of guests) {
+    const baseEmail = extractBaseEmail(guest.email).toLowerCase();
+    if (!emailToGuestMap.has(baseEmail)) {
+      emailToGuestMap.set(baseEmail, guest);
+    }
+  }
 
   const uniqueGuestEmails = deduplicatedGuests.filter((email) => {
     const baseGuestEmail = extractBaseEmail(email).toLowerCase();

--- a/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
@@ -208,7 +208,6 @@ export async function sanitizeAndFilterGuests(
   const guestEmailsLowerCase = deduplicatedGuests.map((email) => extractBaseEmail(email).toLowerCase());
   const emailToRequiresVerification = await getEmailVerificationRequirements(guestEmailsLowerCase);
 
-  // Create a map of email to guest object for easy lookup.
   // deduplicateGuestEmails keeps the FIRST occurrence of a base email, so this
   // map has to keep the first one too - `new Map(entries)` would let a later
   // duplicate overwrite it and we'd return a guest whose email didn't survive

--- a/packages/trpc/server/routers/viewer/bookings/addGuests.sanitize.test.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.sanitize.test.ts
@@ -1,0 +1,107 @@
+import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sanitizeAndFilterGuests } from "./addGuests.handler";
+
+vi.mock("@calcom/features/users/repositories/UserRepository");
+
+vi.mock("@calcom/prisma", () => ({
+  default: {},
+  prisma: {},
+}));
+
+const findManyByEmailsWithEmailVerificationSettings = vi.fn();
+
+type Guest = Parameters<typeof sanitizeAndFilterGuests>[0][number];
+
+const bookingWithAttendees = (emails: string[]) =>
+  ({ attendees: emails.map((email) => ({ email })) } as unknown as Parameters<
+    typeof sanitizeAndFilterGuests
+  >[1]);
+
+describe("fn: sanitizeAndFilterGuests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.BLACKLISTED_GUEST_EMAILS;
+
+    findManyByEmailsWithEmailVerificationSettings.mockResolvedValue([]);
+
+    vi.mocked(UserRepository).mockImplementation(
+      () =>
+        ({
+          findManyByEmailsWithEmailVerificationSettings,
+        } as unknown as UserRepository)
+    );
+  });
+
+  it("should return the guest whose email survived deduplication", async () => {
+    // Both addresses share the base email alice@x.com. deduplicateGuestEmails
+    // keeps the first, so the returned object must be the first one too.
+    const guests: Guest[] = [
+      { email: "alice+work@x.com", name: "Alice Work" },
+      { email: "alice+home@x.com", name: "Alice Home" },
+    ];
+
+    const result = await sanitizeAndFilterGuests(guests, bookingWithAttendees([]));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].email).toEqual("alice+work@x.com");
+    expect(result[0].name).toEqual("Alice Work");
+  });
+
+  it("should keep the first entry when the exact same email is sent twice", async () => {
+    const guests: Guest[] = [
+      { email: "bob@x.com", name: "First", timeZone: "Europe/London" },
+      { email: "bob@x.com", name: "Second", timeZone: "Asia/Seoul" },
+    ];
+
+    const result = await sanitizeAndFilterGuests(guests, bookingWithAttendees([]));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toEqual("First");
+    expect(result[0].timeZone).toEqual("Europe/London");
+  });
+
+  it("should keep distinct guests untouched and in order", async () => {
+    const guests: Guest[] = [
+      { email: "a@x.com", name: "A" },
+      { email: "b@x.com", name: "B" },
+      { email: "c@x.com", name: "C" },
+    ];
+
+    const result = await sanitizeAndFilterGuests(guests, bookingWithAttendees([]));
+
+    expect(result.map((guest) => guest.email)).toEqual(["a@x.com", "b@x.com", "c@x.com"]);
+    expect(result.map((guest) => guest.name)).toEqual(["A", "B", "C"]);
+  });
+
+  it("should drop guests already attending the booking, matching on the base email", async () => {
+    const guests: Guest[] = [
+      { email: "dave+tag@x.com", name: "Dave" },
+      { email: "erin@x.com", name: "Erin" },
+    ];
+
+    const result = await sanitizeAndFilterGuests(guests, bookingWithAttendees(["dave@x.com"]));
+
+    expect(result.map((guest) => guest.email)).toEqual(["erin@x.com"]);
+  });
+
+  it("should drop blacklisted guests", async () => {
+    process.env.BLACKLISTED_GUEST_EMAILS = "blocked@corp.com";
+
+    const guests: Guest[] = [
+      { email: "blocked+anything@corp.com", name: "Blocked" },
+      { email: "fine@x.com", name: "Fine" },
+    ];
+
+    const result = await sanitizeAndFilterGuests(guests, bookingWithAttendees([]));
+
+    expect(result.map((guest) => guest.email)).toEqual(["fine@x.com"]);
+  });
+
+  it("should throw when every guest is filtered out", async () => {
+    const guests: Guest[] = [{ email: "dupe@x.com", name: "Dupe" }];
+
+    await expect(sanitizeAndFilterGuests(guests, bookingWithAttendees(["dupe@x.com"]))).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #29849.

`sanitizeAndFilterGuests()` deduplicates guests by base email in two places that disagree about which duplicate wins.

`deduplicateGuestEmails()` keeps the **first** occurrence. But `emailToGuestMap` was built with `new Map(entries)`, where a later entry **overwrites** an earlier one — so the surviving *email* came from the first duplicate while the guest *object* looked up came from the last.

```js
guests = [
  { email: "alice+work@x.com", name: "Alice Work" },
  { email: "alice+home@x.com", name: "Alice Home" },
];

deduplicated     -> ["alice+work@x.com"]                    // first wins
emailToGuestMap  -> { "alice@x.com" => Alice Home }         // last wins
result           -> [{ email: "alice+home@x.com", ... }]    // wrong guest
```

`addGuestsHandler` then writes that object's `name`, `email`, `timeZone` and `language` to the booking via `updateBookingAttendees` — so the wrong person is invited. `BookingAttendeesService.ts:103` goes through the same function.

The fix builds the map with an explicit first-wins loop, so both halves use the same tie-break.

## How was it tested?

Added `addGuests.sanitize.test.ts` with 6 tests covering the fixed behaviour and the surrounding filtering that must not regress:

- two plus-addressed variants of one base email → the returned guest is the one whose email survived deduplication
- the exact same email twice with different names/timezones → the first entry is kept
- distinct guests pass through unchanged and in order
- a guest already attending the booking is dropped, matched on the base email
- a blacklisted guest is dropped (including via plus-addressing)
- everything filtered out still throws `BAD_REQUEST`

The mocking follows the pattern already used in this package (`BookingAccessService.test.ts` mocks `UserRepository` and `@calcom/prisma` the same way).

**Verification.** I want to be precise about what I could and couldn't run locally. I don't have the monorepo's dependencies installed, so I could not execute this test file in place. What I did instead was extract `deduplicateGuestEmails` and `sanitizeAndFilterGuests`'s filtering logic verbatim into a standalone harness and run **both** the current and the fixed implementation side by side under vitest:

- the current implementation returns `alice+home@x.com` / `"Alice Home"` — the bug, asserted explicitly
- the fixed implementation returns `alice+work@x.com` / `"Alice Work"`
- exact-duplicate, distinct-guest, existing-attendee, blacklist and throw-when-empty cases behave identically under both, confirming the change is confined to the collision case

7 assertions, all passing. Please do run the committed test file in CI — if the mock setup needs adjusting for this package I'll fix it right away.

## Also spotted

`extractBaseEmail()` returns the string `"noatsign@undefined"` for input with no `@`, since `split("@")` leaves `domain` undefined. That value flows into the blacklist comparison and the user lookup. I left it out of this PR to keep the change focused — happy to file and fix separately.
