### PR TITLE
ci: build the cache key from env instead of interpolating the branch name

### DIFF
--- a/.github/workflows/production-build-without-database.yml
+++ b/.github/workflows/production-build-without-database.yml
@@ -67,9 +67,11 @@ jobs:
       - name: Delete old production build caches for this branch
         if: steps.cache-check.outputs.cache-hit != 'true'
         continue-on-error: true
+        env:
+          BRANCH_KEY: ${{ github.head_ref || github.ref_name }}
         run: |
           gh extension install actions/gh-actions-cache
-          for key in $(gh actions-cache list -R ${{ github.repository }} --key "prod-build-${{ github.head_ref || github.ref_name }}" --limit 100 | cut -f1); do
+          for key in $(gh actions-cache list -R ${{ github.repository }} --key "prod-build-$BRANCH_KEY" --limit 100 | cut -f1); do
             gh actions-cache delete "$key" -R ${{ github.repository }} --confirm
           done
         env:


### PR DESCRIPTION
Hi, and thanks for Cal.

In `.github/workflows/production-build-without-database.yml`, the cache-cleanup step builds its lookup key by interpolating the branch name into the command:

```yaml
for key in $(gh actions-cache list -R ${{ github.repository }} --key "prod-build-${{ github.head_ref || github.ref_name }}" --limit 100 | cut -f1); do
```

Actions expands `${{ ... }}` into the script text before bash runs, so the branch name becomes part of the command rather than part of the key string. Git allows `$`, `(`, `)` and backticks in branch names, and `$(...)` runs inside double quotes — and here it sits inside an outer `$( ... )` already being evaluated for the loop.

I want to be clear that I think your setup is in good shape and this is defence in depth, not a hole. This workflow is reached from `pr.yml`, which is `pull_request_target`, but you gate it properly: `prepare` requires `needs.trust-check.outputs.is-trusted == 'true'`, every downstream job needs `prepare`, and there is an explicit warning at the top of `pr.yml` about not checking out PR code before `trust-check` completes. So an untrusted fork PR does not reach this step. What is left is that the workflow-level `env:` here carries a lot of secrets, and a trusted-but-mistaken branch name would be executing in that environment — which seemed worth tightening given the care already taken elsewhere.

The change binds the branch name to an environment variable:

```yaml
env:
  BRANCH_KEY: ${{ github.head_ref || github.ref_name }}
run: |
  ... --key "prod-build-$BRANCH_KEY" ...
```

The key string is identical, so the same caches are matched and deleted. I left `${{ github.repository }}` interpolated — a repository slug cannot contain shell metacharacters — and did not touch the step's existing `continue-on-error`, which is appropriate for a cache cleanup.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow, its callers and the trust-check gate myself.
