### PR TITLE
chore(booker): remove obsolete eslint-disable in useInitialFormValues

### DIFF
--- a/packages/features/bookings/Booker/hooks/useInitialFormValues.ts
+++ b/packages/features/bookings/Booker/hooks/useInitialFormValues.ts
@@ -193,8 +193,6 @@ export function useInitialFormValues({
         key: buildKey({ values: defaults, hasSession, stableHashExtraOptions }),
       });
     })();
-    // TODO: Remove it. It was initially added so that we don't add extraOptions in deps but that is handled using stableHashExtraOptions now.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     eventType?.bookingFields,
     formValues,


### PR DESCRIPTION
## What does this PR do?

Removes the obsolete `eslint-disable-next-line react-hooks/exhaustive-deps` comment rom `useInitialFormValues`.  
  
`extraOptions` is now represented in the dependency array via `stableHashExtraOptions` which is computed by `getStableHash(extraOptions)`. The raw `extraOptions` object is intentionally omitted because it changes reference on every render.  

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
