### PR TITLE
fix: autofilled input text respects theme color in dark mode

### DIFF
--- a/.changeset/autofill-text-color.md
+++ b/.changeset/autofill-text-color.md
@@ -1,0 +1,5 @@
+---
+"@calcom/web": patch
+---
+
+fix: autofilled input text now respects theme text color in both light and dark mode

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -400,6 +400,17 @@ html.todesktop.dark {
   -webkit-appearance: none;
 }
 
+/* WebKit overrides text color on autofilled inputs via -webkit-text-fill-color,
+   ignoring theme variables. Forward --foreground so autofilled text matches
+   the theme in both light and dark mode. */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  -webkit-text-fill-color: var(--foreground);
+  caret-color: var(--foreground);
+}
+
 .react-tel-input .country-list .country:hover,
 .react-tel-input .country-list .country.highlight {
   @apply bg-emphasis!;


### PR DESCRIPTION
## What does this PR do?

WebKit/Blink browsers (Chrome, Edge, Safari) override text color on autofilled inputs through `-webkit-text-fill-color`, which ignores theme CSS variables. This makes autofilled text show up in browser-default black instead of the theme color, which is unreadable in dark mode.

This PR adds a global CSS rule that forwards the existing `--foreground` theme variable to `-webkit-text-fill-color` and `caret-color` on autofilled inputs. The `--foreground` variable is already defined for both light and dark themes in `packages/coss-ui/src/styles/globals.css`, so this works automatically in both modes.

- Fixes #29803

## Visual Demo (For contributors especially)

N/A - CSS-only fix. The visible change is that autofilled text matches the theme text color instead of being forced to black.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the app locally and go to any booking form with a text input (e.g. name field).
2. Save an autofill profile in Chrome/Edge so the browser can autofill the field.
3. Trigger autofill on the input.
4. In light mode: verify the autofilled text color matches manually typed text.
5. Switch to dark mode: verify the autofilled text is light (not black).
6. Check the caret color matches the theme too.

- Are there environment variables that should be set? No
- What are the minimal test data to have? Any booking page with a form field
- What is expected (happy path) to have (input and output)? Autofilled text uses theme --foreground color in both light and dark mode
- Any other important info that could help to test that PR? Firefox is unaffected since it doesn't use -webkit-autofill

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings
- My PR is small and focused
