### PR TITLE
fix(office365video): update and delete the real MS Teams meeting

### DIFF
--- a/packages/app-store/office365video/lib/VideoApiAdapter.test.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.test.ts
@@ -1,11 +1,11 @@
 import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
-
-import { expect, test, vi, describe } from "vitest";
-
+import { describe, expect, test, vi } from "vitest";
 import { OAuthManager } from "../../_utils/oauth/OAuthManager";
-import { internalServerErrorResponse, successResponse } from "../../_utils/testUtils";
+import { generateTextResponse, internalServerErrorResponse, successResponse } from "../../_utils/testUtils";
 import config from "../config.json";
 import VideoApiAdapter from "./VideoApiAdapter";
+
+const MEETING_ID = "MEETING_ID";
 
 const URLS = {
   CREATE_MEETING: {
@@ -13,9 +13,19 @@ const URLS = {
     method: "POST",
   },
   UPDATE_MEETING: {
-    url: "https://graph.microsoft.com/v1.0/me/onlineMeetings",
-    method: "POST",
+    url: `https://graph.microsoft.com/v1.0/me/onlineMeetings/${MEETING_ID}`,
+    method: "PATCH",
   },
+  DELETE_MEETING: {
+    url: `https://graph.microsoft.com/v1.0/me/onlineMeetings/${MEETING_ID}`,
+    method: "DELETE",
+  },
+};
+
+const bookingRef = {
+  type: config.type,
+  uid: MEETING_ID,
+  meetingId: MEETING_ID,
 };
 
 vi.mock("../../_utils/getParsedAppKeysFromSlug", () => ({
@@ -34,7 +44,7 @@ vi.mock("../../_utils/getParsedAppKeysFromSlug", () => ({
 
 const mockRequestRaw = vi.fn();
 vi.mock("../../_utils/oauth/OAuthManager", () => ({
-  OAuthManager: vi.fn().mockImplementation(function() {
+  OAuthManager: vi.fn().mockImplementation(function () {
     return { requestRaw: mockRequestRaw };
   }),
 }));
@@ -61,7 +71,6 @@ const testCredential = {
 
 describe("createMeeting", () => {
   test("Successful `createMeeting` call", async () => {
-
     const videoApi = VideoApiAdapter(testCredential);
 
     mockRequestRaw.mockImplementation(({ url }) => {
@@ -109,7 +118,6 @@ describe("createMeeting", () => {
   });
 
   test(" `createMeeting` when there is no joinWebUrl and only joinUrl", async () => {
-
     const videoApi = VideoApiAdapter(testCredential);
 
     mockRequestRaw.mockImplementation(({ url }) => {
@@ -195,15 +203,15 @@ describe("createMeeting", () => {
 });
 
 describe("updateMeeting", () => {
-  test("Successful `updateMeeting` call", async () => {
+  test("`updateMeeting` patches the existing meeting instead of creating a new one", async () => {
     const videoApi = VideoApiAdapter(testCredential);
 
     mockRequestRaw.mockImplementation(({ url }) => {
-      if (url === URLS.CREATE_MEETING.url) {
+      if (url === URLS.UPDATE_MEETING.url) {
         return Promise.resolve(
           successResponse({
             json: {
-              id: 1,
+              id: MEETING_ID,
               joinWebUrl: "https://join_web_url.example.com",
               joinUrl: "https://join_url.example.com",
             },
@@ -220,12 +228,12 @@ describe("updateMeeting", () => {
       endTime: new Date(),
     };
 
-    const updatedMeeting = await videoApi?.updateMeeting(null, event);
+    const updatedMeeting = await videoApi?.updateMeeting(bookingRef, event);
     expect(OAuthManager).toHaveBeenCalled();
     expect(mockRequestRaw).toHaveBeenCalledWith({
-      url: URLS.CREATE_MEETING.url,
+      url: URLS.UPDATE_MEETING.url,
       options: {
-        method: "POST",
+        method: "PATCH",
         body: JSON.stringify({
           startDateTime: event.startTime,
           endDateTime: event.endTime,
@@ -234,7 +242,7 @@ describe("updateMeeting", () => {
       },
     });
     expect(updatedMeeting).toEqual({
-      id: 1,
+      id: MEETING_ID,
       password: "",
       type: config.type,
       url: "https://join_web_url.example.com",
@@ -245,11 +253,11 @@ describe("updateMeeting", () => {
     const videoApi = VideoApiAdapter(testCredential);
 
     mockRequestRaw.mockImplementation(({ url }) => {
-      if (url === URLS.CREATE_MEETING.url) {
+      if (url === URLS.UPDATE_MEETING.url) {
         return Promise.resolve(
           internalServerErrorResponse({
             json: {
-              id: 1,
+              id: MEETING_ID,
               joinWebUrl: "https://join_web_url.example.com",
               joinUrl: "https://join_url.example.com",
             },
@@ -266,17 +274,61 @@ describe("updateMeeting", () => {
       endTime: new Date(),
     };
 
-    await expect(() => videoApi?.updateMeeting(null, event)).rejects.toThrowError("Internal Server Error");
+    await expect(() => videoApi?.updateMeeting(bookingRef, event)).rejects.toThrowError(
+      "Internal Server Error"
+    );
     expect(OAuthManager).toHaveBeenCalled();
     expect(mockRequestRaw).toHaveBeenCalledWith({
-      url: URLS.CREATE_MEETING.url,
+      url: URLS.UPDATE_MEETING.url,
       options: {
-        method: "POST",
+        method: "PATCH",
         body: JSON.stringify({
           startDateTime: event.startTime,
           endDateTime: event.endTime,
           subject: event.title,
         }),
+      },
+    });
+  });
+});
+
+describe("deleteMeeting", () => {
+  test("`deleteMeeting` deletes the meeting on Microsoft's side", async () => {
+    const videoApi = VideoApiAdapter(testCredential);
+
+    mockRequestRaw.mockImplementation(({ url }) => {
+      if (url === URLS.DELETE_MEETING.url) {
+        return Promise.resolve(generateTextResponse({ text: "", status: 204, statusText: "No Content" }));
+      }
+      throw new Error("Unexpected URL");
+    });
+
+    await videoApi?.deleteMeeting(MEETING_ID);
+
+    expect(OAuthManager).toHaveBeenCalled();
+    expect(mockRequestRaw).toHaveBeenCalledWith({
+      url: URLS.DELETE_MEETING.url,
+      options: {
+        method: "DELETE",
+      },
+    });
+  });
+
+  test("Failing `deleteMeeting` call", async () => {
+    const videoApi = VideoApiAdapter(testCredential);
+
+    mockRequestRaw.mockImplementation(({ url }) => {
+      if (url === URLS.DELETE_MEETING.url) {
+        return Promise.resolve(internalServerErrorResponse({ json: {} }));
+      }
+      throw new Error("Unexpected URL");
+    });
+
+    await expect(() => videoApi?.deleteMeeting(MEETING_ID)).rejects.toThrowError("Internal Server Error");
+    expect(mockRequestRaw).toHaveBeenCalledWith({
+      url: URLS.DELETE_MEETING.url,
+      options: {
+        method: "DELETE",
       },
     });
   });

--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 import { triggerDelegationCredentialErrorWebhook } from "@calcom/features/webhooks/lib/triggerDelegationCredentialErrorWebhook";
 import {
   CalendarAppDelegationCredentialConfigurationError,
@@ -11,7 +9,7 @@ import type { CalendarEvent } from "@calcom/types/Calendar";
 import type { CredentialForCalendarServiceWithTenantId } from "@calcom/types/Credential";
 import type { PartialReference } from "@calcom/types/EventManager";
 import type { VideoApiAdapter, VideoCallData } from "@calcom/types/VideoApiAdapter";
-
+import { z } from "zod";
 import getParsedAppKeysFromSlug from "../../_utils/getParsedAppKeysFromSlug";
 import { OAuthManager } from "../../_utils/oauth/OAuthManager";
 import { oAuthManagerHelper } from "../../_utils/oauth/oAuthManagerHelper";
@@ -108,12 +106,12 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         body: new URLSearchParams(params),
       });
     },
-    isTokenObjectUnusable: async function () {
+    isTokenObjectUnusable: async () => {
       // TODO: Implement this. As current implementation of CalendarService doesn't handle it. It hasn't been handled in the OAuthManager implementation as well.
       // This is a placeholder for future implementation.
       return null;
     },
-    isAccessTokenUnusable: async function () {
+    isAccessTokenUnusable: async () => {
       // TODO: Implement this
       return null;
     },
@@ -230,9 +228,9 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
     updateMeeting: async (bookingRef: PartialReference, event: CalendarEvent) => {
       try {
         const response = await auth.requestRaw({
-          url: `${await getUserEndpoint()}/onlineMeetings`,
+          url: `${await getUserEndpoint()}/onlineMeetings/${bookingRef.uid}`,
           options: {
-            method: "POST",
+            method: "PATCH",
             body: JSON.stringify(translateEvent(event)),
           },
         });
@@ -264,8 +262,31 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         });
       }
     },
-    deleteMeeting:() => {
-      return Promise.resolve([]);
+    deleteMeeting: async (uid: string): Promise<void> => {
+      try {
+        const response = await auth.requestRaw({
+          url: `${await getUserEndpoint()}/onlineMeetings/${uid}`,
+          options: {
+            method: "DELETE",
+          },
+        });
+
+        if (!response.ok) {
+          throw new HttpError({
+            statusCode: response.status,
+            message: response.statusText,
+          });
+        }
+      } catch (error) {
+        log.error(`Error deleting MS Teams meeting ${uid}`, error);
+        if (error instanceof HttpError) {
+          throw error;
+        }
+        throw new HttpError({
+          statusCode: 500,
+          message: `Error deleting MS Teams meeting ${uid}`,
+        });
+      }
     },
     createMeeting: async (event: CalendarEvent): Promise<VideoCallData> => {
       const url = `${await getUserEndpoint()}/onlineMeetings`;


### PR DESCRIPTION
## What does this PR do?

Two methods on the Office 365 Video (MS Teams) adapter never addressed the meeting they were supposed to act on.

- `updateMeeting` sent `POST /onlineMeetings` with no meeting id. That is the create endpoint, so every edit to a booking minted a brand new Teams meeting instead of modifying the existing one. The result is orphaned meetings piling up on the Microsoft side and a join link that no longer matches the booking.
- `deleteMeeting` was `() => Promise.resolve([])`. It never called Graph at all, so cancelling a booking in Cal left the Teams meeting live.

Both now address the meeting by id, which matches the Zoom adapter and the `VideoApiAdapter` contract:

- `updateMeeting` sends `PATCH /onlineMeetings/{bookingRef.uid}`
- `deleteMeeting` sends `DELETE /onlineMeetings/{uid}`

- Fixes #29498

### Reasoning and trade-offs

**Why `bookingRef.uid` is the right id.** `createMeeting` returns the Graph meeting id as `VideoCallData.id`, and `EventManager` stores that as the booking reference `uid` (`uid: createdEventObj ? createdEventObj.id : result.createdEvent?.id?.toString() ?? ""`). `deleteMeeting(uid)` is already called with `reference.uid`. So the id is present at both call sites with no plumbing change.

**No new OAuth consent.** The app already requests `OnlineMeetings.ReadWrite`, which covers PATCH and DELETE on `/me/onlineMeetings`. Users do not have to reconnect.

**Failures throw rather than being swallowed.** `deleteMeeting` now raises `HttpError` on a non-OK response. That is safe for cancellations: `EventManager.deleteEventsAndMeetings` gathers deletions with `Promise.allSettled` and logs rejections as soft warnings, precisely so an already-deleted or missing remote meeting cannot block cancelling a booking. This also matches Zoom, which rejects on delete failure.

**Existing tests encoded the bug.** The two `updateMeeting` tests asserted a POST to the create URL and passed `null` as the booking reference, so they would have kept passing after a correct fix. They are rewritten to assert the PATCH and a real reference. `deleteMeeting` had no coverage at all and now has both a success and a failure test.

Note on diff size: `biome check --write` also moved the `zod` import and converted two `async function () {}` properties to arrow functions in this file, per the repo's documented pre-push step. Those lines are formatter output, not deliberate edits. Net Biome warnings on these two files go from 6 on `main` to 3, because `bookingRef` and `uid` are no longer unused parameters.

## Visual Demo (For contributors especially)

N/A. This is a server-side integration change with no Cal-side UI. The observable difference is on the Microsoft side: editing a booking no longer creates a second Teams meeting, and cancelling one removes it.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A, no developer-facing docs describe this adapter's HTTP verbs.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or test data are required for the unit tests. Graph calls are mocked through `OAuthManager.requestRaw`.

```bash
TZ=UTC yarn vitest run packages/app-store/office365video/lib/VideoApiAdapter.test.ts
```

Expected: 7 passed.

- `updateMeeting` calls `https://graph.microsoft.com/v1.0/me/onlineMeetings/MEETING_ID` with `method: "PATCH"` and returns the meeting id and `joinWebUrl`.
- `deleteMeeting` calls the same URL with `method: "DELETE"` and resolves on 204.
- Both surface `Internal Server Error` when Graph returns 500.

On `main` the four new and rewritten assertions fail (`updateMeeting` hits the collection URL with POST, `deleteMeeting` resolves `[]` without any request). They pass with this change.

Also run:

```bash
yarn turbo run type-check:ci --filter=@calcom/app-store   # passes
```

Manual verification against a real tenant requires a connected MS Teams account: create a booking, edit its time, and confirm only one meeting exists in Teams, then cancel the booking and confirm the meeting is gone.
