### PR TITLE
fix: emailToGuestMap should keep first occurrence to match deduplication logic

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
@@ -208,10 +208,16 @@ export async function sanitizeAndFilterGuests(
   const guestEmailsLowerCase = deduplicatedGuests.map((email) => extractBaseEmail(email).toLowerCase());
   const emailToRequiresVerification = await getEmailVerificationRequirements(guestEmailsLowerCase);
 
-  // Create a map of email to guest object for easy lookup
-  const emailToGuestMap = new Map(
-    guests.map((guest) => [extractBaseEmail(guest.email).toLowerCase(), guest])
-  );
+  // Build the map so the first occurrence wins — matching deduplicateGuestEmails behaviour.
+  // new Map(array) lets later entries overwrite earlier ones, so the returned guest object
+  // could come from the wrong duplicate (mismatched name, timeZone, language, etc.).
+  const emailToGuestMap = new Map<string, (typeof guests)[number]>();
+  for (const guest of guests) {
+    const key = extractBaseEmail(guest.email).toLowerCase();
+    if (!emailToGuestMap.has(key)) {
+      emailToGuestMap.set(key, guest);
+    }
+  }
 
   const uniqueGuestEmails = deduplicatedGuests.filter((email) => {
     const baseGuestEmail = extractBaseEmail(email).toLowerCase();


### PR DESCRIPTION
`deduplicateGuestEmails` (line 154) deduplicates by keeping the **first**
occurrence when two emails share a base address. But `emailToGuestMap` is
built with `new Map(guests.map(...))`, where the standard `Map` constructor
lets later entries overwrite earlier ones.

The surviving email comes from index 0 (correct), but the guest object
returned when building attendee rows comes from the **last** duplicate — so
the wrong `name`, `timeZone`, and `language` are written to the booking.

Fix: iterate `guests` once with a `has()` guard so the first occurrence wins
in both the email list and the guest-object map.