### PR TITLE
fix(ui): add button-icon class and data-name attribute to EndIcon in Button component (#29795)

### DIFF
--- a/packages/ui/components/button/Button.tsx
+++ b/packages/ui/components/button/Button.tsx
@@ -311,11 +311,12 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
             </>
           ) : (
             <Icon
+              data-name="end-icon"
               name={EndIcon}
               className={classNames(
                 "shrink-0",
                 loading ? "invisible" : "visible",
-                "group-[:not(div):active]:translate-y-[0.5px]",
+                "button-icon group-[:not(div):active]:translate-y-[0.5px]",
                 variant === "icon" && "h-4 w-4",
                 variant === "button" && "h-4 w-4 stroke-[1.5px] "
               )}


### PR DESCRIPTION
Fixes #29795

## Description

In `packages/ui/components/button/Button.tsx`, `StartIcon` was rendered with `data-name="start-icon"` and the `"button-icon"` CSS class, but `EndIcon` was missing both attributes:

```tsx
// StartIcon (lines 264-272)
<Icon
  data-name="start-icon"
  name={StartIcon}
  className={classNames("shrink-0", loading ? "invisible" : "visible", "button-icon ...")}
/>

// EndIcon (lines 313-322) - missing data-name and button-icon
<Icon
  name={EndIcon}
  className={classNames("shrink-0", loading ? "invisible" : "visible", "...")}
/>
