### PR TITLE
fix(security): trim the IP parsed from x-forwarded-for

### DIFF
--- a/packages/lib/getIP.test.ts
+++ b/packages/lib/getIP.test.ts
@@ -22,6 +22,29 @@ describe("parseIpFromHeaders", () => {
   it("returns the first element when given an array", () => {
     expect(parseIpFromHeaders(["1.2.3.4", "5.6.7.8"])).toBe("1.2.3.4");
   });
+
+  it("trims whitespace around the IP", () => {
+    // X-Forwarded-For allows optional whitespace around the commas, and the
+    // result is used as an exact-match banlist / rate-limit identifier.
+    expect(parseIpFromHeaders("1.2.3.4 , 5.6.7.8")).toBe("1.2.3.4");
+    expect(parseIpFromHeaders(" 1.2.3.4, 5.6.7.8")).toBe("1.2.3.4");
+    expect(parseIpFromHeaders("  1.2.3.4  ")).toBe("1.2.3.4");
+    expect(parseIpFromHeaders("\t1.2.3.4\t")).toBe("1.2.3.4");
+  });
+
+  it("splits a comma-separated array entry too", () => {
+    expect(parseIpFromHeaders(["1.2.3.4, 5.6.7.8"])).toBe("1.2.3.4");
+  });
+
+  it("gives one identifier for the same client regardless of proxy spacing", () => {
+    const spellings = ["1.2.3.4,5.6.7.8", "1.2.3.4, 5.6.7.8", "1.2.3.4 , 5.6.7.8", " 1.2.3.4 ,5.6.7.8"];
+
+    const parsed = new Set(spellings.map((value) => parseIpFromHeaders(value)));
+
+    // More than one entry means the same client would get separate rate-limit
+    // buckets and could miss an exact-match ban.
+    expect(parsed).toEqual(new Set(["1.2.3.4"]));
+  });
 });
 
 describe("getIP", () => {
@@ -70,6 +93,11 @@ describe("getIP", () => {
 
     it("extracts first IP from comma-separated x-forwarded-for", () => {
       const req = buildRequest({ "x-forwarded-for": "9.9.9.9, 10.0.0.1, 172.16.0.1" });
+      expect(getIP(req)).toBe("9.9.9.9");
+    });
+
+    it("extracts a trimmed IP from a padded x-forwarded-for", () => {
+      const req = buildRequest({ "x-forwarded-for": "9.9.9.9 , 10.0.0.1" });
       expect(getIP(req)).toBe("9.9.9.9");
     });
   });

--- a/packages/lib/getIP.ts
+++ b/packages/lib/getIP.ts
@@ -4,7 +4,12 @@ import z from "zod";
 import logger from "./logger";
 
 export function parseIpFromHeaders(value: string | string[]) {
-  return Array.isArray(value) ? value[0] : value.split(",")[0];
+  // X-Forwarded-For allows optional whitespace around the commas, and the value
+  // is used as an exact-match security identifier (IP banlist, rate limit key),
+  // so an untrimmed IP would silently miss its ban and get its own bucket.
+  const first = Array.isArray(value) ? value[0] : value;
+
+  return first.split(",")[0].trim();
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Fixes #29851.

`parseIpFromHeaders()` split `x-forwarded-for` on `,` but never trimmed. `X-Forwarded-For` permits optional whitespace around the commas, so a proxy emitting `"1.2.3.4 , 5.6.7.8"` produced the IP `"1.2.3.4 "` — with a trailing space.

That value isn't only used for logging. It's an **exact-match security identifier**:

- `isIpInBanlist()` / `isIpInBanListString()` do `banList.includes(IP)`
- `rateLimit.ts:126` uses it to trigger forced slow mode and as the rate-limit key
- `createContext.ts`, `api/book/event.ts`, `recurring-event.ts`, `auth/reset-password`, `auth/forgot-password` all feed it in

```js
banList = ["1.2.3.4"];
banList.includes("1.2.3.4 ");  // false  ← the ban is bypassed
```

It also splits the rate-limit bucket: `"1.2.3.4"` and `"1.2.3.4 "` are two keys for one client, so a caller behind a padding proxy gets a separate quota.

The fix trims, and also splits on `,` for the array branch so both shapes behave the same.

## How was it verified?

I confirmed the header actually survives with its spacing rather than trusting a string literal — sent `x-forwarded-for: 1.2.3.4 , 5.6.7.8` to a real `http.createServer`:

```
req.headers['x-forwarded-for'] -> "1.2.3.4 , 5.6.7.8"
parseIpFromHeaders             -> "1.2.3.4 "
```

Added 5 tests to the existing `getIP.test.ts`:

- whitespace around the IP is trimmed (space, leading space, surrounding spaces, tab)
- a comma-separated array entry is split too
- four different proxy spellings of the same client collapse to **one** identifier, asserted via a `Set` — this is the property that matters for banlist and rate-limit correctness
- `getIP()` end-to-end with a padded `x-forwarded-for`

**Verification:** 21 tests pass (16 pre-existing, 5 new). Reverting `parseIpFromHeaders` to the current implementation fails exactly the 4 new behavioural tests while all 17 others stay green — so the new tests pin the fix and the change doesn't disturb existing behaviour.

## On the array branch

`parseIpFromHeaders` returned `value[0]` verbatim, so `["1.2.3.4, 5.6.7.8"]` came back whole. I checked whether Node can produce that shape for this header and it **cannot** — it joins repeated non-`set-cookie` headers into a single comma-separated string, which I verified by sending a repeated header to a real server. So this branch isn't reachable over HTTP today; I handled it anyway because it's reachable through the `NextApiRequest` type and by direct callers, and it costs one line. Mentioning it so the change isn't read as fixing a live exploit that it isn't.
