### PR TITLE
chore(docker): move images off end-of-life Node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:20 AS builder
+FROM --platform=$BUILDPLATFORM node:22 AS builder
 
 WORKDIR /calcom
 
@@ -50,7 +50,7 @@ RUN yarn --cwd apps/web workspace @calcom/web run copy-app-store-static
 RUN yarn --cwd apps/web workspace @calcom/web run build
 RUN rm -rf node_modules/.cache .yarn/cache apps/web/.next/cache
 
-FROM node:20 AS builder-two
+FROM node:22 AS builder-two
 
 WORKDIR /calcom
 ARG NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000
@@ -74,7 +74,7 @@ ENV NEXT_PUBLIC_WEBAPP_URL=$NEXT_PUBLIC_WEBAPP_URL \
 
 RUN scripts/replace-placeholder.sh http://NEXT_PUBLIC_WEBAPP_URL_PLACEHOLDER ${NEXT_PUBLIC_WEBAPP_URL}
 
-FROM node:20 AS runner
+FROM node:22 AS runner
 
 WORKDIR /calcom
 

--- a/apps/api/v2/Dockerfile
+++ b/apps/api/v2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS build
+FROM node:22-alpine AS build
 
 ARG DATABASE_DIRECT_URL
 ARG DATABASE_URL


### PR DESCRIPTION
**Node 20 reached end-of-life on 2026-04-30** and no longer receives security releases. Both Dockerfiles build their runtime stage on it.

```diff
 Dockerfile
-FROM --platform=$BUILDPLATFORM node:20 AS builder
-FROM node:20 AS builder-two
-FROM node:20 AS runner          # <- the shipped stage (EXPOSE 3000, CMD start.sh)
+FROM --platform=$BUILDPLATFORM node:22 AS builder
+FROM node:22 AS builder-two
+FROM node:22 AS runner

 apps/api/v2/Dockerfile
-FROM node:20-alpine AS build    # <- single stage; EXPOSE 80 + CMD live here
+FROM node:22-alpine AS build
```

### Why this isn't just a version bump

Node states the consequence itself:

> "It's important to note that **End-of-Life versions are always affected** when a security release occurs."

The June 2026 release fixed **twelve CVEs** into 22.x/24.x/26.x, with 20.x excluded — including **CVE-2026-48933** (HIGH, WebCrypto AES integer overflow → remote process abort) and **CVE-2026-48618** (HIGH, Unicode dot separator → TLS wildcard-depth authentication bypass), plus TLS host-identity verification and mTLS authorization bypasses. The July 2026 release, published this week, again patched only 26/24/22.

Nothing announces this: `node:20` keeps resolving, it just stops being fixed. Dependabot's `docker` ecosystem does *version* updates but **not security updates**, so an EOL base raises no alert.

### Choices I made, and why

- **22 rather than 24.** 22 is the oldest currently-supported line, so it's the smallest step that gets off EOL. Happy to go to 24 if you'd rather do it once.
- **I went to 22 knowing you deliberately chose 20** — #19770 and #19760 bumped to Node 20 when it was current. This isn't second-guessing that; the line simply aged out since.
- **Dockerfiles only.** `package.json` has no `engines.node` and there's no root `.nvmrc`, so nothing else needed changing to stay consistent. I didn't touch CI workflows.

### What I could not verify

**I have not built or run this.** I can't execute your test suite from a fork, so I can't tell you the app runs clean on 22 — that's the one thing worth checking before merge. If anything in the native-module or Prisma layer objects to the major bump, this needs more than a tag change and I'd rather you found that in CI than in production.

### On the vehicle

Filed as a PR rather than an issue because `blank_issues_enabled: false` and the bug-report template asks for reproduction steps, browser version and a screen recording — none of which fit a build-configuration finding. A four-line diff seemed more honest than forcing it into that shape.

*Disclosure: AI-assisted (Claude Opus 5). I verified the Dockerfile stages, the Node EOL dates from endoflife.date and the CVE list from nodejs.org myself.*
