### PR TITLE
fix(i18n): format half-hour timezone offsets like whole-hour ones

### DIFF
--- a/packages/lib/timezone.test.ts
+++ b/packages/lib/timezone.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { formatOffset } from "./timezone";
+
+describe("fn: formatOffset", () => {
+  it("should drop the padding zero from whole-hour offsets", () => {
+    expect(formatOffset("+01:00")).toEqual("+1:00");
+    expect(formatOffset("+09:00")).toEqual("+9:00");
+    expect(formatOffset("-04:00")).toEqual("-4:00");
+    expect(formatOffset("-08:00")).toEqual("-8:00");
+  });
+
+  it("should drop the padding zero from half and quarter hour offsets", () => {
+    // Previously these kept their leading zero, so the dropdown mixed
+    // "GMT +05:30" with "GMT +9:00".
+    expect(formatOffset("+05:30")).toEqual("+5:30"); // India, Sri Lanka
+    expect(formatOffset("+05:45")).toEqual("+5:45"); // Nepal
+    expect(formatOffset("+09:30")).toEqual("+9:30"); // Adelaide
+    expect(formatOffset("+03:30")).toEqual("+3:30"); // Iran
+    expect(formatOffset("+06:30")).toEqual("+6:30"); // Myanmar
+    expect(formatOffset("-03:30")).toEqual("-3:30"); // Newfoundland
+  });
+
+  it("should leave two-digit hour offsets alone", () => {
+    expect(formatOffset("+12:45")).toEqual("+12:45"); // Chatham Islands
+    expect(formatOffset("+13:00")).toEqual("+13:00");
+    expect(formatOffset("-11:00")).toEqual("-11:00");
+    expect(formatOffset("+14:00")).toEqual("+14:00"); // Kiritimati, the extreme
+  });
+
+  it("should use one format for every offset", () => {
+    const offsets = ["+01:00", "+05:30", "+05:45", "+09:00", "-04:00", "-03:30"];
+
+    for (const offset of offsets) {
+      // A single-digit hour never keeps its padding zero.
+      expect(formatOffset(offset), offset).not.toMatch(/^[-+]0\d/);
+    }
+  });
+
+  it("should leave anything that isn't an offset untouched", () => {
+    expect(formatOffset("+00:00")).toEqual("+0:00");
+    expect(formatOffset("Z")).toEqual("Z");
+    expect(formatOffset("")).toEqual("");
+  });
+});

--- a/packages/lib/timezone.ts
+++ b/packages/lib/timezone.ts
@@ -24,8 +24,10 @@ export const addTimezonesToDropdown = (timezones: Timezones) => {
   );
 };
 
-const formatOffset = (offset: string) =>
-  offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
+// Drop the padding zero from the hour so every zone reads the same way, whether
+// its offset lands on the hour (+9:00) or not (+5:30, +5:45).
+export const formatOffset = (offset: string) =>
+  offset.replace(/^([-+])0(\d):(\d{2})$/, (_, sign, hour, minutes) => `${sign}${hour}:${minutes}`);
 
 export const handleOptionLabel = (option: ITimezoneOption, timezones: Timezones) => {
   const offsetUnit = option.label.split(/[-+]/)[0].substring(1);


### PR DESCRIPTION
## What does this PR do?

Fixes #29853.

`formatOffset()` strips the padding zero from an hour offset, but its regex ended in `:00` — so it only ever matched whole-hour zones. Half-hour and quarter-hour zones kept their padding, and the timezone dropdown rendered two formats at once:

```
Berlin GMT +1:00
Kolkata GMT +05:30      <- inconsistent
Kathmandu GMT +05:45    <- inconsistent
Seoul GMT +9:00
```

Changing `:00` to `:(\d{2})` and preserving the minutes fixes it. Existing snapshots pin the unpadded form (`"San Francisco GMT -8:00"`), so unpadded is the intended style.

## Who this affects

Every zone whose offset isn't a whole hour: India, Sri Lanka, Nepal, Iran, Myanmar, Afghanistan, parts of Australia, the Chatham Islands, Newfoundland. `Asia/Kolkata` is already in the test fixture in `apps/web/test/lib/getTimezone.test.ts`, so it's a zone the suite already knows about.

```
before          after
+05:30    ->    +5:30
+05:45    ->    +5:45
+09:30    ->    +9:30
-03:30    ->    -3:30
+09:00    ->    +9:00   (unchanged)
```

## How was it tested?

`packages/lib/timezone.ts` had no test file — `handleOptionLabel` is exercised only through `America/Los_Angeles`, a whole-hour zone. Added one with 5 tests:

- whole-hour offsets still lose the padding zero (the pre-existing behaviour)
- half/quarter-hour offsets now lose it too, covering `+05:30`, `+05:45`, `+09:30`, `+03:30`, `+06:30`, `-03:30`
- two-digit hours are left alone (`+12:45`, `+13:00`, `-11:00`, `+14:00`)
- a format-consistency assertion: no offset comes back matching `/^[-+]0\d/`
- non-offset input (`"Z"`, `""`) passes through untouched

**Verification:**

- All 5 pass. Reverting `formatOffset` with the tests in place fails exactly the 2 behavioural tests, so they pin the fix.
- **No snapshot churn:** I ran both the old and new implementation against the two values the existing snapshots depend on (`-08:00`, `-07:00`) — identical output, so `getTimezone.test.ts` needs no updating.

I exported `formatOffset` so it can be tested directly; `handleOptionLabel`'s behaviour is otherwise unchanged.
