### PR TITLE
fix: correct pagination start item display when totalItems is zero

### DIFF
--- a/packages/ui/components/pagination/Pagination.tsx
+++ b/packages/ui/components/pagination/Pagination.tsx
@@ -64,7 +64,7 @@ export const Pagination = ({
     label: `${size}`,
   }));
 
-  const startItem = (currentPage - 1) * pageSize + 1;
+  const startItem = totalItems === 0 ? 0 : (currentPage - 1) * pageSize + 1;
   const endItem = Math.min(currentPage * pageSize, totalItems);
 
   return (


### PR DESCRIPTION
When `totalItems` is zero the pagination showed "1-0 of 0" because `startItem` evaluated to `(0)*pageSize+1 = 1` regardless of item count.

```tsx
// before
const startItem = (currentPage - 1) * pageSize + 1;

// after
const startItem = totalItems === 0 ? 0 : (currentPage - 1) * pageSize + 1;
```

Now renders "0-0 of 0" for empty result sets.