### PR TITLE
fix(bookings): stop fetching credential secrets in bookings procedure

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/util.test.ts
+++ b/packages/trpc/server/routers/viewer/bookings/util.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { bookingInclude } from "./util";
+
+describe("bookingInclude", () => {
+  it("does not fetch the booking owner's credentials", () => {
+    // `credentials: true` pulls every Credential column, including `key`, which holds
+    // OAuth tokens and API secrets. No consumer of this procedure reads them.
+    expect(bookingInclude.user.include).not.toHaveProperty("credentials");
+  });
+
+  it("still fetches the fields editLocation depends on", () => {
+    expect(bookingInclude.user.include).toHaveProperty("destinationCalendar");
+    expect(bookingInclude.user.include.profiles.select).toHaveProperty("organizationId");
+    expect(bookingInclude).toHaveProperty("references");
+    expect(bookingInclude).toHaveProperty("attendees");
+  });
+});

--- a/packages/trpc/server/routers/viewer/bookings/util.ts
+++ b/packages/trpc/server/routers/viewer/bookings/util.ts
@@ -1,19 +1,43 @@
 import { prisma } from "@calcom/prisma";
 import type {
-  Booking,
-  EventType,
-  BookingReference,
   Attendee,
-  Credential,
+  Booking,
+  BookingReference,
   DestinationCalendar,
+  EventType,
   User,
 } from "@calcom/prisma/client";
 import { MembershipRole, SchedulingType } from "@calcom/prisma/enums";
-
 import { TRPCError } from "@trpc/server";
-
 import authedProcedure from "../../../procedures/authedProcedure";
 import { commonBookingSchema } from "./types";
+
+export const bookingInclude = {
+  attendees: true,
+  eventType: {
+    include: {
+      team: {
+        select: {
+          id: true,
+          name: true,
+          parentId: true,
+        },
+      },
+    },
+  },
+  destinationCalendar: true,
+  references: true,
+  user: {
+    include: {
+      destinationCalendar: true,
+      profiles: {
+        select: {
+          organizationId: true,
+        },
+      },
+    },
+  },
+};
 
 export const bookingsProcedure = authedProcedure
   .input(commonBookingSchema)
@@ -21,33 +45,6 @@ export const bookingsProcedure = authedProcedure
     // Endpoints that just read the logged in user's data - like 'list' don't necessary have any input
     const { bookingId } = input;
     const loggedInUser = ctx.user;
-    const bookingInclude = {
-      attendees: true,
-      eventType: {
-        include: {
-          team: {
-            select: {
-              id: true,
-              name: true,
-              parentId: true,
-            },
-          },
-        },
-      },
-      destinationCalendar: true,
-      references: true,
-      user: {
-        include: {
-          destinationCalendar: true,
-          credentials: true,
-          profiles: {
-            select: {
-              organizationId: true,
-            },
-          },
-        },
-      },
-    };
 
     const bookingByBeingAdmin = await prisma.booking.findFirst({
       where: {
@@ -68,7 +65,7 @@ export const bookingsProcedure = authedProcedure
       include: bookingInclude,
     });
 
-    if (!!bookingByBeingAdmin) {
+    if (bookingByBeingAdmin) {
       return next({ ctx: { booking: bookingByBeingAdmin } });
     }
 
@@ -114,7 +111,6 @@ export type BookingsProcedureContext = {
     user:
       | (User & {
           destinationCalendar: DestinationCalendar | null;
-          credentials: Credential[];
           profiles: { organizationId: number }[];
         })
       | null;


### PR DESCRIPTION
## What does this PR do?

The `bookingsProcedure` middleware fetched the booking owner's credentials with `include: { credentials: true }`. Prisma's `include` selects every column on the relation, so this pulled `Credential.key` (OAuth access/refresh tokens and API secrets) into the tRPC context on every call.

- Fixes #29366

While fixing it I traced the consumers, and the relation turns out to be unused:

- `bookingsProcedure` is referenced in exactly one place, `editLocation` in `_router.tsx`.
- `editLocationHandler` reads `booking.user.profiles[0].organizationId` but never `booking.user.credentials`.
- It builds its own credential list via `getUsersCredentialsIncludeServiceAccountKey`, and for a conference credential it calls `CredentialRepository.findFirstByIdWithKeyAndUser` only after `CredentialAccessService.ensureAccessible` authorizes it.
- The other things receiving the booking do not want credentials either: `buildCalEventFromBooking` does not reference them, and `EventManager.updateLocation` takes a `PartialBooking` (`id`, `userId`, `references`, `credentialId`).

So the relation is dropped rather than narrowed to a safe `select`. Nothing needs it, and not fetching secrets is a stronger guarantee than fetching a subset of them.

The query shape is hoisted out of the middleware closure into an exported `bookingInclude` so the invariant is assertable in a test, and `credentials: Credential[]` is removed from `BookingsProcedureContext` so a future consumer cannot silently reintroduce the read.

Note on diff size: `biome check --write` also reordered the type imports and simplified `if (!!booking)` in this file, per the repo's documented pre-push step. Those lines are formatter output, not deliberate edits.

## Visual Demo (For contributors especially)

N/A. This is a server-side data-fetching change with no user-visible behavior difference.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A, no documented behavior changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or test data required.

```bash
TZ=UTC yarn vitest run packages/trpc/server/routers/viewer/bookings/util.test.ts
```

Expected: `bookingInclude.user.include` has no `credentials` property, and still has `destinationCalendar` and `profiles.select.organizationId`.

The first test fails on `main` (`expected { destinationCalendar: true, ...(2) } to not have property "credentials"`) and passes with this change.

Also run:

```bash
TZ=UTC yarn vitest run packages/trpc/server/routers/viewer/bookings/   # 37 passed, 9 skipped
yarn turbo run type-check:ci --filter=@calcom/trpc                     # passes
```

Behavioral check: exercising `editLocation` still resolves the location and updates the connected app, because the handler sources its credentials independently of the middleware.
