### PR TITLE
fix(slugify): remove copyright/registered/other pictographic symbols from slugs

### DIFF
--- a/packages/lib/slugify.test.ts
+++ b/packages/lib/slugify.test.ts
@@ -49,14 +49,15 @@ describe("slugify", () => {
     expect(slugify("Hello -  World 123_ !@#  Test    456   789")).toEqual("hello-world-123-test-456-789");
   });
 
-  // This is failing, if we want to fix it, one approach is as used in getValidRhfFieldName
   it("should remove emoji characters", () => {
     expect(slugify("Hello 📚🕯️ There")).toEqual("hello-there");
     expect(slugify("📚🕯️")).toEqual("");
   });
 
-  it.skip("should remove unicode", () => {
+  it("should remove unicode pictographic symbols", () => {
     expect(slugify("Hello ®️ There")).toEqual("hello-there");
     expect(slugify("®️")).toEqual("");
+    expect(slugify("©2026 Team")).toEqual("2026-team");
+    expect(slugify("Coaching™")).toEqual("coaching");
   });
 });

--- a/packages/lib/slugify.ts
+++ b/packages/lib/slugify.ts
@@ -18,10 +18,8 @@ export const slugify = (str: string, forDisplayingInput?: boolean) => {
     .replace(/^-+/, "") // Remove dashes from start
     .replace(/\.{2,}/g, ".") // Replace consecutive periods with a single period
     .replace(/^\.+/, "") // Remove periods from the start
-    .replace(
-      /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
-      ""
-    ) // Removes emojis
+    // @ts-ignore - Unicode property escapes require ES6+ target in some TS configs
+    .replace(/\p{Extended_Pictographic}/gu, "") // Remove emojis and pictographic symbols. \p{Emoji} in the filter above intentionally keeps these so they can be stripped here; the previous range-based regex missed low-codepoint symbols like the copyright (U+00A9) and registered (U+00AE) signs.
     .replace(/\s+/g, " ")
     .replace(/-+/g, "-"); // Replace consecutive dashes with a single dash
 


### PR DESCRIPTION
## What does this PR do?

`slugify()` left low-codepoint pictographic symbols in its output:

- `slugify("©2026 Team")` returned `"©2026-team"` (expected `"2026-team"`)
- `slugify("Hello ®️ There")` returned `"hello-®-there"` (expected `"hello-there"`)

Root cause: these characters (© U+00A9, ® U+00AE, and similar) carry the Unicode `Emoji` property, so the keep-filter `[^.\p{L}\p{N}\p{Zs}\p{Emoji}]` preserved them, but they sit below the `‑`+ ranges of the hand-rolled emoji-stripping regex, so they were never removed. `™` (U+2122) happens to fall inside one of those ranges, which is why only some symbols leaked and this went unnoticed. There was already a **skipped** `should remove unicode` test in `slugify.test.ts` documenting exactly this.

This replaces the fragile range-based regex with a single `\p{Extended_Pictographic}` strip, which covers ©, ®, ™ and all emoji but not digits, letters, `#` or `.`. The previously-skipped test is un-skipped and extended.

- Fixes: N/A (no open issue; found via the skipped test in `slugify.test.ts`)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A — internal utility behavior only.
- [x] I confirm automated tests are in place that prove my fix is effective (un-skipped and extended `packages/lib/slugify.test.ts`).

## How should this be tested?

```
yarn vitest packages/lib/slugify.test.ts
```

Pure function, no environment variables or test data required.

Expected: all cases pass, including the previously-skipped unicode cases (`©`, `®`, `™`) and the existing emoji / diacritics / CJK / period cases (no regressions).
