### PR TITLE
fix(lib): strip leading zero from non-whole-hour timezone offsets (#29853)

### DIFF
--- a/packages/lib/timezone.test.ts
+++ b/packages/lib/timezone.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { handleOptionLabel } from "./timezone";
 
 describe("timezone handleOptionLabel formatOffset", () => {
-  it("strips leading zeros for single-digit whole-hour and non-whole-hour offsets", () => {
+  it("strips leading zeros for single-digit positive whole-hour and non-whole-hour offsets", () => {
     const mockOptionWholeHour = {
       label: "(GMT+09:00) Tokyo",
       value: "Asia/Tokyo",
@@ -36,5 +36,29 @@ describe("timezone handleOptionLabel formatOffset", () => {
       { label: "Kathmandu", timezone: "Asia/Kathmandu" },
     ]);
     expect(resultQuarter).toContain("+5:45");
+  });
+
+  it("strips leading zeros for single-digit negative whole-hour and non-whole-hour offsets", () => {
+    const mockOptionNegHalfHour = {
+      label: "(GMT-09:30) Marquesas",
+      value: "Pacific/Marquesas",
+      offset: -9.5,
+    };
+
+    const mockOptionNegWholeHour = {
+      label: "(GMT-05:00) New York",
+      value: "America/New_York",
+      offset: -5,
+    };
+
+    const resultNegHalf = handleOptionLabel(mockOptionNegHalfHour, [
+      { label: "Marquesas", timezone: "Pacific/Marquesas" },
+    ]);
+    expect(resultNegHalf).toContain("-9:30");
+
+    const resultNegWhole = handleOptionLabel(mockOptionNegWholeHour, [
+      { label: "New York", timezone: "America/New_York" },
+    ]);
+    expect(resultNegWhole).toContain("-5:00");
   });
 });

--- a/packages/lib/timezone.test.ts
+++ b/packages/lib/timezone.test.ts
@@ -46,8 +46,8 @@ describe("timezone handleOptionLabel formatOffset", () => {
     };
 
     const mockOptionNegWholeHour = {
-      label: "(GMT-05:00) New York",
-      value: "America/New_York",
+      label: "(GMT-05:00) Panama",
+      value: "America/Panama",
       offset: -5,
     };
 
@@ -57,7 +57,7 @@ describe("timezone handleOptionLabel formatOffset", () => {
     expect(resultNegHalf).toContain("-9:30");
 
     const resultNegWhole = handleOptionLabel(mockOptionNegWholeHour, [
-      { label: "New York", timezone: "America/New_York" },
+      { label: "Panama", timezone: "America/Panama" },
     ]);
     expect(resultNegWhole).toContain("-5:00");
   });

--- a/packages/lib/timezone.test.ts
+++ b/packages/lib/timezone.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { handleOptionLabel } from "./timezone";
+
+describe("timezone handleOptionLabel formatOffset", () => {
+  it("strips leading zeros for single-digit whole-hour and non-whole-hour offsets", () => {
+    const mockOptionWholeHour = {
+      label: "(GMT+09:00) Tokyo",
+      value: "Asia/Tokyo",
+      offset: 9,
+    };
+
+    const mockOptionHalfHour = {
+      label: "(GMT+05:30) Kolkata",
+      value: "Asia/Kolkata",
+      offset: 5.5,
+    };
+
+    const mockOptionQuarterHour = {
+      label: "(GMT+05:45) Kathmandu",
+      value: "Asia/Kathmandu",
+      offset: 5.75,
+    };
+
+    const resultWhole = handleOptionLabel(mockOptionWholeHour, [
+      { label: "Tokyo", timezone: "Asia/Tokyo" },
+    ]);
+    expect(resultWhole).toContain("+9:00");
+
+    const resultHalf = handleOptionLabel(mockOptionHalfHour, [
+      { label: "Kolkata", timezone: "Asia/Kolkata" },
+    ]);
+    expect(resultHalf).toContain("+5:30");
+
+    const resultQuarter = handleOptionLabel(mockOptionQuarterHour, [
+      { label: "Kathmandu", timezone: "Asia/Kathmandu" },
+    ]);
+    expect(resultQuarter).toContain("+5:45");
+  });
+});

--- a/packages/lib/timezone.ts
+++ b/packages/lib/timezone.ts
@@ -25,7 +25,7 @@ export const addTimezonesToDropdown = (timezones: Timezones) => {
 };
 
 const formatOffset = (offset: string) =>
-  offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
+  offset.replace(/^([-+])0(\d:\d{2})$/, "$1$2");
 
 export const handleOptionLabel = (option: ITimezoneOption, timezones: Timezones) => {
   const offsetUnit = option.label.split(/[-+]/)[0].substring(1);


### PR DESCRIPTION
Fixes #29853

## Description
`formatOffset()` in `packages/lib/timezone.ts` stripped leading zeros only when the minute offset matched `:00` via regex `/^([-+])(0)(\d):00$/`.
As a result, whole-hour offsets (e.g. `+09:00` -> `+9:00`) were normalized, while half-hour and quarter-hour offsets (e.g. `+05:30`, `+05:45`) retained their leading padding zero, leading to inconsistent timezone formatting in dropdowns.

This PR updates `formatOffset()` regex to `/^([-+])0(\d:\d{2})$/` to strip leading zero padding for all single-digit hour offsets regardless of minute values.

## Tests
Added unit test suite in `packages/lib/timezone.test.ts` covering single-digit whole-hour, half-hour, and quarter-hour timezone offset formatting.