### PR TITLE
fix(api-v2): assign unique operationIds to deprecated singular calendar route aliases (#29903)

### DIFF
--- a/apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.ts
+++ b/apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.ts
@@ -238,14 +238,15 @@ export class CalUnifiedCalendarsController {
       "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
     type: String,
   })
-  @Get(["/:calendar/events/:eventUid", "/:calendar/event/:eventUid"])
+  @Get("/:calendar/events/:eventUid")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @ApiOperation({
+    operationId: "CalUnifiedCalendarsController_getCalendarEventDetails",
     summary: "Get meeting details from calendar",
     description:
-      "Returns detailed information about a meeting including attendance metrics. The singular /event/ path is deprecated \u2014 use /events/ (plural) instead. For connection-scoped access use GET /connections/{connectionId}/events/{eventId}.",
+      "Returns detailed information about a meeting including attendance metrics. For connection-scoped access use GET /connections/{connectionId}/events/{eventId}.",
   })
   async getCalendarEventDetails(
     @Param("calendar") calendar: string,
@@ -266,14 +267,44 @@ export class CalUnifiedCalendarsController {
       "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
     type: String,
   })
-  @Patch(["/:calendar/events/:eventUid", "/:calendar/event/:eventUid"])
+  @Get("/:calendar/event/:eventUid")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @ApiOperation({
+    operationId: "CalUnifiedCalendarsController_getCalendarEventDetailsDeprecated",
+    deprecated: true,
+    summary: "Get meeting details from calendar (Deprecated)",
+    description:
+      "Returns detailed information about a meeting including attendance metrics. The singular /event/ path is deprecated \u2014 use /events/ (plural) instead. For connection-scoped access use GET /connections/{connectionId}/events/{eventId}.",
+  })
+  async getCalendarEventDetailsDeprecated(
+    @Param("calendar") calendar: string,
+    @Param("eventUid") eventUid: string
+  ): Promise<GetUnifiedCalendarEventOutput> {
+    return this.getCalendarEventDetails(calendar, eventUid);
+  }
+
+  @ApiParam({
+    name: "calendar",
+    enum: [GOOGLE_CALENDAR],
+    type: String,
+  })
+  @ApiParam({
+    name: "eventUid",
+    description:
+      "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
+    type: String,
+  })
+  @Patch("/:calendar/events/:eventUid")
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ApiAuthGuard, PermissionsGuard)
+  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiOperation({
+    operationId: "CalUnifiedCalendarsController_updateCalendarEvent",
     summary: "Update meeting details in calendar",
     description:
-      "Updates event information in the specified calendar provider. The singular /event/ path is deprecated \u2014 use /events/ (plural) instead. For connection-scoped access use PATCH /connections/{connectionId}/events/{eventId}.",
+      "Updates event information in the specified calendar provider. For connection-scoped access use PATCH /connections/{connectionId}/events/{eventId}.",
   })
   async updateCalendarEvent(
     @Param("calendar") calendar: string,
@@ -282,6 +313,36 @@ export class CalUnifiedCalendarsController {
   ): Promise<GetUnifiedCalendarEventOutput> {
     const data = await this.unifiedCalendarService.updateEventDetails(calendar, eventUid, updateData);
     return { status: SUCCESS_STATUS, data };
+  }
+
+  @ApiParam({
+    name: "calendar",
+    enum: [GOOGLE_CALENDAR],
+    type: String,
+  })
+  @ApiParam({
+    name: "eventUid",
+    description:
+      "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
+    type: String,
+  })
+  @Patch("/:calendar/event/:eventUid")
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ApiAuthGuard, PermissionsGuard)
+  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiOperation({
+    operationId: "CalUnifiedCalendarsController_updateCalendarEventDeprecated",
+    deprecated: true,
+    summary: "Update meeting details in calendar (Deprecated)",
+    description:
+      "Updates event information in the specified calendar provider. The singular /event/ path is deprecated \u2014 use /events/ (plural) instead. For connection-scoped access use PATCH /connections/{connectionId}/events/{eventId}.",
+  })
+  async updateCalendarEventDeprecated(
+    @Param("calendar") calendar: string,
+    @Param("eventUid") eventUid: string,
+    @Body() updateData: UpdateUnifiedCalendarEventInput
+  ): Promise<GetUnifiedCalendarEventOutput> {
+    return this.updateCalendarEvent(calendar, eventUid, updateData);
   }
 
   @ApiParam({ name: "calendar", enum: UNIFIED_CALENDAR_PARAM, type: String })


### PR DESCRIPTION
Fixes #29903

## Description
In `apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.ts`, singular and plural route aliases (`/:calendar/events/:eventUid` and deprecated `/:calendar/event/:eventUid`) shared single `@Get(...)` and `@Patch(...)` handler method decorators.

Because NestJS Swagger derives default `operationId` identifiers from controller method names, both route aliases generated identical `operationId` values in the OpenAPI specification (`CalUnifiedCalendarsController_getCalendarEventDetails` and `CalUnifiedCalendarsController_updateCalendarEvent`), causing `openapi-spec-validator` validation failures and SDK client generator method collisions.

This PR splits the deprecated singular route aliases into dedicated handler methods with unique explicit `operationId` metadata (`CalUnifiedCalendarsController_getCalendarEventDetailsDeprecated` and `CalUnifiedCalendarsController_updateCalendarEventDeprecated`), ensuring OpenAPI documents validate cleanly and generate unique client operations while preserving 100% runtime HTTP route compatibility.