### PR TITLE
fix(lib): use maxLength param and handle no-space text in truncateOnWord

### DIFF
--- a/packages/lib/text.ts
+++ b/packages/lib/text.ts
@@ -7,14 +7,15 @@ export const truncate = (text: string, maxLength: number, ellipsis = true) => {
 export const truncateOnWord = (text: string, maxLength: number, ellipsis = true) => {
   if (text.length <= maxLength) return text;
 
-  // First split on maxLength chars
-  let truncatedText = text.substring(0, 148);
+  const ellipsisLength = ellipsis ? 3 : 0;
+  let truncatedText = text.substring(0, maxLength - ellipsisLength);
 
-  // Then split on the last space, this way we split on the last word,
-  // which looks just a bit nicer.
-  truncatedText = truncatedText.substring(0, Math.min(truncatedText.length, truncatedText.lastIndexOf(" ")));
+  // Split on the last word boundary for a cleaner result.
+  // Fall back to the hard character cut when no space is present (CJK, URLs, etc.)
+  const lastSpace = truncatedText.lastIndexOf(" ");
+  if (lastSpace > 0) {
+    truncatedText = truncatedText.substring(0, lastSpace);
+  }
 
-  if (ellipsis) truncatedText += "...";
-
-  return truncatedText;
+  return ellipsis ? truncatedText + "..." : truncatedText;
 };


### PR DESCRIPTION
Two bugs in `truncateOnWord`:

1. The `maxLength` argument was ignored — the function always cut at the hardcoded value `148`.
2. When the sliced text has no space (CJK languages, Thai, URLs), `lastIndexOf(" ")` returns `-1`, so `substring(0, -1)` yields `""` and the function returns only `"..."` — the entire text is silently discarded.

`apps/web/app/_utils.tsx` calls this with `maxLength: 158` for `og:description` on 63 pages, so any long CJK/URL description produces `<meta property="og:description" content="...">`.

Fixes #29841