### PR TITLE
fix(trpc): preserve first guest object occurrence in addGuests deduplication (#29849)

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
@@ -208,10 +208,14 @@ export async function sanitizeAndFilterGuests(
   const guestEmailsLowerCase = deduplicatedGuests.map((email) => extractBaseEmail(email).toLowerCase());
   const emailToRequiresVerification = await getEmailVerificationRequirements(guestEmailsLowerCase);
 
-  // Create a map of email to guest object for easy lookup
-  const emailToGuestMap = new Map(
-    guests.map((guest) => [extractBaseEmail(guest.email).toLowerCase(), guest])
-  );
+  // Create a map of email to guest object for easy lookup (preserving first occurrence to match deduplicateGuestEmails)
+  const emailToGuestMap = new Map<string, (typeof guests)[number]>();
+  for (const guest of guests) {
+    const baseEmail = extractBaseEmail(guest.email).toLowerCase();
+    if (!emailToGuestMap.has(baseEmail)) {
+      emailToGuestMap.set(baseEmail, guest);
+    }
+  }
 
   const uniqueGuestEmails = deduplicatedGuests.filter((email) => {
     const baseGuestEmail = extractBaseEmail(email).toLowerCase();

--- a/packages/trpc/server/routers/viewer/bookings/addGuests.test.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { sanitizeAndFilterGuests } from "./addGuests.handler";
+
+vi.mock("@calcom/lib/UserRepository", () => ({
+  UserRepository: vi.fn().mockImplementation(() => ({
+    findManyByEmailsWithEmailVerificationSettings: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+describe("sanitizeAndFilterGuests deduplication", () => {
+  it("keeps the first guest object when emails differ only by plus-addressing", async () => {
+    const guests = [
+      { email: "john+1@example.com", name: "John First" },
+      { email: "john+2@example.com", name: "John Second" },
+    ];
+
+    const mockBooking = {
+      attendees: [],
+    } as any;
+
+    const result = await sanitizeAndFilterGuests(guests, mockBooking);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      email: "john+1@example.com",
+      name: "John First",
+    });
+  });
+});

--- a/packages/trpc/server/routers/viewer/bookings/addGuests.test.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.test.ts
@@ -17,7 +17,7 @@ describe("sanitizeAndFilterGuests deduplication", () => {
 
     const mockBooking = {
       attendees: [],
-    } as any;
+    } as unknown as Parameters<typeof sanitizeAndFilterGuests>[1];
 
     const result = await sanitizeAndFilterGuests(guests, mockBooking);
 

--- a/packages/trpc/server/routers/viewer/bookings/addGuests.test.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.test.ts
@@ -15,9 +15,10 @@ describe("sanitizeAndFilterGuests deduplication", () => {
       { email: "john+2@example.com", name: "John Second" },
     ];
 
-    const mockBooking = {
+    type BookingParam = Parameters<typeof sanitizeAndFilterGuests>[1];
+    const mockBooking: BookingParam = {
       attendees: [],
-    } as unknown as Parameters<typeof sanitizeAndFilterGuests>[1];
+    } as BookingParam;
 
     const result = await sanitizeAndFilterGuests(guests, mockBooking);
 


### PR DESCRIPTION
Fixes #29849

## Description
In `packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts`, `sanitizeAndFilterGuests()` deduplicates guest emails using `deduplicateGuestEmails()`, which retains the **first** occurrence of an email (including plus-addressing normalization).

However, `emailToGuestMap` was created via `new Map(guests.map((g) => [extractBaseEmail(g.email).toLowerCase(), g]))`, which overwrote earlier map entries with the **last** occurrence of a duplicate guest. This resulted in a desync where the first email was paired with the last guest object's name/metadata.

This PR updates `emailToGuestMap` to preserve the first occurrence of each base email key, ensuring consistency with `deduplicateGuestEmails()`.

## Tests
Added unit test suite in `packages/trpc/server/routers/viewer/bookings/addGuests.test.ts` verifying that `sanitizeAndFilterGuests` preserves the first guest object when emails differ only by plus-addressing.