### PR TITLE
fix(settings): prevent vertical layout shift when changing language (#29905)

### DIFF
--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -151,7 +151,7 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
 
   return (
     <SettingsHeader title={t("general")} description={t("general_description")} borderInShellHeader={true}>
-      <div>
+       <div className="min-h-[650px]">
         <Form
           form={formMethods}
           handleSubmit={async (values) => {
@@ -163,7 +163,7 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
               weekStart: values.weekStart.value,
             });
           }}>
-          <div className="border-subtle border-x border-y-0 px-4 py-8 sm:px-6">
+          <div className="border-subtle border-x border-y-0 min-h-[420px] px-4 py-8 sm:px-6">
             <Controller
               name="locale"
               render={({ field: { value, onChange } }) => (


### PR DESCRIPTION
## What does this PR do?

Added container `min-height` constraints to the settings general view (`GeneralView.tsx`) to prevent vertical layout shift (CLS) when changing application language.

- Fixes #29905

## Visual Demo (For contributors especially)

Added min-height constraints to preserve layout stability during i18n translation bundle loading.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Navigate to Settings -> My Account -> General (`/settings/my-account/general`)
- Change application language from the language dropdown
- Verify that the settings page container height remains stable without vertical layout shift (CLS).