### PR TITLE
fix(apps): sort event type duration badges numerically

### DIFF
--- a/apps/web/components/apps/installation/EventTypesStepCard.tsx
+++ b/apps/web/components/apps/installation/EventTypesStepCard.tsx
@@ -43,7 +43,7 @@ const EventTypeCard: FC<EventTypeCardProps> = ({
 
   const durations =
     multipleDuration.length > 0
-      ? [length, ...multipleDuration.filter((duration) => duration !== length)].sort()
+      ? [length, ...multipleDuration.filter((duration) => duration !== length)].sort((a, b) => a - b)
       : [length];
   return (
     <div


### PR DESCRIPTION
The duration badges on the app installation event-type picker were sorted with a bare `.sort()`, which coerces to string and orders lexicographically. An event type with durations [15, 30, 60, 90, 120] rendered as "120m 15m 30m 60m 90m" instead of "15m 30m 60m 90m 120m". Fixed with a numeric comparator, matching the convention already used in getUserAvailability.ts and slots.ts.