### PR TITLE
fix(emails): customReplyToEmail no longer dropped when hideOrganizerEmail is true 

### DIFF
--- a/packages/lib/getReplyToHeader.test.ts
+++ b/packages/lib/getReplyToHeader.test.ts
@@ -8,11 +8,12 @@ import { getReplyToHeader } from "./getReplyToHeader";
  * Spec: https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.2
  */
 
-vi.mock("./getReplyToEmail", () => ({
-  getReplyToEmail: vi.fn((calEvent, excludeOrganizerEmail) => {
-    if (excludeOrganizerEmail) return null;
-    return calEvent.organizer?.email || null;
-  }),
+vi.mock("./getReplyToEmail", () => ({  
+  getReplyToEmail: vi.fn((calEvent, excludeOrganizerEmail) => {  
+    if (calEvent.customReplyToEmail) return calEvent.customReplyToEmail;  
+    if (excludeOrganizerEmail) return null;  
+    return calEvent.organizer?.email || null;  
+  }),  
 }));
 
 const createMockCalEvent = (organizerEmail: string) => ({
@@ -89,4 +90,16 @@ describe("getReplyToHeader", () => {
       expect(result.replyTo).not.toContain("]");
     });
   });
+
+  describe("with hideOrganizerEmail and customReplyToEmail", () => {  
+  it("uses customReplyToEmail even when hideOrganizerEmail is true", () => {  
+    const calEvent = {  
+      organizer: { email: "org@test.com" },  
+      hideOrganizerEmail: true,  
+      customReplyToEmail: "custom@test.com",  
+    };  
+    const result = getReplyToHeader(calEvent as any, undefined, true);  
+    expect(result).toEqual({ replyTo: "custom@test.com" });  
+  });  
+});
 });

--- a/packages/lib/getReplyToHeader.ts
+++ b/packages/lib/getReplyToHeader.ts
@@ -2,32 +2,22 @@ import type { CalendarEvent } from "@calcom/types/Calendar";
 
 import { getReplyToEmail } from "./getReplyToEmail";
 
-export function getReplyToHeader(
-  calEvent: CalendarEvent,
-  additionalEmails?: string | string[],
-  excludeOrganizerEmail?: boolean
-) {
-  if (calEvent.hideOrganizerEmail) return {};
-
-  const replyToEmail = getReplyToEmail(calEvent, excludeOrganizerEmail);
-  const emailArray: string[] = [];
-
-  if (additionalEmails) {
-    if (Array.isArray(additionalEmails)) {
-      emailArray.push(...additionalEmails);
-    } else {
-      emailArray.push(additionalEmails);
-    }
-  }
-
-  if (replyToEmail) {
-    emailArray.push(replyToEmail);
-  }
-
-  if (emailArray.length === 0) {
-    return {};
-  }
-
-  const replyTo = emailArray.join(", ");
-  return { replyTo };
+export function getReplyToHeader(  
+  calEvent: CalendarEvent,  
+  additionalEmails?: string | string[],  
+  excludeOrganizerEmail?: boolean  
+) {  
+  const shouldExcludeOrganizer = excludeOrganizerEmail || calEvent.hideOrganizerEmail;  
+  const replyToEmail = getReplyToEmail(calEvent, shouldExcludeOrganizer);  
+  
+  const emailArray: string[] = [];  
+  if (additionalEmails) {  
+    Array.isArray(additionalEmails) ? emailArray.push(...additionalEmails) : emailArray.push(additionalEmails);  
+  }  
+  if (replyToEmail) {  
+    emailArray.push(replyToEmail);  
+  }  
+  if (emailArray.length === 0) return {};  
+  
+  return { replyTo: emailArray.join(", ") };  
 }


### PR DESCRIPTION
## What does this PR do?

getReplyToHeader previously returned {} immediately whenever  calEvent.hideOrganizerEmail was true, before customReplyToEmail  was ever checked. This meant "Hide organizer email" and "Custom  Reply-To Email" could not be used together. This PR ensures that when both are toggled on  then the reply to header displays the custom reply to mail

- Fixes #21540  (GitHub issue number)


#### Video Demo (if applicable):


[Screencast from 2026-08-08 01-13-01.webm](https://github.com/user-attachments/assets/dc811fb2-0c6b-4add-b2cf-6c96ed8d2ab1)



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.