### PR TITLE
fix: trim whitespace in parseIpFromHeaders to prevent IP banlist bypass

### DIFF
--- a/packages/lib/getIP.test.ts
+++ b/packages/lib/getIP.test.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest } from "next";
-import { describe, expect, it } from "vitest";
-import getIP, { parseIpFromHeaders } from "./getIP";
+import { afterEach, describe, expect, it } from "vitest";
+import getIP, { isIpInBanlist, parseIpFromHeaders } from "./getIP";
 
 function buildRequest(headers: Record<string, string>): Request {
   return new Request("https://example.com", { headers });
@@ -21,6 +21,18 @@ describe("parseIpFromHeaders", () => {
 
   it("returns the first element when given an array", () => {
     expect(parseIpFromHeaders(["1.2.3.4", "5.6.7.8"])).toBe("1.2.3.4");
+  });
+
+  it("trims leading/trailing whitespace from a padded string value", () => {
+    expect(parseIpFromHeaders("  1.2.3.4  , 5.6.7.8")).toBe("1.2.3.4");
+  });
+
+  it("trims whitespace after splitting on comma", () => {
+    expect(parseIpFromHeaders("1.2.3.4 , 5.6.7.8")).toBe("1.2.3.4");
+  });
+
+  it("trims leading/trailing whitespace from a padded array element", () => {
+    expect(parseIpFromHeaders(["  1.2.3.4  ", "5.6.7.8"])).toBe("1.2.3.4");
   });
 });
 
@@ -71,6 +83,20 @@ describe("getIP", () => {
     it("extracts first IP from comma-separated x-forwarded-for", () => {
       const req = buildRequest({ "x-forwarded-for": "9.9.9.9, 10.0.0.1, 172.16.0.1" });
       expect(getIP(req)).toBe("9.9.9.9");
+    });
+  });
+
+  describe("banlist bypass regression (#29851)", () => {
+    const originalBanlist = process.env.IP_BANLIST;
+
+    afterEach(() => {
+      process.env.IP_BANLIST = originalBanlist;
+    });
+
+    it("still detects a banned IP when x-forwarded-for is padded with whitespace", () => {
+      process.env.IP_BANLIST = JSON.stringify(["1.2.3.4"]);
+      const req = buildRequest({ "x-forwarded-for": "  1.2.3.4  , 5.6.7.8" });
+      expect(isIpInBanlist(req)).toBe(true);
     });
   });
 

--- a/packages/lib/getIP.test.ts
+++ b/packages/lib/getIP.test.ts
@@ -34,6 +34,9 @@ describe("parseIpFromHeaders", () => {
   it("trims leading/trailing whitespace from a padded array element", () => {
     expect(parseIpFromHeaders(["  1.2.3.4  ", "5.6.7.8"])).toBe("1.2.3.4");
   });
+  it("returns an empty string for an empty array instead of throwing", () => {
+    expect(parseIpFromHeaders([])).toBe("");
+  });
 });
 
 describe("getIP", () => {
@@ -90,7 +93,11 @@ describe("getIP", () => {
     const originalBanlist = process.env.IP_BANLIST;
 
     afterEach(() => {
-      process.env.IP_BANLIST = originalBanlist;
+      if (originalBanlist === undefined) {
+        delete process.env.IP_BANLIST;
+      } else {
+        process.env.IP_BANLIST = originalBanlist;
+      }
     });
 
     it("still detects a banned IP when x-forwarded-for is padded with whitespace", () => {

--- a/packages/lib/getIP.test.ts
+++ b/packages/lib/getIP.test.ts
@@ -37,6 +37,9 @@ describe("parseIpFromHeaders", () => {
   it("returns an empty string for an empty array instead of throwing", () => {
     expect(parseIpFromHeaders([])).toBe("");
   });
+  it("trims tabs and other whitespace, not just spaces", () => {
+    expect(parseIpFromHeaders("\t1.2.3.4\t, 5.6.7.8")).toBe("1.2.3.4");
+  });
 });
 
 describe("getIP", () => {

--- a/packages/lib/getIP.ts
+++ b/packages/lib/getIP.ts
@@ -5,8 +5,9 @@ import logger from "./logger";
 
 export function parseIpFromHeaders(value: string | string[]) {
   const rawIp = Array.isArray(value) ? value[0] : value.split(",")[0];
-  return rawIp.trim();
+  return rawIp?.trim() ?? "";
 }
+
 
 /**
  * Tries to extract IP address from a request.

--- a/packages/lib/getIP.ts
+++ b/packages/lib/getIP.ts
@@ -4,7 +4,8 @@ import z from "zod";
 import logger from "./logger";
 
 export function parseIpFromHeaders(value: string | string[]) {
-  return Array.isArray(value) ? value[0] : value.split(",")[0];
+  const rawIp = Array.isArray(value) ? value[0] : value.split(",")[0];
+  return rawIp.trim();
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Fixes #29851

`parseIpFromHeaders` split `x-forwarded-for` on commas but never trimmed
whitespace, so a padded header (or padded array element) would return an
IP with leading/trailing spaces. This caused an exact-match lookup against
`IP_BANLIST` to fail silently, letting a banned IP bypass the block.

## Fix

Added `.trim()` to the returned value in both the array and string branches.

## Tests

- Added unit tests for padded string/array inputs
- Added an end-to-end regression test on `isIpInBanlist` reproducing the
  reported bypass scenario
- All 21 tests in `getIP.test.ts` pass locally

## Note

I'm aware of #29852, an earlier PR from the issue reporter with a similar
fix — it was withdrawn by the author for unrelated reasons (not a rejection
of the approach), and the issue remains open, so submitting this fix here.

Note: this closes the specific padding-based bypass of the exact-match
`IP_BANLIST` check. It does not make the banlist airtight against a more
general case of an attacker directly controlling the `x-forwarded-for`
header value — that's a separate, upstream concern outside this fix's scope.