### PR TITLE
fix(bookings): increase touch target for show more button on mobile

### DIFF
--- a/apps/web/modules/bookings/components/HavingTroubleFindingTime.tsx
+++ b/apps/web/modules/bookings/components/HavingTroubleFindingTime.tsx
@@ -33,9 +33,8 @@ export function HavingTroubleFindingTime(props: Props) {
         <InfoIcon className="text-default h-4 w-4" />
         <p className="w-full  leading-none">{t("having_trouble_finding_time")}</p>
       </div>
-      {/* TODO: we should give this more of a touch target on mobile */}
       <button
-        className="inline-flex items-center gap-2 font-medium"
+        className="inline-flex items-center gap-2 font-medium p-2 sm:p-0 -m-2 sm:m-0"
         onClick={(e) => {
           e.preventDefault();
           props.onButtonClick();


### PR DESCRIPTION
## Summary
Resolves an open TODO regarding mobile touch targets by increasing the clickable area of the "Show more" button on the mobile bookings page.
