### PR TITLE
fix: autofilled input text respects theme color in dark mode

### DIFF
--- a/.changeset/autofill-text-color.md
+++ b/.changeset/autofill-text-color.md
@@ -1,0 +1,5 @@
+---
+"@calcom/web": patch
+---
+
+fix: autofilled input text now respects theme text color in both light and dark mode

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -400,6 +400,22 @@ html.todesktop.dark {
   -webkit-appearance: none;
 }
 
+/*
+ * Fix: WebKit/Blink browsers override text color on autofilled inputs via
+ * -webkit-text-fill-color, ignoring theme CSS variables. This causes autofilled
+ * text to render in browser-default black, which is unreadable in dark mode.
+ * Forward the theme's --foreground color so autofilled text matches manually
+ * typed text in both light and dark themes.
+ * @see https://github.com/calcom/cal.diy/issues/29803
+ */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  -webkit-text-fill-color: var(--foreground);
+  caret-color: var(--foreground);
+}
+
 .react-tel-input .country-list .country:hover,
 .react-tel-input .country-list .country.highlight {
   @apply bg-emphasis!;


### PR DESCRIPTION
## Summary

- WebKit/Blink browsers (Chrome, Edge, Safari) override text color on autofilled inputs via `-webkit-text-fill-color`, ignoring theme CSS variables
- This causes autofilled text to render in browser-default black, which is unreadable in dark mode
- Added a global CSS rule that forwards the theme's `--foreground` color to `-webkit-text-fill-color` and `caret-color` on `input:-webkit-autofill` (and its `:hover`, `:focus`, `:active` states)
- The `--foreground` variable is already defined per-theme in `packages/coss-ui/src/styles/globals.css` (light: `var(--color-neutral-800)`, dark: `var(--color-neutral-100)`), so the fix works automatically in both light and dark mode

Closes #29803

## Testing

- [x] Verified `--foreground` CSS variable exists in both `:root` (light) and `.dark` themes
- [x] Confirmed no existing `-webkit-text-fill-color` override in the codebase
- [ ] Manual: Open a booking form in Chrome, trigger autofill, verify text color matches theme in both light and dark mode

#### Test plan
- [ ] Test in Chrome/Edge with autofill profile in light mode
- [ ] Test in Chrome/Edge with autofill profile in dark mode
- [ ] Test in Safari with autofill
- [ ] Verify manually typed text still renders correctly (no regression)

Generated with [Devin](https://devin.ai)
