### PR TITLE
fix(lib): pass numeric dimensions in OG_ASSETS for Satori image rendering (#29895)

### DIFF
--- a/packages/lib/OgImages.tsx
+++ b/packages/lib/OgImages.tsx
@@ -51,23 +51,23 @@ const makeAbsoluteUrl = (url: string) => (/^https?:\/\//.test(url) ? url : `${CA
 
 const OG_ASSETS = {
   meeting: {
-    id: "meeting-og-image-v1", // Bump version when changing Meeting component structure/styling
+    id: "meeting-og-image-v2", // Bump version when changing Meeting component structure/styling
     logo: LOGO,
-    logoWidth: "350",
-    avatarSize: "160",
+    logoWidth: 350,
+    avatarSize: 160,
     variant: "dark" as const,
   },
   app: {
-    id: "app-og-image-v1", // Bump version when changing App component structure/styling
+    id: "app-og-image-v2", // Bump version when changing App component structure/styling
     logo: LOGO,
-    logoWidth: "150",
-    iconSize: "172",
+    logoWidth: 150,
+    iconSize: 172,
     variant: "light" as const,
   },
   generic: {
-    id: "generic-og-image-v1", // Bump version when changing Generic component structure/styling
+    id: "generic-og-image-v2", // Bump version when changing Generic component structure/styling
     logo: LOGO_DARK,
-    logoWidth: "350",
+    logoWidth: 350,
     variant: "light" as const,
   },
 };


### PR DESCRIPTION
Fixes #29895

## Description
In `packages/lib/OgImages.tsx`, `OG_ASSETS` declared image dimensions (`logoWidth`, `avatarSize`, `iconSize`) as string literals (e.g., `"350"`, `"160"`).

When rendering SVG elements, Satori requires numeric dimensions for `width` and `height` properties on `<img>` elements. String dimension props cause Satori to reject the attribute and drop `<img>` elements (logos and user avatars) from the rendered output in all OG image variants (`Meeting`, `App`, `Generic`).

This PR converts `logoWidth`, `avatarSize`, and `iconSize` values in `OG_ASSETS` to numbers and bumps component asset version IDs (`v2`) for clean cache invalidation.