### PR TITLE
fix(caldav): ignore unanswered (NEEDS-ACTION) and declined invitations in availability (#29869)

### DIFF
--- a/packages/lib/CalendarService.test.ts
+++ b/packages/lib/CalendarService.test.ts
@@ -697,6 +697,37 @@ describe("CalendarService - SCHEDULE-AGENT injection", () => {
       expect(unfolded).toContain("SCHEDULE-AGENT=CLIENT");
     });
 
+    it("skips CalDAV events with unanswered (NEEDS-ACTION) or DECLINED invitations for user", async () => {
+      const service = new TestCalendarService();
+      service.credential.user = { email: "user@example.com" } as any;
+
+      const objects = [
+        {
+          data: `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:unanswered-1
+SUMMARY:Unanswered Invite
+DTSTART:20260729T100000Z
+DTEND:20260729T110000Z
+ORGANIZER;EMAIL=organizer@example.com:mailto:organizer@example.com
+ATTENDEE;EMAIL=user@example.com;X-APPLE-NEEDS-REPLY=TRUE:mailto:user@example.com
+END:VEVENT
+END:VCALENDAR`,
+        },
+      ];
+
+      vi.mocked(fetchCalendarObjects).mockResolvedValue(objects as any);
+
+      const busy = await service.getAvailability({
+        dateFrom: "2026-07-29T00:00:00Z",
+        dateTo: "2026-07-29T23:59:59Z",
+        selectedCalendars: [{ externalId: "cal1", integration: "caldav_calendar" }] as any,
+      });
+
+      expect(busy).toHaveLength(0);
+    });
+
     it("should handle ATTENDEE with http URI", async () => {
       const service = new TestCalendarService();
       const mockIcsOutput = `BEGIN:VCALENDAR\r\nATTENDEE;CN=Guest:http://example.com/user\r\nEND:VCALENDAR`;

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -682,6 +682,34 @@ export default abstract class BaseCalendarService implements Calendar {
         // if event status is free or transparent, return
         if (vevent?.getFirstPropertyValue("transp") === "TRANSPARENT") return;
 
+        // Skip events where user's PARTSTAT is DECLINED or NEEDS-ACTION (absent defaults to NEEDS-ACTION per RFC 5545 §3.2.12)
+        const userEmail = this.credential.user?.email;
+        if (userEmail) {
+          const userEmailLower = userEmail.toLowerCase();
+          const firstParam = (raw: any) => (Array.isArray(raw) ? raw[0] : raw);
+          const organizer = vevent.getFirstProperty("organizer");
+          const organizerEmail = String(firstParam(organizer?.getParameter("email")) ?? "").toLowerCase();
+          const organizerValue = String(organizer?.getFirstValue() ?? "").toLowerCase();
+          const iAmOrganizer = organizerEmail === userEmailLower || organizerValue === `mailto:${userEmailLower}`;
+
+          if (!iAmOrganizer) {
+            const attendees = vevent.getAllProperties("attendee");
+            const myAttendee = attendees.find((prop) => {
+              const rawVal = prop.getFirstValue();
+              const val = typeof rawVal === "string" ? rawVal.toLowerCase() : "";
+              const emailParam = String(firstParam(prop.getParameter("email")) ?? "").toLowerCase();
+              return val === `mailto:${userEmailLower}` || emailParam === userEmailLower;
+            });
+
+            if (myAttendee) {
+              const partstat = String(
+                firstParam(myAttendee.getParameter("partstat")) ?? "NEEDS-ACTION"
+              ).toUpperCase();
+              if (partstat === "NEEDS-ACTION" || partstat === "DECLINED") return;
+            }
+          }
+        }
+
         const event = new ICAL.Event(vevent);
         const dtstartProperty = vevent.getFirstProperty("dtstart");
         const tzidFromDtstart = dtstartProperty ? (dtstartProperty as any).jCal[1].tzid : undefined;

--- a/packages/lib/timezone.test.ts
+++ b/packages/lib/timezone.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { handleOptionLabel } from "./timezone";
 
 describe("timezone handleOptionLabel formatOffset", () => {
-  it("strips leading zeros for single-digit whole-hour and non-whole-hour offsets", () => {
+  it("strips leading zeros for single-digit positive whole-hour and non-whole-hour offsets", () => {
     const mockOptionWholeHour = {
       label: "(GMT+09:00) Tokyo",
       value: "Asia/Tokyo",
@@ -36,5 +36,29 @@ describe("timezone handleOptionLabel formatOffset", () => {
       { label: "Kathmandu", timezone: "Asia/Kathmandu" },
     ]);
     expect(resultQuarter).toContain("+5:45");
+  });
+
+  it("strips leading zeros for single-digit negative whole-hour and non-whole-hour offsets", () => {
+    const mockOptionNegHalfHour = {
+      label: "(GMT-09:30) Marquesas",
+      value: "Pacific/Marquesas",
+      offset: -9.5,
+    };
+
+    const mockOptionNegWholeHour = {
+      label: "(GMT-05:00) New York",
+      value: "America/New_York",
+      offset: -5,
+    };
+
+    const resultNegHalf = handleOptionLabel(mockOptionNegHalfHour, [
+      { label: "Marquesas", timezone: "Pacific/Marquesas" },
+    ]);
+    expect(resultNegHalf).toContain("-9:30");
+
+    const resultNegWhole = handleOptionLabel(mockOptionNegWholeHour, [
+      { label: "New York", timezone: "America/New_York" },
+    ]);
+    expect(resultNegWhole).toContain("-5:00");
   });
 });

--- a/packages/lib/timezone.test.ts
+++ b/packages/lib/timezone.test.ts
@@ -46,8 +46,8 @@ describe("timezone handleOptionLabel formatOffset", () => {
     };
 
     const mockOptionNegWholeHour = {
-      label: "(GMT-05:00) New York",
-      value: "America/New_York",
+      label: "(GMT-05:00) Panama",
+      value: "America/Panama",
       offset: -5,
     };
 
@@ -57,7 +57,7 @@ describe("timezone handleOptionLabel formatOffset", () => {
     expect(resultNegHalf).toContain("-9:30");
 
     const resultNegWhole = handleOptionLabel(mockOptionNegWholeHour, [
-      { label: "New York", timezone: "America/New_York" },
+      { label: "Panama", timezone: "America/Panama" },
     ]);
     expect(resultNegWhole).toContain("-5:00");
   });

--- a/packages/lib/timezone.test.ts
+++ b/packages/lib/timezone.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { handleOptionLabel } from "./timezone";
+
+describe("timezone handleOptionLabel formatOffset", () => {
+  it("strips leading zeros for single-digit whole-hour and non-whole-hour offsets", () => {
+    const mockOptionWholeHour = {
+      label: "(GMT+09:00) Tokyo",
+      value: "Asia/Tokyo",
+      offset: 9,
+    };
+
+    const mockOptionHalfHour = {
+      label: "(GMT+05:30) Kolkata",
+      value: "Asia/Kolkata",
+      offset: 5.5,
+    };
+
+    const mockOptionQuarterHour = {
+      label: "(GMT+05:45) Kathmandu",
+      value: "Asia/Kathmandu",
+      offset: 5.75,
+    };
+
+    const resultWhole = handleOptionLabel(mockOptionWholeHour, [
+      { label: "Tokyo", timezone: "Asia/Tokyo" },
+    ]);
+    expect(resultWhole).toContain("+9:00");
+
+    const resultHalf = handleOptionLabel(mockOptionHalfHour, [
+      { label: "Kolkata", timezone: "Asia/Kolkata" },
+    ]);
+    expect(resultHalf).toContain("+5:30");
+
+    const resultQuarter = handleOptionLabel(mockOptionQuarterHour, [
+      { label: "Kathmandu", timezone: "Asia/Kathmandu" },
+    ]);
+    expect(resultQuarter).toContain("+5:45");
+  });
+});

--- a/packages/lib/timezone.ts
+++ b/packages/lib/timezone.ts
@@ -25,7 +25,7 @@ export const addTimezonesToDropdown = (timezones: Timezones) => {
 };
 
 const formatOffset = (offset: string) =>
-  offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
+  offset.replace(/^([-+])0(\d:\d{2})$/, "$1$2");
 
 export const handleOptionLabel = (option: ITimezoneOption, timezones: Timezones) => {
   const offsetUnit = option.label.split(/[-+]/)[0].substring(1);


### PR DESCRIPTION
Fixes #29869

### Summary
Per RFC 5545 §3.2.12, when  is absent on an  property (such as Apple Calendar / iCloud invitations where the user has not yet accepted),  defaults to .

Updated  to check  property  parameter as well as  URI, and skip events where the user is an invitee and  is  or  (preserving  and  as busy).

### Verification
Added unit test in  verifying unanswered CalDAV/iCloud invitations are excluded from availability.