### PR TITLE
fix: strip leading zero from all timezone hour offsets in formatOffset

### DIFF
--- a/packages/lib/timezone.ts
+++ b/packages/lib/timezone.ts
@@ -25,7 +25,7 @@ export const addTimezonesToDropdown = (timezones: Timezones) => {
 };
 
 const formatOffset = (offset: string) =>
-  offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
+  offset.replace(/^([-+])(0)(\d):(\d{2})$/, (_, sign, _zero, hour, minutes) => `${sign}${hour}:${minutes}`);
 
 export const handleOptionLabel = (option: ITimezoneOption, timezones: Timezones) => {
   const offsetUnit = option.label.split(/[-+]/)[0].substring(1);


### PR DESCRIPTION
`formatOffset` strips the leading zero from whole-hour UTC offsets so the
timezone dropdown shows `+9:00` instead of `+09:00`. The regex `/:00$/` only
matches offsets whose minutes are exactly `:00`, so fractional zones like
`+05:30` or `+05:45` are left with the leading zero padded while whole-hour
zones are stripped — inconsistent formatting across the dropdown.

The regex is widened to match any `±0d:mm` offset, removing the leading zero
from the hour portion regardless of minute value.

Before: Berlin `+1:00`, Kolkata `+05:30`, Kathmandu `+05:45`
After: Berlin `+1:00`, Kolkata `+5:30`, Kathmandu `+5:45`